### PR TITLE
Replaced lockboxes with loot spawners

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -39,11 +39,11 @@
 	},
 /area/f13/bunker)
 "abs" = (
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/closet,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -126,7 +126,7 @@
 /turf/open/floor/wood,
 /area/f13/vault)
 "aeS" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/structure/closet,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
@@ -173,7 +173,7 @@
 	},
 /area/f13/wasteland)
 "ahT" = (
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "aim" = (
@@ -187,7 +187,7 @@
 /area/f13/vault)
 "aiY" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13,
 /area/f13/city)
 "ajc" = (
@@ -266,7 +266,7 @@
 /area/f13/bunker)
 "anJ" = (
 /obj/structure/booth,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "anY" = (
@@ -329,7 +329,7 @@
 	},
 /area/space)
 "arO" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
@@ -343,7 +343,7 @@
 /area/f13/wasteland)
 "asP" = (
 /obj/structure/table/glass,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "asT" = (
@@ -383,7 +383,7 @@
 "atF" = (
 /obj/structure/rack,
 /obj/item/storage/crayons,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
@@ -407,7 +407,7 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
 "avm" = (
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "awX" = (
@@ -445,13 +445,13 @@
 /area/space)
 "ayi" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/ammo/tier4,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "ayp" = (
@@ -588,7 +588,7 @@
 /area/f13/bunker)
 "aBh" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
@@ -739,7 +739,7 @@
 /area/f13/bunker)
 "aHE" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
@@ -954,7 +954,7 @@
 /area/f13/bunker)
 "aVI" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "aWc" = (
@@ -971,7 +971,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "aWe" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
@@ -1066,7 +1066,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -1089,11 +1089,11 @@
 /area/f13/bunker)
 "bam" = (
 /obj/structure/closet/fridge/meat,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "baH" = (
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -1170,7 +1170,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "beT" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
@@ -1195,7 +1195,7 @@
 /area/f13/underground/cave)
 "bgD" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -1227,7 +1227,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "bhv" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -1636,7 +1636,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "bBb" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bBo" = (
@@ -1775,7 +1775,7 @@
 /obj/item/clothing/under/f13/vault{
 	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
 	},
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "bJt" = (
@@ -1783,8 +1783,8 @@
 /obj/machinery/button/door{
 	id = 93
 	},
-/obj/item/locked_box/misc/skillbook,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -1793,7 +1793,7 @@
 "bJF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "bKp" = (
@@ -1863,15 +1863,15 @@
 /area/f13/bunker)
 "bPH" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
 	},
 /area/f13/bunker)
 "bPQ" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13,
 /area/f13/city)
 "bQf" = (
@@ -1889,8 +1889,8 @@
 "bQs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/misc/money/all/low,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -1937,7 +1937,7 @@
 	},
 /area/space)
 "bSx" = (
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "bSJ" = (
@@ -2065,7 +2065,7 @@
 "cat" = (
 /obj/structure/table,
 /obj/item/trash/chips,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -2181,7 +2181,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "cgJ" = (
-/obj/item/locked_box/misc/seed,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
@@ -2204,7 +2204,7 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "cic" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ciO" = (
@@ -2291,9 +2291,9 @@
 /area/f13/vault)
 "cmD" = (
 /obj/effect/spawner/lootdrop/armory_contraband,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -2402,7 +2402,7 @@
 /area/f13/bunker)
 "csw" = (
 /obj/structure/bookcase/random,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/book/manual/wiki/detective,
 /obj/item/book/manual/wiki/engineering_guide,
@@ -2492,11 +2492,11 @@
 	},
 /area/f13/city)
 "cwr" = (
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "cwu" = (
@@ -2591,7 +2591,7 @@
 	},
 /area/f13/bunker)
 "cBd" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
@@ -2639,7 +2639,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
 "cEA" = (
-/obj/item/locked_box/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
 /obj/structure/closet,
 /turf/open/floor/f13,
 /area/f13/city)
@@ -2667,7 +2667,7 @@
 	},
 /area/f13/bunker)
 "cGl" = (
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
@@ -2719,7 +2719,7 @@
 /area/space)
 "cHR" = (
 /obj/structure/table/wood/bar,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13,
 /area/f13/city)
 "cIc" = (
@@ -2746,7 +2746,7 @@
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
 	name = "advanced table"
 	},
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "cJR" = (
@@ -2759,10 +2759,10 @@
 /area/f13/bunker)
 "cJY" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /obj/structure/closet,
-/obj/item/locked_box/misc/money/all/medium,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -2844,7 +2844,7 @@
 /area/space)
 "cPi" = (
 /obj/effect/decal/waste,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plating,
 /area/f13/bunker)
 "cPI" = (
@@ -2867,7 +2867,7 @@
 /area/space)
 "cQv" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -2891,7 +2891,7 @@
 /area/f13/bunker)
 "cQM" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13{
@@ -2955,7 +2955,7 @@
 /area/f13/bunker)
 "cUz" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "cUJ" = (
@@ -3009,8 +3009,8 @@
 /area/f13/bunker)
 "cYq" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
 "cYx" = (
@@ -3316,7 +3316,7 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat/security,
 /obj/item/storage/backpack/security,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
@@ -3388,7 +3388,7 @@
 /area/f13/vault)
 "drp" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "drs" = (
@@ -3558,7 +3558,7 @@
 	dir = 1
 	},
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "dCo" = (
@@ -3583,7 +3583,7 @@
 	icon_state = "goo5"
 	},
 /obj/structure/closet,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -3734,7 +3734,7 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13,
 /area/f13/city)
 "dKg" = (
@@ -3848,7 +3848,7 @@
 /area/f13/bunker)
 "dQq" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "dQy" = (
@@ -3945,7 +3945,7 @@
 /area/f13/city)
 "dTH" = (
 /obj/structure/table/glass,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dTR" = (
@@ -3976,7 +3976,7 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "dVh" = (
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
 "dVq" = (
@@ -4097,7 +4097,7 @@
 /area/f13/bunker)
 "eaT" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "eco" = (
@@ -4227,7 +4227,7 @@
 /area/f13/bunker)
 "ejJ" = (
 /obj/machinery/door/window,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/structure/closet,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -4435,7 +4435,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "esS" = (
-/obj/item/locked_box/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "esV" = (
@@ -4479,7 +4479,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "evR" = (
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ewu" = (
@@ -4545,7 +4545,7 @@
 "eBf" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "eBg" = (
@@ -4739,8 +4739,8 @@
 /area/f13/bunker)
 "eJr" = (
 /obj/structure/closet/wardrobe,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "eJz" = (
@@ -4773,7 +4773,7 @@
 "eJU" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
 	},
@@ -4799,11 +4799,11 @@
 /area/f13/bunker)
 "eMT" = (
 /obj/structure/closet/wardrobe,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "eNr" = (
@@ -4890,7 +4890,7 @@
 "eQx" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
@@ -4949,8 +4949,8 @@
 /area/f13/wasteland)
 "eTU" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/item/reagent_containers/food/snacks/burger/superbite,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
@@ -4996,7 +4996,7 @@
 /area/f13/bunker)
 "eWf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "eWA" = (
@@ -5098,7 +5098,7 @@
 /area/f13/vault)
 "fax" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "fay" = (
@@ -5107,7 +5107,7 @@
 /area/f13/ncr)
 "faF" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -5155,8 +5155,8 @@
 /area/f13/vault)
 "fbz" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/armor/tier3,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13,
 /area/f13/wasteland)
 "fbG" = (
@@ -5386,7 +5386,7 @@
 	},
 /area/space)
 "fnR" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fow" = (
@@ -5427,7 +5427,7 @@
 /area/f13/bunker)
 "fqE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fqL" = (
@@ -5638,12 +5638,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "fCG" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "fCL" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
@@ -5655,7 +5655,7 @@
 /area/space)
 "fDt" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fDA" = (
@@ -5736,8 +5736,8 @@
 	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
 	name = "Pre-War Medicine"
 	},
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "fHN" = (
@@ -5848,7 +5848,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
 "fJS" = (
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "fKi" = (
@@ -5976,7 +5976,7 @@
 /area/f13/bunker)
 "fSK" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -6025,7 +6025,7 @@
 /obj/machinery/door/window{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/structure/closet,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -6152,7 +6152,7 @@
 /area/f13/wasteland)
 "fZI" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/f13,
 /area/f13/city)
 "gaz" = (
@@ -6200,7 +6200,7 @@
 /area/f13/tunnel)
 "gdZ" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -6252,7 +6252,7 @@
 /area/f13/bunker)
 "ggC" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
@@ -6266,7 +6266,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
 "ghm" = (
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ghE" = (
@@ -6296,7 +6296,7 @@
 /area/f13/vault)
 "gic" = (
 /obj/structure/closet,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "giH" = (
@@ -6404,8 +6404,8 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/tunnel)
 "gnc" = (
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plating,
 /area/f13/bunker)
 "gnA" = (
@@ -6492,7 +6492,7 @@
 /area/f13/bunker)
 "grL" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/alcohol{
+/obj/effect/spawner/lootdrop/f13/alcoholspawner{
 	pixel_y = 6
 	},
 /turf/open/floor/wood,
@@ -6696,7 +6696,7 @@
 "gAV" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin/construction,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
@@ -6775,7 +6775,7 @@
 /area/f13/vault)
 "gEg" = (
 /obj/structure/closet/wardrobe,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
@@ -6796,7 +6796,7 @@
 "gFw" = (
 /obj/structure/table,
 /obj/item/trash/candy,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -6840,7 +6840,7 @@
 /area/f13/vault)
 "gIz" = (
 /obj/machinery/light,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
@@ -7038,7 +7038,7 @@
 /area/f13/wasteland)
 "gSp" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/unique,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/unique,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "gSq" = (
@@ -7096,7 +7096,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "gUG" = (
-/obj/item/locked_box/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gVz" = (
@@ -7167,7 +7167,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "hbE" = (
@@ -7424,8 +7424,8 @@
 /area/f13/city)
 "hnd" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/tier4,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
@@ -7467,7 +7467,7 @@
 /area/f13/bunker)
 "hoe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
@@ -7552,8 +7552,8 @@
 /area/f13/city)
 "hsq" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -7582,7 +7582,7 @@
 /turf/open/floor/wood,
 /area/f13/vault)
 "hvv" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
@@ -7649,7 +7649,7 @@
 /area/f13/underground/cave)
 "hzI" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
@@ -7684,12 +7684,12 @@
 /area/space)
 "hBH" = (
 /obj/structure/table,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "hBJ" = (
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "hBK" = (
@@ -7902,7 +7902,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "hOE" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -7960,14 +7960,14 @@
 /area/f13/vault)
 "hQD" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
 "hQL" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
@@ -8008,7 +8008,7 @@
 /area/f13/radiation)
 "hWh" = (
 /obj/structure/closet,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -8067,8 +8067,8 @@
 /obj/structure/closet/fridge{
 	anchored = 1
 	},
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/rice,
@@ -8100,7 +8100,7 @@
 /area/f13/legion)
 "hYZ" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "hZl" = (
@@ -8117,7 +8117,7 @@
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
 	name = "advanced table"
 	},
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
@@ -8154,7 +8154,7 @@
 /area/f13/vault)
 "ibz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
@@ -8259,14 +8259,14 @@
 	pixel_y = 3
 	},
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
 "iiF" = (
@@ -8305,7 +8305,7 @@
 "ikG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/range/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "imb" = (
@@ -8327,13 +8327,13 @@
 /area/f13/bunker)
 "imP" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
 "iof" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -8471,7 +8471,7 @@
 /area/f13/vault)
 "iwT" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
@@ -8493,7 +8493,7 @@
 /area/f13/vault)
 "iyj" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -8767,8 +8767,8 @@
 "iQc" = (
 /obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -8780,7 +8780,7 @@
 /area/f13/vault)
 "iQM" = (
 /obj/structure/table/glass,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13,
 /area/f13/city)
 "iRe" = (
@@ -8802,7 +8802,7 @@
 /area/space)
 "iRw" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13,
 /area/f13/city)
 "iSF" = (
@@ -8884,7 +8884,7 @@
 	},
 /area/f13/vault)
 "iXy" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "iXW" = (
@@ -9016,7 +9016,7 @@
 /area/f13/bunker)
 "jcL" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/blueprints/tier3,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
@@ -9109,7 +9109,7 @@
 /area/f13/bunker)
 "jkq" = (
 /obj/structure/table,
-/obj/item/locked_box/armor/prewar_clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "jkZ" = (
@@ -9135,7 +9135,7 @@
 	icon_state = "goo12"
 	},
 /obj/structure/closet,
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -9146,7 +9146,7 @@
 /area/f13/bunker)
 "jnS" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtysolid"
