### PR TITLE
Lay Cables Anywhere!

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -3282,6 +3282,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"cxy" = (
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
+	},
+/area/f13/wasteland)
 "cxL" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -7353,12 +7363,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "fKN" = (
+/obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/wolf/alpha{
 	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
 	faction = list("neutral");
 	name = "Brutus"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "fLc" = (
@@ -7368,6 +7378,7 @@
 	},
 /area/f13/wasteland)
 "fLB" = (
+/obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/wolf{
 	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
 	faction = list("neutral");
@@ -7376,7 +7387,6 @@
 	name = "Lupa";
 	tame = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "fLC" = (
@@ -74085,9 +74095,9 @@ ktX
 bQV
 kdi
 grC
-grC
+cxy
 isL
-grC
+cxy
 xuM
 qyR
 hpj

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/fallout/turfs/ground.dmi'
 	name = "\proper ground"
 	icon_state = "wasteland1"
-	intact = 1
+	intact = 0
 	planetary_atmos = TRUE
 
 	var/flags = NONE


### PR DESCRIPTION
This just makes it so you can lay cables anywhere as well as fix a couple of missing cables at the radio station.

## About The Pull Request

All this does is change one variable that lets cables be placed most wasteland surfaces.

## Why It's Good For The Game

Honestly, plating looks ugly and it makes sense in a in universe standpoint that people would just... string cables around if they need to. 

That and we don't have true HV Power lines... yet.
## Changelog
:cl:
add: Adds 3 cable nodes to the solar farm at the radio station to activate previously un-powered solar panels.

tweak: Changed a 1 to a 0 and let cables lay where they want to. Anywhere.
/:cl:
