### PR TITLE
Scope screen shake fix

### DIFF
--- a/modular_citadel/code/game/objects/cit_screenshake.dm
+++ b/modular_citadel/code/game/objects/cit_screenshake.dm
@@ -15,9 +15,9 @@
 
 	for(var/i in 0 to duration-1)
 		if (i == 0)
-			animate(C, pixel_x=rand(min,max), pixel_y=rand(min,max), time=1)
+			animate(C, pixel_x=rand(min,max)+oldx, pixel_y=rand(min,max)+oldy, time=1)
 		else
-			animate(pixel_x=rand(min,max), pixel_y=rand(min,max), time=1)
+			animate(pixel_x=rand(min,max)+oldx, pixel_y=rand(min,max)+oldy, time=1)
 	animate(pixel_x=oldx, pixel_y=oldy, time=1)
 
 /obj/item/gun/energy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix for issue 186 - Screen shake from firing weapon causing the camera to focus on the mob rather than on the zoom offset. I tested and it seems to work fine, I did encounter a couple of things when I was trying to break them in testing that I wasn't able to replicate but I'm suspecting that these might just be scope related bugginess instead of related to these changes (first was closing the game, relaunching it and the camera not being smooth when moving, which was fixed by respawning, the second was staying zoomed in one direction while moving around, could not replicate either).

## Why It's Good For The Game

Fixes bug!

## Changelog
:cl:
fix: Screen shake being nausea inducing when zoomed in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
