### PR TITLE
wall icon fix

### DIFF
--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -30,7 +30,7 @@
 	name = "wooden wall"
 	desc = "A traditional wooden wall."
 	icon = 'icons/fallout/turfs/walls/wood.dmi'
-	icon_state = "wood"
+	icon_state = "wood0"
 	icon_type_smooth = "wood"
 	hardness = 60
 	smooth = SMOOTH_OLD
@@ -45,7 +45,7 @@
 	name = "house wall"
 	desc = "A weathered pre-War house wall."
 	icon = 'icons/fallout/turfs/walls/house.dmi'
-	icon_state = "house"
+	icon_state = "house0"
 	icon_type_smooth = "house"
 	hardness = 50
 	var/broken = 0
@@ -97,7 +97,7 @@ turf/closed/wall/f13/wood/house/update_damage_overlay()
 	name = "interior wall"
 	desc = "Interesting, what kind of material they have used - these wallpapers still look good after all the centuries..."
 	icon = 'icons/fallout/turfs/walls/interior.dmi'
-	icon_state = "interior"
+	icon_state = "interior0"
 	icon_type_smooth = "interior"
 	hardness = 10
 	smooth = SMOOTH_OLD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed bug with wrong icon set for a few walls which messed up their sprite on the map maker caused by missing a few zeros when changing back to old smoothing.

## Why It's Good For The Game

Bye bug

## Changelog
:cl:
fix: Missing wall sprites in map maker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