@@ -9217,7 +9217,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "jsu" = (
-/obj/item/locked_box/weapon/melee/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jsM" = (
@@ -9478,7 +9478,7 @@
 /area/space)
 "jIQ" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -9543,7 +9543,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jNk" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
@@ -9630,7 +9630,7 @@
 	},
 /area/space)
 "jPa" = (
-/obj/item/locked_box/weapon/range/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /obj/structure/closet,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
@@ -9762,8 +9762,8 @@
 "jUG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
-/obj/item/locked_box/misc/money/all/low,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "jUJ" = (
@@ -9775,7 +9775,7 @@
 	},
 /area/space)
 "jUR" = (
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "jUT" = (
@@ -9865,7 +9865,7 @@
 /area/f13/tunnel)
 "jZx" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/prewar_clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
@@ -9881,7 +9881,7 @@
 	dir = 1
 	},
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
 "jZL" = (
@@ -10027,8 +10027,8 @@
 /area/f13/vault)
 "kiR" = (
 /obj/structure/table/wood/bar,
-/obj/item/locked_box/weapon/ammo/tier4,
-/obj/item/locked_box/weapon/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/f13,
 /area/f13/city)
 "kje" = (
@@ -10039,7 +10039,7 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "kjH" = (
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "kjM" = (
@@ -10113,8 +10113,8 @@
 "kmK" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/structure/closet,
-/obj/item/locked_box/misc/blueprints/tier2,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -10186,7 +10186,7 @@
 	},
 /area/f13/bunker)
 "koD" = (
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
@@ -10377,7 +10377,7 @@
 	},
 /area/f13/bunker)
 "kzj" = (
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "kAE" = (
@@ -10387,7 +10387,7 @@
 "kAQ" = (
 /obj/structure/table,
 /obj/item/pen/fourcolor,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
@@ -10396,11 +10396,11 @@
 	dir = 4
 	},
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/armor/tier4,
-/obj/item/locked_box/misc/blueprints/tier1,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "kBU" = (
@@ -10459,7 +10459,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
 "kEu" = (
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "kEN" = (
@@ -10578,9 +10578,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
 "kMC" = (
-/obj/item/locked_box/weapon/range/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "kMG" = (
@@ -10655,7 +10655,7 @@
 /area/f13/vault)
 "kNT" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
@@ -10679,9 +10679,9 @@
 /area/f13/vault)
 "kPW" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kQd" = (
@@ -10780,7 +10780,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
 "kUq" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -10831,7 +10831,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
 "kWZ" = (
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kXl" = (
@@ -10879,8 +10879,8 @@
 /area/f13/tunnel)
 "laJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/range/unique,
-/obj/item/locked_box/misc/attachments,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/unique,
+/obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -10905,7 +10905,7 @@
 	},
 /area/space)
 "lcs" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "lea" = (
@@ -11121,7 +11121,7 @@
 "lmn" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
@@ -11145,7 +11145,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "lqB" = (
-/obj/item/locked_box/misc/seed,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "lqH" = (
@@ -11172,7 +11172,7 @@
 	},
 /area/f13/bunker)
 "lrj" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -11339,8 +11339,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "lCk" = (
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -11442,7 +11442,7 @@
 "lHF" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/spawner/lootdrop/crafts,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "lHG" = (
@@ -11529,8 +11529,8 @@
 	dir = 4
 	},
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -11553,10 +11553,10 @@
 /area/f13/vault)
 "lOc" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/tier4,
-/obj/item/locked_box/weapon/melee/tier3_5,
-/obj/item/locked_box/weapon/melee/tier3_5,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13,
 /area/f13/city)
 "lOD" = (
@@ -11627,7 +11627,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "lRo" = (
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "lRI" = (
@@ -11698,7 +11698,7 @@
 /obj/item/paper,
 /obj/item/trash/coal,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
@@ -11932,7 +11932,7 @@
 	},
 /area/f13/wasteland)
 "mib" = (
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -12084,7 +12084,7 @@
 /area/f13/radiation)
 "mnI" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "mnN" = (
@@ -12237,7 +12237,7 @@
 /area/f13/vault)
 "mtW" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg2"
 	},
@@ -12264,7 +12264,7 @@
 /obj/effect/turf_decal/arrows{
 	dir = 8
 	},
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "mvR" = (
@@ -12332,7 +12332,7 @@
 "mzk" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/closet,
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "mzm" = (
@@ -12370,7 +12370,7 @@
 /area/f13/bunker)
 "mAu" = (
 /obj/structure/table,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/f13{
@@ -12570,7 +12570,7 @@
 /area/f13/city)
 "mJe" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -12638,7 +12638,7 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "mMt" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "mML" = (
@@ -12733,8 +12733,8 @@
 /area/f13/bunker)
 "mPS" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3_5,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/f13,
 /area/f13/city)
 "mPU" = (
@@ -12762,13 +12762,13 @@
 /area/f13/bunker)
 "mQP" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -12851,7 +12851,7 @@
 /area/f13/bunker)
 "mTc" = (
 /obj/structure/rack,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "mTt" = (
@@ -12902,7 +12902,7 @@
 	},
 /area/f13/bunker)
 "mVP" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -13017,7 +13017,7 @@
 /area/f13/bunker)
 "ndh" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
@@ -13145,7 +13145,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "nmS" = (
@@ -13189,10 +13189,10 @@
 /area/f13/radiation)
 "npF" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -13201,7 +13201,7 @@
 /area/f13/bunker)
 "npR" = (
 /obj/structure/table/wood/bar,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
@@ -13228,7 +13228,7 @@
 /area/f13/bunker)
 "nqF" = (
 /obj/structure/closet/crate/bin,
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -13251,12 +13251,12 @@
 /area/f13/bunker)
 "nqY" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/ammo/tier4,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "nre" = (
@@ -13322,7 +13322,7 @@
 /area/f13/vault)
 "nui" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "nuq" = (
@@ -13354,7 +13354,7 @@
 /area/f13/vault)
 "nvF" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/alcohol{
+/obj/effect/spawner/lootdrop/f13/alcoholspawner{
 	pixel_x = 3;
 	pixel_y = 6
 	},
@@ -13493,7 +13493,7 @@
 "nBV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker)
 "nCC" = (
@@ -13600,9 +13600,9 @@
 /area/f13/bunker)
 "nGv" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
@@ -13618,7 +13618,7 @@
 /obj/structure/booth{
 	dir = 8
 	},
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
 "nHH" = (
@@ -13699,7 +13699,7 @@
 /area/f13/vault)
 "nKH" = (
 /obj/structure/closet/fridge/meat,
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "nLN" = (
@@ -13771,7 +13771,7 @@
 	icon_state = "goo8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/money/all/medium,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "nOE" = (
@@ -13794,7 +13794,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "nPi" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "nPp" = (
@@ -13856,7 +13856,7 @@
 /area/f13/vault)
 "nSi" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/armor/tier1,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "nSn" = (
@@ -14033,7 +14033,7 @@
 /area/f13/tunnel)
 "obv" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -14119,7 +14119,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -14127,9 +14127,9 @@
 /area/f13/bunker)
 "ofx" = (
 /obj/machinery/workbench,
-/obj/item/locked_box/misc/blueprints/tier3,
-/obj/item/locked_box/misc/blueprints/tier3,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 9
 	},
@@ -14227,7 +14227,7 @@
 "oix" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -14340,7 +14340,7 @@
 /area/f13/bunker)
 "ooP" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -14417,7 +14417,7 @@
 /area/f13/bunker)
 "otX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "oub" = (
@@ -14436,7 +14436,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
 "ouy" = (
-/obj/item/locked_box/weapon/range/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ouE" = (
@@ -14470,7 +14470,7 @@
 	},
 /area/space)
 "ovl" = (
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ovr" = (
@@ -14626,7 +14626,7 @@
 /area/f13/legion)
 "oGi" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "oGF" = (
@@ -14668,7 +14668,7 @@
 /area/f13/vault)
 "oHK" = (
 /obj/structure/closet/fridge/standard,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "oHS" = (
@@ -14765,13 +14765,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/space)
 "oPz" = (
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "oPG" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "oPP" = (
@@ -14788,7 +14788,7 @@
 "oRq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "oRF" = (
@@ -14849,7 +14849,7 @@
 /obj/item/clothing/under/f13/vault{
 	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
 	},
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "oVD" = (
@@ -14934,12 +14934,12 @@
 /area/f13/bunker)
 "oZH" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/ammo/tier4,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "oZQ" = (
@@ -14981,7 +14981,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "pcf" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
@@ -14991,7 +14991,7 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "pdk" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -15072,7 +15072,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "pfI" = (
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "pgi" = (
@@ -15106,13 +15106,13 @@
 /area/f13/bunker)
 "pih" = (
 /obj/structure/table/wood/bar,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13,
 /area/f13/city)
 "pix" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "pjL" = (
@@ -15196,10 +15196,10 @@
 	},
 /area/f13/bunker)
 "pls" = (
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "plZ" = (
@@ -15284,13 +15284,13 @@
 "poS" = (
 /obj/item/rack_parts,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/item/ammo_box/a357box,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
@@ -15386,7 +15386,7 @@
 /area/f13/vault)
 "pto" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
@@ -15545,7 +15545,7 @@
 /area/f13/vault)
 "pzP" = (
 /obj/structure/table/reinforced,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
@@ -15554,7 +15554,7 @@
 /obj/structure/chair/f13chair2{
 	dir = 8
 	},
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
@@ -15719,7 +15719,7 @@
 /area/f13/vault)
 "pHx" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
@@ -15969,7 +15969,7 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul/reaver{
 	faction = list("ghoul","bonnie")
@@ -16000,7 +16000,7 @@
 	},
 /area/f13/bunker)
 "pYX" = (
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
@@ -16129,7 +16129,7 @@
 "qhp" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/range/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "qhq" = (
@@ -16228,7 +16228,7 @@
 /area/space)
 "qms" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "qmy" = (
@@ -16243,7 +16243,7 @@
 "qmK" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -16270,13 +16270,13 @@
 /area/space)
 "qog" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/melee/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "qoP" = (
 /obj/structure/table,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "qpm" = (
@@ -16297,7 +16297,7 @@
 	},
 /area/space)
 "qqX" = (
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /mob/living/simple_animal/hostile/deathclaw/mother,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -16348,7 +16348,7 @@
 /obj/structure/closet,
 /obj/item/clothing/gloves/combat,
 /obj/item/clothing/shoes/combat,
-/obj/item/locked_box/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -16400,7 +16400,7 @@
 /area/f13/bunker)
 "qvY" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -16447,7 +16447,7 @@
 /area/f13/bunker)
 "qxJ" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qxK" = (
@@ -16519,8 +16519,8 @@
 "qzF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "qzW" = (
@@ -16625,7 +16625,7 @@
 /obj/structure/closet,
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/gloves/combat,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -16685,8 +16685,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
 "qJH" = (
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "qKG" = (
@@ -16696,7 +16696,7 @@
 "qKP" = (
 /obj/effect/decal/waste,
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "qKT" = (
@@ -16763,8 +16763,8 @@
 /area/f13/vault)
 "qPu" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg3"
 	},
@@ -16871,7 +16871,7 @@
 /area/f13/vault)
 "qUB" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -16891,8 +16891,8 @@
 /area/f13/bunker)
 "qVF" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -17027,7 +17027,7 @@
 	},
 /area/f13/bunker)
 "rbh" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "rbn" = (
@@ -17052,7 +17052,7 @@
 /area/f13/city)
 "rca" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "rcB" = (
@@ -17117,7 +17117,7 @@
 /area/f13/vault)
 "rhd" = (
 /obj/structure/closet/wardrobe,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "rhl" = (
@@ -17155,14 +17155,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "riZ" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "rjk" = (
@@ -17299,7 +17299,7 @@
 	},
 /area/f13/bunker)
 "rqp" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
@@ -17380,7 +17380,7 @@
 /area/f13/wasteland)
 "rsv" = (
 /obj/structure/closet/wardrobe,
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "rsJ" = (
@@ -17414,7 +17414,7 @@
 /area/f13/vault)
 "rtW" = (
 /obj/structure/table,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -17543,7 +17543,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "rzx" = (
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13,
 /area/f13/city)
 "rzT" = (
@@ -17566,7 +17566,7 @@
 /area/f13/vault)
 "rAe" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
@@ -17655,7 +17655,7 @@
 /area/space)
 "rFh" = (
 /obj/structure/closet,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -17727,7 +17727,7 @@
 /area/f13/vault)
 "rIO" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /turf/open/floor/f13,
 /area/f13/city)
 "rIR" = (
@@ -17954,7 +17954,7 @@
 "rTd" = (
 /obj/effect/decal/remains/human,
 /obj/structure/closet,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -17999,12 +17999,12 @@
 	},
 /area/f13/bunker)
 "rVo" = (
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/closet,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -18141,7 +18141,7 @@
 	},
 /area/f13/bunker)
 "see" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
@@ -18155,9 +18155,9 @@
 /area/f13/city)
 "sfh" = (
 /obj/structure/closet/wardrobe,
-/obj/item/locked_box/armor/any_random,
-/obj/item/locked_box/medical/drugs,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
@@ -18214,7 +18214,7 @@
 /area/f13/bunker)
 "siD" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13,
 /area/f13/city)
 "sje" = (
@@ -18311,13 +18311,13 @@
 	dir = 4;
 	icon_state = "bench"
 	},
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "smP" = (
-/obj/item/locked_box/misc/money/legion/high,
-/obj/item/locked_box/misc/money/legion/high,
-/obj/item/locked_box/weapon/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/cash_legion_high,
+/obj/effect/spawner/lootdrop/f13/cash_legion_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /obj/structure/closet,
 /turf/open/floor/f13,
 /area/f13/city)
@@ -18333,7 +18333,7 @@
 	},
 /area/f13/bunker)
 "snY" = (
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
@@ -18382,7 +18382,7 @@
 	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "srh" = (
@@ -18411,7 +18411,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "stF" = (
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /obj/structure/closet,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
@@ -18592,7 +18592,7 @@
 /area/f13/bunker)
 "sDc" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "sDf" = (
@@ -18778,7 +18778,7 @@
 	dir = 8;
 	icon_state = "bench"
 	},
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
@@ -18803,7 +18803,7 @@
 /obj/structure/booth{
 	dir = 1
 	},
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "sNj" = (
@@ -18879,8 +18879,8 @@
 /area/f13/bunker)
 "sPB" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/blueprints/tier1,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "sPO" = (
@@ -18908,7 +18908,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
 "sRd" = (
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
@@ -19073,7 +19073,7 @@
 /area/f13/bunker)
 "tcW" = (
 /obj/structure/chair/bench,
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "tcX" = (
@@ -19236,13 +19236,13 @@
 	},
 /area/f13/bunker)
 "tow" = (
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/structure/closet,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "tpi" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "tpo" = (
@@ -19484,7 +19484,7 @@
 /area/f13/vault)
 "txP" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
@@ -19506,10 +19506,10 @@
 /area/f13/vault)
 "tzo" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "tzB" = (
@@ -19548,7 +19548,7 @@
 /area/f13/vault)
 "tBY" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -19578,7 +19578,7 @@
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
 	name = "advanced table"
 	},
-/obj/item/locked_box/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "tCY" = (
@@ -19699,8 +19699,8 @@
 /obj/item/binoculars,
 /obj/item/binoculars,
 /obj/item/binoculars,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/structure/closet,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
@@ -19775,10 +19775,10 @@
 	},
 /area/f13/bunker)
 "tPc" = (
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/structure/closet,
-/obj/item/locked_box/misc/blueprints/tier1,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
 "tPN" = (
@@ -19919,7 +19919,7 @@
 	},
 /area/f13/bunker)
 "tYt" = (
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "tYu" = (
@@ -19992,7 +19992,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "ucL" = (
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /obj/structure/closet,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -20327,7 +20327,7 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "uvp" = (
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
@@ -20372,7 +20372,7 @@
 /area/f13/vault)
 "uwP" = (
 /obj/structure/closet/wardrobe,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "uwQ" = (
@@ -20390,8 +20390,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "uwY" = (
@@ -20403,7 +20403,7 @@
 /area/f13/vault)
 "uyk" = (
 /obj/structure/closet/wardrobe,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "uym" = (
@@ -20441,7 +20441,7 @@
 "uzm" = (
 /obj/machinery/door/window,
 /obj/structure/closet,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -20627,7 +20627,7 @@
 	},
 /area/f13/bunker)
 "uJF" = (
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "uKd" = (
@@ -20655,7 +20655,7 @@
 /obj/machinery/door/window{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/structure/closet,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -20700,7 +20700,7 @@
 "uMa" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "uMj" = (
@@ -20779,7 +20779,7 @@
 	},
 /area/f13/wasteland)
 "uSQ" = (
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "uST" = (
@@ -20794,7 +20794,7 @@
 /area/f13/bunker)
 "uUf" = (
 /obj/structure/closet/crate/secure/weapon,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -20905,7 +20905,7 @@
 	},
 /area/space)
 "uYl" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "uYr" = (
@@ -20920,8 +20920,8 @@
 	},
 /area/f13/bunker)
 "uZa" = (
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13,
 /area/f13/city)
 "uZd" = (
@@ -21017,8 +21017,8 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "vfv" = (
@@ -21050,7 +21050,7 @@
 /area/f13/bunker)
 "vhT" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "vih" = (
@@ -21085,7 +21085,7 @@
 	},
 /area/f13/bunker)
 "viY" = (
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /obj/structure/closet,
 /turf/open/floor/f13,
 /area/f13/city)
@@ -21117,7 +21117,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/f13/vault)
 "vle" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "vlo" = (
@@ -21253,7 +21253,7 @@
 /area/f13/vault)
 "vsD" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "vsL" = (
@@ -21324,7 +21324,7 @@
 /area/f13/vault)
 "vxu" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -21511,7 +21511,7 @@
 /area/f13/bunker)
 "vFw" = (
 /obj/structure/closet,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "vGi" = (
@@ -21617,11 +21617,11 @@
 /area/f13/vault)
 "vKT" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "vLj" = (
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -21658,7 +21658,7 @@
 "vNb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
-/obj/item/locked_box/misc/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "vNk" = (
@@ -21722,7 +21722,7 @@
 "vPe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
@@ -21733,7 +21733,7 @@
 /area/f13/vault)
 "vPC" = (
 /obj/structure/closet/wardrobe,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "vPG" = (
@@ -21967,7 +21967,7 @@
 /area/f13/tunnel)
 "wbR" = (
 /obj/structure/closet/wardrobe,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
@@ -22144,7 +22144,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "wll" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plating,
 /area/f13/bunker)
 "wlR" = (
@@ -22199,7 +22199,7 @@
 /area/space)
 "wnJ" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "wnY" = (
@@ -22213,7 +22213,7 @@
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
 	name = "advanced table"
 	},
-/obj/item/locked_box/weapon/range/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "wpj" = (
@@ -22344,13 +22344,13 @@
 "wve" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/item/reagent_containers/syringe/medx,
-/obj/item/locked_box/misc/money/all/high,
-/obj/item/locked_box/misc/blueprints/tier2,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3_5,
-/obj/item/locked_box/misc/blueprints/tier3,
-/obj/item/locked_box/weapon/range/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
 "wvj" = (
@@ -22507,7 +22507,7 @@
 	pixel_x = 10;
 	pixel_y = 4
 	},
-/obj/item/locked_box/medical/medicine{
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds{
 	pixel_x = 16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -22751,12 +22751,12 @@
 	},
 /area/f13/bunker)
 "wKE" = (
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wKM" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13{
@@ -22770,7 +22770,7 @@
 /turf/open/floor/carpet/black,
 /area/space)
 "wMn" = (
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "wMC" = (
@@ -22845,7 +22845,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "wRn" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "wRB" = (
@@ -22856,7 +22856,7 @@
 	},
 /area/f13/bunker)
 "wRH" = (
-/obj/item/locked_box/misc/seed,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wSp" = (
@@ -22909,8 +22909,8 @@
 "wTN" = (
 /obj/structure/table,
 /obj/item/clothing/accessory/armband/med,
-/obj/item/locked_box/misc/blueprints/tier1,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -23018,7 +23018,7 @@
 /turf/open/floor/wood,
 /area/f13/vault)
 "wZq" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt"
@@ -23042,7 +23042,7 @@
 /area/f13/tunnel)
 "xav" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13,
 /area/f13/city)
 "xaI" = (
@@ -23159,7 +23159,7 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
@@ -23170,8 +23170,8 @@
 /area/f13/bunker)
 "xgD" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13,
 /area/f13/city)
 "xgJ" = (
@@ -23265,7 +23265,7 @@
 	},
 /area/f13/bunker)
 "xoo" = (
-/obj/item/locked_box/weapon/melee/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xop" = (
@@ -23352,7 +23352,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
@@ -23447,7 +23447,7 @@
 /area/f13/city)
 "xuG" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "xuQ" = (
@@ -23491,7 +23491,7 @@
 /area/f13/vault)
 "xxA" = (
 /obj/structure/closet/crate/bin,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "xxD" = (
@@ -23655,7 +23655,7 @@
 	},
 /area/f13/wasteland)
 "xFE" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "xGM" = (
@@ -23670,7 +23670,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "xIi" = (
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "xIq" = (
@@ -23679,7 +23679,7 @@
 /mob/living/simple_animal/hostile/ghoul/reaver{
 	faction = list("ghoul","bonnie")
 	},
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "xIC" = (
@@ -23883,7 +23883,7 @@
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
@@ -23937,7 +23937,7 @@
 /area/f13/city)
 "xUI" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
@@ -24053,8 +24053,8 @@
 /area/f13/bunker)
 "xZS" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "yao" = (
@@ -24153,12 +24153,12 @@
 /area/space)
 "yeI" = (
 /obj/item/seeds/tower/steel,
-/obj/item/locked_box/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier4,
-/obj/item/locked_box/misc/money/all/medium,
-/obj/item/locked_box/misc/blueprints/tier2,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -24177,7 +24177,7 @@
 "yfz" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "yfE" = (
@@ -24216,7 +24216,7 @@
 /area/space)
 "yil" = (
 /obj/structure/table/wood/bar,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13,
 /area/f13/city)
 "yjg" = (

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -201,7 +201,7 @@
 /obj/effect/decal/remains{
 	icon_state = "remains"
 	},
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -216,7 +216,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/clothing_high,
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -352,7 +352,7 @@
 /area/f13/legion)
 "alN" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "alV" = (
@@ -420,8 +420,8 @@
 /area/f13/legion)
 "aoD" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -599,7 +599,7 @@
 /obj/item/ammo_casing/shotgun/buckshot,
 /obj/item/clothing/head/beret,
 /obj/item/clothing/ears/earmuffs,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark"
@@ -774,7 +774,7 @@
 /area/f13/building)
 "aAR" = (
 /obj/structure/bed/mattress,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirtcorner"
@@ -835,8 +835,8 @@
 /obj/item/seeds/cotton,
 /obj/item/seeds/grass,
 /obj/item/seeds/wheat,
-/obj/item/locked_box/misc/seed,
-/obj/item/locked_box/misc/seed,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "aDl" = (
@@ -861,7 +861,7 @@
 /area/f13/city)
 "aDB" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /obj/item/clothing/under/schoolgirl/orange,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -876,9 +876,9 @@
 /area/f13/ncr)
 "aEe" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -914,8 +914,8 @@
 /area/f13/building)
 "aGb" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/storage/toolbox/mechanical/old,
@@ -963,7 +963,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "aHN" = (
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "aHS" = (
@@ -1037,7 +1037,7 @@
 /area/f13/building)
 "aKu" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -1050,7 +1050,7 @@
 /area/f13/ncr)
 "aLg" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aLh" = (
@@ -1105,7 +1105,7 @@
 /area/f13/wasteland)
 "aNs" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aNu" = (
@@ -1133,13 +1133,13 @@
 /area/f13/village)
 "aOE" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "aPg" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -1155,8 +1155,8 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aPw" = (
@@ -1319,8 +1319,8 @@
 /area/f13/building)
 "aUV" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aUY" = (
@@ -1378,7 +1378,7 @@
 /area/f13/building)
 "aXk" = (
 /obj/structure/closet/crate/bin,
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/wood,
 /area/f13/village)
 "aXu" = (
@@ -1397,7 +1397,7 @@
 /obj/structure/closet/cabinet,
 /obj/item/clothing/shoes/sneakers/black,
 /obj/item/clothing/under/f13/brahmin,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aXL" = (
@@ -1451,7 +1451,7 @@
 /area/f13/city)
 "aZz" = (
 /obj/structure/bed/mattress/pregame,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aZJ" = (
@@ -1645,18 +1645,18 @@
 /area/f13/bar)
 "biU" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "bjg" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -1673,7 +1673,7 @@
 /area/f13/wasteland)
 "bjy" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bjz" = (
@@ -1686,8 +1686,8 @@
 /area/f13/village)
 "bkc" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -1754,12 +1754,12 @@
 /area/f13/city)
 "bmK" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bmV" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bnm" = (
@@ -1917,8 +1917,8 @@
 /area/f13/building)
 "brZ" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
@@ -2075,7 +2075,7 @@
 /area/f13/village)
 "bzR" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -2105,7 +2105,7 @@
 /area/f13/caves)
 "bAS" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bAT" = (
@@ -2296,7 +2296,7 @@
 "bFM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -2426,7 +2426,7 @@
 /area/f13/city)
 "bKJ" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -2476,7 +2476,7 @@
 /area/f13/farm)
 "bNt" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bNN" = (
@@ -2577,7 +2577,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bQO" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
@@ -2903,7 +2903,7 @@
 	id = "house1ladder";
 	layer = 2
 	},
-/obj/item/locked_box/armor/prewar_clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "cia" = (
@@ -2997,7 +2997,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ckB" = (
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "ckJ" = (
@@ -3154,7 +3154,7 @@
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/dog,
 /obj/item/reagent_containers/food/snacks/f13/dog,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cqB" = (
@@ -3311,7 +3311,7 @@
 "czx" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -3446,8 +3446,8 @@
 /area/f13/city)
 "cGL" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -3488,7 +3488,7 @@
 /area/f13/building)
 "cIh" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cIA" = (
@@ -3496,7 +3496,7 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "cIL" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "cIP" = (
@@ -3707,7 +3707,7 @@
 /area/f13/wasteland)
 "cRX" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "cSc" = (
@@ -3768,7 +3768,7 @@
 /area/f13/wasteland)
 "cTK" = (
 /obj/structure/bed/mattress/pregame,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "cTN" = (
@@ -4324,10 +4324,10 @@
 /area/f13/wasteland)
 "doF" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "doM" = (
@@ -4405,12 +4405,12 @@
 "dsi" = (
 /obj/structure/table/wood,
 /obj/item/phone,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/wood,
 /area/f13/village)
 "dss" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dsW" = (
@@ -4436,7 +4436,7 @@
 /area/f13/building)
 "dtS" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
@@ -4491,7 +4491,7 @@
 /area/f13/legion)
 "dvp" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "dwx" = (
@@ -4594,7 +4594,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "dyH" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dyQ" = (
@@ -4700,7 +4700,7 @@
 /area/f13/building)
 "dDr" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/item/clothing/mask/muzzle,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
@@ -4769,7 +4769,7 @@
 /area/f13/wasteland)
 "dGQ" = (
 /obj/structure/table/reinforced,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -4869,8 +4869,8 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/city)
 "dLg" = (
-/obj/item/locked_box/weapon/range/tier1,
-/obj/item/locked_box/weapon/range/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/crafting/goodparts/five,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4889,7 +4889,7 @@
 "dLY" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -4918,7 +4918,7 @@
 /area/f13/legion)
 "dOg" = (
 /obj/structure/bed/mattress/pregame,
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dOl" = (
@@ -4968,12 +4968,12 @@
 /area/f13/legion)
 "dSd" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "dSB" = (
@@ -4985,8 +4985,8 @@
 /area/f13/ncr)
 "dTl" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -5033,7 +5033,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -5214,7 +5214,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -5301,7 +5301,7 @@
 /area/f13/city)
 "ekE" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ekI" = (
@@ -5439,9 +5439,9 @@
 /area/f13/building)
 "eqv" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -5485,7 +5485,7 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /obj/effect/spawner/lootdrop/clothing_middle,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eso" = (
@@ -5519,7 +5519,7 @@
 /area/f13/caves)
 "etG" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -5757,7 +5757,7 @@
 /area/f13/wasteland)
 "eEI" = (
 /obj/structure/closet/crate/wicker,
-/obj/item/locked_box/misc/money/legion/low,
+/obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "eEK" = (
@@ -5783,8 +5783,8 @@
 /area/f13/ncr)
 "eGo" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
@@ -5923,7 +5923,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "eKP" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
@@ -6088,7 +6088,7 @@
 	name = "radio station intercom";
 	pixel_y = 30
 	},
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/village)
 "eQb" = (
@@ -6232,13 +6232,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "eTq" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "eTJ" = (
@@ -6249,7 +6249,7 @@
 /area/f13/wasteland)
 "eTO" = (
 /obj/structure/closet,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -6324,7 +6324,7 @@
 "eVQ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/bundle/costume/chicken,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/item/dildo,
 /obj/item/clothing/suit/f13/sexymaid,
 /obj/item/clothing/head/helmet/f13/brahmincowboyhat,
@@ -6379,7 +6379,7 @@
 /area/f13/building)
 "eYY" = (
 /obj/structure/closet/fridge/cannibal,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "eZf" = (
@@ -6469,7 +6469,7 @@
 "fcH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
-/obj/item/locked_box/misc/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "fcK" = (
@@ -6568,7 +6568,7 @@
 /obj/structure/table/wood,
 /obj/item/paper,
 /obj/item/pen,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "fgp" = (
@@ -6640,7 +6640,7 @@
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "flP" = (
@@ -6813,19 +6813,19 @@
 /area/f13/wasteland)
 "fru" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/item/reagent_containers/food/condiment/yeast,
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/item/reagent_containers/food/condiment/flour,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -7047,7 +7047,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "fyO" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
@@ -7251,7 +7251,7 @@
 /obj/effect/decal/remains{
 	icon_state = "remains"
 	},
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -7588,7 +7588,7 @@
 /area/f13/wasteland)
 "fUb" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -7721,7 +7721,7 @@
 /area/f13/wasteland)
 "gbd" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -7731,7 +7731,7 @@
 /obj/item/storage/box/lights,
 /obj/item/storage/box/lights,
 /obj/item/storage/box/lights,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -8077,13 +8077,13 @@
 /area/f13/city)
 "gok" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/attachments,
-/obj/item/locked_box/misc/attachments,
-/obj/item/locked_box/misc/attachments,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "goC" = (
@@ -8108,7 +8108,7 @@
 /area/f13/ncr)
 "gpE" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -8122,7 +8122,7 @@
 /area/f13/ncr)
 "gpL" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gpQ" = (
@@ -8148,8 +8148,8 @@
 /area/f13/tunnel)
 "gqE" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -8173,7 +8173,7 @@
 /area/f13/wasteland)
 "gsd" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -8228,7 +8228,7 @@
 /area/f13/city)
 "guh" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gun" = (
@@ -8272,7 +8272,7 @@
 /area/f13/village)
 "gvN" = (
 /obj/structure/chair/bench,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gvW" = (
@@ -8328,7 +8328,7 @@
 	},
 /area/f13/legion)
 "gwB" = (
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -8423,14 +8423,14 @@
 "gzY" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/f13/steak,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gAn" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/spearquiver,
 /obj/item/storage/backpack/spearquiver,
-/obj/item/locked_box/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "gAA" = (
@@ -8546,7 +8546,7 @@
 /area/f13/ncr)
 "gDP" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/money/legion/low,
+/obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gDZ" = (
@@ -8614,7 +8614,7 @@
 /area/f13/building)
 "gEZ" = (
 /obj/structure/chair/bench,
-/obj/item/locked_box/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gFg" = (
@@ -8777,12 +8777,12 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "gKI" = (
-/obj/item/locked_box/misc/money/legion/low,
+/obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "gKP" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gLX" = (
@@ -8818,7 +8818,7 @@
 /area/f13/wasteland)
 "gOf" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
 "gOs" = (
@@ -8858,7 +8858,7 @@
 	},
 /area/f13/building)
 "gPy" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
@@ -8984,7 +8984,7 @@
 /obj/structure/closet,
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/gloves/combat,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -9234,7 +9234,7 @@
 /area/f13/building)
 "hdr" = (
 /obj/structure/bed,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/item/bedsheet{
 	icon_state = "sheetgrey"
 	},
@@ -9318,7 +9318,7 @@
 "hgw" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/f13/rag,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hgJ" = (
@@ -9491,7 +9491,7 @@
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
-/obj/item/locked_box/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "hmP" = (
@@ -9648,7 +9648,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "hrx" = (
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hrG" = (
@@ -9741,7 +9741,7 @@
 "hul" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/locked_box/weapon/melee/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -10115,7 +10115,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "hHD" = (
@@ -10262,7 +10262,7 @@
 /area/f13/wasteland)
 "hNL" = (
 /obj/structure/table/wood/fancy,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
@@ -10282,7 +10282,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "hOR" = (
-/obj/item/locked_box/misc/money/legion/low,
+/obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "hPA" = (
@@ -10338,8 +10338,8 @@
 /area/f13/legion)
 "hRU" = (
 /obj/structure/closet/fridge/cannibal,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "hSg" = (
@@ -10353,7 +10353,7 @@
 /area/f13/ncr)
 "hSC" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
@@ -10460,8 +10460,8 @@
 /area/f13/building)
 "hUK" = (
 /obj/structure/table/wood/fancy,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "hUV" = (
@@ -10615,7 +10615,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "hYZ" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "hZo" = (
@@ -10681,7 +10681,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "ibA" = (
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ibD" = (
@@ -10831,7 +10831,7 @@
 /area/f13/city)
 "iiN" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -10966,7 +10966,7 @@
 /area/f13/wasteland)
 "ioU" = (
 /obj/structure/chair/stool,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "ipf" = (
@@ -11025,7 +11025,7 @@
 /area/f13/caves)
 "irk" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
 "irx" = (
@@ -11108,7 +11108,7 @@
 "iuS" = (
 /obj/structure/table,
 /obj/item/kitchen/knife,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -11166,7 +11166,7 @@
 /area/f13/tunnel)
 "iwK" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -11231,8 +11231,8 @@
 /area/f13/caves)
 "izn" = (
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "izt" = (
@@ -11545,7 +11545,7 @@
 /area/f13/village)
 "iKr" = (
 /obj/structure/booth/middle,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/carpet/black,
 /area/f13/city)
 "iKD" = (
@@ -11564,7 +11564,7 @@
 /obj/item/storage/backpack{
 	icon_state = "satchel"
 	},
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iLD" = (
@@ -11696,7 +11696,7 @@
 /area/f13/building)
 "iOr" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -11714,7 +11714,7 @@
 /turf/closed/wall/f13/store,
 /area/f13/village)
 "iOF" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -11763,8 +11763,8 @@
 "iRa" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
-/obj/item/locked_box/armor/any_random,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iRd" = (
@@ -11838,7 +11838,7 @@
 /area/f13/wasteland)
 "iSj" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
@@ -11896,7 +11896,7 @@
 /area/f13/wasteland)
 "iTE" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iTJ" = (
@@ -12038,8 +12038,8 @@
 /area/f13/building)
 "jbr" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/item/reagent_containers/food/condiment/milk,
 /turf/open/floor/f13/wood,
@@ -12081,7 +12081,7 @@
 /area/f13/village)
 "jcl" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jdg" = (
@@ -12095,7 +12095,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
@@ -12112,7 +12112,7 @@
 "jeV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -12147,7 +12147,7 @@
 /area/f13/building)
 "jgt" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -12162,7 +12162,7 @@
 /area/f13/wasteland)
 "jgE" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "jgG" = (
@@ -12311,7 +12311,7 @@
 /obj/item/bedsheet{
 	icon_state = "sheethos"
 	},
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "jmq" = (
@@ -12321,7 +12321,7 @@
 /obj/item/clothing/under/f13/gentlesuit,
 /obj/item/clothing/shoes/f13/fancy,
 /obj/item/clothing/suit/poncho/green,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jmv" = (
@@ -12798,7 +12798,7 @@
 /area/f13/wasteland)
 "jKe" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/item/clothing/under/stripeddress,
 /obj/item/clothing/suit/f13/sexymaid,
 /turf/open/floor/wood/f13/old,
@@ -12814,7 +12814,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "jKV" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -13235,7 +13235,7 @@
 /area/f13/wasteland)
 "kbw" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -13276,8 +13276,8 @@
 /area/f13/wasteland)
 "kcB" = (
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/item/seeds/cannabis,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -13293,12 +13293,12 @@
 "kcJ" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kcP" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "horizontaloutermain1"
@@ -13314,7 +13314,7 @@
 /area/f13/caves)
 "kcX" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -13401,7 +13401,7 @@
 /area/f13/followers)
 "kfo" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kfq" = (
@@ -13456,7 +13456,7 @@
 /obj/structure/decoration/clock{
 	pixel_y = 27
 	},
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -13471,8 +13471,8 @@
 /area/f13/building)
 "kgM" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -13560,7 +13560,7 @@
 "kjI" = (
 /obj/structure/closet/cabinet,
 /obj/item/stack/f13Cash/random/bottle_cap/med,
-/obj/item/locked_box/misc/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -13581,7 +13581,7 @@
 	},
 /area/f13/ncr)
 "kkD" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kkE" = (
@@ -13630,8 +13630,8 @@
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/condiment/yeast,
 /obj/item/reagent_containers/food/condiment/flour,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kmY" = (
@@ -13689,7 +13689,7 @@
 /area/f13/legion)
 "kpe" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kpr" = (
@@ -13741,7 +13741,7 @@
 /area/f13/wasteland)
 "kpW" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kpX" = (
@@ -13750,9 +13750,9 @@
 /area/f13/building)
 "kqe" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "kqk" = (
@@ -13900,7 +13900,7 @@
 /area/f13/ncr)
 "kwV" = (
 /obj/structure/table/reinforced,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -14012,7 +14012,7 @@
 /obj/item/clothing/suit/armor/vest/leather,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/glasses/orange,
-/obj/item/locked_box/weapon/range/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -14050,8 +14050,8 @@
 /area/f13/wasteland)
 "kCA" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -14092,7 +14092,7 @@
 	},
 /area/f13/wasteland)
 "kEB" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -14104,7 +14104,7 @@
 /area/f13/building)
 "kEX" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -14179,13 +14179,13 @@
 "kJB" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/gloves/color/yellow,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kKe" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/melee/any_random,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kKl" = (
@@ -14304,7 +14304,7 @@
 	dir = 1
 	},
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kQC" = (
@@ -14325,7 +14325,7 @@
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "kSd" = (
@@ -14365,7 +14365,7 @@
 "kTx" = (
 /obj/item/clothing/head/helmet/f13/raidermetal,
 /obj/item/clothing/suit/armor/f13/raider/raidermetal,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kUd" = (
@@ -14394,7 +14394,7 @@
 /area/f13/legion)
 "kUV" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -14440,7 +14440,7 @@
 "kXa" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
@@ -15176,7 +15176,7 @@
 /area/f13/ncr)
 "lyG" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/money/all/medium,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "lyY" = (
@@ -15519,7 +15519,7 @@
 /area/f13/ncr)
 "lMp" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "lMr" = (
@@ -15754,8 +15754,8 @@
 "lVa" = (
 /obj/structure/rack,
 /obj/item/bikehorn,
-/obj/item/locked_box/weapon/range/tier2,
-/obj/item/locked_box/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -15874,7 +15874,7 @@
 /area/f13/village)
 "maW" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /obj/item/clothing/under/suit_jacket/female,
 /turf/open/floor/f13{
 	icon_state = "bar"
@@ -15944,7 +15944,7 @@
 /area/f13/village)
 "mee" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -15983,12 +15983,12 @@
 /area/f13/legion)
 "mex" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "meL" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -16074,7 +16074,7 @@
 	name = "radio station intercom";
 	pixel_y = 30
 	},
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/village)
 "mhJ" = (
@@ -16169,8 +16169,8 @@
 "mmL" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pestspray,
-/obj/item/locked_box/weapon/melee/any_random,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -16196,7 +16196,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "mnd" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mnf" = (
@@ -16332,7 +16332,7 @@
 /area/f13/wasteland)
 "mtl" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /obj/item/clothing/under/draculass,
 /turf/open/floor/f13{
 	icon_state = "bar"
@@ -16431,7 +16431,7 @@
 /area/f13/caves)
 "mxI" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -16518,7 +16518,7 @@
 	},
 /area/f13/wasteland)
 "mDh" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/item/clothing/under/f13/shiny,
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/nun,
@@ -16701,7 +16701,7 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/city)
 "mLj" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -16713,7 +16713,7 @@
 /area/f13/wasteland)
 "mLv" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "mMe" = (
@@ -16810,8 +16810,8 @@
 /area/f13/village)
 "mPT" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "mQj" = (
@@ -16880,7 +16880,7 @@
 /area/f13/wasteland)
 "mTy" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "mUx" = (
@@ -16934,14 +16934,14 @@
 /area/f13/legion)
 "mVV" = (
 /obj/structure/table/reinforced,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
 "mVY" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "mWn" = (
@@ -17011,7 +17011,7 @@
 	icon_state = "mattress2";
 	pixel_y = 7
 	},
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -17138,8 +17138,8 @@
 /area/f13/city)
 "ndy" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/garbage,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ndT" = (
@@ -17195,7 +17195,7 @@
 	},
 /area/f13/building)
 "nfY" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -17205,7 +17205,7 @@
 /obj/structure/wreck/trash/halftire{
 	pixel_y = -21
 	},
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -17221,7 +17221,7 @@
 /area/f13/building)
 "nhz" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -17262,7 +17262,7 @@
 /area/f13/radiation)
 "niU" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -17288,7 +17288,7 @@
 "nlv" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/pipe,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nly" = (
@@ -17394,7 +17394,7 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nqU" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -17414,9 +17414,9 @@
 /area/f13/followers)
 "nrB" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -17576,8 +17576,8 @@
 /area/f13/city)
 "nxD" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/prewar_clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/carpet/black,
 /area/f13/city)
 "nxY" = (
@@ -17717,14 +17717,14 @@
 	pixel_y = 32
 	},
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/weapon/range/tier3_5,
-/obj/item/locked_box/weapon/range/tier3_5,
-/obj/item/locked_box/weapon/range/tier3_5,
-/obj/item/locked_box/weapon/range/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -17774,7 +17774,7 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
 "nIz" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
@@ -17991,7 +17991,7 @@
 /area/f13/village)
 "nPV" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/money/all/medium,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
 "nPX" = (
@@ -18005,7 +18005,7 @@
 "nQP" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "nQY" = (
@@ -18041,7 +18041,7 @@
 /area/f13/building)
 "nSK" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "nSP" = (
@@ -18234,7 +18234,7 @@
 "oat" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "oav" = (
@@ -18316,13 +18316,13 @@
 /area/f13/bar)
 "odc" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "odh" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -18331,7 +18331,7 @@
 "ods" = (
 /obj/structure/closet/cabinet,
 /obj/item/stack/sheet/metal,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -18428,7 +18428,7 @@
 /area/f13/village)
 "oic" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -18445,9 +18445,9 @@
 /area/f13/village)
 "oiz" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier4,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "ojr" = (
@@ -18552,7 +18552,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "olZ" = (
-/obj/item/locked_box/armor/tier1,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "oma" = (
@@ -18646,7 +18646,7 @@
 	name = "radio station intercom";
 	pixel_x = 30
 	},
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/village)
 "ooq" = (
@@ -18711,8 +18711,8 @@
 /area/f13/building)
 "orm" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "orB" = (
@@ -18721,8 +18721,8 @@
 /obj/item/seeds/poppy/broc,
 /obj/item/seeds/cotton,
 /obj/item/seeds/wheat,
-/obj/item/locked_box/misc/seed,
-/obj/item/locked_box/misc/seed,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/followers)
 "orO" = (
@@ -18833,7 +18833,7 @@
 /obj/item/stack/sheet/glass{
 	amount = 50
 	},
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -18857,7 +18857,7 @@
 /obj/structure/decoration/clock{
 	pixel_y = 27
 	},
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -18875,7 +18875,7 @@
 /area/f13/village)
 "oxT" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "oyd" = (
@@ -18965,7 +18965,7 @@
 	},
 /area/f13/building)
 "oCg" = (
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -19095,8 +19095,8 @@
 /area/f13/village)
 "oHu" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/melee/any_random,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "oHK" = (
@@ -19180,12 +19180,12 @@
 /area/f13/building)
 "oJm" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oJu" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -19263,7 +19263,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "oNC" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -19410,7 +19410,7 @@
 /area/f13/city)
 "oRV" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -19512,7 +19512,7 @@
 	},
 /area/f13/wasteland)
 "oVH" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -19697,7 +19697,7 @@
 /turf/open/floor/wood,
 /area/f13/village)
 "pdl" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "pdn" = (
@@ -19733,14 +19733,14 @@
 /area/f13/legion)
 "pek" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/weapon/melee/any_random,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/armor/prewar_clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "pes" = (
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "peu" = (
@@ -19850,7 +19850,7 @@
 /area/f13/city)
 "pim" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pis" = (
@@ -19985,8 +19985,8 @@
 /area/f13/legion)
 "pot" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/any_random,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pow" = (
@@ -20022,7 +20022,7 @@
 /area/f13/village)
 "ppp" = (
 /obj/structure/displaycase,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -20267,7 +20267,7 @@
 /area/f13/wasteland)
 "pyl" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /obj/item/clothing/under/pirate,
 /turf/open/floor/f13{
 	icon_state = "bar"
@@ -20551,7 +20551,7 @@
 "pIi" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/doctor,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
@@ -20579,9 +20579,9 @@
 /area/f13/legion)
 "pIC" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -20800,7 +20800,7 @@
 /area/f13/legion)
 "pRo" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "pRv" = (
@@ -20963,7 +20963,7 @@
 /area/f13/farm)
 "pXr" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -20975,7 +20975,7 @@
 "pYa" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pYj" = (
@@ -21076,14 +21076,14 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "qcL" = (
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/any_random,
-/obj/item/locked_box/armor/any_random,
-/obj/item/locked_box/armor/any_random,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/prewar_clothes,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -21535,7 +21535,7 @@
 /area/f13/legion)
 "quV" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /obj/item/clothing/under/geisha,
 /turf/open/floor/f13{
 	icon_state = "bar"
@@ -21780,7 +21780,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -21975,7 +21975,7 @@
 /area/f13/city)
 "qMA" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qMD" = (
@@ -22101,7 +22101,7 @@
 /area/f13/building)
 "qRB" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "qSM" = (
@@ -22389,7 +22389,7 @@
 /area/f13/building)
 "rex" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
@@ -22464,7 +22464,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "rhK" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rhT" = (
@@ -22490,7 +22490,7 @@
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
 	},
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "rjD" = (
@@ -22514,13 +22514,13 @@
 /area/f13/ncr)
 "rjW" = (
 /obj/structure/closet,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "rkb" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/item/stack/f13Cash/random/bottle_cap/med,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
@@ -22545,7 +22545,7 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "rkI" = (
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -22809,7 +22809,7 @@
 /area/f13/farm)
 "ryn" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "ryO" = (
@@ -22913,7 +22913,7 @@
 /area/f13/ncr)
 "rAM" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "rBs" = (
@@ -22982,7 +22982,7 @@
 /obj/item/bedsheet{
 	icon_state = "sheetblue"
 	},
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rEd" = (
@@ -23016,7 +23016,7 @@
 	},
 /area/f13/ncr)
 "rFc" = (
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -23030,7 +23030,7 @@
 /area/f13/wasteland)
 "rFx" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "rGl" = (
@@ -23051,8 +23051,8 @@
 /area/f13/tunnel)
 "rGE" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/misc/attachments,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "rHE" = (
@@ -23062,7 +23062,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "rHO" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rHS" = (
@@ -23085,7 +23085,7 @@
 /area/f13/wasteland)
 "rIR" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -23140,7 +23140,7 @@
 /area/f13/ncr)
 "rLP" = (
 /obj/structure/table/reinforced,
-/obj/item/locked_box/misc/money/all/medium,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -23211,7 +23211,7 @@
 /area/f13/village)
 "rOD" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -23525,7 +23525,7 @@
 /area/f13/village)
 "sbc" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /obj/item/clothing/under/schoolgirl,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -23569,7 +23569,7 @@
 /area/f13/building)
 "sdG" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /obj/machinery/light/broken{
 	dir = 4
 	},
@@ -23612,7 +23612,7 @@
 "seR" = (
 /obj/structure/closet,
 /obj/item/coin/iron,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -23694,7 +23694,7 @@
 	},
 /area/f13/wasteland)
 "sik" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
@@ -23722,7 +23722,7 @@
 /area/f13/ncr)
 "siG" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -23770,8 +23770,8 @@
 /area/f13/building)
 "skE" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -23814,7 +23814,7 @@
 /obj/item/folder/blue,
 /obj/item/pen,
 /obj/item/pen,
