### PR TITLE
Remove St Jeromes and Sunnyvale as voteable maps

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -15,11 +15,10 @@ endmap
 
 map pahrump
 	default
-	votable
 endmap
 map stjeromesvalley
-	votable
+	disabled
 endmap
 map sunnyvale
-	votable
+	disabled
 endmap


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Remove St Jeromes and Sunnyvale as voteable maps. There is still a map vote at the end of the round but Pahrump is the only option. This could stay in case we ever get multiple maps that are of high quality.

## Why It's Good For The Game

These maps are broken.

## Changelog
:cl:
del: St Jeromes and Sunnyvale as voteable maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
