### PR TITLE
Glow revive only revives once

### DIFF
--- a/code/datums/components/glow_heal.dm
+++ b/code/datums/components/glow_heal.dm
@@ -58,7 +58,8 @@
 			livingMob.adjustToxLoss(-livingMob.maxHealth*0.1)
 		if(healing_types[4])	
 			livingMob.adjustOxyLoss(-livingMob.maxHealth*0.1)
-		if(livingMob.stat == DEAD && revive_allowed)
+		if(livingMob.stat == DEAD && revive_allowed && livingMob.glowrevived == FALSE)
 			livingMob.revive(full_heal = TRUE)
+			livingMob.glowrevived = TRUE
 		var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(livingMob)) //shameless copy from blobbernaut
 		H.color = "#d9ff00" //I want yellow because glowing; sidenote: maybe this should be a var so it can be multiple things

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -158,3 +158,6 @@
 	var/sprint_buffer_regen_last = 0		//last world.time this was regen'd for math.
 	var/sprint_stamina_cost = 0.70			//stamina loss per tile while insufficient sprint buffer.
 	//---End
+
+	//Glow heal reviving - makes a mob only get revived once
+	var/glowrevived = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Set as draft as I'm thinking there's a better way to do this that doesn't throw in an extra variable to living_defines.dm and I'm open to suggestions of ways to do so. I'm thinking maybe just changing the component to be for simple mobs or even just ghouls specifically? Jake reckons there'd be a way to keep it that functionality purely within the component but I'm not seeing it. Maybe adding a component to the mobs that can be revived by it?

Makes it so ghouls can't be revived more than once by glowing ghouls.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Prevents player frustration if they end up having to kill the same ghoul 5 times and to prevent large numbers of ghouls from becoming an unkillable monstrosity.

## Changelog
:cl:
balance: ghouls can't be revived more than once by glowing ghouls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
