### PR TITLE
Update wanamingo to legacy

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/alien
-	name = "alien hunter"
+	name = "wanamingo"
 	desc = "Hiss!"
 	icon = 'icons/mob/deathclaw.dmi'
 	icon_state = "wanamingo"
@@ -14,14 +14,13 @@
 	response_harm_continuous = "hits"
 	response_harm_simple = "hit"
 	speed = 0
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 4,
-							/obj/item/stack/sheet/animalhide/xeno = 1)
-	maxHealth = 125
-	health = 125
-	harm_intent_damage = 5
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 4)
+	maxHealth = 275
+	health = 275
+	harm_intent_damage = 8
 	obj_damage = 60
-	melee_damage_lower = 25
-	melee_damage_upper = 25
+	melee_damage_lower = 60
+	melee_damage_upper = 60
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
 	speak_emote = list("hisses")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Wanamingos are just renamed and stat changed /mob/living/simple_animal/hostile/alien. On rebase they had not had their name and stats changed. They probably could do with just being split into its own mob, but that can wait until another time.

## Why It's Good For The Game

Fixes rebase issue.

## Changelog
:cl:
fix: Wanamingos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