-/obj/item/locked_box/weapon/range/tier1{
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1{
 	layer = 2.1
 	},
 /turf/open/floor/wood,
@@ -23995,7 +23995,7 @@
 /area/f13/farm)
 "sto" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "stG" = (
@@ -24205,7 +24205,7 @@
 "sCh" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
@@ -24282,7 +24282,7 @@
 /area/f13/city)
 "sED" = (
 /obj/structure/displaycase,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -24334,7 +24334,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/generic,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -24573,7 +24573,7 @@
 "sPH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -24585,7 +24585,7 @@
 /area/f13/wasteland)
 "sPK" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "sPO" = (
@@ -24600,7 +24600,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "sQl" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
@@ -24681,7 +24681,7 @@
 "sTk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_low,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "sTv" = (
@@ -24763,7 +24763,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "sVD" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -24829,7 +24829,7 @@
 "sXe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/clothing_low,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "sXi" = (
@@ -24932,7 +24932,7 @@
 /obj/structure/rack,
 /obj/item/seeds/poppy/broc,
 /obj/item/seeds/poppy/broc,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tbd" = (
@@ -25014,7 +25014,7 @@
 /area/f13/village)
 "tdU" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tem" = (
@@ -25106,7 +25106,7 @@
 /area/f13/city)
 "tjl" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "tjq" = (
@@ -25231,11 +25231,11 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "tom" = (
@@ -25313,8 +25313,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -25492,7 +25492,7 @@
 /area/f13/wasteland)
 "twr" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "twI" = (
@@ -25555,7 +25555,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tyF" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -25599,7 +25599,7 @@
 /area/f13/village)
 "tAD" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -25655,7 +25655,7 @@
 	},
 /area/f13/ncr)
 "tCq" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "tCu" = (
@@ -25724,7 +25724,7 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "tFM" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_y = 10
@@ -25816,7 +25816,7 @@
 /area/f13/legion)
 "tJe" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/item/stack/f13Cash/random/bottle_cap/low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -25843,7 +25843,7 @@
 /area/f13/building)
 "tJz" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tJQ" = (
@@ -25984,7 +25984,7 @@
 /area/f13/ncr)
 "tQr" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -26014,7 +26014,7 @@
 	dir = 4
 	},
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -26112,7 +26112,7 @@
 	},
 /area/f13/city)
 "tVi" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tVJ" = (
@@ -26219,7 +26219,7 @@
 	},
 /area/f13/legion)
 "uaa" = (
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uaf" = (
@@ -26290,7 +26290,7 @@
 /area/f13/ncr)
 "ucs" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "ucw" = (
@@ -26351,8 +26351,8 @@
 /area/f13/building)
 "uef" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/tier1,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "uel" = (
@@ -26440,7 +26440,7 @@
 /area/f13/wasteland)
 "ugo" = (
 /obj/machinery/workbench,
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
 	icon_state = "rubble"
@@ -26480,11 +26480,11 @@
 /area/f13/building)
 "uhW" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/tier2,
-/obj/item/locked_box/weapon/range/tier2,
-/obj/item/locked_box/weapon/range/tier3_5,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "uhY" = (
@@ -26492,7 +26492,7 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
 "uij" = (
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uio" = (
@@ -26530,7 +26530,7 @@
 /area/f13/legion)
 "ulf" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -26675,7 +26675,7 @@
 /area/f13/building)
 "uqn" = (
 /obj/machinery/workbench,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -26687,7 +26687,7 @@
 	pixel_x = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uqF" = (
@@ -26871,7 +26871,7 @@
 /area/f13/building)
 "uxf" = (
 /obj/structure/bed,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
 	},
@@ -27026,7 +27026,7 @@
 /area/f13/wasteland)
 "uCT" = (
 /obj/structure/rack,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
@@ -27080,9 +27080,9 @@
 /area/f13/wasteland)
 "uDU" = (
 /obj/structure/table,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "uDX" = (
@@ -27106,14 +27106,14 @@
 /area/f13/wasteland)
 "uFK" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "uGc" = (
 /obj/effect/decal/cleanable/oil,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -27180,7 +27180,7 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "uIh" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uIK" = (
@@ -27190,7 +27190,7 @@
 /area/f13/wasteland)
 "uIT" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uIV" = (
@@ -27655,8 +27655,8 @@
 	dir = 1;
 	icon_state = "twindowold"
 	},
-/obj/item/locked_box/weapon/range/tier2,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uYW" = (
@@ -27702,7 +27702,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "vap" = (
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -27710,7 +27710,7 @@
 "vaw" = (
 /obj/structure/table,
 /obj/item/storage/backpack,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vaA" = (
@@ -27718,16 +27718,16 @@
 /area/f13/caves)
 "vaP" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vbi" = (
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vbA" = (
@@ -27743,8 +27743,8 @@
 /obj/structure/closet/crate/trashcart,
 /obj/item/stack/f13Cash/random/bottle_cap/med,
 /obj/item/stack/f13Cash/random/bottle_cap/med,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt"
@@ -27783,7 +27783,7 @@
 /area/f13/building)
 "vdh" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "vdE" = (
@@ -27822,7 +27822,7 @@
 /area/f13/legion)
 "vfs" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "vfu" = (
@@ -27835,19 +27835,19 @@
 /area/f13/caves)
 "vgg" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/machinery/light/small{
 	dir = 8;
 	light_color = "#d8b1b1"
@@ -27902,7 +27902,7 @@
 /area/f13/village)
 "vib" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vik" = (
@@ -28113,7 +28113,7 @@
 /area/f13/building)
 "vrz" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "vrL" = (
@@ -28137,7 +28137,7 @@
 /area/f13/village)
 "vsu" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vsJ" = (
@@ -28188,7 +28188,7 @@
 /area/f13/caves)
 "vuZ" = (
 /obj/structure/closet/crate/wicker,
-/obj/item/locked_box/misc/money/legion/low,
+/obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -28319,7 +28319,7 @@
 "vAm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
@@ -28748,7 +28748,7 @@
 /area/f13/ncr)
 "vUF" = (
 /obj/structure/closet/crate,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -29353,7 +29353,7 @@
 "wxw" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife/combat,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wxB" = (
@@ -29364,8 +29364,8 @@
 /area/f13/city)
 "wxI" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "wxJ" = (
@@ -29419,7 +29419,7 @@
 /area/f13/wasteland)
 "wzw" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
 "wzN" = (
@@ -29500,15 +29500,15 @@
 /area/f13/wasteland)
 "wDK" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/building)
 "wDW" = (
 /obj/structure/bed,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/item/bedsheet{
 	icon_state = "sheetgrey"
 	},
@@ -29517,7 +29517,7 @@
 	},
 /area/f13/village)
 "wEe" = (
-/obj/item/locked_box/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -29696,7 +29696,7 @@
 "wLU" = (
 /obj/structure/closet,
 /obj/item/lighter,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "wMa" = (
@@ -29752,7 +29752,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "wND" = (
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wNF" = (
@@ -29811,7 +29811,7 @@
 /area/f13/caves)
 "wOv" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wOI" = (
@@ -29859,7 +29859,7 @@
 /area/f13/city)
 "wPJ" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /obj/item/clothing/under/schoolgirl/red,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -29902,15 +29902,15 @@
 /area/f13/building)
 "wRb" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "wRG" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "wRK" = (
@@ -29941,7 +29941,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "wSk" = (
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wSv" = (
@@ -29983,7 +29983,7 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "wSX" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -30055,9 +30055,9 @@
 "wVI" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/effect/spawner/lootdrop/clothing_low,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "wWb" = (
@@ -30130,19 +30130,19 @@
 /area/f13/ncr)
 "wXR" = (
 /obj/structure/rack,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "wXT" = (
 /obj/structure/closet/fridge/standard,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "wYa" = (
@@ -30303,7 +30303,7 @@
 /obj/item/clothing/glasses/f13/biker{
 	pixel_y = 7
 	},
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
@@ -30464,7 +30464,7 @@
 /area/f13/building)
 "xfE" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "xfP" = (
@@ -30564,7 +30564,7 @@
 /obj/structure/closet/cabinet,
 /obj/item/clothing/head/helmet/gladiator,
 /obj/item/clothing/under/gladiator,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/f13,
 /area/f13/building)
 "xjH" = (
@@ -30800,7 +30800,7 @@
 /area/f13/caves)
 "xrO" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /obj/item/clothing/under/schoolgirl/green,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -30821,7 +30821,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xsF" = (
@@ -30906,7 +30906,7 @@
 /area/f13/building)
 "xuy" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "xuL" = (
@@ -31112,7 +31112,7 @@
 /area/f13/wasteland)
 "xEx" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xFv" = (
@@ -31309,13 +31309,13 @@
 /area/f13/building)
 "xMe" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/medical/medicine,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xMk" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xMm" = (
@@ -31445,7 +31445,7 @@
 /area/f13/building)
 "xRg" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xRk" = (
@@ -31468,7 +31468,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xRM" = (
-/obj/item/locked_box/armor/tier1,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
@@ -31498,7 +31498,7 @@
 /area/f13/village)
 "xTn" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -31616,7 +31616,7 @@
 /area/f13/wasteland)
 "xXh" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xXl" = (
@@ -31646,7 +31646,7 @@
 /obj/item/clothing/shoes/combat,
 /obj/structure/closet,
 /obj/item/clothing/head/beret,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -31699,8 +31699,8 @@
 /area/f13/farm)
 "yao" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "yau" = (
@@ -31767,14 +31767,14 @@
 /area/f13/city)
 "ybg" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/village)
 "ybq" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -31875,7 +31875,7 @@
 /obj/structure/mirror{
 	pixel_x = 32
 	},
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -31960,7 +31960,7 @@
 /area/f13/building)
 "ykD" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -29,7 +29,7 @@
 /area/f13/bunker)
 "ae" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /obj/effect/spawner/lootdrop/clothing_high,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -63,7 +63,7 @@
 /area/f13/brotherhood)
 "ak" = (
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "al" = (
@@ -179,8 +179,8 @@
 "aI" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/any_random,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
 	},
@@ -342,7 +342,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bj" = (
@@ -424,7 +424,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bx" = (
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
@@ -463,7 +463,7 @@
 /area/f13/brotherhood)
 "bF" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bG" = (
@@ -486,9 +486,9 @@
 /area/f13/brotherhood)
 "bM" = (
 /obj/structure/guncase,
-/obj/item/locked_box/weapon/range/tier2,
-/obj/item/locked_box/weapon/range/tier2,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
@@ -502,8 +502,8 @@
 	},
 /area/f13/tunnel)
 "bQ" = (
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bR" = (
@@ -674,7 +674,7 @@
 /area/f13/bunker)
 "cw" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -803,8 +803,8 @@
 /area/f13/tunnel)
 "cS" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "cT" = (
@@ -866,14 +866,14 @@
 /area/f13/tunnel)
 "db" = (
 /obj/structure/chair/right,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
 "dc" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -1003,7 +1003,7 @@
 /area/f13/brotherhood)
 "dA" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dB" = (
@@ -1111,7 +1111,7 @@
 /turf/open/water,
 /area/f13/tunnel)
 "dS" = (
-/obj/item/locked_box/misc/money/legion/medium,
+/obj/effect/spawner/lootdrop/f13/cash_legion_med,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
@@ -1411,7 +1411,7 @@
 /area/f13/tunnel)
 "eR" = (
 /obj/structure/table/reinforced,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "eS" = (
@@ -1508,7 +1508,7 @@
 /obj/structure/handrail/g_central{
 	pixel_y = -16
 	},
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "fn" = (
@@ -1518,11 +1518,11 @@
 /area/f13/caves)
 "fo" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/weapon/range/tier1,
-/obj/item/locked_box/weapon/range/tier1,
-/obj/item/locked_box/weapon/range/tier2,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "fp" = (
@@ -1917,11 +1917,11 @@
 	},
 /area/f13/tunnel)
 "gz" = (
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gB" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "gC" = (
@@ -2306,7 +2306,7 @@
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
 	},
-/obj/item/locked_box/misc/money/all/medium,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "hI" = (
@@ -2356,7 +2356,7 @@
 	},
 /area/f13/tunnel)
 "hR" = (
-/obj/item/locked_box/misc/money/legion/low,
+/obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "hS" = (
@@ -2372,7 +2372,7 @@
 /area/f13/tunnel)
 "hU" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hV" = (
@@ -2536,14 +2536,14 @@
 /area/f13/clinic)
 "ix" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
 "iy" = (
 /obj/machinery/light/small,
-/obj/item/locked_box/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "iz" = (
@@ -2570,8 +2570,8 @@
 /area/f13/building)
 "iC" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/prewar_clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "iD" = (
@@ -2604,7 +2604,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
@@ -2645,8 +2645,8 @@
 /area/f13/brotherhood)
 "iN" = (
 /obj/structure/table/reinforced,
-/obj/item/locked_box/misc/money/all/high,
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "iP" = (
@@ -2655,7 +2655,7 @@
 	},
 /area/f13/tunnel)
 "iQ" = (
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iR" = (
@@ -2676,7 +2676,7 @@
 /turf/open/water,
 /area/f13/tunnel)
 "iT" = (
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iU" = (
@@ -2691,7 +2691,7 @@
 /area/f13/tunnel)
 "iV" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/item/dildo,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -2730,7 +2730,7 @@
 /area/f13/tunnel)
 "jd" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "je" = (
@@ -2779,7 +2779,7 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
 /obj/item/clothing/under/f13/raider_leather,
-/obj/item/locked_box/armor/prewar_costumes,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -2917,7 +2917,7 @@
 /obj/item/clothing/head/hooded/human_head{
 	pixel_y = -10
 	},
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/item/organ/heart,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
@@ -2939,7 +2939,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "jP" = (
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "jQ" = (
@@ -2988,7 +2988,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jY" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -3022,7 +3022,7 @@
 /area/f13/tunnel)
 "ke" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -3084,7 +3084,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ko" = (
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -3100,8 +3100,8 @@
 /area/f13/tunnel)
 "ks" = (
 /obj/structure/closet/fridge,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -3122,7 +3122,7 @@
 /area/f13/tunnel)
 "kv" = (
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "kw" = (
@@ -3139,7 +3139,7 @@
 /area/f13/tunnel)
 "ky" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	dir = 8;
 	icon_state = "neutralrusty"
@@ -3150,7 +3150,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "kA" = (
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "kB" = (
@@ -3168,7 +3168,7 @@
 /area/f13/tunnel)
 "kD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
@@ -3221,7 +3221,7 @@
 /obj/structure/closet/crate/trashcart{
 	storage_capacity = 10
 	},
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "kM" = (
@@ -3267,7 +3267,7 @@
 /obj/effect/decal/waste{
 	icon_state = "goo10"
 	},
-/obj/item/locked_box/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "kS" = (
@@ -3279,7 +3279,7 @@
 /obj/structure/booth{
 	dir = 8
 	},
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kU" = (
@@ -3317,7 +3317,7 @@
 	},
 /area/f13/tunnel)
 "kZ" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "la" = (
@@ -3369,7 +3369,7 @@
 /area/f13/bunker)
 "lh" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -3433,12 +3433,12 @@
 /area/f13/tunnel)
 "lv" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/item/stack/sheet/prewar/five,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
@@ -3515,7 +3515,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "lI" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
@@ -3586,10 +3586,10 @@
 /obj/item/flashlight,
 /obj/item/flashlight,
 /obj/item/radio,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lU" = (
@@ -3673,9 +3673,9 @@
 	name = "Disguise Closet"
 	},
 /obj/effect/turf_decal/bot_red,
-/obj/item/locked_box/armor/tier2,
-/obj/item/locked_box/armor/tier2,
-/obj/item/locked_box/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "md" = (
@@ -3696,7 +3696,7 @@
 	},
 /area/f13/followers)
 "mg" = (
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -3805,7 +3805,7 @@
 /area/f13/tunnel)
 "mv" = (
 /obj/structure/closet/crate,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "mw" = (
@@ -3831,7 +3831,7 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "mz" = (
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -3895,7 +3895,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "mK" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "mL" = (
@@ -3989,7 +3989,7 @@
 /area/f13/brotherhood)
 "na" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "nb" = (
@@ -4007,7 +4007,7 @@
 /area/f13/caves)
 "nd" = (
 /obj/structure/closet/crate,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -4054,7 +4054,7 @@
 /area/f13/brotherhood)
 "nk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
@@ -4146,7 +4146,7 @@
 /area/f13/tcoms)
 "ny" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nA" = (
@@ -4163,7 +4163,7 @@
 	},
 /area/f13/brotherhood)
 "nB" = (
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
@@ -4210,7 +4210,7 @@
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
 	},
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
@@ -4350,7 +4350,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ok" = (
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ol" = (
@@ -4509,7 +4509,7 @@
 /area/f13/brotherhood)
 "oN" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -4735,7 +4735,7 @@
 /area/f13/tunnel)
 "pC" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	dir = 5;
 	icon_state = "neutralrusty"
@@ -4808,7 +4808,7 @@
 /area/f13/tunnel)
 "pS" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -4936,7 +4936,7 @@
 /obj/structure/booth{
 	dir = 4
 	},
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qq" = (
@@ -4954,11 +4954,11 @@
 /area/f13/brotherhood)
 "qu" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "qv" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
@@ -5245,7 +5245,7 @@
 /area/f13/tunnel)
 "rz" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -5295,7 +5295,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
@@ -5307,7 +5307,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rK" = (
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rL" = (
@@ -5364,7 +5364,7 @@
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
 	},
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -5391,7 +5391,7 @@
 /area/f13/brotherhood)
 "rW" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -5438,22 +5438,22 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sf" = (
-/obj/item/locked_box/armor/tier1,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
 "sg" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/sewer)
 "sh" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "si" = (
@@ -5503,7 +5503,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "sp" = (
@@ -5543,7 +5543,7 @@
 /area/f13/brotherhood)
 "sv" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "sx" = (
@@ -5628,7 +5628,7 @@
 /area/f13/sewer)
 "sO" = (
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sP" = (
@@ -5764,7 +5764,7 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "tp" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -5786,14 +5786,14 @@
 /area/f13/followers)
 "tt" = (
 /obj/machinery/workbench,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/item/locked_box/misc/blueprints/tier3,
-/obj/item/locked_box/misc/blueprints/tier3,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /obj/item/reagent_containers/glass/bottle/blackpowder,
 /obj/item/reagent_containers/glass/bottle/blackpowder,
 /obj/item/reagent_containers/glass/bottle/blackpowder,
@@ -5823,7 +5823,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tz" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tA" = (
@@ -5873,7 +5873,7 @@
 /area/f13/tunnel)
 "tG" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -5937,8 +5937,8 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "tX" = (
@@ -5997,7 +5997,7 @@
 /area/f13/tunnel)
 "uh" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "ui" = (
@@ -6066,7 +6066,7 @@
 	},
 /area/f13/tunnel)
 "us" = (
-/obj/item/locked_box/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ut" = (
@@ -6294,8 +6294,8 @@
 "vd" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/weapon/melee/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ve" = (
@@ -6305,8 +6305,8 @@
 /area/f13/caves)
 "vf" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "vg" = (
@@ -6314,7 +6314,7 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "vi" = (
@@ -6359,7 +6359,7 @@
 /area/f13/tunnel)
 "vq" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vr" = (
@@ -6419,9 +6419,9 @@
 "vy" = (
 /obj/effect/decal/waste,
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/prewar_clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vz" = (
@@ -6604,7 +6604,7 @@
 	dir = 8
 	},
 /obj/item/stack/f13Cash/random/bottle_cap/med,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wc" = (
@@ -6631,9 +6631,9 @@
 "wg" = (
 /obj/structure/rack,
 /obj/item/twohanded/sledgehammer,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wh" = (
@@ -6682,7 +6682,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "wo" = (
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wp" = (
@@ -6754,8 +6754,8 @@
 /area/f13/brotherhood)
 "wA" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/melee/any_random,
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -6787,7 +6787,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wG" = (
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
 	},
@@ -6824,7 +6824,7 @@
 /area/f13/bunker)
 "wM" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wN" = (
@@ -6855,10 +6855,10 @@
 /area/f13/tunnel)
 "wR" = (
 /obj/structure/table/wood,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/item/storage/fancy/candle_box,
-/obj/item/locked_box/weapon/melee/tier3,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wS" = (
@@ -6950,7 +6950,7 @@
 /area/f13/caves)
 "xi" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "xj" = (
@@ -7013,19 +7013,19 @@
 /area/f13/brotherhood)
 "xs" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xt" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/melee/tier4,
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
 "xu" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
 	},
@@ -7123,8 +7123,8 @@
 /area/f13/caves)
 "xK" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
@@ -7168,7 +7168,7 @@
 /area/f13/tunnel)
 "xQ" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
@@ -7199,10 +7199,10 @@
 "xW" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/range/tier4,
-/obj/item/locked_box/weapon/range/tier4,
-/obj/item/locked_box/weapon/range/tier4,
-/obj/item/locked_box/weapon/range/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "xX" = (
@@ -7227,7 +7227,7 @@
 	name = "light tube"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "yb" = (
@@ -7238,7 +7238,7 @@
 /area/f13/ncr)
 "yd" = (
 /obj/structure/chair/bench,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ye" = (
@@ -7282,7 +7282,7 @@
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/brotherhood)
 "yk" = (
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /obj/structure/closet,
 /mob/living/simple_animal/hostile/alien,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7301,7 +7301,7 @@
 	},
 /area/f13/bunker)
 "yr" = (
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "yt" = (
@@ -7355,11 +7355,11 @@
 /area/f13/tunnel)
 "yC" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "yD" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "yE" = (
@@ -7477,12 +7477,12 @@
 	},
 /area/f13/tunnel)
 "yX" = (
-/obj/item/locked_box/weapon/melee/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "yY" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "yZ" = (
@@ -7526,7 +7526,7 @@
 /area/f13/building)
 "zf" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -7571,7 +7571,7 @@
 	},
 /area/f13/tunnel)
 "zo" = (
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /obj/structure/closet,
 /turf/open/floor/f13{
 	icon_state = "dark"
@@ -7623,7 +7623,7 @@
 /area/f13/clinic)
 "zy" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "zz" = (
@@ -7808,7 +7808,7 @@
 "Af" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/pa_wear,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -7909,16 +7909,16 @@
 /area/f13/brotherhood)
 "AA" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/tier3_5,
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "AB" = (
@@ -7940,7 +7940,7 @@
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
 "AF" = (
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "AG" = (
@@ -7951,7 +7951,7 @@
 	},
 /area/f13/tunnel)
 "AH" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
@@ -7998,7 +7998,7 @@
 	},
 /area/f13/tunnel)
 "AP" = (
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "AQ" = (
@@ -8106,7 +8106,7 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "Bq" = (
-/obj/item/locked_box/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "Br" = (
@@ -8137,7 +8137,7 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "Bw" = (
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -8175,10 +8175,10 @@
 "BB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "BC" = (
@@ -8223,7 +8223,7 @@
 "BI" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical/old,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
@@ -8314,8 +8314,8 @@
 /area/f13/sewer)
 "Cb" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -8341,9 +8341,9 @@
 "Cg" = (
 /obj/structure/closet/fridge/standard,
 /obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/locked_box/misc/alcohol,
-/obj/item/locked_box/misc/food,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -8421,8 +8421,8 @@
 /area/f13/tunnel)
 "Cr" = (
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/weapon/ammo/tier4,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "Ct" = (
@@ -8491,7 +8491,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -8514,7 +8514,7 @@
 "CG" = (
 /obj/structure/booth,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "CH" = (
@@ -8579,7 +8579,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "CK" = (
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "CL" = (
@@ -8625,7 +8625,7 @@
 /area/f13/brotherhood)
 "CS" = (
 /obj/structure/table/reinforced,
-/obj/item/locked_box/weapon/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /obj/item/book/granter/crafting_recipe/gunsmith_four,
 /turf/open/floor/f13{
 	icon_state = "dark"
@@ -8956,7 +8956,7 @@
 /area/f13/brotherhood)
 "Ed" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -8965,7 +8965,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "Ef" = (
@@ -9092,9 +9092,9 @@
 /area/f13/brotherhood)
 "Ey" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/weapon/melee/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "Ez" = (
@@ -9109,7 +9109,7 @@
 	},
 /area/f13/tunnel)
 "EB" = (
-/obj/item/locked_box/misc/money/ncr/medium,
+/obj/effect/spawner/lootdrop/f13/cash_ncr_med,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "EC" = (
@@ -9178,7 +9178,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "EO" = (
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "EP" = (
@@ -9196,7 +9196,7 @@
 /area/f13/brotherhood)
 "ER" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -9316,14 +9316,14 @@
 /area/f13/ncr)
 "Fj" = (
 /obj/structure/closet,
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
 "Fk" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -9340,7 +9340,7 @@
 "Fq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/booth/middle,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "Fr" = (
@@ -9371,7 +9371,7 @@
 /area/f13/tunnel)
 "Fw" = (
 /obj/structure/closet,
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	dir = 10;
 	icon_state = "neutralrusty"
@@ -9405,13 +9405,13 @@
 "FC" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/welding,
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "FD" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
@@ -9484,7 +9484,7 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/stack/f13Cash/random/bottle_cap/med,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /obj/machinery/light/fo13colored/Aqua{
 	bulb_colour = "#800080";
 	dir = 4;
@@ -9618,8 +9618,8 @@
 /area/f13/tunnel)
 "Gu" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Gv" = (
@@ -9652,7 +9652,7 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "GA" = (
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "GB" = (
@@ -9713,7 +9713,7 @@
 /area/f13/clinic)
 "GK" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
@@ -9775,8 +9775,8 @@
 /area/f13/tunnel)
 "GW" = (
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/weapon/range/tier2,
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "GX" = (
@@ -9808,9 +9808,9 @@
 /area/f13/tunnel)
 "Hd" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/misc/blueprints/tier2,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -9880,7 +9880,7 @@
 /area/f13/tunnel)
 "Hq" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
@@ -9901,7 +9901,7 @@
 	},
 /area/f13/brotherhood)
 "Hu" = (
-/obj/item/locked_box/misc/money/all/low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "Hv" = (
@@ -9953,14 +9953,14 @@
 /area/f13/tunnel)
 "HD" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
 "HE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -10070,7 +10070,7 @@
 /obj/item/clothing/suit/armor/f13/power_armor/t45d,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/helmet/f13/power_armor/t45d,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -10153,7 +10153,7 @@
 /area/f13/caves)
 "Ip" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "Iq" = (
@@ -10262,7 +10262,7 @@
 "IJ" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
@@ -10289,7 +10289,7 @@
 	},
 /area/f13/clinic)
 "IN" = (
-/obj/item/locked_box/weapon/melee/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "IO" = (
@@ -10323,7 +10323,7 @@
 "IS" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -10423,7 +10423,7 @@
 /area/f13/tunnel)
 "Ji" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "Jj" = (
@@ -10515,7 +10515,7 @@
 	},
 /area/f13/tunnel)
 "Jw" = (
-/obj/item/locked_box/misc/money/all/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "Jy" = (
@@ -10540,7 +10540,7 @@
 	},
 /area/f13/brotherhood)
 "JC" = (
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -10614,8 +10614,8 @@
 "JQ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/prewar_clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "JR" = (
@@ -10634,7 +10634,7 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
 "JU" = (
-/obj/item/locked_box/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "JV" = (
@@ -10686,7 +10686,7 @@
 /area/f13/caves)
 "Kd" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
@@ -10936,7 +10936,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "KU" = (
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "KW" = (
@@ -11065,7 +11065,7 @@
 /area/f13/clinic)
 "Lt" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Lv" = (
@@ -11489,9 +11489,9 @@
 /area/f13/tunnel)
 "ML" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "MM" = (
@@ -11645,7 +11645,7 @@
 /area/f13/tunnel)
 "Nl" = (
 /obj/structure/table,
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "Nm" = (
@@ -11667,7 +11667,7 @@
 	},
 /area/f13/tunnel)
 "Np" = (
-/obj/item/locked_box/misc/skillbook,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "Nq" = (
@@ -11683,9 +11683,9 @@
 /area/f13/brotherhood)
 "Ns" = (
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/armor/tier4,
-/obj/item/locked_box/misc/blueprints/tier2,
-/obj/item/locked_box/misc/blueprints/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "Nt" = (
@@ -11866,8 +11866,8 @@
 "NN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/item/stack/crafting/electronicparts/three,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
@@ -12116,9 +12116,9 @@
 /area/f13/tunnel)
 "Oz" = (
 /obj/structure/guncase,
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/weapon/range/tier3,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -12204,7 +12204,7 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "OL" = (
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/structure/table/wood/poker,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
@@ -12262,14 +12262,14 @@
 "OT" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier1,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier2,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/ammo/tier3,
-/obj/item/locked_box/weapon/ammo/tier4,
-/obj/item/locked_box/weapon/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "OU" = (
@@ -12501,7 +12501,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood)
 "PN" = (
-/obj/item/locked_box/misc/alcohol,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "PO" = (
@@ -12716,7 +12716,7 @@
 /area/f13/brotherhood)
 "Qz" = (
 /obj/structure/table/wood/settler,
-/obj/item/locked_box/medical/medicine,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
@@ -12826,33 +12826,33 @@
 /area/f13/sewer)
 "QW" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/ammo/tier5,
-/obj/item/locked_box/weapon/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
 "QX" = (
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
 "QY" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/garbage,
-/obj/item/locked_box/misc/garbage,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "QZ" = (
@@ -12865,7 +12865,7 @@
 /area/f13/brotherhood)
 "Ra" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "Rb" = (
@@ -13007,7 +13007,7 @@
 /area/f13/tcoms)
 "Rx" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -13068,7 +13068,7 @@
 /area/f13/tunnel)
 "RI" = (
 /obj/structure/closet/crate,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "RJ" = (
@@ -13178,7 +13178,7 @@
 	},
 /area/f13/clinic)
 "RZ" = (
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -13256,7 +13256,7 @@
 /area/f13/brotherhood)
 "Sl" = (
 /obj/structure/rack,
-/obj/item/locked_box/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -13375,7 +13375,7 @@
 /area/f13/brotherhood)
 "SG" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
@@ -13414,7 +13414,7 @@
 	},
 /area/f13/tunnel)
 "SN" = (
-/obj/item/locked_box/misc/money/all/medium,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "SO" = (
@@ -13487,7 +13487,7 @@
 /area/f13/brotherhood)
 "SZ" = (
 /obj/structure/table,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -13522,7 +13522,7 @@
 "Tf" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/ammo,
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "Tg" = (
@@ -13596,9 +13596,9 @@
 /obj/item/advanced_crafting_components/flux,
 /obj/item/advanced_crafting_components/lenses,
 /obj/item/advanced_crafting_components/receiver,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
-/obj/item/locked_box/misc/crafting/advanced,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "To" = (
@@ -13717,10 +13717,10 @@
 /obj/structure/rack,
 /obj/item/stack/sheet/plastic/five,
 /obj/item/stack/sheet/plastic/five,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "TH" = (
@@ -13749,7 +13749,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "TM" = (
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -14080,7 +14080,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
 	},
@@ -14112,7 +14112,7 @@
 	},
 /area/f13/clinic)
 "UR" = (
-/obj/item/locked_box/weapon/range/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "US" = (
@@ -14196,7 +14196,7 @@
 	},
 /area/f13/bunker)
 "Vd" = (
-/obj/item/locked_box/weapon/range/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
@@ -14234,7 +14234,7 @@
 /obj/item/clothing/suit/armor/f13/combat/mk2,
 /obj/item/clothing/head/helmet/f13/combat/mk2,
 /obj/item/clothing/mask/gas/syndicate,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "Vj" = (
@@ -14252,7 +14252,7 @@
 "Vl" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
-/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -14279,7 +14279,7 @@
 /area/f13/tunnel)
 "Vp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/misc/garbage,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
@@ -14640,7 +14640,7 @@
 /area/f13/tunnel)
 "WF" = (
 /obj/structure/table/reinforced,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -14734,7 +14734,7 @@
 /area/f13/brotherhood)
 "WS" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -14755,15 +14755,15 @@
 /area/f13/tunnel)
 "WX" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/range/tier3_5,
-/obj/item/locked_box/weapon/range/tier3_5,
-/obj/item/locked_box/weapon/range/tier3_5,
-/obj/item/locked_box/weapon/range/tier3_5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "WZ" = (
 /obj/structure/closet/crate/trashcart,
-/obj/item/locked_box/weapon/range/any_random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "Xa" = (
@@ -14773,7 +14773,7 @@
 /area/f13/tunnel)
 "Xb" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/food,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "Xc" = (
@@ -14823,15 +14823,15 @@
 /area/f13/tunnel)
 "Xl" = (
 /obj/structure/closet/cabinet,
-/obj/item/locked_box/armor/prewar_clothes,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "Xm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/female/flapper,
-/obj/item/locked_box/armor/any_random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /obj/item/clothing/under/f13/raiderharness,
 /obj/item/clothing/under/f13/raiderharness,
 /turf/open/floor/f13/wood{
@@ -14862,7 +14862,7 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "Xq" = (
-/obj/item/locked_box/weapon/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
@@ -14954,7 +14954,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "XF" = (
-/obj/item/locked_box/misc/money/ncr/low,
+/obj/effect/spawner/lootdrop/f13/cash_ncr_low,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "XG" = (
@@ -15006,7 +15006,7 @@
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/medical/drugs,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
@@ -15074,7 +15074,7 @@
 "XY" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/locked_box/weapon/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "Ya" = (
@@ -15168,7 +15168,7 @@
 /area/f13/ncr)
 "Yu" = (
 /obj/structure/rack,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
@@ -15189,10 +15189,10 @@
 /turf/open/water,
 /area/f13/tunnel)
 "Yz" = (
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
-/obj/item/locked_box/misc/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/item/stack/sheet/hay/fifty,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -15218,7 +15218,7 @@
 /area/f13/brotherhood)
 "YD" = (
 /obj/structure/closet,
-/obj/item/locked_box/weapon/range/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -15361,7 +15361,7 @@
 /area/f13/tunnel)
 "Zi" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /obj/effect/spawner/lootdrop/ammo,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
@@ -15539,7 +15539,7 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "ZJ" = (
-/obj/item/locked_box/misc/blueprints/tier1,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "ZK" = (
@@ -15554,11 +15554,11 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
-/obj/item/locked_box/misc/resource,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ZN" = (

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -476,6 +476,16 @@
 	item_color = "overalls"
 	can_adjust = FALSE
 
+/obj/item/clothing/under/plaid_skirt
+	name = "red plaid skirt"
+	desc = "A preppy red skirt with a white blouse."
+	icon_state = "plaid_red"
+	item_state = "plaid_red"
+	item_color = "plaid_red"
+	fitted = FEMALE_UNIFORM_TOP
+	can_adjust = TRUE
+	alt_covers_chest = TRUE
+
 /obj/item/clothing/under/plaid_skirt/green
 	name = "green plaid skirt"
 	desc = "A preppy green skirt with a white blouse."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR replaces lockboxes on the map with the original loot spawners they replaced.
The lockbox code is untouched, the objects are just no longer on the map.

I had already wanted to fix them by implementing a configurable "variable spawner" that would combine both lootspawners and lockboxes. This has caused me to take a closer look at the lockboxes and realise that in their present form they're deeply flawed and are inferior to the loot spawners they replaced.

Beyond the much discussed over reliance of SPECIAL stats, particularly the luck stat, there are a number of other issues:

`-` They remove weighted probability. This is an essential feature to be able to make loot spawners less predictable. For example, the random armour loot spawner had the following probabilities:

T1 80%
T2 19%
T3 1%
In comparison, its replacement lockbox has:
T1 25%
T2 25%
T3 25%
T4 25%
With 83 of such lockboxes on the map, each spawning 4 pieces of either helmets or armours when spawned, this alone would cause an increase of loot on the map of an average of 83 pieces of t4 armour or helmets without increasing the number of spawn locations (so it would be extremely meta-able)

To look also at high tier random armour spawners:
Before:
T2 59%
T3 30%
T4 10%
Trauma pack 1%
After
T3 1/3
T4 1/3
T5 1/3
There are 32 of these spawners also spawning 4 pieces. Causing an average increase of 30 units of t4 armour/helmets, and 42.66 units of t5 armour/helmets (which are non-salvaged t45 armour and helm, t51 armour and helm)
Similar issues are found elsewhere in cases where weighted probability has been removed.

`-` As the maths above indicates, most lockbox spawns tend to spawn a greater quantity of items than their predecessor, in the case of armour and guns this can be two or three times as much.

`-` Grouped spawns have been removed, as such, guns can no longer spawn with their ammo type and matching armour and clothing cannot spawn together.

`-` Lockboxes were in locations for which they are not suitable, for example the shopkeeper would have to pick the locks of 60% of their merchandise.

## Why It's Good For The Game

Ultimately what we want from loot spawners is greater variety, less predictability while still spawning items that make sense for the location of the loot spawner. The lockboxes unfortunately either make those issues worse or at best does not help with them.
I am a fan of fix don't remove, which is why I have been working on my own spawner system. However the lockbox system has been in place now for a month without significant improvements. As I am at work for a lot of rest of the month, I will be slow to develop my proposed replacement and I found I was rushing it to try and get it done before the stress test. This isn't going to happen so I feel the best cause of action is to revert back to the loot spawners. It would be soul crushing to have the launch of the rebase that we've all worked so hard on to be overshadowed by an inferior overhaul to a critical game mechanic.

## Changelog
:cl:
del: lockboxes on map
add: loot spawners on map
add: red plaid skirt which is an item on the loot spawner list that was not in the code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
