### PR TITLE
mapping stuff, death to the dust bowl

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -30,31 +30,6 @@
 	icon_state = "plating"
 	},
 /area/space)
-"abd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"abs" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/structure/closet,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"abx" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
 "acc" = (
 /obj/structure/table/reinforced,
 /obj/item/paper,
@@ -64,9 +39,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"ace" = (
-/turf/open/floor/f13,
-/area/f13/wasteland)
 "aci" = (
 /obj/machinery/sleeper,
 /obj/machinery/light{
@@ -75,19 +47,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
-"acq" = (
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"adj" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/obj/item/trash/can,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "adk" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -103,10 +62,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"aeh" = (
-/obj/machinery/porta_turret/syndicate,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "aer" = (
 /obj/machinery/computer/upload/ai,
 /turf/open/floor/plasteel/dark,
@@ -116,36 +71,13 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"aeF" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "aeH" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/wood,
 /area/f13/vault)
-"aeS" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/structure/closet,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "aeW" = (
 /turf/open/floor/plating,
 /area/f13/bunker)
-"afC" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/item/target/alien,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"agf" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "agt" = (
 /obj/machinery/light{
 	dir = 1;
@@ -164,14 +96,6 @@
 "ahh" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"ahN" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "ahT" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -185,14 +109,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"aiY" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/f13,
-/area/f13/city)
-"ajc" = (
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "ajs" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood{
@@ -233,17 +149,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/tunnel)
-"alc" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"alN" = (
-/obj/structure/wreck/trash/two_barrels,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "alO" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/doughslice,
@@ -264,11 +169,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"anJ" = (
-/obj/structure/booth,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "anY" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -282,22 +182,9 @@
 	dir = 10
 	},
 /area/f13/vault)
-"aoi" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "apt" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/underground/cave)
-"aqj" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "aqN" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -328,24 +215,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"arO" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"asb" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"asP" = (
-/obj/structure/table/glass,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "asT" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -376,10 +245,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"atb" = (
-/obj/item/cultivator,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "atF" = (
 /obj/structure/rack,
 /obj/item/storage/crayons,
@@ -398,10 +263,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"auy" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "auT" = (
 /obj/structure/spider/stickyweb,
 /turf/closed/mineral/random/low_chance,
@@ -410,50 +271,12 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"awX" = (
-/turf/closed/wall/f13/store,
-/area/f13/underground/cave)
-"axc" = (
-/obj/structure/tires/five,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"axd" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"axY" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "ayb" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
 /area/space)
-"ayi" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "ayp" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/twohanded/required/kirbyplants{
@@ -564,12 +387,6 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/bunker)
-"azV" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
-	},
-/turf/closed/wall/f13/vault,
-/area/f13/brotherhood)
 "aAq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -593,10 +410,6 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
-"aBq" = (
-/obj/machinery/chem_master,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "aBF" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/f13/instamash,
@@ -612,27 +425,10 @@
 /obj/structure/nest/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"aDi" = (
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "aDZ" = (
 /turf/open/floor/f13{
 	dir = 8;
 	icon_state = "yellowsiding"
-	},
-/area/f13/bunker)
-"aEp" = (
-/obj/structure/table,
-/obj/item/pda/security,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "aFl" = (
@@ -660,15 +456,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"aFK" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "aFT" = (
 /obj/machinery/light{
 	dir = 8;
@@ -681,53 +468,12 @@
 	icon_state = "grass2"
 	},
 /area/f13/vault)
-"aGd" = (
-/obj/structure/barricade/sandbags,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/ncr)
-"aGg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"aGn" = (
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"aGB" = (
-/obj/structure/booth{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/mountain_bunker)
-"aGH" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/underground/cave)
 "aGJ" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"aGP" = (
-/obj/effect/turf_decal/caution,
-/turf/open/floor/wood/f13/old,
-/area/f13/ncr)
 "aHh" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -735,13 +481,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
-"aHE" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "aHL" = (
@@ -793,26 +532,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/radiation)
-"aKq" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"aLr" = (
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/obj/structure/curtain,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
-"aLE" = (
-/obj/structure/table/glass,
-/turf/open/floor/f13,
-/area/f13/city)
 "aLF" = (
 /obj/structure/rack,
 /obj/item/crafting/diode,
@@ -834,30 +553,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"aNF" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "aNW" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"aPe" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/city)
-"aPv" = (
-/obj/structure/car/rubbish4,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "aPN" = (
 /obj/machinery/mineral/stacking_unit_console,
 /turf/closed/wall/f13/wood,
@@ -870,17 +570,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"aQq" = (
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"aQA" = (
-/obj/machinery/power/rtg,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "aQB" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/yellow,
@@ -889,12 +578,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"aQF" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/mountain_bunker)
 "aRp" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/barber{
@@ -946,17 +629,6 @@
 "aUx" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"aUz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"aVI" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "aWc" = (
 /obj/machinery/conveyor/inverted{
 	dir = 6;
@@ -1001,29 +673,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"aXW" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"aYl" = (
-/obj/machinery/vending/cola,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"aYt" = (
-/obj/structure/barricade/sandbags,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/ncr)
 "aYB" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -1076,22 +725,11 @@
 /obj/item/clothing/head/helmet/f13/raidermetal,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"bac" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "baj" = (
 /obj/effect/decal/remains/human,
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"bam" = (
-/obj/structure/closet/fridge/meat,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "baH" = (
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plating/tunnel{
@@ -1118,22 +756,6 @@
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
-"bcF" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
-"bdd" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "bdj" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -1141,38 +763,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"bdm" = (
-/turf/closed/wall/f13/tentwall,
-/area/f13/city)
-"bec" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "bek" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
 	},
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plating,
-/area/f13/bunker)
-"bev" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"beT" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "bfl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1189,17 +785,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"bgx" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
-"bgD" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "bgT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1220,11 +805,6 @@
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
-/area/f13/bunker)
-"bhg" = (
-/obj/machinery/light/fo13colored/Red,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "bhv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -1259,13 +839,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"bji" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
-"bjs" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "bjy" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 14
@@ -1357,22 +930,6 @@
 	icon_state = "floorrusty"
 	},
 /area/space)
-"bpg" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_access_txt = "45; 5";
-	req_one_access_txt = ""
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"bpk" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "bpr" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
@@ -1388,16 +945,6 @@
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/space)
-"bqf" = (
-/obj/machinery/chem_master/advanced,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"bql" = (
-/obj/structure/sign/poster/prewar/poster83,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
 "bqE" = (
 /obj/structure/rack,
 /obj/machinery/button/door{
@@ -1408,79 +955,30 @@
 	},
 /turf/open/floor/wood,
 /area/f13/vault)
-"bqL" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13,
-/area/f13/wasteland)
 "bqQ" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/plasteel/freezer,
 /area/space)
-"bru" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"brw" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/mountain_bunker)
 "brC" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/gloves/combat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"brU" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "bsh" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"bso" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/mountain_bunker)
 "bsw" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"bsR" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"bsT" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "btc" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
-"bua" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "bue" = (
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
@@ -1497,22 +995,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"bvl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "bvn" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating/f13/inside/mountain,
 /area/f13/underground/cave)
-"bwk" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "bwT" = (
 /obj/machinery/shower{
 	dir = 8
@@ -1558,10 +1044,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"bys" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "byG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
@@ -1601,10 +1083,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"bzK" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "bAz" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/f13{
@@ -1630,11 +1108,6 @@
 	dir = 5
 	},
 /area/f13/vault)
-"bBa" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "bBb" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1712,12 +1185,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"bEa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "bEK" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1737,24 +1204,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
-"bHl" = (
-/obj/structure/chair/f13chair2,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"bHT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
 "bIM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1763,21 +1212,6 @@
 	icon_state = "stagestairs"
 	},
 /area/f13/vault)
-"bIV" = (
-/obj/item/stack/sheet/prewar,
-/obj/item/stack/sheet/prewar,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"bJj" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "bJt" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -1790,16 +1224,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"bJF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"bKp" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "bKv" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/security,
@@ -1849,36 +1273,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"bOw" = (
-/obj/structure/booth,
-/obj/item/reagent_containers/food/snacks/salad/herbsalad,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"bPe" = (
-/obj/structure/girder/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
 "bPH" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
 	},
-/area/f13/bunker)
-"bPQ" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13,
-/area/f13/city)
-"bQf" = (
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "bQj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1918,12 +1318,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"bRd" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/absinthe,
-/obj/item/reagent_containers/food/snacks/burger/superbite,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "bRz" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1939,14 +1333,6 @@
 "bSx" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"bSJ" = (
-/obj/item/storage/trash_stack,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "bSU" = (
 /obj/structure/sink{
@@ -1994,17 +1380,6 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"bWk" = (
-/obj/structure/chair/bench,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"bWo" = (
-/turf/closed/wall/f13/store,
-/area/f13/wasteland)
 "bWr" = (
 /obj/machinery/shower{
 	dir = 4
@@ -2014,19 +1389,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"bWP" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"bXn" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "bYt" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
@@ -2054,22 +1416,6 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"cah" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
-"cat" = (
-/obj/structure/table,
-/obj/item/trash/chips,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "caQ" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -2134,10 +1480,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"ceA" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "ceF" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/blood/radaway,
@@ -2150,43 +1492,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"ceP" = (
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"cfq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"cgd" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/spawner/lootdrop/trash,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"cgh" = (
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"cgJ" = (
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
 "chr" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -2194,19 +1499,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"chE" = (
-/obj/structure/sign/poster/prewar/poster82,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"chR" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"cic" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "ciO" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault)
@@ -2215,12 +1507,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"cjx" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "ckc" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13{
@@ -2241,20 +1527,11 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
-"clG" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "clM" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light/small,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"cmj" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "cmp" = (
 /obj/machinery/light{
 	dir = 8
@@ -2289,25 +1566,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"cmD" = (
-/obj/effect/spawner/lootdrop/armory_contraband,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "cmM" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/bunker)
-"cmX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "cnA" = (
 /obj/structure/cable{
@@ -2321,14 +1585,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
-"cnB" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/mountain_bunker)
 "cnH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2344,10 +1600,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"coE" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "cpp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -2367,12 +1619,6 @@
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"cqF" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "crs" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -2395,36 +1641,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"csm" = (
-/obj/structure/weightlifter,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"csw" = (
-/obj/structure/bookcase/random,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/book/manual/wiki/detective,
-/obj/item/book/manual/wiki/engineering_guide,
-/obj/item/book/manual/random,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"cta" = (
-/obj/structure/sign/poster/prewar/poster88,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"ctp" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/bunker)
-"ctT" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "cub" = (
 /obj/machinery/door/airlock{
 	name = "Vault 223 storage"
@@ -2433,20 +1649,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"cul" = (
-/obj/structure/booth,
-/obj/item/reagent_containers/food/snacks/salad/desertsalad,
-/obj/item/reagent_containers/food/drinks/bottle/brown/green,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"cut" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "cvc" = (
 /obj/structure/closet/crate,
 /turf/open/floor/f13/wood{
@@ -2461,14 +1663,6 @@
 	dir = 4
 	},
 /area/f13/vault)
-"cvA" = (
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "cvG" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/broken{
@@ -2484,20 +1678,6 @@
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
-/area/f13/bunker)
-"cwo" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"cwr" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "cwu" = (
 /obj/structure/cable{
@@ -2524,14 +1704,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"cwC" = (
-/obj/item/shovel/spade,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"cxq" = (
-/obj/structure/debris/v3,
-/turf/open/floor/plating/tunnel,
-/area/f13/underground/cave)
 "cyk" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
@@ -2600,17 +1772,6 @@
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"cBN" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "cCE" = (
 /obj/structure/rack,
 /obj/item/clothing/under/janimaid,
@@ -2638,11 +1799,6 @@
 /obj/structure/chair/stool/retro,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"cEA" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/structure/closet,
-/turf/open/floor/f13,
-/area/f13/city)
 "cEU" = (
 /obj/machinery/light{
 	dir = 8
@@ -2666,17 +1822,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"cGl" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
-"cGz" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/brews,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "cGB" = (
 /obj/effect/decal/cleanable/vomit/old,
 /obj/effect/decal/remains/human,
@@ -2684,11 +1829,6 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker)
-"cHa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "cHe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2699,14 +1839,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"cHM" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "cHO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -2717,18 +1849,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"cHR" = (
-/obj/structure/table/wood/bar,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/f13,
-/area/f13/city)
-"cIc" = (
-/obj/structure/girder/reinforced,
-/obj/structure/sign/poster/ripped,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
 "cIP" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "Turrets";
@@ -2740,22 +1860,6 @@
 /area/f13/bunker)
 "cIT" = (
 /turf/closed/mineral/random/low_chance,
-/area/f13/bunker)
-"cJB" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"cJR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
 /area/f13/bunker)
 "cJY" = (
 /obj/effect/decal/remains/human,
@@ -2799,28 +1903,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"cMX" = (
-/obj/structure/debris/v4,
-/obj/structure/debris/v3,
-/turf/open/floor/plating/tunnel,
-/area/f13/underground/cave)
-"cNi" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"cNm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "cNv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/costume,
@@ -2873,14 +1955,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"cQA" = (
-/obj/machinery/computer/card,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"cQD" = (
-/obj/item/crafting/fuse,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "cQF" = (
 /obj/machinery/shower{
 	dir = 4
@@ -2905,17 +1979,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"cRI" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"cRS" = (
-/obj/structure/closet/crate/secure/loot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "cSA" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light,
@@ -2953,30 +2016,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"cUz" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "cUJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
-"cUS" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	name = "prewar lounge chair"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "cVt" = (
 /obj/machinery/chem_master,
 /obj/machinery/light{
@@ -2998,15 +2043,6 @@
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
-"cXZ" = (
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"cYa" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "cYq" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -3035,17 +2071,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"dac" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "dai" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"daN" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "dbn" = (
 /obj/item/clothing/suit/toggle/lawyer,
 /obj/structure/cable{
@@ -3073,11 +2102,6 @@
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
-/area/f13/bunker)
-"dcV" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "ddk" = (
 /obj/machinery/conveyor/inverted{
@@ -3155,16 +2179,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
-"dgd" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"dgg" = (
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "dgM" = (
 /obj/structure/bookcase,
 /obj/item/book/codex_gigas,
@@ -3202,34 +2216,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker)
-"djc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "djn" = (
 /obj/effect/decal/waste,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
 /area/f13/bunker)
-"djH" = (
-/obj/structure/table,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
-"dkO" = (
-/obj/effect/turf_decal{
-	dir = 5
-	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"dld" = (
-/obj/structure/tires/half,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "dlq" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/blamco/large,
@@ -3263,10 +2255,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"dmL" = (
-/obj/item/flag/legion,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "dmO" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3306,21 +2294,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
-"dox" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
-"doH" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hooded/wintercoat/security,
-/obj/item/storage/backpack/security,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "dqe" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/clothing_middle,
@@ -3347,10 +2320,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"dqy" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "dqK" = (
 /obj/structure/table,
 /obj/machinery/light/broken{
@@ -3360,13 +2329,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"drc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
 "dre" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -3404,28 +2366,10 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"dtV" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"duV" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "dvm" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"dvL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "dwd" = (
 /obj/structure/barricade/bars,
 /obj/structure/spider/stickyweb,
@@ -3438,25 +2382,6 @@
 	icon_state = "plating"
 	},
 /area/space)
-"dwB" = (
-/obj/structure/chair/f13foldupchair,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"dxk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"dxw" = (
-/obj/structure/sign/poster/ripped,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
 "dxB" = (
 /obj/machinery/door/airlock/mining{
 	name = "Casp Bay"
@@ -3469,29 +2394,12 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"dzb" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
-"dzu" = (
-/obj/item/trash/f13/cram_large,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "dzC" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker)
-"dzK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "dAl" = (
 /obj/structure/sign/departments/medbay,
@@ -3502,14 +2410,6 @@
 "dAJ" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/vault)
-"dAX" = (
-/obj/screen,
-/turf/closed/wall/f13/store,
-/area/f13/wasteland)
-"dBd" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "dBr" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
@@ -3588,10 +2488,6 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
-"dCO" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "dCU" = (
 /obj/item/radio/intercom{
 	dir = 4
@@ -3621,11 +2517,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"dFZ" = (
-/obj/structure/booth,
-/obj/item/reagent_containers/food/snacks/salad/ricepudding,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "dGy" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3635,10 +2526,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"dGD" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "dGU" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
@@ -3654,10 +2541,6 @@
 /obj/item/circuitboard/machine/mechfab,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault)
-"dHa" = (
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "dHs" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -3672,15 +2555,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"dHQ" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
 "dHZ" = (
 /obj/structure/rack{
 	dir = 8;
@@ -3718,49 +2592,15 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
-"dJk" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "dJp" = (
 /turf/closed/wall/r_wall/rust,
 /area/space)
-"dJB" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/f13,
-/area/f13/city)
-"dKg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "dKh" = (
 /obj/machinery/conveyor_switch{
 	id = "mining_area"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"dKI" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"dKL" = (
-/obj/structure/chair/bench,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "dKZ" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/radiation,
@@ -3783,15 +2623,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"dMq" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "dNC" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -3799,18 +2630,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/vault)
-"dOn" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/brown/white,
-/obj/item/reagent_containers/food/snacks/burger/superbite,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"dOr" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
 "dOD" = (
 /obj/machinery/light{
 	dir = 8;
@@ -3835,9 +2654,6 @@
 /obj/effect/decal/waste,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"dPt" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/underground/cave)
 "dPu" = (
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -3858,16 +2674,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"dQX" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "dRi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3878,31 +2684,6 @@
 	icon_state = "floorrusty"
 	},
 /area/space)
-"dRj" = (
-/obj/machinery/light/fo13colored/Red{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"dRr" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/curtain,
-/obj/item/stock_parts/cell/ammo/mfc,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
 "dRs" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -3935,19 +2716,6 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/tcoms)
-"dTs" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowsiding"
-	},
-/area/f13/city)
-"dTH" = (
-/obj/structure/table/glass,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "dTR" = (
 /obj/structure/curtain,
 /obj/structure/decoration/vent,
@@ -3970,11 +2738,6 @@
 /obj/structure/sign/departments/botany,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"dUG" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
 "dVh" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/plating/tunnel,
@@ -4090,37 +2853,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"eaG" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/bunker)
 "eaT" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"eco" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"edr" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"edy" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "edG" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
@@ -4128,25 +2865,10 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"edK" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "edM" = (
 /obj/effect/landmark/start/f13/vaultengineer,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
-"edW" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "eej" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/tunnel{
@@ -4169,15 +2891,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"egY" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "ehx" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -4217,14 +2930,6 @@
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"ejq" = (
-/obj/structure/closet/crate/secure/loot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "ejJ" = (
 /obj/machinery/door/window,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -4234,22 +2939,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"eko" = (
-/obj/structure/table/wood/bar,
-/turf/open/floor/f13,
-/area/f13/city)
 "ekr" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/f13{
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"ekw" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
 "ekD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4263,18 +2958,6 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker)
-"eln" = (
-/obj/item/clothing/under/suit/white,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/suit/f13/lonesome{
-	name = "bonnie's duster"
-	},
-/obj/effect/decal/remains/human{
-	name = "bonnie day"
-	},
-/obj/effect/decal/waste,
-/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "elo" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -4291,13 +2974,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"emb" = (
-/obj/item/stack/sheet/mineral/sandbags,
-/obj/item/stack/sheet/mineral/sandbags,
-/obj/item/stack/sheet/mineral/sandbags,
-/obj/item/stack/sheet/mineral/sandbags,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "emC" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -4336,12 +3012,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault)
-"enB" = (
-/obj/structure/table,
-/obj/machinery/door/window/brigdoor/eastright,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "enC" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13{
@@ -4438,21 +3108,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"esV" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/mountain_bunker)
-"ete" = (
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "eub" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -4460,23 +3115,6 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker)
-"evm" = (
-/obj/machinery/light,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"evy" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"evL" = (
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "evR" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
@@ -4491,18 +3129,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
-"ewK" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"ewT" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "exl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4517,31 +3143,10 @@
 	icon_state = "yellowdirtysolid"
 	},
 /area/space)
-"eyl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"ezy" = (
-/obj/machinery/computer/operating,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "eAJ" = (
 /obj/item/clothing/head/helmet/skull,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
-"eAM" = (
-/obj/structure/booth{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"eAZ" = (
-/obj/structure/table,
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
 "eBf" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate,
@@ -4560,10 +3165,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"eCq" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "eCN" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4605,15 +3206,6 @@
 	dir = 1
 	},
 /area/f13/vault)
-"eEc" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"eEu" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/f13,
-/area/f13/city)
 "eET" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -4631,21 +3223,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"eFc" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"eFW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"eGl" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "eHa" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/f13/borscht,
@@ -4680,18 +3257,6 @@
 /obj/item/stack/f13Cash/random/med,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"eHK" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/bunker)
-"eHN" = (
-/obj/structure/booth,
-/obj/item/reagent_containers/food/snacks/burger/fish,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "eIE" = (
 /obj/item/clothing/head/ushanka,
 /obj/item/clothing/head/ushanka,
@@ -4702,47 +3267,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/space)
-"eIM" = (
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/turf_decal/loading_area,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"eIW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
-"eJa" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"eJd" = (
-/obj/structure/chair/f13chair2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"eJr" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "eJz" = (
 /obj/machinery/button/door{
 	id = "stalin";
@@ -4764,12 +3288,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"eJH" = (
-/obj/structure/chair/comfy/lime{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "eJU" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -4797,27 +3315,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"eMT" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"eNr" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"eNO" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/legion)
 "eOg" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -4839,12 +3336,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
-"ePu" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
 "ePz" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -4869,13 +3360,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"eQn" = (
-/obj/structure/booth{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/snacks/salad/ricepork,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "eQq" = (
 /obj/structure/vaultdoor{
 	name = "vault 113 door";
@@ -4887,14 +3371,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"eQx" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "eRb" = (
 /turf/closed/wall/r_wall/f13composite{
 	icon_state = "rubblepillar"
@@ -4907,61 +3383,12 @@
 /obj/machinery/aug_manipulator,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"eRi" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"eRx" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"eRM" = (
-/obj/structure/debris/v3,
-/turf/closed/indestructible/rock,
-/area/f13/underground/cave)
-"eRP" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "eSQ" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
 	},
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg2"
-	},
-/area/f13/bunker)
-"eTe" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
-"eTx" = (
-/obj/structure/nest/ghoul,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"eTU" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/item/reagent_containers/food/snacks/burger/superbite,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"eUH" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
 "eUU" = (
@@ -4990,15 +3417,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"eVK" = (
-/obj/machinery/doorButtons/vaultButton,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"eWf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "eWA" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -5017,21 +3435,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/vault)
-"eWR" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"eWW" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "eXq" = (
 /obj/item/radio/intercom{
 	dir = 4
@@ -5039,11 +3442,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
-/area/f13/bunker)
-"eXQ" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/cans,
-/obj/item/ammo_box/c10mm,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "eXR" = (
 /obj/structure/table/reinforced,
@@ -5053,11 +3451,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"eYD" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "eZg" = (
 /obj/machinery/computer/security/wooden_tv{
 	desc = "";
@@ -5067,31 +3460,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"eZq" = (
-/obj/structure/sign/departments/medbay,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"eZr" = (
-/obj/structure/nest/ghoul,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "eZw" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/wood,
 /area/f13/vault)
-"eZL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	faction = list("bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "eZM" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -5101,17 +3473,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"fay" = (
-/obj/item/flag/ncr,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/ncr)
-"faF" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "faN" = (
 /obj/machinery/shower{
 	pixel_y = 20
@@ -5121,15 +3482,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/tunnel)
-"faQ" = (
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "faV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5153,16 +3505,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"fbz" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/f13,
-/area/f13/wasteland)
-"fbG" = (
-/obj/structure/weightlifter,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "fcb" = (
 /obj/structure/table/wood,
 /obj/item/storage/book,
@@ -5202,11 +3544,6 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"fea" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "feS" = (
 /obj/structure/chair/middle{
 	dir = 1
@@ -5221,14 +3558,6 @@
 	desc = "This is a plaque detailing and honoring the corporate dollars lost creating the vault. All craftsmanship is of the highest quality. The Business men are laughing. The Workers are crying. It menaces with spikes of gold."
 	},
 /area/f13/vault)
-"ffR" = (
-/obj/structure/sign/departments/security,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"fgc" = (
-/obj/structure/fireaxecabinet,
-/turf/closed/wall/mineral/wood,
-/area/f13/city)
 "fgp" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5243,19 +3572,10 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/f13/vault)
-"fgH" = (
-/obj/machinery/computer/upload/ai,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "fhe" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"fhu" = (
-/obj/structure/table,
-/obj/item/coin/diamond,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "fhA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5264,14 +3584,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"fiA" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "fiJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -5304,11 +3616,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
-"fjZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "fke" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13{
@@ -5348,30 +3655,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"fkU" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"flD" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "fnr" = (
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/bunker)
-"fnx" = (
-/obj/structure/stacklifter,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fnD" = (
 /obj/structure/table/reinforced,
@@ -5385,10 +3673,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"fnR" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "fow" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/dandyapples,
@@ -5425,37 +3709,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"fqE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"fqL" = (
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "yellowsiding"
-	},
-/area/f13/city)
-"frh" = (
-/turf/closed/wall/mineral/iron,
-/area/f13/ncr)
-"frk" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "frJ" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/f13/sugarbombs,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/bunker)
-"fsd" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "ftz" = (
 /obj/machinery/door/airlock/freezer,
@@ -5488,30 +3747,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"fuM" = (
-/obj/item/storage/trash_stack,
-/obj/structure/spider/stickyweb,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"fvT" = (
-/obj/structure/timeddoor,
-/turf/closed/wall/f13/tunnel,
-/area/f13/bunker)
 "fvZ" = (
 /obj/structure/sign/departments/custodian,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
 /area/f13/vault)
-"fwe" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "fwn" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -5544,18 +3785,6 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
-"fxF" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"fxL" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Impassable Airlock"
-	},
 /area/f13/bunker)
 "fyg" = (
 /obj/structure/cable{
@@ -5591,9 +3820,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"fzu" = (
-/turf/closed/wall/f13/vault,
-/area/f13/wasteland)
 "fzC" = (
 /obj/structure/rack,
 /obj/machinery/light/broken{
@@ -5622,25 +3848,6 @@
 	icon_state = "grass2"
 	},
 /area/f13/vault)
-"fzW" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"fAu" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"fBP" = (
-/obj/item/crafting/fuse,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"fCG" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "fCL" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -5653,17 +3860,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"fDt" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"fDA" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "fDJ" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /obj/structure/cable{
@@ -5727,19 +3923,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"fHx" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "fHN" = (
 /obj/structure/cable,
 /obj/machinery/light/small/broken,
@@ -5792,14 +3975,6 @@
 	dir = 1
 	},
 /area/f13/vault)
-"fIw" = (
-/obj/structure/rack,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
-"fIy" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "fIK" = (
 /obj/structure/table/wood,
 /obj/item/storage/bag/books,
@@ -5825,12 +4000,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/f13/bunker)
-"fJM" = (
-/obj/structure/chair/right{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "fJN" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -5847,53 +4016,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"fJS" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "fKi" = (
 /obj/structure/weightlifter,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"fKD" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
-	},
-/turf/closed/wall/mineral/iron,
-/area/f13/legion)
-"fMc" = (
-/obj/machinery/door/airlock/public/glass{
-	req_access_txt = "31"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"fMf" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/f13,
-/area/f13/city)
-"fNg" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "fNj" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"fNl" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "fNo" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/lavendergrass{
@@ -5919,35 +4049,15 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/radiation)
-"fNN" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "fPm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/vault)
-"fPp" = (
-/obj/structure/debris/v3,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
 "fPP" = (
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"fQS" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
 "fRk" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall/r_wall/rust,
@@ -5971,25 +4081,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/f13/bunker)
-"fSq" = (
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"fSK" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"fTa" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
 "fTs" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -5997,9 +4088,6 @@
 	},
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
-"fTL" = (
-/turf/closed/wall/mineral/wood,
-/area/f13/legion)
 "fTR" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -6016,10 +4104,6 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker)
-"fUY" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "fVk" = (
 /obj/machinery/door/window{
@@ -6050,11 +4134,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"fWm" = (
-/obj/structure/barricade/bars,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/f13/wasteland)
 "fWt" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/grenade/smokebomb,
@@ -6067,12 +4146,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"fWv" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "fWM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6095,19 +4168,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"fXt" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "fYn" = (
 /obj/structure/table/wood,
 /obj/item/grenade/flashbang,
@@ -6146,26 +4206,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"fZH" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"fZI" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/turf/open/floor/f13,
-/area/f13/city)
-"gaz" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/city)
-"gbt" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/grimy,
-/area/f13/ncr)
 "gco" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -6224,9 +4264,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"gfq" = (
-/turf/closed/wall/f13/vault,
-/area/f13/city)
 "ggf" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -6243,16 +4280,9 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"ggx" = (
-/obj/item/soap/deluxe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
 "ggC" = (
 /obj/effect/decal/remains/human,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
@@ -6274,22 +4304,6 @@
 	dir = 4
 	},
 /area/f13/vault)
-"ghG" = (
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"ghO" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "gia" = (
 /obj/structure/reagent_dispensers/barrel,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -6325,30 +4339,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"gji" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "gkf" = (
 /obj/machinery/door/window/brigdoor/security/cell/northleft{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
-"gkh" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"gku" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "gkv" = (
 /obj/machinery/door/airlock/security{
 	name = "Barracks";
@@ -6408,16 +4404,6 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plating,
 /area/f13/bunker)
-"gnA" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"gnD" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "gnU" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6464,12 +4450,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"gpV" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "gpZ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/three_course_meal,
@@ -6484,12 +4464,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/space)
-"grb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
 "grL" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner{
@@ -6520,10 +4494,6 @@
 /obj/item/storage/box/PDAs,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"gsB" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "gte" = (
 /obj/structure/barricade/sandbags{
 	dir = 8
@@ -6545,25 +4515,6 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"gtZ" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
-"guS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"guY" = (
-/obj/machinery/light/sign/kebab,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "gvl" = (
 /obj/item/clothing/under/patriotsuit,
 /obj/effect/decal/cleanable/cobweb,
@@ -6601,13 +4552,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"gxI" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "gxR" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/plating/tunnel{
@@ -6622,16 +4566,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"gyx" = (
-/obj/structure/chair/left{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"gyL" = (
-/obj/item/trash/can,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "gyP" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -6640,38 +4574,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"gzl" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"gzv" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/item/toy/redbutton{
-	anchored = 1;
-	desc = "A large button which is connected to a mass of wires that snake across the room... can't be good. It was triggered long ago.";
-	name = "Used Detonator"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"gAl" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "gAH" = (
 /obj/machinery/computer/security{
 	network = list("vault")
@@ -6686,13 +4588,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"gAU" = (
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "gAV" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin/construction,
@@ -6705,13 +4600,6 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"gBi" = (
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "gBD" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -30
@@ -6773,45 +4661,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"gEg" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "gEI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"gEW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
-"gFw" = (
-/obj/structure/table,
-/obj/item/trash/candy,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "gGe" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"gHd" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "gHj" = (
 /obj/structure/table/wood/bar,
 /obj/machinery/chem_dispenser/drinks,
@@ -6838,23 +4697,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"gIz" = (
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"gIZ" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
-/obj/machinery/light,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "gJk" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd1";
@@ -6862,15 +4704,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"gKe" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "gKr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/f13composite{
@@ -6892,14 +4725,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"gLt" = (
-/obj/structure/table,
-/obj/item/holosign_creator/security,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "gLD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6929,15 +4754,6 @@
 /obj/item/stamp/denied,
 /turf/open/floor/plasteel/neutral,
 /area/f13/vault)
-"gML" = (
-/obj/structure/bed/mattress/pregame,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"gNm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "gNy" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall/r_wall/f13vault{
@@ -6981,10 +4797,6 @@
 "gPW" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"gPZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/rock,
-/area/f13/underground/cave)
 "gQm" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel{
@@ -7016,12 +4828,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/space)
-"gRw" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "gRF" = (
 /obj/machinery/door/airlock/command{
 	name = "Bot Control";
@@ -7032,15 +4838,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
-"gSh" = (
-/obj/item/candle/tribal_torch,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"gSp" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/unique,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "gSq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -7071,19 +4868,6 @@
 	icon_state = "plating"
 	},
 /area/space)
-"gUc" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "gUu" = (
 /obj/structure/table/glass,
 /obj/item/defibrillator/loaded,
@@ -7103,18 +4887,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/f13/vault)
-"gVP" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"gWk" = (
-/obj/item/rack_parts,
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "gWz" = (
 /obj/machinery/light{
 	dir = 1
@@ -7139,36 +4911,12 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"gZE" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "hah" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/head/f13/gambler,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/bunker)
-"hal" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"hbc" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "hbE" = (
 /obj/structure/table/reinforced,
@@ -7249,20 +4997,6 @@
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
-"hek" = (
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/bunker)
-"hen" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "heK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -7272,24 +5006,6 @@
 "heT" = (
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
-"hgt" = (
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"hgB" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "hgR" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -7298,27 +5014,12 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"hgU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"hhj" = (
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "hhp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"hhU" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "hif" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner,
@@ -7354,14 +5055,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/vault)
-"hkf" = (
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "hkv" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/f13{
@@ -7374,17 +5067,6 @@
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
-/area/f13/bunker)
-"hlv" = (
-/obj/structure/chair/bench,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "hlY" = (
 /obj/structure/window/reinforced{
@@ -7400,10 +5082,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"hmn" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "hmE" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug/coco{
@@ -7416,25 +5094,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"hnc" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"hnd" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "hnk" = (
 /obj/structure/table/wood,
 /obj/item/storage/book/bible,
@@ -7453,24 +5112,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"hnT" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "hnU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria,
-/area/f13/bunker)
-"hoe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
 /area/f13/bunker)
 "hol" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -7514,10 +5159,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"hqq" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "hqs" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/instamash,
@@ -7540,16 +5181,6 @@
 	dir = 1
 	},
 /area/f13/vault)
-"hsa" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"hsk" = (
-/obj/structure/chair/bench,
-/obj/structure,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "hsq" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -7559,20 +5190,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"htp" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
-"htx" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	name = "prewar lounge chair"
-	},
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "huM" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker{
@@ -7581,11 +5198,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/vault)
-"hvv" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "hvB" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -7601,14 +5213,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"hvL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "hwO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line,
@@ -7622,12 +5226,6 @@
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"hyc" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "hys" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
@@ -7643,17 +5241,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"hzn" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
-"hzI" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "hzJ" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
@@ -7682,16 +5269,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/space)
-"hBH" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"hBJ" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "hBK" = (
 /obj/structure/bookcase,
 /obj/structure/window/reinforced/tinted,
@@ -7720,33 +5297,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"hCz" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
 "hCL" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
 /area/f13/radiation)
-"hCQ" = (
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
-"hEu" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
-"hEv" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/cans,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "hEy" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/cram,
@@ -7782,15 +5338,6 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
-"hGd" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "hHm" = (
 /obj/item/gun/ballistic/shotgun/riot,
 /obj/structure/guncase/shotgun,
@@ -7811,13 +5358,6 @@
 /obj/structure/decoration/clock/active,
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
-"hHH" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/ncr)
 "hIF" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/yellow,
@@ -7827,16 +5367,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"hIN" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"hIW" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "hJf" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plasteel/freezer,
@@ -7885,29 +5415,6 @@
 /obj/structure/toilet,
 /turf/open/floor/plasteel/freezer,
 /area/space)
-"hNp" = (
-/obj/structure/vault_door/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/debris/v3,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"hNR" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
-"hOC" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"hOE" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "hOX" = (
 /obj/structure/sink{
 	dir = 4;
@@ -7929,16 +5436,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"hPB" = (
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"hQi" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "hQl" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
@@ -7964,12 +5461,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
-"hQL" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "hQR" = (
@@ -8032,10 +5523,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"hWw" = (
-/obj/item/trash/can,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "hXc" = (
 /obj/structure/toilet{
 	dir = 8
@@ -8048,12 +5535,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
-	},
-/area/f13/bunker)
-"hXs" = (
-/obj/structure/debris/v3,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "hYb" = (
@@ -8083,44 +5564,6 @@
 	icon_state = "plating"
 	},
 /area/space)
-"hYI" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"hYY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
-"hYZ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"hZl" = (
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "25"
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"hZz" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "hZN" = (
 /turf/open/floor/plasteel/caution{
 	dir = 5
@@ -8154,7 +5597,7 @@
 /area/f13/vault)
 "ibz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
@@ -8178,18 +5621,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"icM" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"icS" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "icY" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/darkpurple/side,
@@ -8212,12 +5643,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ifh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
 "ifu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13{
@@ -8234,12 +5659,6 @@
 "igB" = (
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
-"igG" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "igH" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable{
@@ -8269,12 +5688,6 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
-"iiF" = (
-/obj/structure/bed,
-/obj/item/trash/f13/bubblegum,
-/obj/machinery/light/broken,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "iiK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -8293,21 +5706,6 @@
 	icon_state = "rubblepillar"
 	},
 /area/space)
-"ikC" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"ikG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
 "imb" = (
 /obj/machinery/shower{
 	dir = 4
@@ -8316,14 +5714,6 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker)
-"iml" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "imP" = (
 /obj/structure/table/wood,
@@ -8338,11 +5728,6 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker)
-"ioK" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "ipO" = (
 /obj/structure/toilet{
@@ -8383,12 +5768,6 @@
 /obj/effect/landmark/start/f13/vaultsecurityofficer,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"itO" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "iuz" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -8411,13 +5790,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/space)
-"iuM" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy{
-	faction = list("bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "ivo" = (
 /obj/structure/table,
 /obj/item/circular_saw,
@@ -8499,15 +5871,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"iys" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
-"iyZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/bunker)
 "izh" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/bunker)
@@ -8537,28 +5900,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"iBb" = (
-/turf/closed/wall/mineral/wood,
-/area/f13/city)
-"iBt" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "iBQ" = (
 /obj/item/stack/sheet/animalhide/deathclaw,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
-"iCz" = (
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/f13,
-/area/f13/wasteland)
 "iCR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -8590,10 +5935,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
-"iGl" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "iHk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/f13,
@@ -8660,17 +6001,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"iKf" = (
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "yellowsiding"
-	},
-/area/f13/city)
-"iKz" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
-/obj/item/ammo_box/c45,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "iKK" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -8683,36 +6013,9 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"iLC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"iLH" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "iMf" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/r_wall/f13/vault,
-/area/f13/bunker)
-"iNv" = (
-/obj/structure/vault_door/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"iNF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "iOh" = (
 /obj/structure/chair,
@@ -8741,29 +6044,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"iOJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"iOQ" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"iOU" = (
-/mob/living/simple_animal/hostile/supermutant/legendary,
-/turf/open/floor/f13,
-/area/f13/city)
 "iOW" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtysolid"
 	},
 /area/space)
-"iPR" = (
-/obj/structure/simple_door/tent,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "iQc" = (
 /obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
 /obj/structure/closet,
@@ -8778,11 +6063,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
-"iQM" = (
-/obj/structure/table/glass,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/f13,
-/area/f13/city)
 "iRe" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
@@ -8800,11 +6080,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"iRw" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/f13,
-/area/f13/city)
 "iSF" = (
 /obj/machinery/status_display/supply{
 	pixel_y = 32
@@ -8813,51 +6088,15 @@
 	dir = 1
 	},
 /area/f13/vault)
-"iSM" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
-"iSS" = (
-/obj/structure/barricade/bars,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"iTn" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"iTp" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
 "iTE" = (
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
-"iTO" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/obj/item/storage/trash_stack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "iTR" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
 /area/f13/vault)
-"iUy" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/burger/bigbite,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "iVn" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 6;
@@ -8887,12 +6126,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"iXW" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "iYb" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -8913,11 +6146,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/vault)
-"iYs" = (
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/ncr)
 "iYZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8956,14 +6184,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"jaj" = (
-/obj/structure/chair/f13foldupchair,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "jaG" = (
 /obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/cobweb{
@@ -8994,31 +6214,6 @@
 /obj/item/reagent_containers/food/snacks/f13/galette,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
-	},
-/area/f13/bunker)
-"jby" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"jbL" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"jcL" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "jdx" = (
@@ -9065,15 +6260,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"jhU" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "jip" = (
 /obj/structure/rack,
 /obj/machinery/button/door{
@@ -9084,34 +6270,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/vault)
-"jiL" = (
-/mob/living/simple_animal/hostile/handy{
-	faction = list("bonnie")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"jjw" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"jjU" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"jjW" = (
-/obj/machinery/light/fo13colored/Red{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"jkq" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "jkZ" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste,
@@ -9140,10 +6298,6 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
-"jmX" = (
-/obj/structure/sign/poster/prewar/vault_tec,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
 "jnS" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -9152,21 +6306,6 @@
 	icon_state = "yellowdirtysolid"
 	},
 /area/space)
-"joD" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
-"joN" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "jpw" = (
 /obj/structure/rack,
 /obj/item/storage/box/flashbangs,
@@ -9211,15 +6350,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker)
-"jsg" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"jsu" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "jsM" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -9229,30 +6359,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"jta" = (
-/obj/machinery/status_display{
-	desc = "A large glass display, used to show various types of information.";
-	text = "REACTOR FAILURE"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"jtU" = (
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
-"jus" = (
-/obj/structure/debris/v3,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"jut" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "jvp" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -9287,11 +6393,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"jvX" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "jwz" = (
 /obj/effect/decal/remains/human,
 /obj/item/kitchen/fork,
@@ -9308,56 +6409,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jxv" = (
-/obj/effect/turf_decal/box,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"jxX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
 "jyl" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/f13/vault)
-"jyO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "jzn" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/underground/cave)
-"jzK" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "jAa" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
-"jBj" = (
-/obj/structure/booth{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/item/reagent_containers/food/snacks/salad/desertsalad,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"jBs" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "jBD" = (
 /obj/machinery/light{
 	dir = 4
@@ -9374,10 +6436,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"jCG" = (
-/obj/screen,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "jDJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable{
@@ -9453,12 +6511,6 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"jHn" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/beer,
-/obj/item/reagent_containers/food/snacks/burger/superbite,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "jHx" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/floor/plasteel/barber{
@@ -9492,40 +6544,12 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
-"jJC" = (
-/obj/effect/turf_decal/bot,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"jKp" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/brown/beer,
-/obj/item/reagent_containers/food/snacks/burger/superbite,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"jLc" = (
-/obj/effect/turf_decal/loading_area/white{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "jLk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/tunnel)
-"jMj" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "jMv" = (
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/f13/wood,
@@ -9537,25 +6561,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"jMW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/bunker)
 "jNk" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
-"jNo" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	name = "prewar lounge chair"
-	},
-/obj/item/target/clown,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "jNI" = (
 /obj/structure/window/reinforced{
 	color = "#000000";
@@ -9642,11 +6653,6 @@
 	dir = 4
 	},
 /area/f13/vault)
-"jPD" = (
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "jPK" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
@@ -9670,14 +6676,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jPY" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "jQh" = (
 /obj/machinery/conveyor{
 	dir = 9;
@@ -9720,17 +6718,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"jRw" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "NCR No Mans Land Entrance";
-	req_access = null;
-	req_access_txt = "121"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/ncr)
 "jSG" = (
 /obj/effect/decal/waste,
 /obj/structure/reagent_dispensers/barrel/four,
@@ -9742,17 +6729,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"jTn" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"jTO" = (
-/obj/structure/campfire/barrel,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "jUA" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/barber{
@@ -9774,10 +6750,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/space)
-"jUR" = (
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "jUT" = (
 /obj/item/radio/intercom{
 	dir = 4
@@ -9834,15 +6806,6 @@
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"jXW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "jYg" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -9870,12 +6833,6 @@
 	icon_state = "plating"
 	},
 /area/space)
-"jZE" = (
-/obj/structure/timeddoor,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
 "jZI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9884,16 +6841,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"jZL" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "jZN" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/barber{
@@ -9956,30 +6903,9 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"kcJ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "kcN" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"kcS" = (
-/obj/item/trash/can,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"keh" = (
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "keC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -9989,31 +6915,16 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/tunnel)
-"keL" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "kfq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"kfI" = (
-/obj/structure/punching_bag,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "kfJ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"kfZ" = (
-/obj/machinery/light/fo13colored/Red{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "kgh" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -10025,23 +6936,6 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
-"kiR" = (
-/obj/structure/table/wood/bar,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/turf/open/floor/f13,
-/area/f13/city)
-"kje" = (
-/obj/machinery/status_display{
-	desc = "A large glass display, used to show various types of information.";
-	text = "E__RORORORoOOOoRRR"
-	},
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"kjH" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "kjM" = (
 /obj/machinery/conveyor/inverted,
 /obj/effect/turf_decal/stripes/line{
@@ -10053,10 +6947,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"kkf" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "kkC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10074,12 +6964,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/tunnel)
-"kkI" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/underground/cave)
 "kkJ" = (
 /obj/structure/table,
 /obj/item/scalpel,
@@ -10088,13 +6972,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
-"kkR" = (
-/obj/structure/table/reinforced,
-/obj/item/stock_parts/cell/ammo/mfc,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "klX" = (
@@ -10148,20 +7025,6 @@
 /obj/machinery/mineral/processing_unit_console,
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
-"knQ" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"knZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button{
-	id = bonnie
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "koh" = (
 /turf/closed/indestructible/rock,
 /area/f13/bunker)
@@ -10179,54 +7042,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"koy" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"koD" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"koZ" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"kpM" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
-"kqg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "kqn" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"kqy" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "krK" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -10245,14 +7064,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
-/area/f13/bunker)
-"kst" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "ksu" = (
 /obj/structure/closet/crate{
@@ -10318,25 +7129,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"kuY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"kuZ" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"kve" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "kvA" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/caution{
@@ -10370,39 +7162,6 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
-"kyR" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"kzj" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"kAE" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/wall/f13/store,
-/area/f13/underground/cave)
-"kAQ" = (
-/obj/structure/table,
-/obj/item/pen/fourcolor,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"kBx" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "kBU" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -10423,11 +7182,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"kCA" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "kCB" = (
 /obj/item/detective_scanner,
 /obj/structure/closet,
@@ -10556,37 +7310,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"kJq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "kKj" = (
 /obj/machinery/computer/robotics{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"kKF" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowbroken"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "kLr" = (
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
-"kMC" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"kMG" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "kMR" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -10614,23 +7346,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"kNg" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "Legion"
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/legion)
-"kNm" = (
-/obj/structure/tires/half,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "kNp" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -10660,12 +7375,6 @@
 	icon_state = "plating"
 	},
 /area/space)
-"kOB" = (
-/obj/machinery/autolathe/ammo,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "kOH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
@@ -10697,26 +7406,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"kQq" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "bonnief3"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"kQs" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "68";
-	req_one_access_txt = "68"
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "kQV" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
@@ -10733,14 +7422,6 @@
 "kRy" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"kRM" = (
-/obj/structure/spider/stickyweb,
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "kSv" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -10749,10 +7430,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"kSM" = (
-/obj/effect/turf_decal/arrows,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "kTb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mechanic,
@@ -10779,12 +7456,6 @@
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
-"kUq" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "kUP" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks,
@@ -10793,13 +7464,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
-"kVn" = (
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "kVE" = (
 /obj/effect/landmark/start/f13/vaultscientist,
 /obj/structure/cable{
@@ -10830,14 +7494,6 @@
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
-"kWZ" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"kXl" = (
-/mob/living/simple_animal/hostile/supermutant/legendary,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "kYb" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light{
@@ -10851,25 +7507,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"kYG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "kZg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"kZY" = (
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "lah" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/cleanable/dirt,
@@ -10879,8 +7522,8 @@
 /area/f13/tunnel)
 "laJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/unique,
 /obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -10904,17 +7547,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"lcs" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"lea" = (
-/obj/structure/chair/bench,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "led" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -11045,10 +7677,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/f13/bunker)
-"lhN" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/wood/f13/old,
-/area/f13/ncr)
 "liq" = (
 /obj/structure/sign/departments/botany,
 /turf/closed/wall/r_wall/f13/vault,
@@ -11078,19 +7706,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"ljI" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"ljX" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "lkx" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -11100,11 +7715,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/f13/bunker)
-"lkO" = (
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/legion)
 "lmc" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/meson/engine,
@@ -11113,41 +7723,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"lmg" = (
-/obj/structure/vault_door/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"lmn" = (
-/obj/structure/wreck/trash/three_barrels,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"loO" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/f13/ncr)
-"lpD" = (
-/obj/structure/tires/five,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"lqq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/debris/v3,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"lqB" = (
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "lqH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -11157,14 +7732,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"lqS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "lqY" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/f13/wood{
@@ -11213,11 +7780,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"lte" = (
-/obj/structure/debris/v4,
-/obj/structure/debris/v3,
-/turf/closed/indestructible/rock,
-/area/f13/underground/cave)
 "ltA" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -11228,14 +7790,6 @@
 "luk" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/underground/cave)
-"luy" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "luH" = (
 /obj/effect/turf_decal/stripes/red/full,
 /obj/structure/guncase,
@@ -11299,25 +7853,10 @@
 /obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
-"lyX" = (
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "lzE" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/freezer,
 /area/space)
-"lAg" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	name = "prewar lounge chair"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "lAq" = (
 /obj/structure/window/reinforced/spawner,
 /obj/item/stack/sheet/mineral/uranium{
@@ -11338,42 +7877,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"lCk" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"lCl" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"lCA" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"lCC" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"lDz" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
-	},
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
 "lDQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder/reinforced,
@@ -11381,17 +7884,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"lDR" = (
-/obj/machinery/status_display{
-	desc = "A large glass display, used to show various types of information.";
-	text = "WARNING!!"
-	},
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"lEG" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "lFA" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/gloves/f13/leather,
@@ -11422,12 +7914,6 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
-"lHb" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "lHp" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/blood/old,
@@ -11439,23 +7925,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"lHF" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/crafts,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"lHG" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
-	},
-/turf/closed/wall/mineral/wood,
-/area/f13/legion)
-"lIE" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "lJj" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -11464,14 +7933,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"lKx" = (
-/mob/living/simple_animal/hostile/handy{
-	faction = list("bonnie")
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "lKA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -11488,20 +7949,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
-	},
-/area/f13/bunker)
-"lLw" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/city)
-"lMi" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "lMC" = (
@@ -11536,10 +7983,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"lNk" = (
-/obj/structure/wreck/car,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "lNE" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/building)
@@ -11551,21 +7994,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
-"lOc" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/f13,
-/area/f13/city)
-"lOD" = (
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "lPy" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -11594,26 +8022,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"lQk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/bunker)
-"lQE" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"lQS" = (
-/obj/structure/sign/departments/chemistry,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
 "lQZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -11626,10 +8034,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"lRo" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "lRI" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -11638,20 +8042,6 @@
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"lSJ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	dir = 1;
-	icon_state = "yellowsiding"
-	},
-/area/f13/city)
-"lTu" = (
-/obj/structure/mirror,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
 "lTw" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/barber{
@@ -11666,11 +8056,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
-	},
-/area/f13/bunker)
-"lVg" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "lVp" = (
@@ -11703,22 +8088,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"lWx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
-"lWY" = (
-/obj/structure/timeddoor,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
-"lXh" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "lXR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility/full/engi,
@@ -11726,12 +8095,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"lXU" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "lXW" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
@@ -11763,15 +8126,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"maf" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/trophy/bronze_cup,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "man" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11828,12 +8182,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
-"mcw" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "mcE" = (
 /mob/living/simple_animal/hostile/giantant{
 	mob_size = 3;
@@ -11868,20 +8216,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/space)
-"mfu" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "mfA" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/f13/power_armor/excavator,
 /obj/item/clothing/head/helmet/f13/power_armor/excavator,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"mfN" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/f13/tunnel,
-/area/f13/bunker)
 "mgb" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/f13/wood{
@@ -11924,13 +8264,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"mhs" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "mib" = (
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/plating/tunnel{
@@ -11954,35 +8287,9 @@
 	},
 /turf/open/floor/carpet/black,
 /area/space)
-"miT" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"mje" = (
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"mjf" = (
-/obj/structure/campfire/barrel,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "mjg" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"mjh" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "mjL" = (
 /obj/machinery/door/poddoor/shutters{
@@ -12042,42 +8349,12 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
-"mnc" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "mno" = (
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
 /area/space)
-"mnt" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"mnw" = (
-/obj/structure/sign/poster/contraband/smoke,
-/turf/closed/wall/mineral/wood,
-/area/f13/city)
-"mnx" = (
-/obj/structure/chair/f13chair2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "mnC" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/tunnel,
@@ -12096,17 +8373,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"moI" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"mpI" = (
-/obj/structure/debris/v3,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "mpJ" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/f13{
@@ -12218,11 +8484,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
-"mtz" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "mtB" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13{
@@ -12260,13 +8521,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
-"mvQ" = (
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "mvR" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -12280,12 +8534,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"mwd" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "mwr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12352,37 +8600,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"mzD" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"mzF" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"mzY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"mAu" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"mAB" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
 "mAN" = (
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
@@ -12397,18 +8614,6 @@
 	icon_state = "plating"
 	},
 /area/space)
-"mBc" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "mCu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12426,16 +8631,6 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
-	},
-/area/f13/bunker)
-"mDq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
 "mDr" = (
@@ -12466,13 +8661,6 @@
 	dir = 1
 	},
 /area/f13/vault)
-"mFN" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "mFO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -12494,13 +8682,6 @@
 	dir = 1
 	},
 /area/f13/vault)
-"mGr" = (
-/turf/closed/wall/f13/store,
-/area/f13/mountain_bunker)
-"mGs" = (
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "mGu" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -12525,15 +8706,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"mHc" = (
-/obj/structure/chair/bench,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "mHf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12543,18 +8715,6 @@
 	dir = 6
 	},
 /area/f13/vault)
-"mIm" = (
-/obj/structure/table,
-/obj/item/ship_in_a_bottle,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
-"mII" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "mIJ" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -12564,10 +8724,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"mIX" = (
-/obj/structure/window/fulltile/ruins,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "mJe" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
@@ -12612,14 +8768,6 @@
 "mKW" = (
 /turf/open/floor/wood,
 /area/f13/vault)
-"mLm" = (
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "mLP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12629,18 +8777,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
-"mLV" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"mMo" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"mMt" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "mML" = (
 /obj/machinery/conveyor{
 	dir = 5;
@@ -12655,11 +8791,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
-"mMQ" = (
-/obj/structure/rack,
-/obj/item/stack/medical/gauze/cyborg,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "mNt" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -12669,13 +8800,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
-"mNx" = (
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "mNE" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/barber{
@@ -12705,15 +8829,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"mPi" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "mPq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -12721,35 +8836,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/vault)
-"mPu" = (
-/obj/structure/debris/v3,
-/turf/closed/indestructible/rock,
-/area/f13/bunker)
-"mPD" = (
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"mPS" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/turf/open/floor/f13,
-/area/f13/city)
-"mPU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"mQo" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "mQv" = (
 /obj/structure/sink{
 	dir = 4;
@@ -12758,23 +8844,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
-"mQP" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "mRj" = (
@@ -12849,11 +8918,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"mTc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "mTt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12866,15 +8930,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"mTD" = (
-/obj/structure/debris/v3,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"mTE" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "mTG" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/tunnel{
@@ -12888,25 +8943,10 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/radiation)
-"mUY" = (
-/obj/structure/wreck/car,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "mVq" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
-	},
-/area/f13/bunker)
-"mVP" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "mWs" = (
@@ -12918,10 +8958,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
-"mYn" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "mYL" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/tunnel{
@@ -12941,48 +8977,16 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"naG" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "naO" = (
 /obj/structure/simple_door/house,
 /turf/closed/mineral/random/low_chance,
 /area/f13/underground/cave)
-"nbt" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"nbx" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
 "nbF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
-"nbO" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/trophy/silver_cup,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "nbW" = (
 /obj/structure/rack,
 /obj/item/pen,
@@ -13003,43 +9007,10 @@
 /obj/structure/mirror,
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
-"ncR" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/obj/structure/decoration/vent,
-/obj/item/soap,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/bunker)
-"ndh" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"nee" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "nfs" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"ngJ" = (
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "nhA" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Research Storage";
@@ -13068,23 +9039,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"njj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"njS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"nkn" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "nkK" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -13148,34 +9102,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"nmS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"nnF" = (
-/obj/structure/mirror,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"nnG" = (
-/obj/structure/closet/crate/bin,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "nnW" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
-"noe" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"nom" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
 /area/f13/bunker)
 "noS" = (
 /obj/structure/decoration/hatch{
@@ -13187,27 +9116,6 @@
 /obj/effect/decal/waste,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"npF" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"npR" = (
-/obj/structure/table/wood/bar,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/f13,
-/area/f13/city)
 "nqg" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13{
@@ -13220,20 +9128,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"nqm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"nqF" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "nqG" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -13249,16 +9143,6 @@
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"nqY" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "nre" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -13282,10 +9166,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
-/area/f13/bunker)
-"nsX" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "nsZ" = (
 /obj/machinery/light,
@@ -13320,11 +9200,6 @@
 /obj/item/storage/fancy/rollingpapers,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"nui" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "nuq" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13{
@@ -13337,13 +9212,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"nvk" = (
-/obj/effect/turf_decal/box,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "nvz" = (
 /obj/structure/flora/ausbushes,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -13411,36 +9279,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
-"nyV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
-"nzD" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13,
-/area/f13/city)
-"nzE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/debris/v3,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"nzJ" = (
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 8;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "nzU" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13{
@@ -13453,26 +9291,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"nAh" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "nAA" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"nAB" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/crafts,
-/obj/effect/spawner/lootdrop/crafts,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "nBk" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/apron/chef,
@@ -13510,17 +9334,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"nCM" = (
-/obj/machinery/vending/nukacolavend,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"nCU" = (
-/obj/structure/tires/half,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "nDB" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -13598,16 +9411,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"nGv" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "nGI" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/barber{
@@ -13621,12 +9424,6 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"nHH" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "nIB" = (
 /obj/item/radio/intercom{
 	dir = 4
@@ -13652,13 +9449,6 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"nJB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	faction = list("bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "nJR" = (
 /obj/machinery/computer/security{
 	network = list("vault")
@@ -13672,20 +9462,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"nKh" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"nKs" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "nKv" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -13697,19 +9473,6 @@
 "nKy" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"nKH" = (
-/obj/structure/closet/fridge/meat,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"nLN" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "nLZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13719,23 +9482,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"nMM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"nMR" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/supermutant/legendary,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "nNi" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/cleanable/greenglow,
@@ -13748,17 +9494,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/bunker)
-"nNv" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "bonnief2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"nOd" = (
-/obj/structure/debris/v3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
 "nOi" = (
 /obj/item/am_containment,
 /obj/effect/turf_decal/stripes/corner{
@@ -13793,10 +9528,6 @@
 /obj/item/stack/sheet/plasteel/twenty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
-"nPi" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "nPp" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
@@ -13822,27 +9553,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"nQa" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "nQe" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/vault)
-"nQB" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "nRJ" = (
 /obj/structure/fence{
 	icon_state = "metal_fence3"
@@ -13874,14 +9590,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"nST" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "nSY" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
@@ -13921,43 +9629,6 @@
 /obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"nXx" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"nXV" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"nXX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "bonnief2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"nYn" = (
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	faction = list("bonnie")
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"nYo" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "nYB" = (
 /obj/structure/table/wood,
 /obj/item/crafting/bulb,
@@ -13969,20 +9640,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"nZa" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/item/stock_parts/cell/ammo/mfc,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "nZb" = (
 /obj/structure/wreck/trash/secway,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"nZh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "nZl" = (
 /obj/structure/chair{
 	dir = 8
@@ -14060,13 +9721,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"ocJ" = (
-/obj/structure/chair/right{
-	dir = 4
-	},
-/obj/item/target/alien,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "ocL" = (
 /obj/structure/sign/poster/prewar/corporate_espionage,
 /turf/closed/wall/r_wall/f13vault{
@@ -14085,10 +9739,6 @@
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"odo" = (
-/obj/structure/chair/bench,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "odp" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/barber{
@@ -14106,15 +9756,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"oeR" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "ofh" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -14142,24 +9783,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"ofX" = (
-/obj/item/target/syndicate,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"ofY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"ogp" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/f13,
-/area/f13/wasteland)
 "ogw" = (
 /obj/structure/rack,
 /obj/item/crafting/large_gear,
@@ -14183,9 +9806,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"ogO" = (
-/turf/open/floor/wood/f13/old,
-/area/f13/ncr)
 "ogQ" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -14233,21 +9853,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"ojc" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "yellowsiding"
-	},
-/area/f13/city)
-"ojn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "ojG" = (
 /obj/structure/sign/directions/science{
 	dir = 4;
@@ -14257,11 +9862,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
-/area/f13/bunker)
-"okx" = (
-/obj/machinery/light/broken,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
 /area/f13/bunker)
 "oky" = (
 /obj/structure/simple_door/wood,
@@ -14285,12 +9885,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"olP" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/mountain_bunker)
 "oma" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14303,12 +9897,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"omv" = (
-/turf/open/floor/f13{
-	dir = 9;
-	icon_state = "yellowsiding"
-	},
-/area/f13/city)
 "omC" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
@@ -14326,44 +9914,6 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
-"ono" = (
-/obj/machinery/light/fo13colored/Red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"onY" = (
-/obj/item/ammo_box/c9mm,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
-"ooP" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"opn" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
-"opq" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"oqd" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/ncr)
 "oqf" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/combat,
@@ -14372,15 +9922,6 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker)
-"orn" = (
-/obj/machinery/door/poddoor/preopen{
-	id = bonnie
-	},
-/obj/effect/turf_decal/loading_area/white{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "orV" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -14405,21 +9946,6 @@
 "osK" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
-"otV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"otX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "oub" = (
 /obj/machinery/light{
 	dir = 4
@@ -14439,18 +9965,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ouE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
 "ouI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -14555,34 +10069,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
-"ozV" = (
-/obj/structure/timeddoor/sixtyminute,
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/indestructible/rock,
-/area/f13/underground/cave)
-"oAF" = (
-/obj/item/trash/f13/dandyapples,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
-"oBS" = (
-/obj/structure/booth{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/snacks/salad/desertsalad,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"oCz" = (
-/obj/structure/chair/comfy/lime{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "oDj" = (
 /obj/item/clothing/under/f13/vault{
 	desc = "A blue jumpsuit with a yellow vault pattern and the number 223 printed on it.";
@@ -14603,12 +10089,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"oEC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "oFE" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -14617,24 +10097,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"oFM" = (
-/obj/structure/sign/poster/prewar/poster91,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"oFW" = (
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
-"oGi" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"oGF" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "oGQ" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/uranium{
@@ -14666,11 +10128,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"oHK" = (
-/obj/structure/closet/fridge/standard,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "oHS" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/autolathe/constructionlathe,
@@ -14687,9 +10144,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"oJn" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/ncr)
 "oJF" = (
 /obj/item/candle/tribal_torch,
 /obj/effect/decal/cleanable/blood/old{
@@ -14710,29 +10164,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
-/area/f13/bunker)
-"oKg" = (
-/obj/effect/turf_decal{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"oKT" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"oLv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/waste,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"oNr" = (
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "oNI" = (
 /obj/structure/closet/crate/wooden,
@@ -14764,53 +10195,11 @@
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/freezer,
 /area/space)
-"oPz" = (
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
-"oPG" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"oPP" = (
-/obj/structure/debris/v4,
-/turf/open/floor/plating/tunnel,
-/area/f13/underground/cave)
-"oQU" = (
-/obj/structure/table/glass,
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "oRq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/cafeteria,
-/area/f13/bunker)
-"oRF" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"oSx" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
-"oST" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "oTJ" = (
 /obj/structure/cable{
@@ -14833,25 +10222,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"oTT" = (
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "oUH" = (
 /obj/structure/table,
 /obj/item/integrated_circuit_printer,
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
-"oVk" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "oVD" = (
 /obj/structure/table/wood,
 /obj/item/crafting/board,
@@ -14866,14 +10241,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/f13/bunker)
-"oWH" = (
-/obj/structure/booth{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/item/reagent_containers/food/snacks/salad/oatmeal,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "oWN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -14883,10 +10250,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
-"oWZ" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "oXi" = (
 /obj/item/storage/wallet/random,
 /obj/structure/table,
@@ -14924,24 +10287,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"oZl" = (
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
-"oZn" = (
-/obj/structure/spider/stickyweb,
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"oZH" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "oZQ" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/light/small{
@@ -14980,22 +10325,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"pcf" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "pcr" = (
 /obj/structure/chair/stool,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"pdk" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "pdp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15007,48 +10340,16 @@
 	icon_state = "floorrusty"
 	},
 /area/space)
-"pdP" = (
-/obj/structure/table,
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	faction = list("bonnie")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "pdR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"pdT" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"pdW" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/ncr)
-"peo" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "per" = (
 /obj/structure/bed,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
 /area/f13/bunker)
-"pes" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/mineral/random/low_chance,
-/area/f13/underground/cave)
 "pet" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -15071,21 +10372,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
-"pfI" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"pgi" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"pgX" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "phj" = (
 /obj/structure/window/spawner/east,
 /obj/structure/window/spawner/north,
@@ -15100,27 +10386,12 @@
 	icon_state = "grass2"
 	},
 /area/f13/vault)
-"phu" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"pih" = (
-/obj/structure/table/wood/bar,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13,
-/area/f13/city)
 "pix" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"pjL" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "pjP" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -15151,20 +10422,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"pkP" = (
-/obj/structure,
-/turf/closed/wall/mineral/wood,
-/area/f13/city)
 "pkU" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker)
-"plc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "plg" = (
 /obj/structure/spider/stickyweb,
@@ -15179,13 +10442,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"pll" = (
-/obj/structure/chair/bench,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "plr" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
@@ -15195,18 +10451,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"pls" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"plZ" = (
-/obj/structure/table,
-/obj/item/dice/d100,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "pmp" = (
 /obj/structure/simple_door/house{
 	icon_state = "room"
@@ -15214,16 +10458,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"pmw" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/obj/structure/curtain{
-	color = "red"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "pmE" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/barber{
@@ -15234,24 +10468,10 @@
 /obj/structure/mirror,
 /turf/closed/wall/r_wall/rust,
 /area/space)
-"pmT" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"pnq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "pnz" = (
 /obj/structure/sink,
 /turf/open/floor/plasteel/freezer,
 /area/space)
-"pnY" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "pnZ" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/broken{
@@ -15281,24 +10501,6 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"poS" = (
-/obj/item/rack_parts,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/item/ammo_box/a357box,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"poW" = (
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "ppl" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/structure/timeddoor,
@@ -15340,12 +10542,6 @@
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
-/area/f13/bunker)
-"pst" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/granter/crafting_recipe/gunsmith_one,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "psy" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -15402,27 +10598,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"pua" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"pug" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/bunker)
 "puo" = (
 /obj/structure/sink{
 	dir = 4;
@@ -15436,22 +10611,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault)
-"pup" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "BOS"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
-"puP" = (
-/obj/structure/chair/bench,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "pvc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -15527,13 +10686,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"pyT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "pzq" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -15543,21 +10695,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
-"pzP" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"pAj" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "pAm" = (
 /obj/structure/table,
 /obj/machinery/light/fo13colored/Aqua{
@@ -15571,22 +10708,6 @@
 /obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"pAu" = (
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/structure/table,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"pAw" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"pBb" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "pBf" = (
 /obj/item/bedsheet/qm,
 /obj/structure/bed,
@@ -15594,12 +10715,6 @@
 	dir = 9
 	},
 /area/f13/vault)
-"pBu" = (
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "pBP" = (
 /obj/item/grown/nettle/basic{
 	name = "Kuzudu"
@@ -15608,11 +10723,6 @@
 	icon_state = "floorrusty"
 	},
 /area/space)
-"pCm" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "pCA" = (
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
@@ -15634,72 +10744,13 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"pDb" = (
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/structure/closet,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"pDj" = (
-/obj/structure/sign/departments/examroom,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"pDs" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"pDu" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"pDZ" = (
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
 "pEA" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/caution,
 /area/f13/vault)
-"pFk" = (
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"pFp" = (
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "pFL" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"pGC" = (
-/obj/structure/table,
-/obj/item/crafting/fuse,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"pGL" = (
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "pGP" = (
 /obj/machinery/light/small{
@@ -15717,12 +10768,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
-"pHx" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "pIa" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/f13{
@@ -15751,9 +10796,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"pJP" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "pKG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15762,17 +10804,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"pKM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"pLV" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "pMg" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -15790,10 +10821,6 @@
 /obj/item/stock_parts/cell/ammo/mfc,
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/vault)
-"pMR" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
 "pMT" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/plasteel/barber{
@@ -15801,13 +10828,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"pNO" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "pOK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15857,14 +10877,6 @@
 	icon_state = "yellowdirtysolid"
 	},
 /area/space)
-"pRH" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "pSi" = (
 /obj/item/clothing/under/f13/rag,
 /turf/open/floor/plating,
@@ -15879,15 +10891,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
-"pSp" = (
-/obj/structure/wreck/trash/two_barrels,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "pSK" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -15895,26 +10898,10 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"pTk" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/salad/validsalad,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"pUe" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "pVj" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"pVE" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "pVH" = (
 /obj/structure/bed,
 /obj/structure/cable{
@@ -15948,15 +10935,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"pWl" = (
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	faction = list("bonnie")
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "pXf" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
@@ -15964,17 +10942,6 @@
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
-/area/f13/bunker)
-"pXR" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "pYa" = (
 /obj/effect/landmark/start/f13/overseer,
@@ -15987,10 +10954,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"pYs" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "pYQ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16004,10 +10967,6 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/bunker)
-"pYY" = (
-/obj/structure/sign/poster/prewar/poster90,
-/turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "qan" = (
 /obj/structure/sign/poster/official/help_others,
@@ -16023,15 +10982,6 @@
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
-"qbI" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "qbU" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -16040,18 +10990,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/bunker)
-"qbV" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
-"qce" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "qcZ" = (
 /obj/structure/rack{
@@ -16073,18 +11011,10 @@
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
-"qdl" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "qdv" = (
 /mob/living/simple_animal/hostile/giantant,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
-"qdz" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "qdC" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/fullgrass{
@@ -16123,13 +11053,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"qhn" = (
-/turf/open/floor/f13,
-/area/f13/city)
 "qhp" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "qhq" = (
@@ -16141,20 +11068,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"qhB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"qiJ" = (
-/obj/structure/nest/ghoul,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
 "qiN" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -16165,12 +11078,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"qiO" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "qjn" = (
 /obj/structure/chair{
 	dir = 4
@@ -16179,10 +11086,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"qjq" = (
-/obj/structure/car/rubbish1,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "qkv" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -16226,11 +11129,6 @@
 	icon_state = "floorrusty"
 	},
 /area/space)
-"qms" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "qmy" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/waffles,
@@ -16248,10 +11146,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"qnn" = (
-/obj/structure/car/rubbish1,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "qof" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16273,19 +11167,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/bunker)
-"qoP" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"qpm" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
 /area/f13/bunker)
 "qqJ" = (
 /obj/structure/rack,
@@ -16361,17 +11242,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"qtQ" = (
-/obj/structure/debris/v3,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"qva" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
 "qvb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16391,21 +11261,6 @@
 "qvG" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
-"qvP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"qvY" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "qwn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16417,21 +11272,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"qwH" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "qxa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16463,19 +11303,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"qya" = (
-/obj/structure/showcase/machinery/tv,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"qyn" = (
-/mob/living/simple_animal/hostile/deathclaw/legendary,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "qyv" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bowl,
@@ -16489,19 +11316,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
-"qyV" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "qzz" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
@@ -16516,13 +11330,6 @@
 	icon_state = "grass2"
 	},
 /area/f13/bunker)
-"qzF" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "qzW" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/f13{
@@ -16534,24 +11341,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"qAg" = (
-/obj/structure/chalkboard,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"qBq" = (
-/obj/structure/tires/half,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
-"qBA" = (
-/obj/machinery/door/poddoor/shutters{
-	name = "gate shutters"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "qBS" = (
 /obj/structure/bodycontainer/crematorium{
 	id = 700
@@ -16631,12 +11420,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"qGo" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
 "qGq" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -16644,13 +11427,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/radiation)
-"qGr" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "qGR" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13/wood{
@@ -16668,11 +11444,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"qII" = (
-/obj/structure/bed/mattress/pregame,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "qIP" = (
 /obj/structure/table/wood,
 /obj/machinery/light/broken,
@@ -16680,33 +11451,11 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"qJw" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/grimy,
-/area/f13/ncr)
-"qJH" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"qKG" = (
-/obj/item/target/alien,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "qKP" = (
 /obj/effect/decal/waste,
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"qKT" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "qLP" = (
 /obj/machinery/door/window/brigdoor/security/cell/northleft{
@@ -16773,12 +11522,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
-"qPT" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "qPU" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -16789,35 +11532,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"qQc" = (
-/turf/open/floor/plasteel/grimy,
-/area/f13/ncr)
-"qQJ" = (
-/obj/structure/chair/bench,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "qQK" = (
 /obj/structure/musician/piano{
 	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
-	},
-/area/f13/bunker)
-"qQQ" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
 "qRI" = (
@@ -16876,38 +11596,12 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
-"qVp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"qVs" = (
-/obj/effect/turf_decal,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"qVF" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "qVM" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
 /area/f13/vault)
-"qVQ" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/mountain_bunker)
 "qWe" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/dirt,
@@ -16951,19 +11645,6 @@
 "qWq" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"qWR" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/underground/cave)
-"qWS" = (
-/obj/effect/turf_decal/loading_area/white{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/bunker)
 "qWZ" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/dark,
@@ -16972,18 +11653,9 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"qXG" = (
-/obj/structure/debris/v3,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "qYk" = (
 /obj/structure/timeddoor,
 /turf/closed/mineral/random/low_chance,
-/area/f13/bunker)
-"qYm" = (
-/obj/structure/debris/v4,
-/obj/structure/debris/v3,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "qZR" = (
 /obj/structure/reagent_dispensers/barrel/four,
@@ -17026,35 +11698,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"rbh" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "rbn" = (
 /obj/structure/sign/poster/official/report_crimes,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
 /area/f13/vault)
-"rbF" = (
-/obj/effect/turf_decal/delivery,
-/obj/item/soap/deluxe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
-"rbT" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"rca" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "rcB" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -17079,11 +11728,6 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
-"reY" = (
-/obj/item/trash/f13/cram,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "rfn" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -17099,9 +11743,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"rfE" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/city)
 "rgv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -17115,11 +11756,6 @@
 /obj/item/reagent_containers/food/condiment/yeast,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
-"rhd" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "rhl" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17143,28 +11779,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"rhR" = (
-/obj/item/rack_parts,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/ammo_box/a762box,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"rir" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"riZ" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
 "rjk" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd2";
@@ -17182,18 +11796,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"rka" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
-"rkB" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "rkE" = (
 /obj/machinery/light{
 	dir = 8;
@@ -17241,12 +11843,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"rnd" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "rnl" = (
 /obj/structure/closet/crate/bin,
 /obj/item/reagent_containers/pill/patch/jet,
@@ -17271,12 +11867,6 @@
 "rog" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"roX" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "rpl" = (
 /obj/structure/sign/poster/prewar/protectron,
 /turf/closed/wall/r_wall/f13vault{
@@ -17293,16 +11883,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"rpV" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
-"rqp" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/bunker)
 "rqq" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -17341,19 +11921,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"rrL" = (
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"rrO" = (
-/obj/structure/dresser,
-/obj/item/stack/medical/gauze/cyborg,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "rrS" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -17374,15 +11941,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"rso" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"rsv" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "rsJ" = (
 /obj/structure/simple_door/bunker,
 /obj/machinery/door/poddoor/shutters{
@@ -17393,47 +11951,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"rtb" = (
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"rto" = (
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "rtx" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"rtW" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"ruq" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"ruw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "ruy" = (
 /obj/machinery/shower{
 	dir = 4
@@ -17444,16 +11967,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"ruE" = (
-/obj/structure/booth,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/mountain_bunker)
-"ruP" = (
-/obj/structure/flora/tree/tall,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "rvm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17463,16 +11976,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"rvI" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"rvS" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/burger/baseball,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "rwc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/rock,
@@ -17542,10 +12045,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
-"rzx" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13,
-/area/f13/city)
 "rzT" = (
 /obj/item/grenade/syndieminibomb/concussion/frag,
 /turf/open/floor/plasteel/barber{
@@ -17564,12 +12063,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
-"rAe" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "rAP" = (
 /obj/machinery/button/door{
 	id = "marx";
@@ -17599,19 +12092,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"rCX" = (
-/obj/structure/chair/right{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"rDz" = (
-/obj/structure/chair/comfy/lime{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "rEj" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Science";
@@ -17635,16 +12115,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/tunnel,
 /area/f13/vault)
-"rEU" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "NCR"
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/ncr)
 "rEX" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -17666,13 +12136,6 @@
 /obj/item/stack/crafting/electronicparts/three,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"rFI" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "rGw" = (
 /obj/structure/rack{
 	dir = 8;
@@ -17706,30 +12169,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"rGy" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/f13/ncr)
-"rId" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "rIK" = (
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
 /area/f13/vault)
-"rIO" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/turf/open/floor/f13,
-/area/f13/city)
 "rIR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -17755,12 +12199,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"rJv" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "rJC" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -17774,12 +12212,6 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg2"
 	},
-/area/f13/bunker)
-"rJQ" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/debris/v3,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "rKb" = (
 /obj/machinery/iv_drip,
@@ -17796,18 +12228,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/cafeteria,
-/area/f13/bunker)
-"rKM" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"rLk" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "rLU" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
@@ -17847,23 +12267,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
-"rNm" = (
-/obj/structure/table,
-/obj/item/kitchen/knife/butcher,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"rOb" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"rOc" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "rOf" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -17892,16 +12295,6 @@
 	icon_state = "plating"
 	},
 /area/space)
-"rPe" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "rPm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain{
@@ -17909,37 +12302,6 @@
 	},
 /turf/open/floor/plating/f13,
 /area/f13/vault)
-"rPD" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"rRv" = (
-/obj/structure/debris/v3,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
-"rRX" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
-"rSd" = (
-/obj/effect/turf_decal/bot,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"rSB" = (
-/obj/effect/decal/cleanable/blood,
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "rSG" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -17964,16 +12326,6 @@
 /obj/item/twohanded/spear/bonespear/deathclaw,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
-"rTO" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "rUE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17982,42 +12334,6 @@
 	dir = 4
 	},
 /area/f13/vault)
-"rVe" = (
-/turf/open/floor/f13{
-	icon_state = "yellowsiding"
-	},
-/area/f13/city)
-"rVg" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"rVo" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/structure/closet,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"rVu" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	name = "prewar lounge chair"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "rVO" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -18057,42 +12373,9 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
-"rXd" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"rXf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/mountain_bunker)
-"rYM" = (
-/obj/machinery/light,
-/turf/open/floor/wood/f13/old,
-/area/f13/ncr)
 "rZP" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/bunker)
-"saH" = (
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"sbf" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"sbg" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/mountain_bunker)
 "sbq" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/f13/vaultscientist,
@@ -18102,18 +12385,6 @@
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"scf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "sct" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
@@ -18125,62 +12396,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"scX" = (
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "sdl" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/bunker)
-"see" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"seY" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"sfh" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"sfi" = (
-/obj/structure/wreck/car,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"sfo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"sfz" = (
-/obj/structure/table,
-/obj/machinery/door/window/brigdoor/eastright{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "sga" = (
 /obj/structure/cable{
@@ -18202,9 +12422,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"shU" = (
-/turf/closed/wall/mineral/iron,
-/area/f13/legion)
 "sie" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/barber{
@@ -18212,11 +12429,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"siD" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13,
-/area/f13/city)
 "sje" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -18249,13 +12461,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"skn" = (
-/obj/machinery/status_display{
-	desc = "A large glass display, used to show various types of information.";
-	text = "REACTOR FAILURE"
-	},
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
 "slg" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -18266,17 +12471,6 @@
 "slE" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
-/area/f13/bunker)
-"slO" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/curtain,
-/obj/item/soap/homemade,
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
 /area/f13/bunker)
 "smw" = (
 /obj/structure/table,
@@ -18290,14 +12484,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"smC" = (
-/obj/structure/table/reinforced,
-/obj/item/defibrillator/compact/loaded,
-/obj/effect/spawner/lootdrop/f13/medical/surgical,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "smD" = (
 /obj/machinery/door/airlock/command{
 	name = "Bathroom"
@@ -18306,32 +12492,6 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/vault)
-"smL" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"smP" = (
-/obj/effect/spawner/lootdrop/f13/cash_legion_high,
-/obj/effect/spawner/lootdrop/f13/cash_legion_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/obj/structure/closet,
-/turf/open/floor/f13,
-/area/f13/city)
-"snE" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/brews,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"snK" = (
-/obj/structure/rack,
-/obj/item/clothing/under/rank/security/officer/skirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "snY" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /mob/living/simple_animal/hostile/radscorpion,
@@ -18340,27 +12500,11 @@
 "soK" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
-"sps" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"spu" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "spI" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
-"sqp" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "sqC" = (
 /obj/structure/cable{
@@ -18376,19 +12520,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"srg" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
-"srh" = (
-/obj/structure/window/fulltile/ruins,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "srt" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table,
@@ -18404,17 +12535,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"stC" = (
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	faction = list("bonnie")
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
-"stF" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/obj/structure/closet,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "sur" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -18450,11 +12570,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"swQ" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "swU" = (
 /obj/structure/chair/f13chair1{
 	dir = 8
@@ -18464,11 +12579,6 @@
 "swV" = (
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
-"sxz" = (
-/obj/structure/chair/bench,
-/obj/item/soap,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "sxZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain{
@@ -18554,15 +12664,6 @@
 	icon_state = "plating"
 	},
 /area/space)
-"sBn" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"sBr" = (
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/ncr)
 "sBI" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/security.dmi';
@@ -18572,11 +12673,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"sBU" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/underground/cave)
 "sCJ" = (
 /obj/structure/door_assembly/door_assembly_hatch,
 /turf/open/floor/plasteel/barber{
@@ -18589,11 +12685,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/bunker)
-"sDc" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "sDf" = (
 /obj/structure/chair/comfy/lime{
@@ -18622,15 +12713,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"sEc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "sEk" = (
 /obj/machinery/vending/hydroseeds,
 /obj/machinery/light,
@@ -18654,10 +12736,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"sFq" = (
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "sFs" = (
 /obj/structure/cable,
 /obj/structure/booth/single,
@@ -18671,10 +12749,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"sFu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "sGb" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/remains/human,
@@ -18692,14 +12766,6 @@
 /obj/structure/table/wood/bar,
 /turf/open/floor/f13{
 	icon_state = "bar"
-	},
-/area/f13/bunker)
-"sHG" = (
-/obj/structure/rack,
-/obj/item/clothing/under/rank/security/warden/formal,
-/obj/item/storage/backpack/security,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "sIf" = (
@@ -18736,10 +12802,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"sJg" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "sJr" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical,
@@ -18747,12 +12809,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"sJY" = (
-/obj/structure/tires/half,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "sKE" = (
 /obj/structure/sink{
 	dir = 4
@@ -18767,21 +12823,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"sLz" = (
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "yellowsiding"
-	},
-/area/f13/city)
-"sLG" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "sLM" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
@@ -18792,20 +12833,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"sMt" = (
-/obj/structure/closet/crate/bin{
-	name = "trash-point"
-	},
-/obj/item/crafting/reloader,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"sMT" = (
-/obj/structure/booth{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "sNj" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -18824,23 +12851,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"sNV" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
-"sOl" = (
-/obj/structure/chair/f13chair2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "sOJ" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18869,36 +12879,6 @@
 	dir = 4
 	},
 /area/f13/vault)
-"sPA" = (
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/loading_area,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"sPB" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"sPO" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"sQT" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "sQV" = (
 /obj/structure/table/reinforced,
 /obj/item/crafting/coffee_pot{
@@ -18907,12 +12887,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
-"sRd" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "sRp" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -18932,16 +12906,6 @@
 	dir = 8
 	},
 /area/f13/vault)
-"sSh" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/ncr)
-"sSu" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "sSE" = (
 /obj/machinery/vending/snack/green,
 /turf/open/floor/plasteel/f13{
@@ -18958,27 +12922,8 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"sSR" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "sST" = (
 /turf/open/floor/f13/wood,
-/area/f13/bunker)
-"sTk" = (
-/mob/living/simple_animal/hostile/handy{
-	faction = list("bonnie")
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "sTy" = (
 /obj/structure/chair/wood,
@@ -19003,14 +12948,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"sWg" = (
-/obj/structure/chair/f13chair2{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "sWT" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/fyellow,
@@ -19018,34 +12955,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"sWW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
-"sXL" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/underground/cave)
-"sXT" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
-"sYw" = (
-/turf/closed/wall/f13/vault,
-/area/f13/underground/cave)
-"sZm" = (
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/bunker)
 "tak" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/floor/f13{
@@ -19059,22 +12968,11 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"taO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "tbT" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg3"
 	},
-/area/f13/bunker)
-"tcW" = (
-/obj/structure/chair/bench,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "tcX" = (
 /obj/structure/table,
@@ -19104,16 +13002,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"teF" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/f13/deadrodent_or_brainwashdisk,
-/obj/item/target/alien,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "tfS" = (
 /obj/structure/table/wood,
 /obj/item/crafting/buzzer,
@@ -19122,11 +13010,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/bunker)
-"tgg" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "tgq" = (
 /obj/structure/closet/secure_closet/freezer/meat,
@@ -19140,20 +13023,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"thn" = (
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"thB" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/item/stock_parts/cell/ammo/ec,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"tif" = (
-/obj/machinery/vending/cola/space_up,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "tju" = (
 /obj/structure/sink{
 	dir = 8;
@@ -19166,36 +13035,11 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/bunker)
-"tki" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
-/obj/item/target/alien,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "tkj" = (
 /obj/machinery/chem_master/advanced,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"tks" = (
-/obj/structure/chair/f13chair2,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"tlH" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "Waster"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/mountain_bunker)
 "tlL" = (
 /obj/effect/turf_decal/box,
 /obj/structure/cable{
@@ -19213,21 +13057,10 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"tmO" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "tmY" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"tnG" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "tnQ" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/barber{
@@ -19235,16 +13068,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"tow" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/structure/closet,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"tpi" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "tpo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -19259,15 +13082,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"tpU" = (
-/obj/structure/rack,
-/obj/item/clothing/under/rank/security/officer,
-/obj/item/gun/energy/laser/wattz,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "tqm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19286,13 +13100,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"tqn" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "trf" = (
 /obj/structure/chair{
 	dir = 1
@@ -19321,26 +13128,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"trE" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "trF" = (
 /obj/structure/urinal{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"tsD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "tsM" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
@@ -19391,14 +13184,6 @@
 	dir = 1
 	},
 /area/f13/vault)
-"ttW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "tut" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -19427,12 +13212,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"tvI" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13,
-/area/f13/city)
 "tvM" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -19442,16 +13221,6 @@
 	icon_state = "plating"
 	},
 /area/space)
-"tvT" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Clinic Storage";
-	req_access_txt = "68"
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "tvY" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/shoes/combat,
@@ -19461,11 +13230,6 @@
 /obj/item/storage/belt/military/assault,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"tws" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "txu" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -19504,14 +13268,6 @@
 /obj/machinery/computer/terminal,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
-"tzo" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "tzB" = (
 /obj/structure/chair/wood/fancy{
 	dir = 4
@@ -19528,13 +13284,6 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/radiation)
-"tAt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "tAP" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/floor/plating/tunnel{
@@ -19554,10 +13303,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"tBZ" = (
-/obj/item/target/syndicate,
-/turf/open/floor/f13,
-/area/f13/city)
 "tCc" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1
@@ -19573,45 +13318,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
-"tCx" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"tCY" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"tDf" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "tDI" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"tDL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
-"tDO" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "tEt" = (
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
@@ -19625,14 +13337,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
-	},
-/area/f13/bunker)
-"tFl" = (
-/obj/structure/table,
-/obj/item/clothing/suit/hooded/wintercoat/security,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "tFW" = (
@@ -19688,22 +13392,6 @@
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/floor/plating,
 /area/f13/bunker)
-"tJX" = (
-/obj/structure/kitchenspike/cross,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"tKQ" = (
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/item/binoculars,
-/obj/item/binoculars,
-/obj/item/binoculars,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/structure/closet,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "tLi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -19736,16 +13424,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
-"tMd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/debris/v3,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
-"tMn" = (
-/obj/structure/sign/poster/prewar/vault_tec,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
 "tNM" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/barber{
@@ -19781,15 +13459,6 @@
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"tPN" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "tQi" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -19805,20 +13474,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/space)
-"tQw" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"tQJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"tRj" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "tRn" = (
 /obj/machinery/light{
 	dir = 1
@@ -19827,12 +13482,6 @@
 	dir = 1
 	},
 /area/f13/vault)
-"tRO" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "tRT" = (
 /obj/structure/chair{
 	dir = 1
@@ -19862,16 +13511,6 @@
 /obj/item/gun/ballistic/automatic/toy,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"tUW" = (
-/obj/structure/chair/bench,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "tVb" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -19880,14 +13519,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"tVz" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"tVN" = (
-/obj/structure/closet/wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "tWp" = (
 /turf/closed/indestructible/fakeglass,
 /area/f13/building)
@@ -19901,26 +13532,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"tWR" = (
-/obj/structure/booth,
-/obj/item/reagent_containers/food/snacks/burger/superbite,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "tWT" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/bunker)
-"tYd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"tYt" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "tYu" = (
 /turf/open/floor/plasteel/darkred/side{
@@ -19944,22 +13560,6 @@
 "uau" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"ucc" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"uci" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
-"uck" = (
-/obj/item/trash/chips,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "ucr" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -19999,12 +13599,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"udo" = (
-/obj/machinery/door/poddoor/shutters{
-	name = "gate shutters"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "udY" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -20016,18 +13610,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"ueo" = (
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/mountain_bunker)
-"uez" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "bonnief2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "ufd" = (
 /obj/structure/chair{
 	dir = 8
@@ -20040,30 +13622,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"ufN" = (
-/obj/machinery/autolathe,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"ufX" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/bunker)
 "uga" = (
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"ugx" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "ugB" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel/dark,
@@ -20081,12 +13643,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
-"uhC" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
 "uhH" = (
 /obj/structure/chair{
 	dir = 8
@@ -20102,44 +13658,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"uiN" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "uiV" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
-"ujl" = (
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "ujC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
-"ujL" = (
-/turf/open/floor/f13{
-	dir = 1;
-	icon_state = "yellowsiding"
-	},
-/area/f13/city)
-"ujX" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "ukN" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -20217,12 +13744,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"uoZ" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "upg" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/barber{
@@ -20230,27 +13751,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"upT" = (
-/obj/machinery/computer/robotics,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"uqm" = (
-/obj/item/flag/bos,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
 "ura" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"urn" = (
-/obj/effect/turf_decal/bot,
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "urV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20278,20 +13784,10 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"usT" = (
-/obj/effect/turf_decal/loading_area/white,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "utf" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"utC" = (
-/obj/structure/table,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "uuu" = (
 /obj/structure/table/wood,
 /obj/item/paper,
@@ -20299,10 +13795,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"uux" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "uuz" = (
 /obj/structure/chair/e_chair,
 /obj/structure/cable{
@@ -20312,13 +13804,6 @@
 /area/f13/vault)
 "uuM" = (
 /turf/open/floor/plasteel/elevatorshaft,
-/area/f13/bunker)
-"uuZ" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
 /area/f13/bunker)
 "uvh" = (
 /obj/structure/cable{
@@ -20351,10 +13836,6 @@
 /obj/effect/decal/waste,
 /turf/open/floor/plating,
 /area/f13/bunker)
-"uwD" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "uwE" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/f13/inside/mountain,
@@ -20370,30 +13851,10 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/vault)
-"uwP" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"uwQ" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/f13,
-/area/f13/city)
 "uwS" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/freezer,
 /area/space)
-"uwW" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "uwY" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
@@ -20401,11 +13862,6 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
-"uyk" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "uym" = (
 /obj/item/wirerod,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -20452,39 +13908,6 @@
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"uzG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button{
-	id = bonnie
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"uzL" = (
-/obj/machinery/door/airlock/grunge/abandoned,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"uAo" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench"
-	},
-/obj/item/storage/backpack/security,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"uAx" = (
-/obj/item/clothing/under/rank/hydroponics,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"uAF" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "uAJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -20497,19 +13920,6 @@
 /obj/machinery/light/fo13colored/Red,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"uBl" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"uBU" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/cans,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "uCu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -20544,10 +13954,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"uDI" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "uDP" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/barricade/wooden/strong,
@@ -20562,10 +13968,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"uGF" = (
-/obj/structure/debris/v4,
-/turf/closed/indestructible/rock,
-/area/f13/underground/cave)
 "uGH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_dispenser/drinks,
@@ -20583,19 +13985,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"uIL" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/curtain,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/bunker)
 "uIR" = (
 /obj/structure/sink{
 	dir = 8
@@ -20606,12 +13995,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
-/area/f13/bunker)
-"uIS" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "uJx" = (
 /obj/structure/toilet{
@@ -20643,14 +14026,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"uKD" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "bonnief3"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "uKP" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -20697,12 +14072,6 @@
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"uMa" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "uMj" = (
 /obj/structure/chair/left,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -20729,17 +14098,6 @@
 /obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"uNI" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
-"uOu" = (
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"uPS" = (
-/obj/structure/statue/sandstone/gravestone,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "uRl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20772,26 +14130,11 @@
 "uRG" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
-"uSa" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"uSQ" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "uST" = (
 /obj/item/storage/bag/books,
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"uTo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "uUf" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
@@ -20871,19 +14214,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"uWO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
-"uXd" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "uXu" = (
 /obj/machinery/computer/upload/borg,
 /turf/open/floor/plasteel/dark,
@@ -20904,10 +14234,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"uYl" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "uYr" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -20919,23 +14245,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"uZa" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/f13,
-/area/f13/city)
 "uZd" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"uZi" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "uZS" = (
 /obj/effect/decal/remains/human,
 /obj/structure/spider/stickyweb,
@@ -20944,25 +14259,12 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"van" = (
-/obj/structure/closet/wardrobe,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "vbG" = (
 /obj/item/bedsheet/patriot,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
 /area/space)
-"vcG" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "vcL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21013,14 +14315,6 @@
 "veO" = (
 /turf/open/floor/plating/f13/inside/mountain,
 /area/f13/underground/cave)
-"veW" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "vfv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/barber{
@@ -21047,11 +14341,6 @@
 	},
 /obj/effect/decal/waste,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"vhT" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
 "vih" = (
 /obj/structure/table,
@@ -21084,11 +14373,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"viY" = (
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/structure/closet,
-/turf/open/floor/f13,
-/area/f13/city)
 "vjd" = (
 /obj/structure/toilet,
 /turf/open/floor/f13{
@@ -21116,15 +14400,6 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/neutral,
 /area/f13/vault)
-"vle" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"vlo" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "vlG" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /obj/effect/decal/cleanable/dirt,
@@ -21149,13 +14424,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
-/area/f13/bunker)
-"vob" = (
-/obj/structure/table,
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	faction = list("bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "voz" = (
 /obj/structure/cable{
@@ -21198,11 +14466,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/bunker)
-"vpH" = (
-/obj/item/storage/trash_stack,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "vpQ" = (
 /obj/structure/closet/crate/wooden,
@@ -21256,27 +14519,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"vsL" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/trophy,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "vts" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/engineering,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"vwa" = (
-/obj/structure/tires/five,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "vwf" = (
 /obj/machinery/deepfryer,
 /obj/machinery/light{
@@ -21301,10 +14548,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
-"vws" = (
-/obj/structure/sign/poster/prewar/poster92,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
 "vwM" = (
 /obj/structure/safe,
 /obj/item/stack/spacecash/c1000,
@@ -21330,17 +14573,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"vxG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
-"vye" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
 "vyw" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -21349,29 +14581,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"vyC" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_2"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "vzk" = (
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
-"vzF" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "vzY" = (
 /obj/structure/chair{
 	dir = 4
@@ -21419,19 +14634,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"vBo" = (
-/obj/effect/turf_decal{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"vBp" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "vBQ" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 6;
@@ -21446,12 +14648,6 @@
 /obj/structure/chair/stool/retro,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
-"vCf" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
 "vCD" = (
 /obj/structure/table,
 /obj/item/clothing/head/soft/black,
@@ -21459,30 +14655,12 @@
 /obj/item/clothing/shoes/wheelys,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"vCQ" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"vDF" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13,
-/area/f13/city)
 "vDU" = (
 /obj/structure/sign/basic{
 	color = "#FFFF00";
 	name = "yellow room"
 	},
 /turf/closed/wall/r_wall/f13/vault,
-/area/f13/bunker)
-"vDX" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "bonnief3"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "vEH" = (
 /obj/structure/cable{
@@ -21527,26 +14705,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ruins)
-"vHF" = (
-/obj/structure/ladder/unbreakable{
-	desc = "An extremely sturdy metal ladder that leads up to the surface, over 500 feet above. Don't fall...";
-	height = 1;
-	id = "digsite";
-	name = "ladder to the surface"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"vHR" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"vIb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/ripped,
-/turf/closed/indestructible/vaultdoor,
-/area/f13/bunker)
 "vId" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
@@ -21559,10 +14717,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/space)
-"vJi" = (
-/obj/structure/debris/v3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
 "vJy" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
@@ -21575,14 +14729,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"vJP" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "vKe" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/f13/tunnel,
@@ -21594,15 +14740,6 @@
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"vKu" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	faction = list("bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "vKC" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -21615,11 +14752,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/f13/vault)
-"vKT" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "vLj" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plating/tunnel{
@@ -21642,19 +14774,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"vLR" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	name = "prewar lounge chair"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"vLS" = (
-/obj/structure/car/rubbish4,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "vNb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -21667,10 +14786,6 @@
 /obj/item/book/manual/ripley_build_and_repair,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"vNq" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "vNt" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -21703,15 +14818,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"vOQ" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"vOT" = (
-/obj/structure/chalkboard,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/bunker)
 "vPd" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -21719,23 +14825,10 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"vPe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "vPj" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"vPC" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "vPG" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers,
@@ -21749,20 +14842,9 @@
 	icon_state = "rubbleslab"
 	},
 /area/f13/bunker)
-"vQx" = (
-/obj/structure/timeddoor,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "vQS" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
-"vRq" = (
-/obj/structure/chair/right{
-	dir = 8
-	},
-/obj/item/target/alien,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "vRu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -21773,15 +14855,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"vRy" = (
-/mob/living/simple_animal/hostile/handy{
-	faction = list("bonnie")
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
-"vRR" = (
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "vSE" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -21832,12 +14905,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"vUF" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "vUX" = (
 /obj/structure/chair{
 	dir = 4
@@ -21856,23 +14923,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
-"vVP" = (
-/obj/structure/table,
-/obj/item/defibrillator,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"vWq" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
-"vWF" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "vWY" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13{
@@ -21889,9 +14939,6 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"vXn" = (
-/turf/closed/wall/f13/wood,
-/area/f13/city)
 "vXw" = (
 /obj/structure/fireaxecabinet{
 	pixel_y = 30
@@ -21899,11 +14946,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"vYb" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "vYm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21921,33 +14963,6 @@
 /obj/effect/landmark/start/f13/vaultscientist,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"vZy" = (
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/bunker)
-"vZV" = (
-/obj/machinery/rnd/server,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"wai" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
-"waP" = (
-/obj/item/storage/belt/security,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "wbb" = (
 /obj/structure/table,
 /obj/item/stamp/hos,
@@ -21965,12 +14980,6 @@
 "wbl" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
-"wbR" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "wbX" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -21979,13 +14988,6 @@
 	icon_state = "floorrusty"
 	},
 /area/space)
-"wcw" = (
-/obj/structure/tires/half,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "wcE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button{
@@ -21996,16 +14998,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"wcT" = (
-/obj/structure/debris/v4,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"wed" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/underground/cave)
 "wey" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -22050,15 +15042,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
-"wgF" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "wgN" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -22067,11 +15050,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"wgZ" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
 "whq" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/freezer,
@@ -22106,20 +15084,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"whO" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"wiW" = (
-/obj/structure/rack,
-/obj/item/clothing/under/rank/security/officer,
-/obj/item/holosign_creator/security,
-/obj/item/gun/energy/laser/wattz,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "wjA" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -22127,21 +15091,6 @@
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/bunker)
-"wjN" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/f13{
-	icon_state = "dark"
-	},
-/area/f13/ncr)
-"wky" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "wll" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -22165,28 +15114,10 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"wmB" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
-	},
-/turf/closed/wall/mineral/iron,
-/area/f13/ncr)
-"wmH" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "wmI" = (
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"wmQ" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/ncr)
 "wmV" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -22208,24 +15139,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
-"woZ" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"wpj" = (
-/obj/structure/chair/stool{
-	icon_state = "bench_center"
-	},
-/obj/item/clothing/under/rank/security/officer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "wqa" = (
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg2"
@@ -22285,15 +15198,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/f13/bunker)
-"wse" = (
-/obj/item/gun/energy/laser/aer9,
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "wsg" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -22305,18 +15209,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"wtu" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/item/stock_parts/cell/ammo/mfc,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"wtA" = (
-/obj/structure/booth,
-/obj/item/reagent_containers/food/snacks/salad/jungle,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "wui" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
@@ -22326,12 +15218,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
-/area/f13/bunker)
-"wuU" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "wvb" = (
 /obj/structure/table/reinforced,
@@ -22463,13 +15349,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"wxG" = (
-/obj/item/storage/pill_bottle/chem_tin/mentats{
-	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
-	name = "Pre-War Medicine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "wxR" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/latex/nitrile{
@@ -22515,12 +15394,6 @@
 "wyU" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault)
-"wza" = (
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "wzj" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mechanic,
@@ -22562,13 +15435,6 @@
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"wAB" = (
-/obj/machinery/vending/hydronutrients,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "wAT" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/black,
@@ -22586,10 +15452,6 @@
 	dir = 1
 	},
 /area/f13/vault)
-"wBM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "wBX" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable{
@@ -22597,22 +15459,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
-"wCs" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"wCx" = (
-/obj/structure/wreck/trash/three_barrels,
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "wCN" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
@@ -22698,14 +15544,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
-"wHI" = (
-/obj/effect/turf_decal{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "wHR" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife/butcher,
@@ -22727,9 +15565,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"wIN" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/city)
 "wJB" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -22742,18 +15577,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"wKt" = (
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
-"wKE" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "wKM" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -22817,12 +15640,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"wOk" = (
-/obj/machinery/porta_turret/syndicate/vehicle_turret{
-	faction = list("bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "wOA" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase/lawyer,
@@ -22844,10 +15661,6 @@
 "wQi" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
-"wRn" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
 "wRB" = (
 /mob/living/simple_animal/hostile/handy/securitron,
 /obj/effect/decal/cleanable/dirt,
@@ -22855,10 +15668,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"wRH" = (
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "wSp" = (
 /obj/machinery/computer{
 	desc = "Some kind of machine.Seems broken and useless.";
@@ -22883,11 +15692,6 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"wTd" = (
-/obj/effect/turf_decal/arrows,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "wTv" = (
 /obj/machinery/light{
 	dir = 1;
@@ -22932,12 +15736,6 @@
 	dir = 8
 	},
 /area/f13/vault)
-"wVf" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/underground/cave)
 "wVn" = (
 /turf/open/floor/f13{
 	dir = 1;
@@ -22974,15 +15772,6 @@
 	dir = 1
 	},
 /area/f13/vault)
-"wWK" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
-/area/f13/bunker)
 "wXu" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -22994,11 +15783,6 @@
 "wYe" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
-"wYF" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/sandbags,
-/turf/open/floor/f13,
-/area/f13/city)
 "wYN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23017,13 +15801,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/vault)
-"wZq" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "wZw" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/high,
@@ -23040,11 +15817,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"xav" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/f13,
-/area/f13/city)
 "xaI" = (
 /obj/structure/window/reinforced{
 	color = "#000000";
@@ -23077,19 +15849,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
-"xbz" = (
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"xcF" = (
-/obj/structure/closet/wardrobe,
-/obj/item/clothing/under/f13/vault{
-	desc = "The regulation clothing worn by the vault dwellers of Vault-Tec vaults. It's made of sturdy leather.<br>This particular jumpsuit has the number 132 on the back."
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "xdd" = (
 /obj/structure/table/glass,
 /obj/item/healthanalyzer,
@@ -23097,10 +15856,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"xdy" = (
-/obj/item/flag/oasis,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
 "xdK" = (
 /obj/structure/chair,
 /obj/effect/decal/remains/human,
@@ -23116,27 +15871,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"xfe" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/underground/cave)
-"xfk" = (
-/obj/structure/debris/v3,
-/turf/closed/wall/f13/tunnel,
-/area/f13/bunker)
-"xfs" = (
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"xfz" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/turf/open/floor/f13,
-/area/f13/wasteland)
 "xfG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -23149,31 +15883,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"xfM" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"xgf" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"xgh" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
-/obj/item/ammo_box/m44box,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"xgD" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/f13,
-/area/f13/city)
 "xgJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -23188,10 +15897,6 @@
 "xhC" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/cafeteria,
-/area/f13/bunker)
-"xhG" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "xiS" = (
 /obj/machinery/newscaster/security_unit{
@@ -23211,10 +15916,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"xjr" = (
-/obj/item/flag/ncr,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "xjU" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/barricade/sandbags{
@@ -23230,9 +15931,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"xmE" = (
-/turf/closed/wall/f13/vault,
-/area/f13/brotherhood)
 "xmF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23245,11 +15943,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"xmY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
 "xnc" = (
 /obj/machinery/sleeper,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -23292,12 +15985,6 @@
 	icon_state = "rubbleslab"
 	},
 /area/f13/bunker)
-"xpw" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "xpD" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/caves)
@@ -23322,14 +16009,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"xqg" = (
-/obj/structure/window/plastitanium{
-	desc = "A heavy duty window dirtied with dust and grime. Below, you see an expansive cave filled with ruined buildings, coated in glowing green sludge. Mulling around are ghouls. Thousands. Tens of thousands. An army, sealed and forgotten below the earth. They are trapped... for now.";
-	name = "viewport"
-	},
-/obj/structure/grille,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "xqk" = (
 /obj/structure/table/reinforced,
 /obj/item/circular_saw,
@@ -23348,15 +16027,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"xqQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "xrJ" = (
 /obj/structure/table,
 /obj/machinery/light/small,
@@ -23366,12 +16036,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"xrM" = (
-/obj/machinery/light/sign/kebab,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "xrO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/botany,
@@ -23428,28 +16092,10 @@
 	icon_state = "floorgrime"
 	},
 /area/space)
-"xtO" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "xuu" = (
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plasteel/freezer,
 /area/space)
-"xuF" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/nukashine,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
-"xuG" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "xuQ" = (
 /obj/machinery/door/airlock{
 	name = "Restrooms"
@@ -23489,27 +16135,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"xxA" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "xxD" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/vault)
-"xyH" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
-	},
-/obj/machinery/light,
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/trophy,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "xyU" = (
 /obj/structure/rack,
 /obj/machinery/button/door{
@@ -23520,13 +16151,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/vault)
-"xzm" = (
-/obj/structure/chair/left{
-	dir = 4
-	},
-/obj/item/target/alien,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "xzw" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/barber{
@@ -23576,12 +16200,6 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
-"xAA" = (
-/obj/structure/chair/bench,
-/obj/item/soap,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/bunker)
 "xBm" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/rollingpin,
@@ -23620,22 +16238,6 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
-"xCj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"xCq" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/mountain_bunker)
-"xEu" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/plasteel/grimy,
-/area/f13/ncr)
 "xEJ" = (
 /obj/structure/cable,
 /obj/item/radio/intercom{
@@ -23645,23 +16247,6 @@
 	},
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
-"xFf" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"xFE" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"xGM" = (
-/obj/structure/toilet,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "xHP" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -23672,15 +16257,6 @@
 "xIi" = (
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
-"xIq" = (
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "xIC" = (
 /obj/machinery/newscaster/security_unit{
@@ -23728,27 +16304,6 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"xIV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"xJo" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"xJI" = (
-/obj/structure/tires/five,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "xKn" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -23789,12 +16344,6 @@
 	dir = 4
 	},
 /area/f13/vault)
-"xMn" = (
-/obj/structure/window/fulltile/ruins,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "xMF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -23817,12 +16366,6 @@
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/f13/vault)
-"xNG" = (
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "xNP" = (
 /obj/effect/decal/cleanable/blood/gibs{
 	icon_state = "gibup1"
@@ -23852,41 +16395,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"xQD" = (
-/obj/structure/table/optable,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
-"xRe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/waste,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"xRj" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
 "xRs" = (
 /obj/machinery/computer/shuttle/miningelevator{
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"xRP" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "xSr" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/darkpurple/side{
@@ -23927,14 +16441,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/bunker)
-"xUd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "xUI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -23947,10 +16453,6 @@
 /obj/structure/sign/departments/science,
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
-"xVZ" = (
-/obj/machinery/hydroponics/soil/crafted,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "xWJ" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/medical.dmi';
@@ -23960,12 +16462,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/space)
-"xWK" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "xXn" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -23988,10 +16484,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
-"xXK" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/indestructible/rock,
-/area/f13/underground/cave)
 "xYe" = (
 /obj/machinery/shower{
 	pixel_y = 22
@@ -24001,21 +16493,11 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
-"xYu" = (
-/obj/item/rack_parts,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "xYC" = (
 /obj/machinery/gibber/autogibber,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
-/area/f13/bunker)
-"xYF" = (
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
-"xYO" = (
-/turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "xYP" = (
 /obj/machinery/light/fo13colored/Red{
@@ -24037,32 +16519,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
-"xZn" = (
-/obj/item/soap,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"xZz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver{
-	faction = list("ghoul","bonnie")
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/bunker)
-"xZS" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"yao" = (
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "yaD" = (
 /obj/structure/chair,
 /obj/machinery/light/broken{
@@ -24110,43 +16566,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"ycU" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
-"ydg" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/carpet/black,
-/area/f13/bunker)
-"ydy" = (
-/mob/living/simple_animal/hostile/handy{
-	faction = list("bonnie")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
-"ydR" = (
-/obj/item/stock_parts/cell/ammo/mfc,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "yec" = (
 /turf/closed/wall/r_wall/f13composite{
 	icon_state = "rubbleslab"
 	},
 /area/f13/tunnel)
-"yed" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
 "yeA" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
@@ -24180,28 +16604,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"yfE" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "ygg" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
-"ygG" = (
-/obj/item/trash/f13/cram,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"ygY" = (
-/obj/structure/simple_door/metal/barred,
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
 "yhl" = (
 /obj/structure/door_assembly/door_assembly_hatch,
 /turf/open/floor/plasteel/barber{
@@ -24214,11 +16622,6 @@
 	icon_state = "yellowdirtysolid"
 	},
 /area/space)
-"yil" = (
-/obj/structure/table/wood/bar,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13,
-/area/f13/city)
 "yjg" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -24226,28 +16629,12 @@
 /obj/effect/landmark/start/f13/vaultsecurityofficer,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"yjV" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
 "ykh" = (
 /obj/structure/sign/poster/official/do_not_question,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
 /area/f13/vault)
-"ykr" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/medical,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "yks" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -24259,20 +16646,10 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
-"ylb" = (
-/obj/machinery/workbench,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/book/granter/crafting_recipe/gunsmith_two,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "ylm" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
-"ylS" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 
 (1,1,1) = {"
 heT
@@ -37280,14 +29657,14 @@ heT
 heT
 heT
 heT
-mGr
-mGr
-mGr
-mGr
-mGr
-mGr
-mGr
-mGr
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -37537,14 +29914,14 @@ heT
 heT
 heT
 heT
-mGr
-ueo
-ueo
-ueo
-mGr
-tlH
-tlH
-mGr
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -37794,14 +30171,14 @@ heT
 heT
 heT
 heT
-mGr
-rXf
-ueo
-ueo
-bso
-rXf
-ueo
-bso
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -38051,14 +30428,14 @@ heT
 heT
 heT
 heT
-mGr
-ruE
-aGB
-ueo
-mGr
-mGr
-sbg
-mGr
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -38308,14 +30685,14 @@ heT
 heT
 heT
 heT
-mGr
-cnB
-cnB
-ueo
-ueo
-ueo
-ueo
-mGr
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -38565,14 +30942,14 @@ heT
 heT
 heT
 heT
-mGr
-ueo
-ueo
-ueo
-ueo
-ueo
-ueo
-mGr
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -38822,14 +31199,14 @@ heT
 heT
 heT
 heT
-mGr
-rXf
-ueo
-ueo
-ueo
-ueo
-ueo
-mGr
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -39079,14 +31456,14 @@ heT
 heT
 heT
 heT
-mGr
-ueo
-ueo
-ueo
-olP
-olP
-olP
-mGr
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -39336,15 +31713,15 @@ heT
 heT
 heT
 heT
-mGr
-ueo
-ueo
-ueo
-ueo
-ueo
-ueo
-mGr
-mGr
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -39593,29 +31970,29 @@ heT
 heT
 heT
 heT
-mGr
-ueo
-ueo
-ueo
-olP
-ueo
-ueo
-brw
-mGr
-mGr
-bso
-mGr
-bso
-mGr
-bso
-mGr
-awX
-xXK
-xXK
-xXK
-xXK
-xXK
-ozV
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -39850,29 +32227,29 @@ heT
 heT
 heT
 heT
-mGr
-mGr
-mGr
-mGr
-mGr
-mGr
-brw
-brw
-brw
-xCq
-aQF
-brw
-brw
-brw
-qVQ
-brw
-kkI
 heT
 heT
 heT
 heT
 heT
-xXK
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -40112,24 +32489,24 @@ heT
 heT
 heT
 heT
-mGr
-mGr
-brw
-brw
-brw
-brw
-xCq
-brw
-brw
-qVQ
-brw
-kkI
 heT
 heT
 heT
 heT
 heT
-xXK
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -40370,23 +32747,23 @@ heT
 heT
 heT
 heT
-mGr
-mGr
-mGr
-mGr
-bso
-mGr
-bso
-mGr
-bso
-esV
-kkI
 heT
 heT
 heT
 heT
 heT
-xXK
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -40635,15 +33012,15 @@ heT
 heT
 heT
 heT
-xXK
-sBU
-kkI
 heT
 heT
 heT
 heT
 heT
-xXK
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -40892,15 +33269,15 @@ heT
 heT
 heT
 heT
-xXK
-sBU
-kkI
 heT
 heT
 heT
 heT
 heT
-xXK
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -41149,15 +33526,15 @@ heT
 heT
 heT
 heT
-xXK
-sBU
-kkI
 heT
 heT
 heT
 heT
 heT
-xXK
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -41406,15 +33783,15 @@ heT
 heT
 heT
 heT
-xXK
-sBU
-kkI
 heT
 heT
 heT
 heT
 heT
-xXK
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -41663,15 +34040,15 @@ heT
 heT
 heT
 heT
-xXK
-sXL
-wed
-qWR
-qWR
-qWR
-qWR
 heT
-xXK
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -41920,15 +34297,15 @@ heT
 heT
 heT
 heT
-xXK
-wVf
-wVf
-wVf
-wVf
-xfe
-aGH
 heT
-xXK
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -42143,125 +34520,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-pes
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-xXK
-apt
-apt
-apt
-apt
-sBU
-kkI
-apt
-pes
-apt
 heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (71,1,1) = {"
@@ -42400,125 +34777,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-pes
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-xXK
-apt
-apt
-apt
-apt
-sBU
-kkI
-apt
-pes
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (72,1,1) = {"
@@ -42657,125 +35034,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-xXK
-apt
-apt
-apt
-apt
-sBU
-kkI
-apt
-pes
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-vNq
-hPB
-apt
-apt
-apt
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (73,1,1) = {"
@@ -42914,125 +35291,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-xXK
-apt
-apt
-apt
-apt
-sBU
-kkI
-apt
-pes
-apt
-apt
-apt
-apt
-apt
-jUR
-hPB
-hPB
-hPB
-hPB
-hPB
-aeh
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (74,1,1) = {"
@@ -43171,125 +35548,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-xXK
-xXK
-xXK
-kAE
-kAE
-ygY
-ygY
-kAE
-kAE
-apt
-apt
-apt
-apt
-apt
-hPB
-saH
-hPB
-saH
-hPB
-tpi
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (75,1,1) = {"
@@ -43428,125 +35805,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-lIE
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-flD
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-bji
-xdy
-bji
-bji
-xdy
-bji
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-tpi
-hPB
-hPB
-hPB
-saH
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (76,1,1) = {"
@@ -43685,125 +36062,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-lIE
-qPT
-pAw
-cXZ
-pAw
-pAw
-pAw
-pAw
-lHb
-xpw
-flD
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-bji
-bji
-qiJ
-bji
-apt
-apt
-apt
-apt
-apt
-apt
-tpi
-hPB
-hPB
-hPB
-tpi
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (77,1,1) = {"
@@ -43942,125 +36319,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-kYG
-pAw
-pAw
-kYG
-pAw
-pAw
-cXZ
-lHb
-xpw
-flD
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-bji
-bji
-bji
-bji
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-saH
-hPB
-saH
-hPB
-tpi
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vLS
-hPB
-hPB
-hPB
-hPB
-vLS
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mnc
-hPB
-mnc
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (78,1,1) = {"
@@ -44193,131 +36570,131 @@ bsh
 bsh
 heT
 heT
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-oJn
-fay
-wmB
-jRw
-jRw
-wmB
-xjr
-pAw
-pAw
-pAw
-pAw
-lHb
-flD
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-bji
-bji
-bji
-bji
-apt
-apt
-apt
-apt
-apt
-saH
-saH
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-axd
-fzu
-fWm
-fWm
-fWm
-fzu
-eco
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (79,1,1) = {"
@@ -44450,131 +36827,131 @@ bsh
 bsh
 heT
 heT
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-frh
-wmQ
-wmQ
-frh
-iYs
-iYs
-frh
-wmQ
-wmQ
-frh
-xjr
-pAw
-pAw
-xWK
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-bji
-bji
-bji
-bji
-apt
-apt
-apt
-apt
-apt
-aeh
-hPB
-hPB
-tpi
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-fWm
-fbz
-bqL
-bqL
-fWm
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (80,1,1) = {"
@@ -44707,131 +37084,131 @@ bsh
 bsh
 heT
 heT
-frh
-frh
-frh
-wmB
-wmB
-sSh
-ogO
-ogO
-ogO
-ogO
-ogO
-ogO
-ogO
-ogO
-frh
-frh
-pdW
-pdW
-wjN
-iYs
-iYs
-wjN
-pdW
-pdW
-frh
-frh
-eRP
-cXZ
-xWK
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-bji
-bji
-bji
-bji
-apt
-apt
-apt
-apt
-ceA
-ceA
-ceA
-ceA
-ceA
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-lIE
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-flD
-hPB
-hPB
-hPB
-hPB
-fWm
-iCz
-ace
-ace
-fWm
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (81,1,1) = {"
@@ -44964,131 +37341,131 @@ bsh
 bsh
 heT
 heT
-frh
-rEU
-sBr
-sBr
-ogO
-sSh
-hHH
-ogO
-qJw
-qJw
-qJw
-xEu
-ogO
-ogO
-frh
-wjN
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-aYt
-wmQ
-pAw
-pAw
-xWK
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-apt
-apt
-bji
-bji
-bji
-bji
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-lIE
-xpw
-qPT
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-fWm
-bqL
-ace
-ace
-fWm
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (82,1,1) = {"
@@ -45221,131 +37598,131 @@ bsh
 bsh
 heT
 heT
-frh
-rEU
-sBr
-sBr
-rYM
-sSh
-aGP
-ogO
-xEu
-rGy
-qQc
-qJw
-ogO
-rYM
-wmB
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-pdW
-wmQ
-pAw
-pAw
-xWK
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-apt
-apt
-bji
-bji
-bji
-bji
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-knQ
-hPB
-hPB
-hPB
-hPB
-lIE
-xpw
-qPT
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-fWm
-bqL
-ace
-xfz
-fWm
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (83,1,1) = {"
@@ -45478,131 +37855,131 @@ bsh
 bsh
 heT
 heT
-frh
-rEU
-sBr
-sBr
-ogO
-lhN
-aGP
-ogO
-qQc
-qQc
-gbt
-qJw
-ogO
-ogO
-jRw
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-pdW
-wmQ
-pAw
-pAw
-xWK
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-apt
-apt
-bji
-bji
-bji
-bji
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-lHb
-qPT
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-nHH
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-iTn
-pAw
-pAw
-pAw
-lHb
-xpw
-xpw
-xpw
-icM
-fzu
-fWm
-ogp
-fWm
-fzu
-eco
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (84,1,1) = {"
@@ -45735,131 +38112,131 @@ bsh
 bsh
 heT
 heT
-frh
-rEU
-sBr
-sBr
-ogO
-lhN
-aGP
-ogO
-qQc
-qQc
-gbt
-qJw
-ogO
-ogO
-jRw
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-pdW
-wmQ
-pAw
-pAw
-xWK
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-wKE
-ceA
-hPB
-apt
-apt
-bji
-bji
-bji
-bji
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-lIE
-qPT
-pAw
-pAw
-pAw
-pAw
-tQw
-pAw
-pAw
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-gSh
-dox
-iTn
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-uXd
-pAw
-uXd
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (85,1,1) = {"
@@ -45992,131 +38369,131 @@ bsh
 bsh
 heT
 heT
-frh
-rEU
-sBr
-sBr
-rYM
-sSh
-aGP
-ogO
-xEu
-loO
-qQc
-qJw
-ogO
-rYM
-wmB
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-pdW
-wmQ
-pAw
-pAw
-xWK
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-kWZ
-ceA
-hPB
-apt
-apt
-apt
-hzn
-hzn
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-nHH
-uSa
-iSM
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-dox
-iTn
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-lHb
-flD
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (86,1,1) = {"
@@ -46249,131 +38626,131 @@ bsh
 bsh
 heT
 heT
-frh
-rEU
-sBr
-sBr
-ogO
-sSh
-hHH
-ogO
-qJw
-qJw
-qJw
-xEu
-ogO
-ogO
-frh
-oqd
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-iYs
-aGd
-wmQ
-pAw
-pAw
-xWK
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-bji
-apt
-bji
-bji
-bji
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-nHH
-iSM
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-hPB
-hPB
-dox
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-iTn
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (87,1,1) = {"
@@ -46506,131 +38883,131 @@ bsh
 bsh
 heT
 heT
-frh
-frh
-frh
-wmB
-wmB
-sSh
-ogO
-ogO
-ogO
-ogO
-ogO
-ogO
-ogO
-ogO
-frh
-frh
-pdW
-pdW
-oqd
-iYs
-iYs
-oqd
-pdW
-pdW
-frh
-frh
-eRP
-cXZ
-xWK
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vNq
-hPB
-hPB
-hPB
-ceA
-hPB
-bji
-bji
-bji
-bji
-bji
-bji
-bji
-bji
-bji
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-pAw
-nHH
-uSa
-iSM
-hPB
-hPB
-hPB
-hPB
-hPB
-qnn
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (88,1,1) = {"
@@ -46763,131 +39140,131 @@ bsh
 bsh
 heT
 heT
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-frh
-wmQ
-wmQ
-frh
-iYs
-iYs
-frh
-wmQ
-wmQ
-frh
-xjr
-pAw
-pAw
-xWK
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-fJS
-ceA
-hPB
-bji
-apt
-bji
-bji
-bji
-bji
-bji
-bji
-bji
-hPB
-hPB
-knQ
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-pAw
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-dox
-iTn
-pAw
-pAw
-xWK
-gSh
-mnc
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mnc
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (89,1,1) = {"
@@ -47020,131 +39397,131 @@ bsh
 bsh
 heT
 heT
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-sSh
-oJn
-fay
-wmB
-jRw
-jRw
-wmB
-pAw
-pAw
-pAw
-pAw
-pAw
-nHH
-iSM
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-wKE
-hPB
-ceA
-hPB
-apt
-apt
-bji
-bji
-bji
-bji
-bji
-bji
-bji
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-guY
-mQo
-pAw
-pAw
-pAw
-pAw
-nHH
-iSM
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-sJY
-pAw
-pAw
-lpD
-hPB
-gfq
-wYF
-wYF
-wYF
-wYF
-gfq
-wYF
-wYF
-wYF
-wYF
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (90,1,1) = {"
@@ -47283,125 +39660,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uXd
-pAw
-pAw
-uXd
-pAw
-pAw
-cXZ
-nHH
-uSa
-iSM
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-wKE
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-asb
-pAw
-pAw
-pAw
-pAw
-mPi
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-sJY
-pAw
-pAw
-dld
-hPB
-wYF
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-wYF
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (91,1,1) = {"
@@ -47540,125 +39917,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-dox
-iTn
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-nHH
-uSa
-iSM
-hPB
-hPB
-hPB
-rso
-hPB
-ceA
-ceA
-ceA
-ceA
-ceA
-ceA
-ceA
-ceA
-hPB
-ceA
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-udo
-udo
-udo
-udo
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-xJI
-pAw
-pAw
-dld
-hPB
-wYF
-qhn
-vDF
-qhn
-qhn
-vDF
-qhn
-qhn
-vDF
-qhn
-wYF
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (92,1,1) = {"
@@ -47797,125 +40174,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-dox
-uSa
-xfs
-pAw
-pAw
-nHH
-uSa
-iSM
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-udo
-udo
-udo
-udo
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mfu
-gfq
-gfq
-eEu
-eEu
-gfq
-gfq
-gfq
-eEu
-gfq
-gfq
-eEu
-gfq
-eEu
-gfq
-gfq
-eEu
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (93,1,1) = {"
@@ -48054,125 +40431,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-pAw
-bpk
-pAw
-qKG
-pAw
-qKG
-wIN
-rbT
-uOu
-uOu
-uOu
-uOu
-fIy
-rfE
-kXl
-fDA
-fDA
-rca
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-nXV
-hPB
-hPB
-gfq
-omv
-qhn
-qhn
-iKf
-iKf
-iKf
-qhn
-iKf
-iKf
-qhn
-iKf
-qhn
-iKf
-iKf
-qhn
-iKf
-iKf
-iKf
-iKf
-iKf
-iKf
-fqL
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (94,1,1) = {"
@@ -48311,125 +40688,125 @@ heT
 heT
 heT
 heT
-pes
-pes
-rso
-rso
-rso
-rso
-rso
-rso
-rso
-rso
-rso
-rso
-bac
-uAF
-uAF
-sQT
-rso
-rso
-rso
-rso
-rso
-rso
-rso
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-pAw
-jsu
-atb
-pAw
-pAw
-pAw
-pAw
-wRH
-pAw
-pAw
-ylS
-pAw
-pAw
-lcs
-pAw
-tRj
-uOu
-uOu
-fCG
-jkq
-uOu
-uOu
-qBA
-uOu
-kXl
-uOu
-rca
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-gSh
-hPB
-mfu
-gfq
-wYF
-wYF
-gfq
-lSJ
-qhn
-sLz
-sLz
-sLz
-sLz
-sLz
-qhn
-qhn
-sLz
-sLz
-sLz
-qhn
-qhn
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-qhn
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (95,1,1) = {"
@@ -48568,125 +40945,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-eTx
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-pAw
-bpk
-pAw
-pAw
-pAw
-pAw
-kKF
-uOu
-uOu
-uOu
-jkq
-uOu
-uOu
-rfE
-tKQ
-uOu
-uOu
-tow
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-eEu
-qhn
-rVe
-gfq
-gfq
-gfq
-gfq
-gfq
-eEu
-eEu
-gfq
-gfq
-gfq
-eEu
-eEu
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (96,1,1) = {"
@@ -48825,125 +41202,125 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-pAw
-bpk
-pAw
-pAw
-pAw
-pAw
-tRj
-uOu
-uOu
-uOu
-utC
-afC
-uOu
-rfE
-tKQ
-kXl
-uOu
-oPG
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-gfq
-ujL
-qhn
-eEu
-qhn
-qhn
-iOU
-qhn
-qhn
-qhn
-qhn
-gfq
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-iOU
-qhn
-eEu
-qhn
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (97,1,1) = {"
@@ -49080,127 +41457,127 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-lHb
-flD
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-pAw
-bpk
-pAw
-pAw
-dKI
-pAw
-wIN
-qQJ
-fCG
-uOu
-plZ
-uOu
-fIy
-rfE
-tKQ
-uOu
-uOu
-tow
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-gfq
-ujL
-qhn
-eEu
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-gfq
-bPQ
-rIO
-qhn
-qhn
-bPQ
-uZa
-qhn
-qhn
-eEu
-qhn
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (98,1,1) = {"
@@ -49337,127 +41714,127 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-knQ
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-pAw
-wRH
-atb
-pAw
-pAw
-pAw
-atb
-pAw
-pAw
-pAw
-ylS
-lcs
-pAw
-pAw
-pAw
-wIN
-odo
-uOu
-uOu
-utC
-hIN
-hIN
-rfE
-kMC
-agf
-nMR
-tow
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-eEu
-qhn
-rVe
-gfq
-nzD
-aLE
-aLE
-aLE
-aLE
-aLE
-uwQ
-gfq
-dJB
-tBZ
-iOU
-qhn
-rzx
-fZI
-qhn
-uwQ
-gfq
-ujL
-dTs
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (99,1,1) = {"
@@ -49593,128 +41970,128 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-xVZ
-pAw
-bpk
-pAw
-pAw
-pAw
-pAw
-wIN
-wIN
-wIN
-wIN
-iBb
-tRj
-tRj
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-mfu
-gfq
-wYF
-wYF
-gfq
-ujL
-rVe
-gfq
-qhn
-aLE
-tBZ
-qhn
-qhn
-aLE
-qhn
-gfq
-fZI
-qhn
-qhn
-qhn
-qhn
-rIO
-qhn
-rzx
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (100,1,1) = {"
@@ -49850,128 +42227,128 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-dox
-iTn
-pAw
-pAw
-lHb
-xpw
-xpw
-flD
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-eRP
-pAw
-pAw
-xWK
-ruP
-hPB
-wIN
-uOu
-uOu
-uOu
-fDA
-iSS
-uOu
-pNO
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-iOJ
-hPB
-hPB
-gfq
-ujL
-rVe
-gfq
-qhn
-iQM
-qhn
-qhn
-qhn
-aLE
-qhn
-gfq
-gfq
-gfq
-eEu
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (101,1,1) = {"
@@ -50106,129 +42483,129 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-nXV
-hPB
-hPB
-hPB
-hPB
-nXV
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-oHK
-uOu
-evm
-iBb
-uOu
-iBb
-jTn
-uOu
-xzm
-fJM
-iBb
-pAw
-pAw
-pAw
-xWK
-hPB
-axd
-wIN
-uOu
-uOu
-uOu
-uOu
-bXn
-uOu
-gML
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gfq
-ujL
-rVe
-gfq
-iOU
-iQM
-iQM
-qhn
-aLE
-aLE
-qhn
-gfq
-qhn
-qhn
-qhn
-qhn
-tvI
-qhn
-qhn
-xgD
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (102,1,1) = {"
@@ -50362,130 +42739,130 @@ bsh
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-bWo
-bWo
-bWo
-bWo
-bWo
-hPB
-dox
-iTn
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-oHK
-uOu
-uOu
-tRj
-uOu
-tRj
-uOu
-uOu
-eHN
-jBj
-iBb
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-wIN
-iBb
-iBb
-iBb
-uOu
-iBb
-iBb
-iBb
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vLS
-hPB
-gfq
-lSJ
-rVe
-gfq
-nzD
-qhn
-qhn
-qhn
-qhn
-qhn
-uwQ
-gfq
-fMf
-qhn
-iOU
-qhn
-qhn
-qhn
-qhn
-uwQ
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (103,1,1) = {"
@@ -50619,130 +42996,130 @@ bsh
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-ajc
-ajc
-uSQ
-ajc
-bWo
-eco
-gSh
-dox
-uSa
-iTn
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-ceA
-ceA
-ceA
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-qdl
-uOu
-uOu
-iBb
-uOu
-iBb
-uOu
-uOu
-rCX
-tki
-iBb
-pAw
-pAw
-dKI
-xWK
-hPB
-hPB
-wIN
-fNl
-uOu
-iSS
-kXl
-iSS
-uOu
-pNO
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gfq
-ujL
-rVe
-gfq
-qhn
-qhn
-qhn
-lOc
-qhn
-qhn
-qhn
-gfq
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (104,1,1) = {"
@@ -50875,131 +43252,131 @@ bsh
 bsh
 heT
 heT
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mfu
-bWo
-uSQ
-ajc
-wBM
-ajc
-uux
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-fZH
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-rNm
-uOu
-evm
-iBb
-uOu
-iBb
-uOu
-uOu
-uOu
-uOu
-tRj
-pAw
-dKI
-pAw
-xWK
-hPB
-hPB
-wIN
-qII
-uOu
-bXn
-uOu
-bXn
-uOu
-gML
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-gfq
-ujL
-rVe
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-eko
-eko
-eko
-eko
-eko
-iOU
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (105,1,1) = {"
@@ -51132,131 +43509,131 @@ bsh
 bsh
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mfu
-bWo
-ajc
-wBM
-ajc
-ajc
-uux
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-vKT
-uOu
-uOu
-iBb
-uOu
-iBb
-uOu
-uOu
-xzm
-ocJ
-iBb
-pAw
-pAw
-pAw
-wZq
-hPB
-hPB
-wIN
-iBb
-iBb
-iBb
-uOu
-iBb
-iBb
-iBb
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gfq
-ujL
-rVe
-gfq
-siD
-xav
-aiY
-gfq
-qhn
-cEA
-gfq
-cEA
-iOU
-gfq
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (106,1,1) = {"
@@ -51389,131 +43766,131 @@ bsh
 bsh
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-ajc
-ajc
-ajc
-ajc
-bWo
-eco
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-qnn
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-vKT
-uOu
-uOu
-iBb
-uOu
-iBb
-pUe
-uOu
-cul
-eAM
-mIX
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-wIN
-fNl
-uOu
-iSS
-kXl
-iSS
-uOu
-fNN
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gfq
-ujL
-rVe
-gfq
-iOU
-qhn
-qhn
-gfq
-qhn
-iRw
-gfq
-iRw
-qhn
-eEu
-qhn
-qhn
-qhn
-qhn
-qhn
-pih
-gfq
-ujL
-dTs
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (107,1,1) = {"
@@ -51646,131 +44023,131 @@ bsh
 bsh
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-bWo
-bWo
-bWo
-bWo
-bWo
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-vKT
-uOu
-uOu
-aeF
-uOu
-dOn
-naG
-uOu
-rCX
-cjx
-iBb
-pAw
-pAw
-pAw
-xWK
-hPB
-miT
-wIN
-gML
-uOu
-bXn
-kBx
-bXn
-uOu
-gML
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gfq
-ujL
-rVe
-gfq
-qhn
-qhn
-qhn
-eEu
-qhn
-viY
-gfq
-mPS
-qhn
-eEu
-qhn
-qhn
-qhn
-qhn
-qhn
-pih
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (108,1,1) = {"
@@ -51903,131 +44280,131 @@ bsh
 bsh
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-dJk
-hPB
-hPB
-hPB
-hPB
-dJk
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-nKH
-uOu
-uOu
-whO
-uOu
-eTU
-naG
-uOu
-gyx
-fJM
-iBb
-pAw
-dKI
-pAw
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-nXV
-hPB
-hPB
-gfq
-ujL
-rVe
-gfq
-nzD
-tBZ
-qhn
-gfq
-iOU
-iRw
-gfq
-smP
-qhn
-gfq
-kiR
-qhn
-qhn
-qhn
-qhn
-pih
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (109,1,1) = {"
@@ -52160,131 +44537,131 @@ bsh
 bsh
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-knQ
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-nKH
-uOu
-uOu
-iUy
-uOu
-bRd
-naG
-uOu
-bOw
-eAM
-mIX
-pAw
-pAw
-pAw
-srh
-uOu
-mMo
-jut
-iBb
-uOu
-dwB
-bKp
-uOu
-jut
-uOu
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-knQ
-hPB
-mfu
-gfq
-wYF
-wYF
-gfq
-lSJ
-rVe
-gfq
-fZI
-fZI
-qhn
-gfq
-gfq
-gfq
-gfq
-viY
-qhn
-gfq
-yil
-yil
-npR
-yil
-yil
-yil
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (110,1,1) = {"
@@ -52417,131 +44794,131 @@ bsh
 bsh
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-bam
-vWF
-uOu
-rvS
-uOu
-jHn
-naG
-uOu
-vRq
-tki
-iBb
-eRP
-pAw
-pAw
-srh
-uOu
-uOu
-uOu
-iBb
-uOu
-vYb
-bKp
-uOu
-uOu
-uOu
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-eEu
-qhn
-rVe
-gfq
-qhn
-qhn
-qhn
-eko
-qhn
-qhn
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-ujL
-rVe
-gfq
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (111,1,1) = {"
@@ -52674,131 +45051,131 @@ bsh
 bsh
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-qnn
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-iBb
-iBb
-iBb
-iBb
-uOu
-jKp
-naG
-uOu
-gyx
-fJM
-iBb
-pAw
-pAw
-pAw
-srh
-uOu
-eEc
-seY
-iBb
-uOu
-bKp
-bKp
-uOu
-cUz
-uOu
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-gfq
-ujL
-rVe
-gfq
-qhn
-qhn
-qhn
-qhn
-tBZ
-qhn
-gfq
-omv
-iKf
-iKf
-iKf
-iKf
-iKf
-iKf
-iKf
-iKf
-iKf
-qhn
-dTs
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (112,1,1) = {"
@@ -52931,131 +45308,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-lIE
-qPT
-pAw
-pAw
-lHb
-flD
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-gVP
-uOu
-uOu
-tRj
-uOu
-mnw
-pUe
-uOu
-dFZ
-eQn
-mIX
-pAw
-pAw
-lCA
-wIN
-jNo
-fhu
-uOu
-tRj
-uOu
-uOu
-uOu
-uOu
-cUz
-uOu
-fgc
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-gfq
-ujL
-rVe
-gfq
-qhn
-qhn
-qhn
-cHR
-cHR
-eko
-gfq
-ujL
-qhn
-sLz
-sLz
-sLz
-ojc
-sLz
-sLz
-sLz
-sLz
-sLz
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (113,1,1) = {"
@@ -53188,131 +45565,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-knQ
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-xuF
-uOu
-uOu
-tRj
-uOu
-iBb
-uOu
-uOu
-rCX
-cjx
-iBb
-lcs
-pAw
-pAw
-srh
-uOu
-chR
-seY
-iBb
-uOu
-bKp
-vYb
-uOu
-sPB
-uOu
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-eEu
-qhn
-qhn
-eEu
-qhn
-iOU
-qhn
-qhn
-qhn
-qhn
-eEu
-qhn
-rVe
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (114,1,1) = {"
@@ -53445,131 +45822,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-lIE
-qPT
-pAw
-pAw
-pAw
-pAw
-lHb
-flD
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-pgi
-uOu
-gVP
-iBb
-iBb
-iBb
-uOu
-uOu
-gyx
-ocJ
-iBb
-pAw
-pAw
-pAw
-srh
-uOu
-uOu
-uOu
-iBb
-mMo
-bKp
-bKp
-uOu
-uOu
-uOu
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-mfu
-gfq
-nzD
-qhn
-gfq
-ujL
-qhn
-eEu
-qhn
-qhn
-qhn
-qhn
-qhn
-qhn
-eEu
-qhn
-rVe
-gfq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-iOJ
-hPB
-iOJ
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (115,1,1) = {"
@@ -53702,131 +46079,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-lIE
-qPT
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-lHb
-flD
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-uOu
-bKp
-pTk
-iBb
-tif
-uOu
-uOu
-uOu
-tWR
-sMT
-mIX
-pAw
-pAw
-pAw
-srh
-uOu
-uOu
-nqF
-iBb
-uOu
-cgd
-bKp
-uOu
-wmH
-uOu
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-eEu
-qhn
-rVe
-gfq
-eko
-cHR
-eko
-cHR
-eko
-cHR
-gfq
-ujL
-rVe
-gfq
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (116,1,1) = {"
@@ -53959,131 +46336,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-knQ
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-pAw
-nHH
-iTn
-pAw
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-iBb
-iBb
-iBb
-iBb
-aYl
-uOu
-uOu
-uOu
-rCX
-cjx
-iBb
-pAw
-pAw
-pAw
-wIN
-wIN
-wIN
-wIN
-iBb
-tRj
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-gfq
-ujL
-rVe
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-ujL
-rVe
-gfq
-xpw
-xpw
-xpw
-flD
-hPB
-nXV
-hPB
-hPB
-hPB
-hPB
-nXV
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (117,1,1) = {"
@@ -54216,131 +46593,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mnc
-hPB
-hPB
-hPB
-hPB
-hPB
-mnc
-hPB
-mQo
-pAw
-pAw
-nHH
-iSM
-dox
-iTn
-pAw
-pAw
-xWK
-hPB
-mnc
-hPB
-hPB
-hPB
-hPB
-hPB
-mnc
-ceA
-ceA
-ceA
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-uOu
-uOu
-sMt
-iBb
-uOu
-uOu
-uOu
-uOu
-gyx
-fJM
-iBb
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-tRj
-uOu
-uOu
-uOu
-uOu
-uOu
-uOu
-maf
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-wYF
-qhn
-qhn
-gfq
-lSJ
-qhn
-iKf
-iKf
-iKf
-iKf
-iKf
-iKf
-iKf
-iKf
-qhn
-qhn
-eEu
-pAw
-pAw
-pAw
-xWK
-gSh
-bWo
-bWo
-bWo
-bWo
-bWo
-bWo
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (118,1,1) = {"
@@ -54473,131 +46850,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vXn
-ewT
-ewT
-ewT
-ewT
-ewT
-vXn
-hPB
-mQo
-pAw
-pAw
-xWK
-vNq
-vNq
-mQo
-pAw
-pAw
-xWK
-hPB
-vXn
-ewT
-ewT
-ewT
-ewT
-ewT
-vXn
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-xGM
-uOu
-uOu
-tRj
-uOu
-uOu
-uOu
-uOu
-anJ
-oBS
-mIX
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-tRj
-uOu
-uOu
-jkq
-utC
-rOb
-uOu
-gIZ
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-gSh
-hPB
-wYF
-qhn
-qhn
-eEu
-sLz
-sLz
-ojc
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-ojc
-sLz
-sLz
-eEu
-pAw
-pAw
-pAw
-xWK
-hPB
-bWo
-ajc
-ajc
-ajc
-ajc
-bWo
-eco
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (119,1,1) = {"
@@ -54730,131 +47107,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gaz
-moI
-moI
-moI
-moI
-moI
-aoi
-xpw
-qPT
-pAw
-pAw
-mUY
-xpw
-xpw
-sfi
-pAw
-pAw
-lHb
-xpw
-aoi
-moI
-moI
-moI
-moI
-moI
-pRH
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-kuZ
-uOu
-uOu
-iBb
-bKp
-uOu
-uOu
-uOu
-vRq
-cjx
-iBb
-eRP
-pAw
-pAw
-nHH
-see
-hYI
-wIN
-pUe
-qdz
-utC
-gpV
-uOu
-uOu
-oeR
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-mfu
-gfq
-wYF
-wYF
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-gfq
-iTn
-pAw
-pAw
-xWK
-mfu
-bWo
-ajc
-uSQ
-wBM
-ajc
-uux
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (120,1,1) = {"
@@ -54987,131 +47364,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gaz
-moI
-pmT
-pmT
-ofX
-moI
-aoi
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-aoi
-moI
-ofX
-pmT
-pmT
-moI
-pRH
-hPB
-hPB
-hPB
-qnn
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-iBb
-iBb
-iBb
-iBb
-jaj
-uOu
-uOu
-uOu
-uOu
-uOu
-tRj
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-wIN
-uOu
-uOu
-rOb
-uOu
-uOu
-uOu
-vsL
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-iOJ
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-iOJ
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-iOJ
-mQo
-pAw
-pAw
-xWK
-mfu
-bWo
-uSQ
-wBM
-ajc
-ajc
-uux
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (121,1,1) = {"
@@ -55244,131 +47621,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gaz
-moI
-ofX
-pmT
-pmT
-pmT
-vXn
-vXn
-vXn
-pmT
-pmT
-vXn
-vXn
-vXn
-vXn
-pmT
-pmT
-vXn
-vXn
-vXn
-pmT
-pmT
-pmT
-ofX
-moI
-pRH
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-uOu
-uOu
-xxA
-iBb
-bKp
-uOu
-uOu
-uOu
-gyx
-fJM
-iBb
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-wIN
-bKp
-uOu
-utC
-uOu
-uOu
-uOu
-nbO
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-bWo
-ajc
-ajc
-ajc
-ajc
-bWo
-eco
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (122,1,1) = {"
@@ -55501,131 +47878,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gaz
-moI
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-moI
-pRH
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-xGM
-uOu
-uOu
-tRj
-uOu
-uOu
-uOu
-uOu
-wtA
-oWH
-iBb
-lcs
-pAw
-pAw
-xWK
-vyC
-hPB
-wIN
-bKp
-uOu
-rOb
-uOu
-uOu
-uOu
-oeR
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-bWo
-bWo
-bWo
-bWo
-bWo
-bWo
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (123,1,1) = {"
@@ -55758,131 +48135,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gaz
-moI
-moI
-pmT
-pmT
-pmT
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-pmT
-pmT
-pmT
-moI
-moI
-pRH
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-kuZ
-uOu
-uOu
-iBb
-peo
-uOu
-uOu
-uOu
-rCX
-cjx
-iBb
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-wIN
-jaj
-uOu
-uOu
-uOu
-uOu
-uOu
-xyH
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-xWK
-gSh
-dJk
-hPB
-hPB
-hPB
-hPB
-dJk
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (124,1,1) = {"
@@ -56015,131 +48392,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-vXn
-aoi
-aoi
-vXn
-pmT
-pmT
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-pmT
-pmT
-vXn
-aoi
-aoi
-vXn
-hPB
-hPB
-gSh
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-pkP
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-eRP
-pAw
-pAw
-xWK
-hPB
-hPB
-wIN
-bKp
-uOu
-uOu
-uOu
-uOu
-uOu
-maf
-iBb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vNq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (125,1,1) = {"
@@ -56272,130 +48649,130 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-lCA
-vXn
-pmT
-pmT
-pmT
-pmT
-moI
-moI
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-moI
-moI
-pmT
-pmT
-pmT
-pmT
-vXn
-eRP
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-emb
-emb
-mQo
-pAw
-pAw
-pAw
-xFf
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-wIN
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-fZH
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-ceA
-ceA
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 "}
@@ -56529,130 +48906,130 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-vXn
-vXn
-pmT
-pmT
-pmT
-ofX
-pmT
-pmT
-pmT
-lEG
-pmT
-pmT
-pmT
-ofX
-pmT
-vXn
-vXn
-vXn
-vXn
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-emb
-emb
-mQo
-pAw
-pAw
-pAw
-lHb
-wIN
-bec
-bsR
-bsR
-bec
-wIN
-smC
-jPD
-wIN
-bIV
-vUF
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 "}
@@ -56786,129 +49163,129 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vLS
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-xuG
-vXn
-vXn
-lCl
-pmT
-pmT
-rnd
-rTO
-pmT
-pmT
-rPe
-fWv
-pmT
-lEG
-pmT
-vXn
-ayi
-bev
-vXn
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-hPB
-hPB
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-iBb
-hPB
-hPB
-pcf
-pAw
-pAw
-pAw
-pAw
-hZl
-jPD
-jPD
-jPD
-jPD
-wIN
-xQD
-iXW
-wIN
-kcJ
-pjL
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -57043,128 +49420,128 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-pmT
-xuG
-vXn
-pmT
-lEG
-pmT
-aFK
-bdm
-iPR
-iPR
-bdm
-xUd
-pmT
-pmT
-pmT
-vXn
-ayi
-pmT
-vXn
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-iBb
-iBb
-jut
-uOu
-odo
-hsk
-bWk
-iBb
-tJX
-lIE
-qPT
-pAw
-pAw
-pAw
-nHH
-wIN
-rtW
-hnc
-rtW
-jPD
-wIN
-ezy
-jPD
-wIN
-qyn
-pDb
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-nXV
-hPB
-hPB
-hPB
-hPB
-nXV
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -57300,128 +49677,128 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-rFI
-xuG
-vXn
-pmT
-pmT
-pmT
-lXh
-bdm
-pmT
-lRo
-bdm
-lLw
-pmT
-pmT
-pmT
-vXn
-ayi
-pmT
-vXn
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-frk
-uOu
-uOu
-frk
-odo
-odo
-odo
-iBb
-iBb
-qPT
-pAw
-pAw
-pAw
-pAw
-wZq
-xMn
-jPD
-teF
-jPD
-jPD
-wIN
-cwo
-jPD
-wIN
-jPD
-cmD
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-bWo
-bWo
-bWo
-bWo
-bWo
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -57557,127 +49934,127 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-pmT
-xuG
-vXn
-pmT
-pmT
-pmT
-lXh
-bdm
-lRo
-pmT
-bdm
-lLw
-pmT
-pmT
-pmT
-vXn
-ayi
-pmT
-vXn
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-iBb
-uOu
-uOu
-utC
-uOu
-uOu
-frk
-uOu
-uOu
-tRj
-coE
-pAw
-pAw
-pAw
-pAw
-xWK
-xMn
-jPD
-jPD
-jPD
-jPD
-wIN
-pjL
-iXW
-wIN
-kcJ
-rVo
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-ajc
-ajc
-ajc
-ajc
-bWo
-eco
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -57814,127 +50191,127 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-lCA
-vXn
-rFI
-pmT
-pmT
-pmT
-pmT
-pmT
-lXh
-bdm
-pmT
-pmT
-bdm
-lLw
-pmT
-pmT
-pmT
-pmT
-pmT
-bev
-vXn
-eRP
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-rfE
-uOu
-uOu
-utC
-uOu
-uOu
-uOu
-uOu
-uOu
-tRj
-coE
-pAw
-pAw
-pAw
-pAw
-xWK
-xMn
-cHM
-jPD
-jPD
-cHM
-wIN
-vUF
-jPD
-wIN
-jPD
-abs
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mfu
-bWo
-ajc
-ajc
-wBM
-ajc
-uux
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -58071,126 +50448,126 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-vLS
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-rFI
-pmT
-pmT
-pmT
-pmT
-pmT
-lXh
-bdm
-lRo
-pmT
-bdm
-lLw
-pmT
-pmT
-pmT
-pmT
-pmT
-bev
-vXn
-pAw
-pAw
-xWK
-hPB
-gSh
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-rfE
-gSp
-uOu
-uOu
-uOu
-odo
-odo
-odo
-iBb
-iBb
-iTn
-pAw
-lcs
-pAw
-pAw
-xFf
-wIN
-wIN
-wIN
-hZl
-wIN
-wIN
-wIN
-kQs
-wIN
-tvT
-wIN
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-mfu
-bWo
-uSQ
-wBM
-ajc
-jCG
-uux
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -58328,123 +50705,123 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-pmT
-aeS
-vXn
-pmT
-pmT
-pmT
-lXh
-bdm
-lRo
-lRo
-bdm
-lLw
-pmT
-pmT
-pmT
-vXn
-nqY
-pmT
-vXn
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-rfE
-rfE
-rfE
-vWF
-frk
-odo
-odo
-lea
-iBb
-tJX
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-wIN
-jPD
-nbt
-jPD
-jPD
-qyn
-nbt
-jPD
-jPD
-jPD
-nbt
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-ajc
-ajc
-ajc
-ajc
-dAX
-eco
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -58585,123 +50962,123 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-pmT
-aeS
-vXn
-pmT
-pmT
-pmT
-lXh
-bdm
-pmT
-pmT
-bdm
-lLw
-pmT
-lEG
-pmT
-vXn
-nqY
-pmT
-vXn
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-fZH
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-hPB
-hPB
-rfE
-rfE
-rfE
-rfE
-iBb
-iBb
-iBb
-hPB
-mQo
-pAw
-pAw
-pAw
-lcs
-xWK
-wIN
-jPD
-jPD
-jPD
-jPD
-jPD
-jPD
-jPD
-jPD
-jPD
-jPD
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-bWo
-bWo
-bWo
-bWo
-dAX
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-vNq
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -58842,123 +51219,123 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-rFI
-aeS
-vXn
-pmT
-pmT
-pmT
-aFK
-bdm
-iPR
-iPR
-bdm
-xUd
-pmT
-pmT
-pmT
-vXn
-oZH
-pmT
-vXn
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-wIN
-jPD
-wCs
-nLN
-jPD
-rtW
-nLN
-jPD
-wIN
-bpg
-wIN
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-dJk
-hPB
-hPB
-hPB
-hPB
-dJk
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -59099,123 +51476,123 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-stF
-vXn
-vXn
-lCl
-pmT
-lEG
-jzK
-wgF
-pmT
-pmT
-sEc
-oGF
-pmT
-pmT
-pmT
-vXn
-oZH
-bev
-vXn
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-hPB
-hPB
-uPS
-hPB
-uPS
-hPB
-uPS
-hPB
-uPS
-hPB
-mQo
-lcs
-pAw
-pAw
-pAw
-xWK
-wIN
-jPD
-nLN
-hnc
-jPD
-nLN
-wCs
-jPD
-wIN
-kcJ
-evy
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -59356,123 +51733,123 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-vXn
-vXn
-vXn
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-vXn
-vXn
-vXn
-vXn
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-wIN
-jPD
-jPD
-jPD
-jPD
-jPD
-jPD
-jPD
-wIN
-edK
-rkB
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-knQ
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -59613,122 +51990,122 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-lCA
-vXn
-pmT
-pmT
-pmT
-pmT
-moI
-moI
-pmT
-pmT
-pmT
-lEG
-pmT
-pmT
-moI
-moI
-pmT
-pmT
-pmT
-pmT
-vXn
-eRP
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-hPB
-hPB
-uPS
-hPB
-uPS
-hPB
-uPS
-hPB
-uPS
-hPB
-pcf
-pAw
-pAw
-pAw
-pAw
-xWK
-wIN
-jPD
-rtW
-nLN
-jPD
-hnc
-nLN
-jPD
-wIN
-jPD
-bqf
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -59870,122 +52247,122 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vXn
-aoi
-aoi
-vXn
-pmT
-pmT
-pmT
-pmT
-moI
-ofX
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-ofX
-pmT
-pmT
-pmT
-vXn
-aoi
-aoi
-vXn
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-wIN
-jPD
-nLN
-hnc
-jPD
-nLN
-hnc
-jPD
-wIN
-jPD
-mAu
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-qnn
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -60127,121 +52504,121 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gaz
-moI
-moI
-pmT
-pmT
-pmT
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-ofX
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-pmT
-pmT
-pmT
-moI
-moI
-pRH
-hPB
-gSh
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-hPB
-hPB
-uPS
-hPB
-uPS
-hPB
-uPS
-hPB
-uPS
-hPB
-mQo
-qKG
-lcs
-qKG
-pAw
-xFf
-wIN
-jPD
-cHM
-jPD
-jPD
-jPD
-cHM
-jPD
-wIN
-kcJ
-ykr
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -60384,120 +52761,120 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-fZH
-hPB
-hPB
-hPB
-hPB
-hPB
-gaz
-moI
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-moI
-pmT
-pmT
-pmT
-pmT
-pmT
-pmT
-moI
-pRH
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-udo
-udo
-udo
-udo
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -60641,120 +53018,120 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gaz
-moI
-pmT
-pmT
-pmT
-pmT
-vXn
-vXn
-vXn
-pmT
-pmT
-vXn
-vXn
-vXn
-vXn
-pmT
-pmT
-vXn
-vXn
-vXn
-pmT
-pmT
-pmT
-pmT
-moI
-pRH
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-udo
-udo
-udo
-udo
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-rfE
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -60898,120 +53275,120 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gaz
-moI
-pmT
-pmT
-pmT
-moI
-aoi
-pAw
-pAw
-pAw
-pAw
-lNk
-pAw
-pAw
-lNk
-pAw
-pAw
-pAw
-pAw
-aoi
-moI
-pmT
-pmT
-ofX
-moI
-pRH
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ahN
-pAw
-pAw
-pAw
-pAw
-hgB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-eZr
-hPB
-hPB
-hPB
-hPB
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -61155,120 +53532,120 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gaz
-moI
-moI
-moI
-moI
-moI
-aoi
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-aoi
-moI
-moI
-moI
-moI
-moI
-pRH
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-xrM
-pAw
-pAw
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-ceA
-ceA
-gSh
-mQo
-pAw
-pAw
-xWK
-gSh
-ceA
-ceA
-ceA
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -61412,120 +53789,120 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vXn
-aPe
-aPe
-aPe
-aPe
-aPe
-vXn
-uSa
-wcw
-pAw
-pAw
-nHH
-uSa
-uSa
-iTn
-pAw
-pAw
-nCU
-uSa
-vXn
-aPe
-aPe
-aPe
-aPe
-aPe
-vXn
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-vLS
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-rso
-rso
-rso
-rso
-rso
-bac
-uAF
-uAF
-sQT
-rso
-rso
-rso
-pes
-pes
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -61669,120 +54046,120 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-iOJ
-hPB
-hPB
-hPB
-hPB
-hPB
-iOJ
-hPB
-sJY
-pAw
-pAw
-vwa
-rOc
-tnG
-axc
-pAw
-pAw
-dld
-hPB
-iOJ
-hPB
-hPB
-hPB
-hPB
-hPB
-iOJ
-hPB
-hPB
-hPB
-fZH
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vNq
-hPB
-hPB
-apt
-bji
-bji
-bji
-apt
-bji
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-vNq
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-igG
-xpw
-xpw
-xpw
-xpw
-xpw
-qPT
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -61926,120 +54303,120 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-sJY
-pAw
-pAw
-pAw
-vwa
-axc
-pAw
-pAw
-pAw
-dld
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vLS
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bji
-bji
-bji
-bji
-apt
-bji
-bji
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-lIE
-xpw
-xpw
-mII
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -62183,119 +54560,119 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-sJY
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-dld
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bji
-bji
-bji
-bji
-bji
-bji
-bji
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-pAw
-pAw
-pAw
-pAw
-jTO
-pAw
-pAw
-jTO
-lHb
-xpw
-hPB
-hPB
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -62440,131 +54817,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-sJY
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-dld
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-bji
-apt
-bji
-bji
-bji
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-uAF
-pAw
-pAw
-pAw
-dmL
-lHG
-pMR
-pMR
-lHG
-dmL
-pAw
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (150,1,1) = {"
@@ -62697,131 +55074,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-qBq
-uSa
-iTn
-pAw
-pAw
-pAw
-pAw
-nHH
-uSa
-kNm
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-bji
-bji
-bji
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-qnn
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-dmL
-fTL
-ycU
-ycU
-fTL
-oFW
-oFW
-fTL
-ycU
-ycU
-fTL
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (151,1,1) = {"
@@ -62954,131 +55331,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-dox
-iTn
-pAw
-pAw
-nHH
-iSM
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-vNq
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-bji
-bji
-bji
-apt
-hPB
-hPB
-ceA
-ceA
-ceA
-ceA
-ceA
-ceA
-ceA
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-fTL
-fTL
-wai
-wai
-sNV
-oFW
-oFW
-sNV
-wai
-wai
-fTL
-fTL
-fTL
-oFW
-opn
-oFW
-oFW
-opn
-oFW
-shU
-shU
-shU
-shU
-shU
-shU
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (152,1,1) = {"
@@ -63211,131 +55588,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-bji
-bji
-bji
-apt
-hPB
-hPB
-ceA
-wKE
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-ycU
-fTa
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-sNV
-oFW
-fTL
-oFW
-yjV
-eAZ
-eAZ
-eAZ
-oFW
-shU
-oFW
-lkO
-lkO
-kNg
-shU
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (153,1,1) = {"
@@ -63468,131 +55845,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-aPv
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-bji
-bji
-bji
-apt
-hPB
-hPB
-ceA
-wKE
-wKE
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-ycU
-wai
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-lHG
-oFW
-eAZ
-oFW
-qva
-yjV
-oFW
-fKD
-rRX
-lkO
-lkO
-kNg
-shU
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (154,1,1) = {"
@@ -63725,131 +56102,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-qnn
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-bji
-bji
-bji
-apt
-hPB
-hPB
-vLS
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-ycU
-wai
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-pMR
-oFW
-eAZ
-uhC
-oFW
-oFW
-oFW
-hEu
-oFW
-lkO
-lkO
-kNg
-shU
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (155,1,1) = {"
@@ -63982,131 +56359,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-pAw
-pAw
-xWK
-gSh
-hPB
-ceA
-ceA
-ceA
-ceA
-ceA
-ceA
-ceA
-ceA
-apt
-apt
-apt
-apt
-bji
-bji
-bji
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-uAF
-ycU
-wai
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-pMR
-oFW
-eAZ
-uhC
-oFW
-oFW
-oFW
-hEu
-oFW
-lkO
-lkO
-kNg
-shU
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (156,1,1) = {"
@@ -64239,131 +56616,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-mQo
-pAw
-pAw
-lHb
-xpw
-flD
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-lIE
-xpw
-xpw
-qPT
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-ceA
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-apt
-apt
-apt
-apt
-bji
-bji
-bji
-apt
-hPB
-hPB
-ceA
-hPB
-fJS
-hPB
-hPB
-hPB
-cic
-ceA
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-ycU
-wai
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-lHG
-oFW
-eAZ
-oFW
-ekw
-yjV
-oFW
-fKD
-rRX
-lkO
-lkO
-kNg
-shU
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (157,1,1) = {"
@@ -64496,131 +56873,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-qnn
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-lHb
-xpw
-flD
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-xWK
-ceA
-aeh
-hPB
-hPB
-tpi
-hPB
-hPB
-tpi
-hPB
-hPB
-apt
-apt
-apt
-apt
-bji
-bji
-bji
-apt
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-ycU
-nyV
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-oFW
-hYY
-oFW
-fTL
-oFW
-yjV
-eAZ
-eAZ
-eAZ
-oFW
-shU
-oFW
-lkO
-lkO
-kNg
-shU
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (158,1,1) = {"
@@ -64753,131 +57130,131 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-nXV
-hPB
-hPB
-hPB
-hPB
-nXV
-hPB
-mQo
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-lHb
-xpw
-flD
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-lIE
-xpw
-xpw
-qPT
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-xWK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-tpi
-hPB
-hPB
-pes
-apt
-apt
-apt
-apt
-bji
-bji
-bji
-apt
-hPB
-kWZ
-ceA
-hPB
-hPB
-hPB
-hPB
-xFE
-hPB
-ceA
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-fTL
-fTL
-wai
-wai
-hYY
-oFW
-oFW
-hYY
-wai
-wai
-fTL
-fTL
-fTL
-oFW
-abx
-oFW
-oFW
-abx
-oFW
-shU
-shU
-shU
-shU
-shU
-shU
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (159,1,1) = {"
@@ -64963,27 +57340,6 @@ heT
 heT
 heT
 heT
-xYO
-eyl
-xYO
-xYO
-xYO
-xYO
-xYO
-jxX
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
 heT
 heT
@@ -65010,131 +57366,152 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-bWo
-bWo
-bWo
-bWo
-bWo
-hPB
-dox
-iTn
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-lHb
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-xpw
-qPT
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-nHH
-uSa
-uSa
-iSM
-hPB
-hPB
-saH
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-pes
-apt
-apt
-apt
-apt
-bji
-bji
-bji
-apt
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-dmL
-fTL
-ycU
-ycU
-fTL
-oFW
-oFW
-fTL
-ycU
-ycU
-fTL
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (160,1,1) = {"
@@ -65206,41 +57583,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-kUq
-cgh
-tgg
-plc
-plc
-dac
-plc
-dac
-nKs
-gzl
-uTo
-gzl
-uTo
-uTo
-uTo
-cBN
-plc
-gzl
-plc
-xYO
 heT
 heT
 heT
@@ -65267,131 +57609,166 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-hBJ
-ajc
-ajc
-ajc
-bWo
-eco
-gSh
-dox
-uSa
-iTn
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-kkf
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-xWK
-gSh
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-pes
-apt
-apt
-apt
-apt
-bji
-qiJ
-bji
-apt
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-mQo
-pAw
-pAw
-uAF
-pAw
-pAw
-pAw
-dmL
-lHG
-pMR
-pMR
-lHG
-dmL
-pAw
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
-eNO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 "}
 (161,1,1) = {"
@@ -65463,41 +57840,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-jxX
-eyl
-xYO
-xYO
-xYO
-xYO
-xYO
-plc
-xIq
-tgg
-plc
-tDO
-dac
-dac
-bua
-plc
-nKs
-jyO
-plc
-fqE
-plc
-plc
-plc
-tsD
-plc
-dac
-xYO
 heT
 heT
 heT
@@ -65524,119 +57866,154 @@ heT
 heT
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mfu
-bWo
-ajc
-ajc
-wBM
-uSQ
-uux
-hPB
-hPB
-hPB
-hPB
-dox
-uSa
-uSa
-iTn
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-qjq
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-nHH
-uSa
-uSa
-uSa
-iSM
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-saH
-hPB
-apt
-pes
-apt
-apt
-apt
-pes
-bgx
-bgx
-bgx
-pes
-hPB
-hPB
-ceA
-hPB
-hPB
-gSh
-hPB
-hPB
-vLS
-ceA
-hPB
-hPB
-gSh
-mQo
-pAw
-pAw
-uAF
-pAw
-pAw
-pAw
-pAw
-mjf
-pAw
-pAw
-mjf
-nHH
-uSa
-iSM
-hPB
-hPB
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -65720,41 +58097,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-qya
-dac
-eWf
-ojn
-jjw
-plc
-plc
-dac
-ojn
-ojn
-plc
-mzD
-xYO
-dac
-nKs
-xYO
-plc
-ioK
-xYO
-jxX
-xYO
-xYO
-pJP
-xYO
-pJP
-xYO
-xYO
-xYO
-pJP
-jxX
-pJP
-xYO
-xYO
 heT
 heT
 heT
@@ -65781,120 +58123,155 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-mfu
-bWo
-ajc
-wBM
-ajc
-ajc
-uux
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-dox
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-iSM
-gSh
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-saH
-hPB
-jUR
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-pes
-uqm
-bji
-uqm
-pes
-hPB
-hPB
-ceA
-ceA
-ceA
-ceA
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-dox
-uSa
-uSa
-kve
-pAw
-pAw
-pAw
-pAw
-pAw
-pAw
-nHH
-uSa
-iSM
-hPB
-gSh
-hPB
-hPB
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -65968,50 +58345,6 @@ heT
 heT
 heT
 heT
-gPZ
-heT
-heT
-heT
-heT
-heT
-heT
-gPZ
-gPZ
-xYO
-xYO
-rPD
-sBn
-alc
-plc
-jxX
-aGn
-jby
-plc
-jxv
-plc
-uZi
-dac
-xYO
-arO
-dac
-bru
-dac
-kZY
-dac
-dac
-xYO
-xcF
-pJP
-pll
-pJP
-uci
-xYO
-rsv
-pJP
-aqj
-cmX
-uci
-xYO
 heT
 heT
 heT
@@ -66038,120 +58371,164 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-ajc
-uSQ
-ajc
-ajc
-bWo
-eco
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-saH
-hPB
-hPB
-hPB
-apt
-apt
-apt
-xXK
-sYw
-qbV
-sYw
-xXK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-gSh
-mhs
-uSa
-uSa
-uSa
-uSa
-uSa
-uSa
-iSM
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -66224,51 +58601,6 @@ heT
 heT
 heT
 heT
-xYO
-jxX
-mTD
-xYO
-jxX
-xYO
-xYO
-xYO
-xYO
-jxX
-xYO
-xYO
-pls
-iLH
-egY
-bWP
-qiO
-uTo
-jby
-dac
-jxv
-plc
-uBl
-dac
-xYO
-iLH
-axY
-xYO
-nPi
-wTd
-plc
-tDO
-jxX
-wbR
-cmX
-puP
-pJP
-uci
-xYO
-uyk
-gNm
-dHa
-pJP
-vPC
-xYO
 heT
 heT
 heT
@@ -66295,120 +58627,165 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-bWo
-bWo
-bWo
-bWo
-bWo
-bWo
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-knQ
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-tpi
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-vNq
-hPB
-hPB
-hPB
-hPB
-saH
-apt
-apt
-apt
-xXK
-bji
-bji
-bji
-xXK
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-gSh
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -66481,51 +58858,6 @@ heT
 heT
 heT
 heT
-jxX
-xYO
-mTD
-xYO
-sFu
-sFu
-sFu
-rLk
-sFu
-lqq
-rLk
-xYO
-jxX
-qiO
-tgg
-tgg
-jxX
-aGg
-lQE
-dac
-jxv
-plc
-edr
-hhU
-xYO
-qiO
-tgg
-xYO
-xYO
-xYO
-bQf
-plc
-xYO
-uci
-cmX
-cah
-cmX
-uci
-xYO
-eWW
-pJP
-hlv
-gNm
-uyk
-xYO
 heT
 heT
 heT
@@ -66552,120 +58884,165 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-dJk
-hPB
-hPB
-hPB
-hPB
-dJk
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-tpi
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-xXK
-bji
-bji
-bji
-xXK
 heT
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -66738,51 +59115,6 @@ heT
 heT
 heT
 heT
-jxX
-jxX
-tMd
-jus
-hyc
-xhG
-jus
-oST
-sFu
-sFu
-oST
-dac
-yfE
-plc
-dac
-yfE
-plc
-yfE
-ojn
-gzl
-plc
-yfE
-uTo
-yfE
-uTo
-ojn
-yfE
-xZn
-fnR
-xYO
-dac
-plc
-jxX
-oVk
-cmX
-dKL
-uck
-uci
-jxX
-uMa
-pJP
-dKL
-cmX
-eTe
-xYO
 heT
 heT
 heT
@@ -66809,120 +59141,165 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-aeh
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-saH
-hPB
-hPB
-saH
-hPB
-hPB
-apt
-apt
-apt
-xXK
-bji
-bji
-bji
-xXK
 heT
 heT
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -66995,51 +59372,6 @@ heT
 heT
 heT
 heT
-jxX
-jxX
-tMd
-hNp
-icS
-rLk
-sFu
-icS
-rLk
-rLk
-icS
-lmg
-dac
-plc
-nee
-plc
-dac
-dac
-dac
-uTo
-dac
-plc
-uTo
-plc
-plc
-hgU
-dac
-plc
-bua
-xYO
-dac
-plc
-xYO
-iTO
-cmX
-sxz
-cmX
-gEg
-xYO
-uyk
-cmX
-tcW
-cmX
-wbR
-xYO
 heT
 heT
 heT
@@ -67066,120 +59398,165 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-tpi
-hPB
-hPB
-hPB
-hPB
-saH
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-xXK
-bji
-bji
-bji
-xXK
 heT
 heT
 heT
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -67252,51 +59629,6 @@ heT
 heT
 heT
 heT
-jxX
-jxX
-mTD
-sFu
-oST
-rLk
-xhG
-hyc
-icS
-rJQ
-oST
-plc
-ruq
-dac
-uTo
-yfE
-dac
-ruq
-dac
-yfE
-plc
-yfE
-plc
-yfE
-dac
-dac
-ruq
-plc
-dvL
-xYO
-aDi
-plc
-xYO
-uyk
-pJP
-uIS
-cmX
-uci
-xYO
-uNI
-pJP
-dHa
-pJP
-uci
-xYO
 heT
 heT
 heT
@@ -67323,120 +59655,165 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-saH
-hPB
-hPB
-hPB
-apt
-apt
-apt
-xXK
-bji
-bji
-bji
-bgx
-bji
-bji
 heT
 heT
 heT
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -67509,51 +59886,6 @@ heT
 heT
 heT
 heT
-jxX
-jxX
-tMd
-jxX
-xhG
-sFu
-sFu
-rLk
-sFu
-icS
-xhG
-xYO
-xYO
-tgg
-tgg
-qiO
-xYO
-nqm
-nvk
-dac
-edW
-plc
-sSR
-hhU
-xYO
-bru
-xYO
-plc
-plc
-xYO
-dac
-plc
-xYO
-uci
-cmX
-mHc
-cmX
-uci
-xYO
-uci
-gNm
-puP
-cmX
-oSx
-xYO
 heT
 heT
 heT
@@ -67580,120 +59912,165 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-hPB
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-ceA
-hPB
-gSh
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-xXK
-bji
-bji
-bji
-bgx
-bji
-bji
-bji
 heT
 heT
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-rso
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -67766,51 +60143,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-pgX
-pgX
-pgX
-xYO
-xYO
-xYO
-fzW
-brU
-fxF
-jbL
-tgg
-dac
-bzK
-dac
-jby
-uTo
-uBl
-dac
-xYO
-duV
-xYO
-plc
-plc
-jxX
-dac
-mGs
-xYO
-bJj
-cmX
-tcW
-cmX
-uci
-xYO
-rsv
-hvv
-iys
-pJP
-vPC
-xYO
 heT
 heT
 heT
@@ -67837,120 +60169,165 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-hPB
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-xXK
-bji
-bji
-bji
-bgx
-bji
-bji
-bji
-bji
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-pes
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -68026,57 +60403,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-pgX
-pgX
-pgX
-xYO
-xYO
-xYO
-cwr
-kjH
-vle
-aQq
-jxX
-plc
-bzK
-dac
-jxv
-uTo
-uBl
-dac
-xYO
-plc
-xYO
-aLr
-aLr
-jxX
-lDz
-lDz
-xYO
-bcF
-pJP
-iys
-dcV
-vPC
-xYO
-uci
-cmX
-iys
-cmX
-rhd
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
 heT
 heT
@@ -68094,120 +60420,171 @@ heT
 heT
 heT
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-xXK
 heT
 heT
 heT
-xXK
 heT
 heT
-bji
-bji
 heT
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-pes
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
-apt
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -68283,57 +60660,6 @@ heT
 heT
 heT
 heT
-xYO
-skn
-xYF
-xYF
-njS
-njS
-njS
-jta
-jxX
-qya
-sBn
-dac
-alc
-bru
-dac
-plc
-plc
-plc
-uTo
-uTo
-vOQ
-xYO
-plc
-xYO
-ggx
-xbh
-ouE
-ifh
-xbh
-xYO
-srg
-pJP
-cah
-pJP
-bcF
-xYO
-vPC
-pJP
-cah
-gNm
-uci
-xYO
-qAg
-nZa
-hOE
-uwD
-qJH
-lCk
-mMt
-uwD
-xYO
 heT
 heT
 heT
@@ -68436,8 +60762,59 @@ heT
 heT
 heT
 heT
-bji
-bji
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -68538,59 +60915,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-jjW
-njS
-nZh
-nZh
-njS
-xYF
-oWZ
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-dac
-xYO
-mAB
-joD
-rbF
-joD
-joD
-eyl
-uci
-pJP
-dHa
-pJP
-uci
-jxX
-uci
-pJP
-xAA
-gNm
-van
-jxX
-iNF
-noe
-pKM
-noe
-noe
-noe
-noe
-uwD
-xYO
 heT
 heT
 heT
@@ -68693,8 +61017,61 @@ heT
 heT
 heT
 heT
-bji
-bji
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -68795,59 +61172,6 @@ heT
 heT
 heT
 heT
-xYO
-lDR
-xYF
-xYF
-woZ
-xtO
-xYF
-xYF
-nST
-cJB
-xYF
-xYO
-vZV
-sRd
-pSp
-kqy
-xYO
-hnd
-sfo
-qQQ
-kJq
-pdT
-kJq
-jxX
-dac
-xYO
-dRr
-slO
-uIL
-sXT
-uIL
-xYO
-xcF
-pJP
-tUW
-pJP
-uci
-xYO
-gEg
-cmX
-jZL
-pJP
-tVN
-xYO
-vOT
-fSq
-fSq
-sOl
-sOl
-fSq
-fSq
-thB
-xYO
 heT
 heT
 heT
@@ -68950,8 +61274,61 @@ heT
 heT
 heT
 heT
-bji
-bji
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -69052,59 +61429,6 @@ heT
 heT
 heT
 heT
-pgX
-xqg
-njS
-bsT
-njS
-njS
-xYF
-mNx
-xYF
-njS
-bsT
-xYO
-alN
-vPe
-rKM
-ctT
-xYO
-xYO
-gji
-knZ
-eQx
-kJq
-hsa
-jxX
-dac
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-pJP
-xYO
-pJP
-xYO
-xYO
-xYO
-cmX
-xYO
-pJP
-xYO
-jmX
-noe
-reY
-adj
-hOC
-hOC
-kAQ
-noe
-thB
-xYO
 heT
 heT
 heT
@@ -69112,11 +61436,6 @@ heT
 heT
 heT
 heT
-eRM
-lte
-eRM
-eRM
-uGF
 heT
 heT
 heT
@@ -69207,8 +61526,66 @@ heT
 heT
 heT
 heT
-bji
-bji
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -69309,59 +61686,6 @@ heT
 heT
 heT
 heT
-pgX
-xqg
-nZh
-bsT
-vLR
-njS
-xYF
-njS
-njS
-lAg
-fiA
-xYO
-hzI
-lmn
-hGd
-sRd
-xYO
-xYO
-nKh
-jxX
-luy
-jxX
-gRw
-xYO
-duV
-plc
-plc
-plc
-wza
-dac
-dac
-bru
-dac
-kVn
-tRO
-kVn
-dac
-sBn
-plc
-kVn
-tRO
-kVn
-dac
-ruq
-noe
-noe
-fSq
-fSq
-noe
-noe
-fSq
-fSq
-xYO
 heT
 heT
 heT
@@ -69369,11 +61693,64 @@ heT
 heT
 heT
 heT
-oPP
-dPt
-cxq
-cMX
-cxq
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -69464,8 +61841,8 @@ heT
 heT
 heT
 heT
-bji
-bji
+heT
+heT
 heT
 heT
 heT
@@ -69566,104 +61943,104 @@ heT
 heT
 heT
 heT
-pgX
-xqg
-nMM
-nQa
-njS
-njS
-ttW
-njS
-njS
-taO
-uiN
-jxX
-aQA
-hQL
-abd
-kqy
-xYO
-jxX
-kJq
-kJq
-jLc
-hsa
-kJq
-xYO
-jxX
-xYO
-gRw
-xYO
-xYO
-xYO
-xYO
-xYO
-dac
-ygG
-bQf
-plc
-duV
-uTo
-duV
-plc
-plc
-uTo
-wza
-plc
-iNF
-noe
-noe
-noe
-uDI
-noe
-iNF
-fSq
-xYO
 heT
 heT
 heT
 heT
-izh
-xfk
-izh
-ucc
-ucc
-ucc
-izh
-ucc
-fvT
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -69721,8 +62098,8 @@ heT
 heT
 heT
 heT
-bji
-bji
+heT
+heT
 heT
 heT
 heT
@@ -69823,104 +62200,104 @@ heT
 heT
 heT
 heT
-xYO
-kje
-dRj
-nZh
-xtO
-hal
-njS
-njS
-nQa
-uiN
-njS
-eyl
-jxX
-xYO
-mcw
-xYO
-xYO
-xYO
-qWS
-xYO
-xYO
-hsa
-qhB
-kJq
-hsa
-hsa
-qhB
-hsa
-xYO
-xYO
-xYO
-xYO
-mzD
-dac
-dac
-dac
-dac
-plc
-dac
-dac
-dac
-dac
-plc
-yfE
-noe
-fSq
-iNF
-iNF
-cfq
-noe
-iNF
-fSq
-xYO
 heT
 heT
 heT
 heT
-hXs
-qXG
-kRy
-ulM
-kRy
-hvL
-kRy
-kRy
-vQx
-nmg
-tWT
-kRy
-rJv
-kRy
-qXG
-kRy
-kRy
-kRy
-kRy
-kRy
-hvL
-kRy
-kRy
-kRy
-ucc
-ulM
-ucc
-kRy
-kRy
-hvL
-nmg
-kRy
-kRy
-uXT
-kRy
-tWT
-kRy
-mpI
-uXT
-kRy
-izh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -69978,8 +62355,8 @@ heT
 heT
 heT
 heT
-bji
-bji
+heT
+heT
 heT
 heT
 heT
@@ -70080,104 +62457,104 @@ heT
 heT
 heT
 heT
-lDR
-nQa
-njS
-oLv
-njS
-njS
-njS
-njS
-xYF
-njS
-njS
-nzJ
-aXW
-aUz
-aUz
-aXW
-hgt
-aXW
-jMW
-rqp
-xYO
-ofY
-tPN
-mVP
-hsa
-kyR
-sfo
-kJq
-xYO
-xYO
-xYO
-xYO
-xYO
-eRx
-eRx
-eRx
-nAh
-eRx
-eRx
-eRx
-eRx
-eRx
-xYO
-tMn
-iNF
-fSq
-sDc
-noe
-hOC
-fSq
-pHx
-fSq
-xYO
 heT
 heT
 heT
 heT
-hXs
-rRv
-kRy
-kRy
-uXT
-kRy
-nmg
-nmg
-lWY
-kRy
-uXT
-kWn
-kRy
-nmg
-ulM
-kRy
-uXT
-nmg
-kRy
-vCf
-ulM
-kRy
-uXT
-rRv
-kRy
-tWT
-kRy
-kRy
-kRy
-ulM
-kRy
-uXT
-kRy
-kRy
-kRy
-ucc
-kRy
-uXT
-nkn
-ulM
-izh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -70235,8 +62612,8 @@ heT
 heT
 heT
 heT
-bji
-bji
+heT
+heT
 heT
 heT
 heT
@@ -70337,104 +62714,104 @@ heT
 heT
 heT
 heT
-skn
-gzv
-xRe
-eln
-oLv
-njS
-njS
-scf
-xYF
-xYF
-taO
-nZh
-aUz
-aXW
-aUz
-ghO
-aUz
-iyZ
-jMW
-iyZ
-jxX
-sfo
-gHd
-hsa
-gIz
-xYO
-ruw
-kJq
-fxL
-poW
-tYd
-pdk
-xYO
-koy
-ooP
-hQi
-koy
-cat
-hQi
-gxI
-faF
-koy
-xYO
-xYO
-dKg
-fSq
-sPO
-noe
-sPO
-fSq
-rXd
-auy
-xYO
 heT
 heT
 heT
 heT
-qXG
-qXG
-nmg
-uXT
-vHF
-kRy
-kRy
-kRy
-jZE
-kRy
-kRy
-kRy
-ucc
-kRy
-kRy
-ucc
-kRy
-kRy
-kRy
-kRy
-kRy
-kRy
-nmg
-kRy
-uXT
-kRy
-nmg
-fQS
-ulM
-kRy
-kRy
-qXG
-uXT
-vWq
-kRy
-ucc
-kRy
-ulM
-kRy
-kRy
-izh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -70492,8 +62869,8 @@ heT
 heT
 heT
 heT
-bji
-bji
+heT
+heT
 heT
 heT
 heT
@@ -70594,104 +62971,104 @@ heT
 heT
 heT
 heT
-kje
-nQa
-njS
-xRe
-njS
-njS
-njS
-njS
-xYF
-mNx
-njS
-ono
-aXW
-aXW
-aUz
-pyT
-aXW
-aXW
-eaG
-hek
-xYO
-keh
-kJq
-sfo
-wKt
-hen
-kJq
-hsa
-xYO
-tYd
-poW
-mDq
-tYd
-tYd
-poW
-poW
-poW
-mBc
-tYd
-gAl
-xZz
-otV
-aNF
-eRx
-fSq
-fSq
-bBa
-fSq
-vhT
-fSq
-tmO
-fSq
-xYO
 heT
 heT
 heT
 heT
-qXG
-hXs
-kRy
-kRy
-nmg
-uXT
-ulM
-kRy
-vQx
-nmg
-uXT
-ucc
-kRy
-ulM
-uXT
-kRy
-tWT
-nmg
-kRy
-kRy
-kRy
-ulM
-kRy
-ucc
-kRy
-kRy
-ulM
-kRy
-kRy
-uXT
-kRy
-kRy
-nmg
-kRy
-kRy
-tWT
-nmg
-kRy
-kRy
-qXG
-izh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -70749,8 +63126,8 @@ heT
 heT
 heT
 heT
-dHQ
-dHQ
+heT
+heT
 heT
 heT
 heT
@@ -70851,104 +63228,104 @@ heT
 heT
 heT
 heT
-xYO
-lDR
-kfZ
-njS
-fXt
-edy
-njS
-ttW
-nQa
-nQa
-njS
-xYO
-xYO
-xYO
-nom
-jxX
-xYO
-xYO
-orn
-xYO
-xYO
-hsa
-qhB
-kJq
-kJq
-hsa
-ugx
-cRI
-xYO
-tYd
-mLm
-tYd
-poW
-tYd
-tYd
-tYd
-poW
-poW
-poW
-ngJ
-tYd
-bHl
-dQX
-eRx
-fSq
-fSq
-rXd
-noe
-sPO
-fSq
-rXd
-hWw
-xYO
 heT
 heT
 heT
 heT
-rRv
-kRy
-kRy
-kRy
-kRy
-tDf
-nmg
-kRy
-vQx
-kRy
-tWT
-kRy
-kRy
-kRy
-kRy
-kRy
-kRy
-nmg
-qXG
-kRy
-tDf
-kRy
-kRy
-kRy
-ucc
-kRy
-qXG
-kRy
-kRy
-gkh
-kRy
-kRy
-ulM
-kRy
-nmg
-ucc
-kRy
-kRy
-kRy
-kRy
-izh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -71005,10 +63382,10 @@ heT
 heT
 heT
 heT
-azV
-jtU
-jtU
-azV
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -71108,104 +63485,104 @@ heT
 heT
 heT
 heT
-pgX
-xqg
-njS
-hal
-nZh
-njS
-xYF
-njS
-xYF
-xYF
-nQa
-xYO
-itO
-eNr
-hoe
-dtV
-xYO
-xYO
-hsa
-hsa
-usT
-hsa
-sfo
-xYO
-xYO
-xYO
-gRw
-xYO
-xYO
-tYd
-pLV
-jxX
-xYO
-lXU
-poW
-mnt
-xYO
-xYO
-wtu
-poW
-poW
-mDq
-koy
-eRx
-fSq
-noe
-tmO
-noe
-hOC
-fSq
-tmO
-fSq
-xYO
 heT
 heT
 heT
 heT
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-fvT
-izh
-izh
-izh
-kRy
-hXs
-rRv
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-izh
-tWT
-jTg
-jTg
-kWn
-ucc
-izh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -71262,19 +63639,19 @@ heT
 heT
 heT
 heT
-xmE
-jtU
-jtU
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -71365,79 +63742,6 @@ heT
 heT
 heT
 heT
-pgX
-pgX
-njS
-xtO
-cUS
-xYF
-mNx
-njS
-xYF
-htx
-fiA
-skn
-nGv
-xqQ
-rtb
-sRd
-xYO
-xYO
-nKh
-xYO
-nKh
-xYO
-iBt
-xYO
-xYO
-hYZ
-plc
-fDt
-xYO
-tYd
-poW
-eyl
-eyl
-xRj
-poW
-lXU
-xYO
-xYO
-eUH
-poW
-jBs
-iLC
-lXU
-eRx
-fSq
-noe
-rXd
-iNF
-pAj
-fSq
-rXd
-fSq
-xYO
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-izh
-gkh
-uXT
-kRy
-izh
 heT
 heT
 heT
@@ -71456,13 +63760,86 @@ heT
 heT
 heT
 heT
-izh
-mzY
-kRy
-fPp
-kRy
-pVE
-izh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -71519,19 +63896,19 @@ heT
 heT
 heT
 heT
-xmE
-jtU
-jtU
-qGo
-dzb
-jtU
-jtU
-jtU
-jtU
-dzb
-jtU
-jtU
-xmE
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -71622,79 +63999,6 @@ heT
 heT
 heT
 heT
-pgX
-xqg
-njS
-xtO
-nZh
-njS
-xYF
-xYF
-xYF
-xYF
-nQa
-xYO
-dtV
-wCx
-joN
-jcL
-xYO
-xYO
-pzP
-uzG
-kkR
-kJq
-sfo
-xYO
-xYO
-cRS
-lqS
-plc
-xYO
-poW
-fkU
-tYd
-poW
-tYd
-tYd
-nYo
-poW
-poW
-tYd
-tYd
-poW
-tks
-koy
-eRx
-fSq
-noe
-rAe
-noe
-mwd
-noe
-hOC
-fSq
-xYO
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-izh
-izh
-izh
-izh
-izh
 heT
 heT
 heT
@@ -71713,13 +64017,86 @@ heT
 heT
 heT
 heT
-mfN
-kRy
-kRy
-ulM
-kRy
-uXT
-mfN
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -71776,19 +64153,19 @@ heT
 heT
 heT
 heT
-xmE
-jtU
-jtU
-qGo
-jtU
-jtU
-jtU
-jtU
-jtU
-hCz
-jtU
-jtU
-xmE
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -71879,59 +64256,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-njS
-xYF
-tCx
-uiN
-xYF
-xYF
-nQa
-hZz
-xYF
-xYO
-npF
-aUz
-koD
-ejq
-xYO
-mQP
-kJq
-gUc
-cNi
-tPN
-cvA
-xYO
-xYO
-oGi
-plc
-hYZ
-xYO
-poW
-poW
-poW
-rrL
-poW
-tYd
-eJd
-iLC
-jBs
-mnx
-sWg
-poW
-poW
-ooP
-eRx
-fSq
-kcS
-rXd
-iNF
-pDs
-noe
-sPO
-fSq
-xYO
 heT
 heT
 heT
@@ -71969,15 +64293,68 @@ heT
 heT
 heT
 heT
-cIT
-okW
-kRy
-ulM
-nmg
-kRy
-iOE
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -72033,19 +64410,19 @@ heT
 heT
 heT
 heT
-xmE
-jtU
-qGo
-qGo
-jtU
-jtU
-jtU
-jtU
-jtU
-xmE
-azV
-xmE
-xmE
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -72136,59 +64513,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-jjW
-xYF
-xYF
-nZh
-xYF
-mNx
-bhg
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-koy
-qvY
-gxI
-fSK
-qpm
-qVF
-koy
-gFw
-lXU
-gxI
-qpm
-gxI
-koy
-xYO
-xYO
-hIW
-fSq
-bgD
-noe
-bBa
-noe
-ndh
-auy
-xYO
 heT
 heT
 heT
@@ -72226,15 +64550,68 @@ heT
 heT
 heT
 heT
-cIT
-okW
-kRy
-gEI
-kRy
-kOH
-gEI
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -72290,19 +64667,19 @@ heT
 heT
 heT
 heT
-xmE
-jtU
-jtU
-jtU
-jtU
-jtU
-jtU
-jtU
-jtU
-ePu
-jtU
-pup
-xmE
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -72393,59 +64770,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-kje
-xYF
-njS
-njS
-njS
-njS
-lDR
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-eRx
-eRx
-eRx
-eRx
-eRx
-eRx
-eRx
-eRx
-eRx
-eRx
-nAh
-eRx
-eRx
-xYO
-xYO
-keL
-iNF
-rXd
-noe
-fAu
-fSq
-rXd
-fSq
-xYO
 heT
 heT
 heT
@@ -72460,17 +64784,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-heT
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
 heT
 heT
@@ -72482,17 +64795,81 @@ heT
 heT
 heT
 heT
-cIT
-cIT
-okW
-kRy
-iOE
-iOE
-iOE
-kRy
-okW
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -72547,19 +64924,19 @@ heT
 heT
 heT
 heT
-xmE
-jtU
-yed
-jtU
-jtU
-jtU
-yed
-jtU
-jtU
-xmE
-yed
-pup
-xmE
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -72650,59 +65027,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYF
-xYF
-xYF
-xYF
-njS
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-mzD
-dac
-dac
-dac
-dac
-dac
-dac
-dac
-dac
-dac
-dac
-plc
-pfI
-plc
-plc
-dac
-dac
-dac
-nui
-xYO
-fSq
-gAU
-noe
-noe
-noe
-fSq
-noe
-fSq
-xYO
 heT
 heT
 heT
@@ -72716,20 +65040,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-nYn
-xYO
-nYn
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
 heT
 heT
@@ -72739,17 +65049,84 @@ heT
 heT
 heT
 heT
-cIT
-oNr
-okW
-kRy
-iOE
-iOE
-gEI
-kRy
-okW
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -72804,19 +65181,19 @@ heT
 heT
 heT
 heT
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
-xmE
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -72907,59 +65284,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-wgZ
-xYO
-jjU
-xYO
-wgZ
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-jxX
-jxX
-xYO
-xYO
-xYO
-dac
-fnx
-dac
-fbG
-dac
-fnx
-dac
-csm
-plc
-fnx
-plc
-csm
-uTo
-fnx
-dac
-fbG
-sBn
-fnx
-bua
-xYO
-phu
-uWO
-fSq
-fSq
-fSq
-fSq
-qce
-phu
-xYO
 heT
 heT
 heT
@@ -72973,21 +65297,6 @@ heT
 heT
 heT
 heT
-xYO
-lVg
-lVg
-njj
-qbI
-lVg
-xYO
-xYO
-xYO
-lVg
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
 heT
 heT
@@ -72995,17 +65304,85 @@ heT
 heT
 heT
 heT
-cIT
-cIT
-okW
-okW
-fRE
-iOE
-iOE
-iOE
-ulM
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -73164,59 +65541,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-gtZ
-dUG
-oZl
-sWW
-oZl
-oZl
-tYt
-dUG
-gtZ
-xYO
-xYO
-xYO
-lQE
-plc
-vzF
-eYD
-pXR
-dac
-wza
-plc
-vOQ
-xYO
-plc
-bdd
-plc
-rSd
-dac
-jJC
-dac
-bdd
-plc
-ikC
-plc
-rSd
-uTo
-jJC
-dac
-koZ
-plc
-bdd
-sBn
-xYO
-xYO
-jmX
-yao
-dac
-dac
-gBi
-jmX
-xYO
-xYO
 heT
 heT
 heT
@@ -73230,39 +65554,92 @@ heT
 heT
 heT
 heT
-xYO
-lVg
-qyV
-bEa
-jPY
-bEa
-vBp
-bEa
-bEa
-tAt
-lVg
-lVg
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
 heT
 heT
 heT
 heT
-cIT
-okW
-okW
-okW
-iOE
-fRE
-iOE
-iOE
-kRy
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -73421,58 +65798,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-dUG
-gtZ
-cGl
-tDL
-ikG
-bHT
-oZl
-dUG
-dUG
-xYO
-xYO
-xYO
-aQq
-plc
-eCq
-eIM
-pFp
-plc
-uTo
-beT
-vpH
-xYO
-nqm
-mvQ
-plc
-yao
-dac
-yao
-dac
-gBi
-plc
-mje
-plc
-yao
-dac
-yao
-plc
-gBi
-dac
-mje
-plc
-kSM
-plc
-fjZ
-plc
-plc
-plc
-oQU
-fnR
-xYO
 heT
 heT
 heT
@@ -73487,40 +65812,92 @@ heT
 heT
 heT
 heT
-xYO
-bEa
-mzF
-aHE
-fNg
-bEa
-xYO
-xYO
-xYO
-tAt
-cJR
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
 heT
 heT
-cIT
-cIT
-okW
-okW
-okW
-iOE
-kOH
-nmg
-qGr
-kRy
-okW
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -73678,58 +66055,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-dUG
-dUG
-cGl
-oZl
-bHT
-tDL
-tDL
-gtZ
-dUG
-xYO
-xYO
-xYO
-dac
-dac
-eCq
-sPA
-ujl
-ojn
-plc
-wky
-dac
-xYO
-plc
-plc
-plc
-dzu
-dac
-dac
-plc
-plc
-plc
-dac
-dac
-uTo
-uTo
-plc
-dac
-dac
-dac
-dac
-plc
-dac
-plc
-plc
-fjZ
-plc
-plc
-eYD
-xgf
-xYO
 heT
 heT
 heT
@@ -73744,40 +66069,92 @@ heT
 heT
 heT
 heT
-xYO
-bEa
-bEa
-ydR
-bEa
-qbI
-jxX
-xYO
-xYO
-xYO
-bEa
-ghG
-bEa
-bEa
-waP
-lVg
-doH
-xYO
 heT
 heT
 heT
-cIT
-cIT
-okW
-okW
-okW
-iOE
-iOE
-kRy
-fRE
-kRy
-okW
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -73935,58 +66312,6 @@ heT
 heT
 heT
 heT
-xYO
-jxX
-iTp
-dUG
-oZl
-oPz
-oZl
-tYt
-oZl
-gtZ
-dUG
-xYO
-xYO
-xYO
-lQE
-plc
-lQE
-pYs
-dMq
-uTo
-tDO
-plc
-aKq
-xYO
-dBd
-eYD
-plc
-dac
-kSM
-rSd
-plc
-dac
-kSM
-jJC
-plc
-plc
-wTd
-koZ
-plc
-plc
-kSM
-rSd
-dac
-kSM
-dac
-plc
-plc
-daN
-dac
-dac
-dac
-xYO
 heT
 heT
 heT
@@ -74001,39 +66326,91 @@ heT
 heT
 heT
 heT
-xYO
-ydR
-bEa
-lMi
-tAt
-lVg
-xYO
-jxX
-xYO
-xYO
-bEa
-bEa
-cJR
-hkf
-fwe
-rto
-sHG
-xYO
 heT
 heT
 heT
 heT
-cIT
-okW
-okW
-mfN
-fRE
-iOE
-fRE
-iOE
-iOE
-mfN
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -74192,58 +66569,6 @@ heT
 heT
 heT
 heT
-xYO
-jxX
-iTp
-gtZ
-gtZ
-gtZ
-gtZ
-gtZ
-gtZ
-gtZ
-dUG
-xYO
-xYO
-xYO
-daN
-fjZ
-daN
-xYO
-xYO
-bvl
-plc
-duV
-dac
-xYO
-dac
-asP
-uTo
-dac
-dac
-kfI
-dac
-qvP
-dac
-kfI
-pua
-dac
-dac
-kfI
-plc
-jyO
-vle
-kfI
-mzD
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
 heT
 heT
@@ -74258,39 +66583,91 @@ heT
 heT
 heT
 heT
-xYO
-lVg
-bEa
-bEa
-bEa
-lVg
-xYO
-xYO
-xYO
-xYO
-lVg
-kOB
-gLt
-tFl
-lVg
-bEa
-tpU
-xYO
 heT
 heT
 heT
 heT
-cIT
-okW
-okW
-izh
-eFW
-kRy
-kOH
-iOE
-drc
-izh
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -74449,50 +66826,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-gtZ
-kpM
-dUG
-gtZ
-sqp
-gtZ
-dUG
-nbx
-iTp
-xYO
-xYO
-xYO
-uZi
-uTo
-ujX
-xYO
-smL
-plc
-plc
-plc
-dac
-xYO
-oTT
-oTT
-uTo
-dac
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
 heT
 heT
@@ -74515,38 +66848,82 @@ heT
 heT
 heT
 heT
-xYO
-ffR
-iGl
-xYO
-vCQ
-ffR
-xYO
-xYO
-jxX
-xYO
-vBp
-xYO
-xYO
-xYO
-rVg
-hkf
-snK
-xYO
 heT
 heT
-cIT
-cIT
-okW
-okW
-okW
-okW
-kRy
-fRE
-iOE
-uXT
-iOE
-okW
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -74706,35 +67083,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-jxX
-jxX
-jxX
-jxX
-jxX
-jxX
-jxX
-xYO
-xYO
-xYO
-plc
-uTo
-plc
-xYO
-sLG
-plc
-plc
-plc
-wza
-xYO
-plc
-plc
-scX
-dac
-xYO
 heT
 heT
 heT
@@ -74773,37 +67121,66 @@ heT
 heT
 heT
 heT
-xYO
-xhG
-sFu
-sFu
-xYO
-xYO
-xYO
-aEp
-hkf
-ydR
-wse
-mzF
-xYO
-wpj
-bEa
-snK
-xYO
 heT
-cIT
-cIT
-okW
-okW
-okW
-okW
-okW
-ulM
-iOE
-iOE
-kRy
-iOE
-okW
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -74963,35 +67340,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-ujX
-uTo
-cut
-xYO
-wxG
-dac
-dac
-plc
-dac
-xYO
-dac
-dac
-plc
-dac
-xYO
 heT
 heT
 heT
@@ -75020,48 +67368,77 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-jxX
-jxX
-jxX
-jxX
-xYO
 heT
 heT
 heT
-xYO
-icS
-hhj
-icS
-xYO
-xYO
-xYO
-lVg
-bEa
-lCC
-lVg
-pAu
-xYO
-uAo
-bEa
-wiW
-xYO
-cIT
-okW
-okW
-okW
-okW
-okW
-okW
-okW
-kRy
-dzK
-fRE
-kRy
-iOE
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -75233,22 +67610,6 @@ heT
 heT
 heT
 heT
-xYO
-plc
-plc
-plc
-xYO
-dBd
-dTH
-tDO
-plc
-xRP
-xYO
-faQ
-plc
-plc
-yao
-xYO
 heT
 heT
 heT
@@ -75277,48 +67638,64 @@ heT
 heT
 heT
 heT
-xYO
-mTc
-sFu
-nAB
-eJr
-eMT
-xYO
-xYO
-xYO
-xYO
-ffR
-iGl
-xYO
-iGl
-ffR
-xYO
-xYO
-mzF
-bEa
-bEa
-lCC
-lVg
-xYO
-xYO
-xYO
-xYO
-jmX
-wOk
-okW
-hCQ
-okW
-oNr
-okW
-okW
-stC
-kRy
-dzK
-xNG
-nmg
-iOE
-stC
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -75490,22 +67867,6 @@ heT
 heT
 heT
 heT
-xYO
-plc
-plc
-plc
-xYO
-dac
-pYs
-plc
-plc
-dac
-bSJ
-dac
-plc
-duV
-dac
-xYO
 heT
 heT
 heT
@@ -75534,49 +67895,65 @@ heT
 heT
 heT
 heT
-xYO
-opq
-hnT
-rLk
-jMj
-icS
-jxX
-jxX
-xYO
-jmX
-nCM
-icS
-wOk
-icS
-icS
-jmX
-xYO
-xYO
-uuZ
-uuZ
-uuZ
-xYO
-xYO
-xYO
-xYO
-tzo
-veW
-sFu
-vxG
-okW
-okW
-okW
-okW
-okW
-mfN
-iOE
-vye
-iOE
-kRy
-iOE
-mfN
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -75747,22 +68124,6 @@ heT
 heT
 heT
 heT
-xYO
-dac
-kQq
-dac
-xYO
-dac
-plc
-duV
-plc
-dac
-dac
-wza
-dac
-plc
-plc
-xYO
 heT
 heT
 heT
@@ -75791,49 +68152,65 @@ heT
 heT
 heT
 heT
-xYO
-gsB
-vHR
-sSu
-guS
-icS
-xYO
-eZL
-sFu
-bys
-icS
-sFu
-icS
-icS
-bys
-oKT
-jxX
-nJB
-sFu
-sFu
-sFu
-nJB
-xYO
-xYO
-uwW
-kqg
-sFu
-sFu
-sFu
-icS
-okW
-okW
-okW
-izh
-izh
-eFW
-kRy
-uXT
-kRy
-kuY
-izh
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -76004,22 +68381,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-dac
-plc
-dac
-plc
-plc
-plc
-plc
-plc
-dac
-dac
-xYO
 heT
 heT
 heT
@@ -76048,49 +68409,65 @@ heT
 heT
 heT
 heT
-xYO
-jxX
-enB
-rka
-eyl
-jvX
-xYO
-sFu
-kqg
-rId
-sFu
-sFu
-xhG
-jMj
-sFu
-sFu
-eyl
-fea
-pFk
-fea
-pFk
-pFk
-xYO
-eVK
-kqg
-pnq
-swQ
-vJP
-cqF
-hyc
-icS
-nmg
-nmg
-rJv
-kOH
-kRy
-kRy
-iOE
-kRy
-iOE
-okW
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -76265,18 +68642,6 @@ heT
 heT
 heT
 heT
-xYO
-urn
-urn
-kst
-kst
-kst
-kst
-jhU
-kst
-kst
-urn
-xYO
 heT
 heT
 heT
@@ -76305,48 +68670,60 @@ heT
 heT
 heT
 heT
-xYO
-nXX
-jMj
-sFu
-vJP
-icS
-hhj
-icS
-cqF
-vJP
-kqg
-kqg
-bys
-hyc
-sFu
-kqg
-fMc
-icS
-oST
-icS
-sFu
-oKg
-icS
-vBo
-sFu
-kqg
-hnT
-sFu
-kqg
-sFu
-bys
-hyc
-nmg
-nmg
-kOH
-nmg
-kRy
-iOE
-gEI
-ulM
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -76522,18 +68899,6 @@ heT
 heT
 heT
 heT
-xYO
-nnF
-nnF
-nnF
-nnF
-nnF
-nnF
-lTu
-nnF
-nnF
-nnF
-xYO
 heT
 heT
 heT
@@ -76562,48 +68927,60 @@ heT
 heT
 heT
 heT
-jmX
-xCj
-sFu
-sFu
-xIV
-sFu
-sFu
-icS
-kqg
-sFu
-xIV
-kqg
-icS
-icS
-sFu
-sFu
-fMc
-icS
-sFu
-sFu
-fUY
-xJo
-iNv
-qVs
-mtz
-kqg
-kqg
-icS
-sFu
-qVp
-sFu
-sFu
-icS
-iOE
-nmg
-kRy
-iOE
-kRy
-iOE
-kRy
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -76819,49 +69196,49 @@ heT
 heT
 heT
 heT
-xYO
-nNv
-icS
-acq
-oST
-icS
-icS
-sFu
-swQ
-vJP
-acq
-pnq
-swQ
-hyc
-kqg
-sFu
-fMc
-icS
-hyc
-sFu
-sFu
-dkO
-icS
-wHI
-sFu
-sFu
-acq
-sFu
-icS
-qVp
-cqF
-oST
-iOE
-dxk
-kOH
-kOH
-kRy
-nmg
-kRy
-uXT
-okW
-cIT
-koh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -77076,49 +69453,49 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-sfz
-wgZ
-xYO
-dGD
-xYO
-icS
-xhG
-sFu
-kqg
-kqg
-sFu
-sFu
-icS
-icS
-xYO
-pFk
-pFk
-pFk
-pFk
-pFk
-xYO
-icS
-icS
-sFu
-nQB
-hyc
-cqF
-gKe
-icS
-nmg
-nmg
-gEW
-nmg
-kRy
-kRy
-uXT
-kRy
-pVE
-izh
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -77333,49 +69710,49 @@ heT
 heT
 heT
 heT
-xYO
-gsB
-xfM
-mFN
-ceP
-icS
-xYO
-vKu
-icS
-bys
-icS
-pBu
-sFu
-icS
-bys
-oKT
-xYO
-nJB
-sFu
-sFu
-sFu
-nJB
-xYO
-xYO
-rir
-sFu
-sFu
-icS
-sFu
-icS
-okW
-hCQ
-okW
-izh
-izh
-okW
-okW
-okW
-okW
-izh
-izh
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -77590,48 +69967,48 @@ heT
 heT
 heT
 heT
-xYO
-opq
-hnT
-rId
-rLk
-sFu
-xYO
-xYO
-xYO
-jmX
-icS
-icS
-sFu
-sFu
-nCM
-jmX
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-tzo
-qzF
-sFu
-vxG
-vxG
-okW
-okW
-okW
-oNr
-okW
-okW
-okW
-okW
-okW
-okW
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -77847,48 +70224,48 @@ heT
 heT
 heT
 heT
-xYO
-xZS
-icS
-uwP
-lHF
-sfh
-jxX
-xYO
-xYO
-xYO
-xYO
-icS
-wOk
-icS
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-jmX
-wOk
-okW
-cIT
-cIT
-cIT
-cIT
-cIT
-okW
-okW
-okW
-okW
-oNr
-okW
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -78104,21 +70481,6 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-heT
-heT
-heT
-xYO
-iGl
-xYO
-iGl
-xYO
 heT
 heT
 heT
@@ -78127,24 +70489,39 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-cIT
-cIT
-cIT
 heT
 heT
 heT
 heT
-cIT
-okW
-okW
-okW
-okW
-okW
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -78371,11 +70748,6 @@ heT
 heT
 heT
 heT
-xYO
-rpV
-pDZ
-heT
-xYO
 heT
 heT
 heT
@@ -78384,23 +70756,28 @@ heT
 heT
 heT
 heT
-okW
-xYO
-xYO
-xYO
-cIT
-cIT
-cIT
 heT
 heT
 heT
 heT
 heT
-cIT
-cIT
-cIT
-cIT
-cIT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -78628,11 +71005,6 @@ heT
 heT
 heT
 heT
-xYO
-pDZ
-heT
-heT
-xYO
 heT
 heT
 heT
@@ -78641,10 +71013,15 @@ heT
 heT
 heT
 heT
-cIT
-cIT
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -78885,11 +71262,11 @@ heT
 heT
 heT
 heT
-xYO
 heT
 heT
 heT
-xYO
+heT
+heT
 heT
 heT
 heT
@@ -79399,9 +71776,9 @@ heT
 heT
 heT
 heT
-nOd
-eRM
-eRM
+heT
+heT
+heT
 heT
 heT
 heT
@@ -79652,13 +72029,13 @@ heT
 heT
 heT
 heT
-okW
-riZ
 heT
-okW
-riZ
-vJi
-mPu
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -79907,15 +72284,15 @@ heT
 heT
 heT
 heT
-riZ
-okW
-okW
-riZ
-vRy
-okW
-okW
-okW
-vJi
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -80165,14 +72542,14 @@ heT
 heT
 heT
 heT
-okW
-okW
-okW
-okW
-koh
-riZ
-okW
-koh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -80403,30 +72780,30 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-okW
-okW
-okW
-okW
-onY
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -80660,28 +73037,28 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-okW
-okW
-okW
-riZ
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -80917,27 +73294,27 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-pug
-ufX
-lQk
-ncR
-xYO
 heT
-xYO
-lQS
-gnD
-hBH
-sFu
-sFu
-pGC
-gsB
-pDj
-xYO
-hNR
-okW
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -81174,37 +73551,37 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-lQk
-vZy
-eHK
-wWK
-jxX
-gPZ
-xYO
-oFM
-nsX
-ydy
-cQD
-icS
-jiL
-kqg
-grb
-vxG
-rpV
-rpV
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -81430,38 +73807,38 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-ctp
-xYO
-xYO
-xYO
-xYO
 heT
-xYO
-xYO
-fsd
-cQD
-sFq
-dgd
-sFu
-icS
-bPe
-cgJ
-okW
-rpV
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -81687,39 +74064,39 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-mMQ
-lWx
-htp
-sZm
-xYO
-xYO
 heT
-xYO
-xYO
-rbh
-sFu
-sFu
-sFu
-sFu
-icS
-xYO
-eIW
-rpV
-hNR
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -81944,39 +74321,39 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-gyL
-trE
-okx
-sZm
-xYO
-xYO
 heT
-xYO
-lQS
-qoP
-gnD
-sFu
-sFu
-hBH
-bjs
-cIc
-grb
-rpV
-icS
-xbz
-sFu
-sFu
-eWR
-ydy
-cwC
-sps
-rvI
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -82201,40 +74578,40 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-clG
-oAF
-xmY
-rrO
-xYO
-xYO
-xYO
-xYO
-vws
-aBq
-jiL
-sFu
-fBP
-jiL
-icS
-bql
-grb
-xYO
-hqq
-icS
-icS
-dgg
-sFu
-sFu
-uAx
-icS
-ljI
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -82458,40 +74835,40 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-djH
-ydg
-lWx
-trE
-vRR
-xYO
-xYO
-xYO
-xYO
-nnG
-icS
-sFu
-sFu
-fBP
-gZE
-hNR
-rpV
-rpV
-sFu
-icS
-lqB
-vlo
-jiL
-vlo
-ydy
-hmn
-sFu
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -82715,40 +75092,40 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-mIm
-qwH
-fIw
-lWx
-iiF
-xYO
-xYO
-xYO
-xYO
-icS
-sFu
-ete
-sFu
-icS
-icS
-xYO
-hNR
-xYO
-thn
-sFu
-icS
-hmn
-kqg
-hmn
-icS
-hmn
-sFu
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -82972,42 +75349,42 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-uzL
-xYO
-xYO
-xYO
-xYO
-xYO
-pDj
-pCm
-uoZ
-icS
-sFu
-qoP
-gsB
-lQS
-dOr
-xYO
-eFc
-tVz
-iuM
-hmn
-sFu
-vlo
-icS
-hmn
-pDu
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -83229,43 +75606,43 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-lyX
-jsg
-lyX
-cYa
-xYO
-xYO
-xYO
-cta
-iOQ
-jiL
-icS
-sFu
-ydy
-nsX
-chE
-xYO
-xYO
-kMG
-icS
-sFu
-vlo
-sFu
-hmn
-jiL
-hmn
-sFu
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -83486,44 +75863,44 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-dCO
-dqy
-djc
-djc
-pnY
-lyX
-dCO
-xYO
-xYO
-fsd
-icS
-icS
-cQD
-ete
-mjh
-xYO
-xYO
-xYO
-wAB
-icS
-uAx
-sFu
-mLV
-icS
-sFu
-dgg
-tQJ
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -83743,46 +76120,46 @@ heT
 heT
 heT
 heT
-xYO
-aVI
-djc
-lyX
-mPD
-cHa
-djc
-lyX
-dqy
-xYO
-xYO
-ete
-sFu
-sFu
-sFu
-kqg
-evL
-xYO
-xYO
-xYO
-eGl
-ydy
-kqg
-iuM
-jiL
-sFu
-sFu
-lqB
-uAx
-xYO
-xYO
-xYO
-xYO
-xYO
-sps
-sps
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -84000,48 +76377,48 @@ heT
 heT
 heT
 heT
-xYO
-oRF
-djc
-lyX
-djc
-djc
-vcG
-lyX
-lyX
-xYO
-eZq
-eRx
-eRx
-dGD
-eRx
-eRx
-eZq
-xYO
-xYO
-xYO
-eRx
-eRx
-eRx
-eRx
-eRx
-eRx
-eRx
-eRx
-nAh
-xYO
-xYO
-xYO
-dxw
-ewK
-kzj
-sps
-oZn
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -84257,48 +76634,48 @@ heT
 heT
 heT
 heT
-xYO
-sbf
-djc
-lyX
-qKT
-pdP
-djc
-djc
-lOD
-pmw
-oZn
-sps
-icS
-icS
-sFu
-icS
-xYO
-xYO
-xYO
-xYO
-fuM
-uYl
-sFu
-sFu
-sFu
-sFu
-kqg
-sFu
-rbh
-xYO
-xYO
-xYO
-otX
-sFu
-kqg
-sFu
-sFu
-bJF
-jmX
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -84514,48 +76891,48 @@ heT
 heT
 heT
 heT
-xYO
-upT
-djc
-lyX
-djc
-vVP
-rDz
-lyX
-lyX
-pmw
-sps
-icS
-tCY
-sFu
-oST
-oKT
-sps
-xYO
-mTD
-mTD
-jus
-qms
-icS
-icS
-sFu
-icS
-sFu
-icS
-sFu
-roX
-jmX
-oEC
-icS
-sFu
-kqg
-icS
-sFu
-sFu
-qms
-ewK
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -84771,48 +77148,48 @@ heT
 heT
 heT
 heT
-xYO
-hbc
-djc
-lyX
-djc
-mTE
-eJH
-djc
-gnA
-xYO
-oEC
-icS
-jMj
-sFu
-sFu
-icS
-icS
-qYm
-jus
-qYm
-icS
-sFu
-icS
-hyc
-cNm
-sFu
-sFu
-kqg
-kqg
-ljX
-oST
-spu
-sFu
-kqg
-sFu
-sps
-oST
-sFu
-uez
-sFu
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -85028,48 +77405,48 @@ heT
 heT
 heT
 heT
-xYO
-csw
-lyX
-rSB
-rVu
-eRi
-lyX
-cHa
-lyX
-dGD
-sFu
-kqg
-icS
-kqg
-icS
-icS
-icS
-jus
-jus
-jus
-qtQ
-sFu
-icS
-tqn
-sFu
-sFu
-icS
-icS
-spu
-sFu
-spu
-sFu
-kqg
-pnq
-rvI
-sps
-rvI
-sFu
-icS
-sFu
-dxw
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -85285,48 +77662,48 @@ heT
 heT
 heT
 heT
-pYY
-fHx
-djc
-lyX
-djc
-eRi
-oCz
-cHa
-cmj
-xYO
-oEC
-pnq
-wuU
-rId
-tCY
-sFu
-sps
-jus
-wcT
-wcT
-icS
-sFu
-icS
-oST
-icS
-sFu
-icS
-sFu
-kqg
-spu
-oST
-spu
-sFu
-cNm
-sFu
-sFu
-hyc
-sFu
-uez
-sFu
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -85542,48 +77919,48 @@ heT
 heT
 heT
 heT
-xYO
-fgH
-djc
-lOD
-djc
-eRi
-rDz
-mPU
-djc
-pmw
-sFu
-pnq
-icS
-sFu
-sFu
-sFu
-icS
-xYO
-xYO
-xYO
-sps
-sFu
-icS
-sFu
-sFu
-icS
-sFu
-sFu
-sFu
-oKT
-jmX
-oEC
-icS
-sFu
-sFu
-rvI
-icS
-sFu
-icS
-ewK
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -85799,48 +78176,48 @@ heT
 heT
 heT
 heT
-xYO
-cQA
-djc
-lyX
-mTE
-vob
-djc
-djc
-lyX
-pmw
-eJa
-sFu
-kqg
-sFu
-pnq
-oKT
-dxw
-xYO
-xYO
-xYO
-kRM
-pst
-sFu
-sFu
-icS
-icS
-icS
-icS
-uYl
-xYO
-xYO
-xYO
-sps
-sps
-kqg
-sFu
-sFu
-roX
-jmX
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -86056,46 +78433,46 @@ heT
 heT
 heT
 heT
-xYO
-mYn
-djc
-djc
-lyX
-djc
-lyX
-djc
-wRn
-xYO
-vIb
-sFu
-jXW
-sFu
-sFu
-sFu
-xYO
-xYO
-xYO
-xYO
-eRx
-eRx
-nAh
-nAh
-eRx
-eRx
-eRx
-eRx
-eRx
-xYO
-xYO
-xYO
-dxw
-oZn
-sFu
-sFu
-kCA
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -86313,45 +78690,45 @@ heT
 heT
 heT
 heT
-xYO
-dCO
-lyX
-djc
-djc
-lyX
-lyX
-wRn
-lyX
-xYO
-xYO
-sFu
-sFu
-sFu
-sFu
-lqq
-xYO
-xYO
-xYO
-xYO
-sJg
-sFu
-icS
-icS
-sFu
-lKx
-sFu
-sFu
-sFu
-xYO
-xYO
-xYO
-xYO
-xYO
-qms
-otX
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -86570,44 +78947,44 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-dCO
-lyX
-djc
-pGL
-dqy
-lyX
-dCO
-xYO
-xYO
-sFu
-sFu
-sFu
-sFu
-sFu
-xYO
-xYO
-xYO
-xYO
-gku
-jiL
-bwk
-kqg
-cGz
-icS
-xYu
-jiL
-bwk
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -86827,42 +79204,42 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-lyX
-lyX
-lyX
-cYa
-xYO
-xYO
-xYO
-xYO
-sFu
-kqg
-icS
-sFu
-qms
-xYO
-xYO
-xYO
-xYO
-sJg
-icS
-rhR
-icS
-gku
-icS
-gku
-sFu
-xgh
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -87084,42 +79461,42 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-jmX
-xCj
-iml
-sFu
-tCY
-nmS
-jmX
-xYO
-xYO
-xYO
-eXQ
-jiL
-bwk
-iuM
-hEv
-jiL
-gWk
-icS
-nXx
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -87341,40 +79718,40 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-sFu
-sFu
-icS
-sFu
-sFu
-xYO
-xYO
-xYO
-xYO
-gku
-icS
-hEv
-icS
-poS
-sFu
-tws
-icS
-uBU
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -87607,31 +79984,31 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-sFu
-nzE
-icS
-sFu
-sFu
-xYO
-xYO
-xYO
-xYO
-snE
-ufN
-pBb
-rvI
-sJg
-ylb
-sJg
-sTk
-iKz
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -87864,31 +80241,31 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-sFu
-kqg
-icS
-sFu
-sFu
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -88121,30 +80498,30 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-sFu
-sFu
-icS
-sFu
-evL
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -88378,29 +80755,29 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-icS
-uKD
-icS
-vDX
-icS
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -88635,16 +81012,16 @@ heT
 heT
 heT
 heT
-xYO
-jmX
-ewK
-icS
-pWl
-icS
-ewK
-jmX
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -88892,15 +81269,15 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT
@@ -89150,13 +81527,13 @@ heT
 heT
 heT
 heT
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
-xYO
+heT
+heT
+heT
+heT
+heT
+heT
+heT
 heT
 heT
 heT

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -234,8 +234,7 @@
 "ahD" = (
 /obj/structure/toilet{
 	dir = 8;
-	icon_state = "toilet00";
-	tag = "icon-toilet00 (WEST)"
+	icon_state = "toilet00"
 	},
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -364,12 +363,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/legion)
-"alN" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
-	tag = "icon-verticalleftborderleft0"
-	},
-/area/f13/wasteland)
 "alV" = (
 /obj/item/shard,
 /turf/open/floor/f13/wood,
@@ -674,12 +667,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"awD" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2top";
-	tag = "icon-verticalleftborderright2top"
-	},
-/area/f13/wasteland)
 "awK" = (
 /obj/structure/toilet{
 	dir = 4
@@ -701,12 +688,6 @@
 /obj/effect/landmark/start/f13/auxilia,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"axz" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2";
-	tag = "icon-verticalinnermain2"
-	},
-/area/f13/wasteland)
 "ayJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/two_tire,
@@ -881,12 +862,6 @@
 "aDY" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/ncr)
-"aEe" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft1";
-	tag = "icon-verticalrightborderleft1"
-	},
-/area/f13/wasteland)
 "aFf" = (
 /obj/item/target{
 	pixel_x = 1
@@ -1453,13 +1428,11 @@
 /area/f13/building)
 "aYK" = (
 /obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken (NORTHEAST)"
+	icon_state = "housewindowbroken"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "aYY" = (
@@ -1569,13 +1542,6 @@
 /mob/living/simple_animal/pet/dog/protectron,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
-"beA" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerbordercorner";
-	tag = "icon-outerbordercorner (EAST)"
-	},
-/area/f13/wasteland)
 "beG" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
@@ -1625,12 +1591,6 @@
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"bgO" = (
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
-	tag = "icon-wasteland33"
-	},
-/area/f13/wasteland)
 "bgR" = (
 /obj/structure/flora/tree/tall{
 	density = 0;
@@ -1684,13 +1644,6 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"biU" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerborder";
-	tag = "icon-outerborder (NORTH)"
-	},
-/area/f13/wasteland)
 "bjg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -1768,12 +1721,6 @@
 	dir = 10
 	},
 /area/f13/village)
-"bml" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0";
-	tag = "icon-horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland)
 "bmr" = (
 /obj/structure/chair{
 	dir = 8
@@ -1794,8 +1741,7 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "bmK" = (
@@ -1804,17 +1750,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bmV" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2";
-	tag = "icon-verticalleftborderright2"
-	},
-/area/f13/wasteland)
 "bnf" = (
 /obj/structure/chair{
 	dir = 8;
-	icon_state = "chair";
-	tag = "icon-chair (WEST)"
+	icon_state = "chair"
 	},
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/desert,
@@ -1913,12 +1852,10 @@
 "bpb" = (
 /obj/structure/fence{
 	dir = 4;
-	icon_state = "straight";
-	tag = "icon-metal_fence3"
+	icon_state = "straight"
 	},
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
-	tag = "icon-wasteland33"
+	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
 "bph" = (
@@ -2170,13 +2107,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"bAJ" = (
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 1;
-	icon_state = "rubblecorner";
-	tag = "icon-rubblecorner (NORTH)"
-	},
-/area/f13/wasteland)
 "bAO" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -2199,13 +2129,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"bAX" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt";
-	tag = "icon-dirt (SOUTHEAST)"
-	},
-/area/f13/wasteland)
 "bBi" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -2288,13 +2211,6 @@
 /obj/machinery/microwave,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bDM" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner (EAST)"
-	},
-/area/f13/wasteland)
 "bDO" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -2417,8 +2333,7 @@
 /area/f13/building)
 "bHa" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
-	tag = "icon-remains"
+	icon_state = "remains"
 	},
 /obj/item/clothing/under/f13/tribal,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2449,12 +2364,6 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblecorner"
-	},
-/area/f13/wasteland)
-"bIZ" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain3";
-	tag = "icon-verticalinnermain3"
 	},
 /area/f13/wasteland)
 "bJe" = (
@@ -2636,12 +2545,6 @@
 /obj/structure/chair/f13foldupchair,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"bQq" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2";
-	tag = "icon-verticalrightborderleft2"
-	},
-/area/f13/wasteland)
 "bQr" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -2676,13 +2579,6 @@
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/city)
-"bSN" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt";
-	tag = "icon-dirt (NORTHWEST)"
-	},
-/area/f13/wasteland)
 "bSR" = (
 /obj/machinery/autolathe,
 /turf/open/floor/f13{
@@ -2754,13 +2650,6 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bVY" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner (WEST)"
-	},
-/area/f13/wasteland)
 "bWb" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -2919,8 +2808,7 @@
 "ceI" = (
 /obj/structure/chair{
 	dir = 4;
-	icon_state = "chair";
-	tag = "icon-chair (EAST)"
+	icon_state = "chair"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -3311,13 +3199,6 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cuG" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerbordercorner";
-	tag = "icon-outerbordercorner (NORTH)"
-	},
-/area/f13/wasteland)
 "cuY" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/f13/ncrcorporal,
@@ -3388,12 +3269,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"cxF" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
-	},
-/area/f13/village)
 "cxL" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -3660,12 +3535,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"cLM" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0";
-	tag = "icon-verticalrightborderright0"
-	},
-/area/f13/wasteland)
 "cLP" = (
 /obj/item/paper,
 /obj/machinery/light/small{
@@ -3751,12 +3620,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
-"cPH" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2bottom";
-	tag = "icon-verticalleftborderright2bottom"
 	},
 /area/f13/wasteland)
 "cPR" = (
@@ -4257,12 +4120,6 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"dii" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2bottom";
-	tag = "icon-verticalrightborderleft2bottom"
-	},
-/area/f13/wasteland)
 "dit" = (
 /turf/open/floor/f13{
 	icon_state = "floordirty"
@@ -4785,12 +4642,6 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
-"dBH" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0";
-	tag = "icon-verticalleftborderright0"
-	},
-/area/f13/wasteland)
 "dCa" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/wasteland)
@@ -5073,12 +4924,6 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
-"dPc" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0";
-	tag = "icon-verticalinnermain0"
-	},
-/area/f13/wasteland)
 "dPe" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -5128,8 +4973,7 @@
 "dTG" = (
 /obj/structure/chair/stool{
 	dir = 2;
-	icon_state = "bench";
-	tag = "icon-bench"
+	icon_state = "bench"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -5276,12 +5120,6 @@
 /obj/item/trash/cheesie,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ebM" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0";
-	tag = "icon-verticalrightborderleft0"
-	},
-/area/f13/wasteland)
 "ebT" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
@@ -5584,8 +5422,7 @@
 "eqo" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0";
-	tag = "icon-verticalrightborderleft0"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
 "eqv" = (
@@ -5639,12 +5476,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"eso" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1";
-	tag = "icon-verticalinnermain1"
-	},
-/area/f13/wasteland)
 "esE" = (
 /obj/structure/rack,
 /obj/item/stack/f13Cash/random/banker,
@@ -6193,8 +6024,7 @@
 "eOK" = (
 /obj/structure/chair/wood/modern{
 	dir = 4;
-	icon_state = "wooden_chair_old";
-	tag = "icon-wooden_chair_old (EAST)"
+	icon_state = "wooden_chair_old"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -6501,8 +6331,7 @@
 /area/f13/building)
 "eXA" = (
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
-	tag = "icon-rubbleslab"
+	icon_state = "rubbleslab"
 	},
 /area/f13/village)
 "eXE" = (
@@ -6710,13 +6539,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
-"ffT" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2bottom";
-	tag = "icon-verticalleftborderright2bottom"
-	},
-/area/f13/wasteland)
 "ffY" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6934,8 +6756,7 @@
 "fpF" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
-	icon_state = "sheetcmo";
-	tag = "icon-sheetcmo"
+	icon_state = "sheetcmo"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
@@ -7159,14 +6980,6 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/ncr)
-"fvF" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetgrey";
-	tag = "icon-sheetgrey"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "fwG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
@@ -7517,13 +7330,6 @@
 	icon_state = "verticalleftborderrightbottom"
 	},
 /area/f13/wasteland)
-"fKc" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt";
-	tag = "icon-dirt (EAST)"
-	},
-/area/f13/wasteland)
 "fKt" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -7710,8 +7516,7 @@
 "fRK" = (
 /obj/structure/fence{
 	dir = 4;
-	icon_state = "straight";
-	tag = "icon-metal_fence3"
+	icon_state = "straight"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -8185,8 +7990,7 @@
 "gkE" = (
 /obj/structure/chair{
 	dir = 1;
-	icon_state = "chair";
-	tag = "icon-chair (NORTH)"
+	icon_state = "chair"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -8400,8 +8204,7 @@
 "gsu" = (
 /obj/structure/chair/stool{
 	dir = 1;
-	icon_state = "bench";
-	tag = "icon-bench (NORTH)"
+	icon_state = "bench"
 	},
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -8583,8 +8386,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "gwW" = (
@@ -8866,12 +8668,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"gEZ" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2bottom";
-	tag = "icon-verticalinnermain2bottom"
-	},
-/area/f13/wasteland)
 "gFQ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -9068,12 +8864,10 @@
 "gNc" = (
 /obj/structure/chair/wood{
 	dir = 4;
-	icon_state = "wooden_chair_settler";
-	tag = "icon-wooden_chair_settler (EAST)"
+	icon_state = "wooden_chair_settler"
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "gNA" = (
@@ -9089,8 +8883,7 @@
 "gNL" = (
 /obj/structure/chair{
 	dir = 1;
-	icon_state = "chair";
-	tag = "icon-chair (NORTH)"
+	icon_state = "chair"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
@@ -9590,12 +9383,6 @@
 /obj/item/shovel/spade,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
-"hgm" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
-	tag = "icon-housewood2-broken"
-	},
-/area/f13/village)
 "hgw" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/f13/rag,
@@ -10290,17 +10077,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"hCR" = (
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblepillar";
-	tag = "icon-rubblepillar"
-	},
-/area/f13/wasteland)
 "hCV" = (
 /obj/structure/fence{
 	dir = 4;
-	icon_state = "straight";
-	tag = "icon-metal_fence3"
+	icon_state = "straight"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -10310,8 +10090,7 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "hDQ" = (
@@ -10705,8 +10484,7 @@
 "hTe" = (
 /obj/structure/chair/wood/modern{
 	dir = 1;
-	icon_state = "wooden_chair_new";
-	tag = "icon-wooden_chair_new (NORTH)"
+	icon_state = "wooden_chair_new"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -11328,13 +11106,6 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
-"iqJ" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/village)
 "iqN" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -11378,8 +11149,7 @@
 "isy" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "isJ" = (
@@ -11445,8 +11215,7 @@
 "iuS" = (
 /obj/structure/chair/wood/modern{
 	dir = 4;
-	icon_state = "wooden_chair_old";
-	tag = "icon-wooden_chair_old (EAST)"
+	icon_state = "wooden_chair_old"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -11559,8 +11328,7 @@
 "iyR" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
-	icon_state = "sheethos";
-	tag = "icon-sheethos"
+	icon_state = "sheethos"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -11608,8 +11376,7 @@
 "iAs" = (
 /obj/structure/chair/wood/modern{
 	dir = 8;
-	icon_state = "wooden_chair_new";
-	tag = "icon-wooden_chair_new (WEST)"
+	icon_state = "wooden_chair_new"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -11646,8 +11413,7 @@
 "iBK" = (
 /obj/structure/chair/stool{
 	dir = 1;
-	icon_state = "bench";
-	tag = "icon-bench (NORTH)"
+	icon_state = "bench"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -11916,8 +11682,7 @@
 /area/f13/legion)
 "iKO" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
-	tag = "icon-remains"
+	icon_state = "remains"
 	},
 /obj/item/clothing/under/f13/female/tribal,
 /turf/open/indestructible/ground/outside/dirt,
@@ -12211,13 +11976,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"iSB" = (
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 4;
-	icon_state = "rubblecorner";
-	tag = "icon-rubblecorner (WEST)"
-	},
-/area/f13/wasteland)
 "iSE" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -13293,12 +13051,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"jOc" = (
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblecorner";
-	tag = "icon-rubblecorner"
-	},
-/area/f13/wasteland)
 "jOq" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -13314,14 +13066,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"jOA" = (
-/obj/structure/chair{
-	dir = 4;
-	icon_state = "chair";
-	tag = "icon-chair (EAST)"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "jOH" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/shovel,
@@ -13484,8 +13228,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "jWb" = (
@@ -14188,8 +13931,7 @@
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken (NORTHEAST)"
+	icon_state = "housewindowbroken"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -14259,8 +14001,7 @@
 /obj/structure/sink{
 	dir = 1;
 	icon_state = "sink";
-	pixel_y = 16;
-	tag = "icon-sink (NORTH)"
+	pixel_y = 16
 	},
 /obj/structure/mirror{
 	dir = 8;
@@ -14375,8 +14116,7 @@
 "kyC" = (
 /obj/structure/chair/stool{
 	dir = 1;
-	icon_state = "bench";
-	tag = "icon-bench (NORTH)"
+	icon_state = "bench"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -14509,13 +14249,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"kEa" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	tag = "icon-tree_3"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "kEh" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/wasteland)
@@ -14590,13 +14323,6 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
-	},
-/area/f13/village)
-"kHs" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
 	},
 /area/f13/village)
 "kHB" = (
@@ -14825,12 +14551,10 @@
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken (NORTHEAST)"
+	icon_state = "housewindowbroken"
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "kUs" = (
@@ -14926,8 +14650,7 @@
 "kYz" = (
 /obj/structure/chair/stool{
 	dir = 4;
-	icon_state = "bench";
-	tag = "icon-bench (EAST)"
+	icon_state = "bench"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -15011,8 +14734,7 @@
 	},
 /obj/structure/chair/stool{
 	dir = 8;
-	icon_state = "bench";
-	tag = "icon-bench (WEST)"
+	icon_state = "bench"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -15288,8 +15010,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "lnc" = (
@@ -15649,8 +15370,7 @@
 /obj/structure/simple_door/house,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "lyY" = (
@@ -15979,8 +15699,7 @@
 /mob/living/simple_animal/hostile/wolf,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
-	icon_state = "rubble";
-	tag = "icon-rubble (NORTH)"
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "lLB" = (
@@ -16100,8 +15819,7 @@
 "lRm" = (
 /obj/structure/chair/stool{
 	dir = 2;
-	icon_state = "bench_center";
-	tag = "icon-bench_center"
+	icon_state = "bench_center"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -16145,8 +15863,7 @@
 "lRZ" = (
 /obj/structure/chair/stool{
 	dir = 8;
-	icon_state = "bench";
-	tag = "icon-bench (WEST)"
+	icon_state = "bench"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -16286,8 +16003,7 @@
 "lWX" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
-	tag = "icon-shower (EAST)"
+	icon_state = "shower"
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -16469,12 +16185,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
-"mex" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2";
-	tag = "icon-horizontalinnermain2"
-	},
-/area/f13/wasteland)
 "meL" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -16823,12 +16533,6 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mtc" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/village)
 "mtl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -17101,8 +16805,7 @@
 /area/f13/wasteland)
 "mHt" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "floor5-old";
-	tag = "icon-floor5-old"
+	icon_state = "floor5-old"
 	},
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -17356,14 +17059,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"mSo" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/village)
 "mSs" = (
 /obj/structure/decoration/rag{
 	icon_state = "flag_ncr";
@@ -17635,8 +17330,7 @@
 /obj/structure/sink{
 	dir = 1;
 	icon_state = "sink";
-	pixel_y = 15;
-	tag = "icon-sink (NORTH)"
+	pixel_y = 15
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -18622,8 +18316,7 @@
 	dir = 4;
 	icon_state = "toilet00";
 	pixel_x = -3;
-	pixel_y = 0;
-	tag = "icon-toilet00 (EAST)"
+	pixel_y = 0
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -18757,8 +18450,7 @@
 "oai" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
-	tag = "icon-shower (WEST)"
+	icon_state = "shower"
 	},
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -19486,13 +19178,6 @@
 /obj/structure/fireplace,
 /turf/open/floor/carpet/black,
 /area/f13/city)
-"oBc" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/village)
 "oBh" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
@@ -20120,8 +19805,7 @@
 /obj/structure/sink{
 	dir = 1;
 	icon_state = "sink";
-	pixel_y = 15;
-	tag = "icon-sink (NORTH)"
+	pixel_y = 15
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -20324,8 +20008,7 @@
 "peY" = (
 /obj/structure/chair{
 	dir = 1;
-	icon_state = "chair";
-	tag = "icon-chair (NORTH)"
+	icon_state = "chair"
 	},
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
@@ -20473,12 +20156,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/tunnel)
-"pkN" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "shadowright";
-	tag = "icon-shadowright"
-	},
-/area/f13/wasteland)
 "plq" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermainleft"
@@ -20805,8 +20482,7 @@
 /obj/structure/table/wood,
 /obj/item/stack/cable_coil,
 /obj/item/bedsheet{
-	icon_state = "sheetcmo";
-	tag = "icon-sheetcmo"
+	icon_state = "sheetcmo"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
@@ -21065,8 +20741,7 @@
 "pHi" = (
 /obj/structure/bed,
 /obj/effect/decal/remains{
-	icon_state = "remains";
-	tag = "icon-remains"
+	icon_state = "remains"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -21575,13 +21250,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"pZd" = (
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 1;
-	icon_state = "rubble";
-	tag = "icon-rubble (NORTH)"
-	},
-/area/f13/wasteland)
 "pZl" = (
 /obj/structure/decoration/clock{
 	pixel_y = 21
@@ -21619,12 +21287,6 @@
 "qal" = (
 /turf/open/water,
 /area/f13/radiation)
-"qaW" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	tag = "icon-dirt"
-	},
-/area/f13/wasteland)
 "qbe" = (
 /obj/structure/table,
 /obj/item/storage/box/drinkingglasses,
@@ -21769,13 +21431,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/city)
-"qeS" = (
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 8;
-	icon_state = "rubblecorner";
-	tag = "icon-rubblecorner (WEST)"
-	},
-/area/f13/wasteland)
 "qfh" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -21915,8 +21570,7 @@
 /obj/item/weldingtool,
 /obj/item/crowbar,
 /obj/item/wirecutters{
-	icon_state = "cutters";
-	tag = "icon-cutters"
+	icon_state = "cutters"
 	},
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
@@ -22139,13 +21793,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"qtL" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/village)
 "qul" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
@@ -22604,12 +22251,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"qMy" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "shadowleft";
-	tag = "icon-shadowleft"
-	},
-/area/f13/wasteland)
 "qMA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -23132,8 +22773,7 @@
 "rja" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/clinic)
 "rjD" = (
@@ -23280,13 +22920,6 @@
 /obj/structure/booth/middle,
 /turf/open/floor/carpet/black,
 /area/f13/city)
-"roR" = (
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 4;
-	icon_state = "rubblecorner";
-	tag = "icon-rubblecorner (EAST)"
-	},
-/area/f13/wasteland)
 "roX" = (
 /obj/structure/chair/wood{
 	dir = 1;
@@ -23372,8 +23005,7 @@
 /area/f13/wasteland)
 "rtl" = (
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate";
-	tag = "icon-rubbleplate"
+	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
 "rtR" = (
@@ -23389,18 +23021,10 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/ncr)
-"ruo" = (
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 9;
-	icon_state = "rubble";
-	tag = "icon-rubble (NORTHWEST)"
-	},
-/area/f13/wasteland)
 "ruy" = (
 /obj/structure/chair{
 	dir = 4;
-	icon_state = "chair";
-	tag = "icon-chair (EAST)"
+	icon_state = "chair"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
@@ -23753,8 +23377,7 @@
 "rIZ" = (
 /obj/structure/fence{
 	dir = 4;
-	icon_state = "straight";
-	tag = "icon-metal_fence3"
+	icon_state = "straight"
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -23831,13 +23454,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rML" = (
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 4;
-	icon_state = "rubble";
-	tag = "icon-rubble (EAST)"
-	},
-/area/f13/wasteland)
 "rNa" = (
 /obj/structure/closet,
 /turf/open/floor/f13{
@@ -24378,8 +23994,7 @@
 "sic" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
-	tag = "icon-shower (WEST)"
+	icon_state = "shower"
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -25204,13 +24819,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"sNk" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2";
-	tag = "icon-verticalleftborderright2"
-	},
-/area/f13/wasteland)
 "sNz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -25751,12 +25359,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
-"tfA" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner"
-	},
-/area/f13/wasteland)
 "tfM" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
@@ -25799,8 +25401,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "tiu" = (
@@ -26002,8 +25603,7 @@
 /area/f13/tunnel)
 "tpA" = (
 /obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical";
-	tag = "icon-housewindowvertical (NORTHEAST)"
+	icon_state = "housewindowvertical"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
@@ -26274,8 +25874,7 @@
 "tym" = (
 /obj/structure/chair/stool{
 	dir = 2;
-	icon_state = "bench_center";
-	tag = "icon-bench_center"
+	icon_state = "bench_center"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -26434,8 +26033,7 @@
 /area/f13/village)
 "tDX" = (
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate";
-	tag = "icon-rubbleplate"
+	icon_state = "rubbleplate"
 	},
 /area/f13/village)
 "tEp" = (
@@ -27396,8 +26994,7 @@
 "upA" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 2;
-	icon_state = "rubblecorner";
-	tag = "icon-rubblecorner (WEST)"
+	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
 "upG" = (
@@ -27698,8 +27295,7 @@
 /area/f13/village)
 "uzs" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "floor2-old";
-	tag = "icon-floor2-old"
+	icon_state = "floor2-old"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -27824,13 +27420,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"uDU" = (
-/obj/structure/car,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0";
-	tag = "icon-verticalinnermain0"
-	},
-/area/f13/wasteland)
 "uDX" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -27848,8 +27437,7 @@
 "uFp" = (
 /obj/structure/chair/stool{
 	dir = 4;
-	icon_state = "bench_center";
-	tag = "icon-bench_center (EAST)"
+	icon_state = "bench_center"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
@@ -27896,8 +27484,7 @@
 "uGT" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
-	tag = "icon-shower (WEST)"
+	icon_state = "shower"
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -28254,8 +27841,7 @@
 "uTA" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/clinic)
 "uTG" = (
@@ -28444,8 +28030,7 @@
 "uZg" = (
 /obj/structure/chair/stool{
 	dir = 1;
-	icon_state = "bench";
-	tag = "icon-bench (NORTH)"
+	icon_state = "bench"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
@@ -28740,8 +28325,7 @@
 "vjG" = (
 /obj/structure/chair/stool{
 	dir = 2;
-	icon_state = "bench";
-	tag = "icon-bench"
+	icon_state = "bench"
 	},
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -28839,13 +28423,6 @@
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
-	},
-/area/f13/wasteland)
-"voS" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt";
-	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
 "voV" = (
@@ -29268,8 +28845,7 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
-	icon_state = "dirt";
-	tag = "icon-dirt (SOUTHEAST)"
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "vGA" = (
@@ -30059,14 +29635,6 @@
 /obj/item/stack/f13Cash/random/low,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"wqN" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt";
-	tag = "icon-dirt (NORTH)"
-	},
-/area/f13/wasteland)
 "wqS" = (
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/building)
@@ -30152,8 +29720,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "wvV" = (
@@ -30166,8 +29733,7 @@
 "wwp" = (
 /obj/structure/chair/stool{
 	dir = 2;
-	icon_state = "bench_center";
-	tag = "icon-bench_center"
+	icon_state = "bench_center"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -30409,13 +29975,6 @@
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"wFD" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner (NORTH)"
-	},
-/area/f13/wasteland)
 "wFG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -30667,19 +30226,16 @@
 "wOw" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
-	icon_state = "rubble";
-	tag = "icon-rubble (WEST)"
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "wOA" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
-	icon_state = "sheetgrey";
-	tag = "icon-sheetgrey"
+	icon_state = "sheetgrey"
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
+	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
 "wOI" = (
@@ -30850,12 +30406,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"wTm" = (
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
-	tag = "icon-rubbleslab"
-	},
-/area/f13/wasteland)
 "wTJ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -31391,8 +30941,7 @@
 "xir" = (
 /obj/structure/chair/comfy/black{
 	dir = 8;
-	icon_state = "comfychair";
-	tag = "icon-comfychair (WEST)"
+	icon_state = "comfychair"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -31841,8 +31390,7 @@
 "xyo" = (
 /obj/structure/chair{
 	dir = 1;
-	icon_state = "chair";
-	tag = "icon-chair (NORTH)"
+	icon_state = "chair"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -31991,8 +31539,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "xFv" = (
@@ -32426,9 +31973,7 @@
 "xUq" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2";
-	step_x = 0;
-	step_y = 0;
-	tag = "icon-tree_2"
+	
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -32476,8 +32021,7 @@
 /area/f13/village)
 "xVN" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "floor4-old";
-	tag = "icon-floor4-old"
+	icon_state = "floor4-old"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -32634,8 +32178,7 @@
 "yaz" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old";
-	tag = "icon-floor5-old"
+	icon_state = "floor5-old"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -32653,15 +32196,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"yaG" = (
-/obj/structure/chair/comfy{
-	dir = 1
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/village)
 "yaI" = (
 /obj/structure/table/wood,
 /obj/item/pickaxe,
@@ -42019,14 +41553,14 @@ fyf
 pis
 fyf
 fyf
-bgO
+hAC
 fyf
 qOV
-fKc
-bAX
+cWG
+daU
 bpD
 fyf
-bgO
+hAC
 fyf
 fyf
 fyf
@@ -42278,7 +41812,7 @@ fyf
 fyf
 fyf
 qOV
-bAX
+daU
 fMW
 pXo
 vbi
@@ -43308,7 +42842,7 @@ tBN
 mvv
 mvv
 mvv
-bSN
+aBH
 hCg
 fyf
 bnf
@@ -43561,9 +43095,9 @@ jJb
 fyf
 fyf
 qOV
-bAX
+daU
 mvv
-bSN
+aBH
 mfD
 hCg
 fyf
@@ -44339,8 +43873,8 @@ hCV
 fyf
 fyf
 qOV
-fKc
-bDM
+cWG
+wDc
 fyf
 fyf
 hCV
@@ -45109,9 +44643,9 @@ fyf
 krm
 cCf
 aMw
-qtL
-hgm
-qtL
+bXw
+jxq
+bXw
 uRJ
 uRJ
 ndV
@@ -45367,10 +44901,10 @@ qFk
 tlr
 sic
 cbk
-mtc
+pJd
 cbk
 uMb
-hgm
+jxq
 qFk
 fyf
 lQD
@@ -45624,12 +45158,12 @@ qFk
 cbk
 cbk
 cbk
-kHs
+lnw
 cbk
 uRJ
-cxF
+qMi
 qFk
-iSB
+cdt
 fyf
 olZ
 fyf
@@ -45881,12 +45415,12 @@ qFk
 jTq
 wvq
 mxR
-mtc
+pJd
 cbk
-hgm
+jxq
 faW
 faW
-pZd
+nHP
 fyf
 fyf
 fyf
@@ -46131,19 +45665,19 @@ fyf
 fyf
 fyf
 qOV
-bDM
+wDc
 fyf
 qOV
 kUk
 uRJ
-mtc
+pJd
 mvJ
-mtc
+pJd
 cbk
-cxF
-hCR
-ruo
-bAJ
+qMi
+jYB
+mji
+bph
 fyf
 fyf
 fyf
@@ -46394,12 +45928,12 @@ tBN
 lyG
 uRJ
 iFb
-mtc
-hgm
+pJd
+jxq
 cbk
-wTm
-ruo
-bAJ
+lrQ
+mji
+bph
 fyf
 fyf
 fyf
@@ -46650,10 +46184,10 @@ fyf
 nlO
 qFk
 rLP
-mtc
-yaG
+pJd
+fgp
 faW
-hCR
+jYB
 faW
 lLv
 fyf
@@ -46910,9 +46444,9 @@ qFk
 qFk
 qFk
 rtl
-wTm
-ruo
-bAJ
+lrQ
+mji
+bph
 fyf
 fyf
 fyf
@@ -47165,10 +46699,10 @@ fyf
 fyf
 fyf
 fyf
-qeS
+cAs
 wOw
 wOw
-bAJ
+bph
 fyf
 fyf
 fyf
@@ -51024,12 +50558,12 @@ fyf
 fyf
 fyf
 fyf
-kEa
+trW
 upA
-rML
-rML
-rML
-roR
+rjD
+rjD
+rjD
+cdt
 fyf
 fyf
 fyf
@@ -51795,10 +51329,10 @@ fyf
 fyf
 fyf
 aYK
-mSo
-mtc
-oBc
-mtc
+pOb
+pJd
+qgl
+pJd
 tis
 qFk
 fyf
@@ -52052,8 +51586,8 @@ fyf
 fyf
 fyf
 qFk
-iqJ
-mtc
+onU
+pJd
 qFk
 qFk
 qFk
@@ -52309,10 +51843,10 @@ fyf
 fyf
 fyf
 qFk
-mtc
-mtc
-oBc
-mtc
+pJd
+pJd
+qgl
+pJd
 hDE
 aYK
 fyf
@@ -52569,7 +52103,7 @@ qFk
 qFk
 qFk
 qFk
-mtc
+pJd
 gNc
 qFk
 fyf
@@ -52825,8 +52359,8 @@ fyf
 aYK
 cCf
 pne
-oBc
-mtc
+qgl
+pJd
 isy
 qFk
 fyf
@@ -53083,7 +52617,7 @@ qFk
 cSc
 ahD
 qFk
-mtc
+pJd
 jWa
 qFk
 fyf
@@ -54117,7 +53651,7 @@ rIZ
 cWG
 cWG
 cWG
-bDM
+wDc
 fyf
 fyf
 fyf
@@ -54628,7 +54162,7 @@ fyf
 tBN
 mvv
 mvv
-bSN
+aBH
 mfD
 mfD
 hCg
@@ -63205,59 +62739,59 @@ ybI
 ybI
 ybI
 ybI
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-alN
-beA
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+nkp
 dMW
 fyf
 fyf
@@ -63462,59 +62996,59 @@ cdc
 idu
 idu
 idu
-awD
-bmV
-cPH
-dBH
-dBH
-awD
-bmV
-ffT
-dBH
-dBH
-dBH
-awD
-bmV
-mex
-dBH
-dBH
-dBH
-awD
-bmV
-cPH
-dBH
-sNk
-dBH
-dBH
-dBH
-dBH
-awD
-bmV
-cPH
-dBH
-dBH
-dBH
-awD
-bmV
-ffT
-dBH
-dBH
-dBH
-awD
-bmV
-mex
-dBH
-dBH
-dBH
-awD
-bmV
-cPH
-dBH
-sNk
-dBH
-dBH
-qMy
-bml
+hBN
+aJb
+tUb
+idu
+idu
+hBN
+aJb
+agr
+idu
+idu
+idu
+hBN
+aJb
+cdc
+idu
+idu
+idu
+hBN
+aJb
+tUb
+idu
+dbY
+idu
+idu
+idu
+idu
+hBN
+aJb
+tUb
+idu
+idu
+idu
+hBN
+aJb
+agr
+idu
+idu
+idu
+hBN
+aJb
+cdc
+idu
+idu
+idu
+hBN
+aJb
+tUb
+idu
+dbY
+idu
+idu
+nFL
+koD
 dMW
 fyf
 fyf
@@ -63719,59 +63253,59 @@ cdc
 ehN
 ehN
 hOl
-axz
-bIZ
-axz
-dPc
-eso
-axz
-bIZ
-axz
-gEZ
-dPc
-dPc
-dPc
-eso
-mex
-dPc
-dPc
-eso
-axz
-bIZ
-axz
-gEZ
-bIZ
-uDU
-dPc
-dPc
-eso
-axz
-bIZ
-axz
-gEZ
-dPc
-eso
-axz
-bIZ
-axz
-gEZ
-dPc
-dPc
-dPc
-eso
-mex
-dPc
-dPc
-eso
-axz
-bIZ
-axz
-gEZ
-bIZ
-dPc
-dPc
-dPc
-bml
+sgz
+dmL
+sgz
+ehN
+hOl
+sgz
+dmL
+sgz
+kjQ
+ehN
+ehN
+ehN
+hOl
+cdc
+ehN
+ehN
+hOl
+sgz
+dmL
+sgz
+kjQ
+dmL
+rbi
+ehN
+ehN
+hOl
+sgz
+dmL
+sgz
+kjQ
+ehN
+hOl
+sgz
+dmL
+sgz
+kjQ
+ehN
+ehN
+ehN
+hOl
+cdc
+ehN
+ehN
+hOl
+sgz
+dmL
+sgz
+kjQ
+dmL
+ehN
+ehN
+ehN
+koD
 dMW
 fyf
 fyf
@@ -63976,59 +63510,59 @@ ehN
 ehN
 ehN
 ehN
-aEe
-bQq
-dii
-ebM
-ebM
-aEe
-bQq
-dii
-ebM
-ebM
-aEe
-bQq
-bQq
-mex
-ebM
-ebM
-ebM
-aEe
-bQq
-dii
-ebM
-bQq
-ebM
-ebM
-ebM
-ebM
-aEe
-bQq
-dii
-ebM
-ebM
-ebM
-aEe
-bQq
-dii
-ebM
-ebM
-aEe
-bQq
-bQq
-mex
-ebM
-ebM
-ebM
-aEe
-bQq
-dii
-ebM
-bQq
-ebM
+qoS
+btW
+fvz
+kaM
+kaM
+qoS
+btW
+fvz
+kaM
+kaM
+qoS
+btW
+btW
+cdc
+kaM
+kaM
+kaM
+qoS
+btW
+fvz
+kaM
+btW
+kaM
+kaM
+kaM
+kaM
+qoS
+btW
+fvz
+kaM
+kaM
+kaM
+qoS
+btW
+fvz
+kaM
+kaM
+qoS
+btW
+btW
+cdc
+kaM
+kaM
+kaM
+qoS
+btW
+fvz
+kaM
+btW
+kaM
 eqo
-pkN
-bml
+huu
+koD
 dMW
 fyf
 fyf
@@ -64233,59 +63767,59 @@ erY
 erY
 erY
 erY
-biU
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cLM
-cuG
+geM
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+sVF
 dMW
 fyf
 fyf
@@ -64490,7 +64024,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 sUX
 ptf
 ptf
@@ -64747,7 +64281,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 fyf
@@ -65004,7 +64538,7 @@ erY
 cdc
 erY
 erY
-bml
+koD
 dMW
 fyf
 fyf
@@ -65261,7 +64795,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 fyf
@@ -65285,7 +64819,7 @@ tBN
 mvv
 mvv
 mvv
-voS
+bpD
 gts
 gts
 gts
@@ -65518,7 +65052,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 ekE
@@ -65542,7 +65076,7 @@ tBN
 mvv
 mvv
 mvv
-voS
+bpD
 gts
 xXl
 fXj
@@ -65775,7 +65309,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -65799,7 +65333,7 @@ tBN
 mvv
 mvv
 mvv
-voS
+bpD
 gts
 vYv
 vYv
@@ -66032,7 +65566,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -66056,7 +65590,7 @@ tBN
 mvv
 mvv
 mvv
-voS
+bpD
 gts
 gts
 gts
@@ -66289,7 +65823,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -66313,7 +65847,7 @@ tBN
 uRa
 mvv
 mvv
-voS
+bpD
 toB
 ybq
 uKY
@@ -66546,7 +66080,7 @@ erY
 erY
 sCK
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -66570,7 +66104,7 @@ tBN
 mvv
 mvv
 mvv
-wqN
+lRH
 toB
 ykq
 vYv
@@ -66803,7 +66337,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -66827,7 +66361,7 @@ tBN
 mvv
 mvv
 mvv
-voS
+bpD
 toB
 twY
 vYv
@@ -67060,7 +66594,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -67084,7 +66618,7 @@ tBN
 mvv
 mvv
 mvv
-voS
+bpD
 toB
 iHj
 vYv
@@ -67317,7 +66851,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -67341,7 +66875,7 @@ tBN
 mvv
 mvv
 mvv
-voS
+bpD
 gts
 gts
 gts
@@ -67574,7 +67108,7 @@ erY
 cdc
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -67598,7 +67132,7 @@ tBN
 mvv
 mvv
 mvv
-voS
+bpD
 fyf
 fyf
 fyf
@@ -67831,7 +67365,7 @@ hsy
 hsy
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -67855,7 +67389,7 @@ tBN
 mvv
 mvv
 mvv
-voS
+bpD
 fyf
 fyf
 fyf
@@ -68088,7 +67622,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -68099,7 +67633,7 @@ sYX
 hxp
 dhC
 iTJ
-jOA
+oKd
 rpu
 rpu
 sYX
@@ -68108,11 +67642,11 @@ sDp
 uqa
 fyf
 fyf
-bVY
+nlO
 tem
 mfD
 mfD
-wFD
+hCg
 fyf
 fyf
 sju
@@ -68345,7 +67879,7 @@ erY
 erY
 erY
 cdc
-bml
+koD
 dMW
 fyf
 hCV
@@ -68602,7 +68136,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 cOk
 dDC
 hCV
@@ -68859,7 +68393,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -69116,7 +68650,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -69137,10 +68671,10 @@ cuv
 fyf
 fyf
 fyf
-tfA
-fKc
-fKc
-fKc
+qOV
+cWG
+cWG
+cWG
 wDc
 fyf
 xJd
@@ -69373,7 +68907,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -69394,11 +68928,11 @@ sYX
 fyf
 fyf
 fyf
-qaW
+tBN
 mvv
 mvv
 mvv
-voS
+bpD
 fyf
 fyf
 fyf
@@ -69630,7 +69164,7 @@ hsy
 hsy
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -69651,11 +69185,11 @@ fyf
 fyf
 fyf
 fyf
-qaW
+tBN
 mvv
 pIn
 mvv
-voS
+bpD
 fyf
 fyf
 fyf
@@ -69666,7 +69200,7 @@ fyf
 fyf
 fyf
 fyf
-jOc
+nZS
 gts
 lRZ
 rpu
@@ -69887,7 +69421,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -69908,11 +69442,11 @@ fyf
 fyf
 fyf
 fyf
-qaW
+tBN
 mvv
 mvv
 mvv
-voS
+bpD
 fyf
 fyf
 fyf
@@ -70144,7 +69678,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -70165,11 +69699,11 @@ fyf
 fyf
 fyf
 fyf
-qaW
+tBN
 mvv
 mvv
 mvv
-voS
+bpD
 fyf
 fyf
 fyf
@@ -70401,7 +69935,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -70422,11 +69956,11 @@ fyf
 fyf
 fyf
 fyf
-bVY
+nlO
 mfD
 mfD
 mfD
-wFD
+hCg
 fyf
 fyf
 fyf
@@ -70658,7 +70192,7 @@ cdc
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -70915,7 +70449,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -71172,14 +70706,14 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
 fyf
 fyf
 cuv
-fvF
+ccF
 rpu
 rpu
 jbx
@@ -71429,7 +70963,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -71686,14 +71220,14 @@ cdc
 erY
 cdc
 erY
-bml
+koD
 dMW
 fyf
 hCV
 fyf
 fyf
 cuv
-fvF
+ccF
 rpu
 rpu
 jbx
@@ -71943,7 +71477,7 @@ erY
 erY
 cdc
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -72200,7 +71734,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -72457,7 +71991,7 @@ erY
 sCK
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -72714,14 +72248,14 @@ erY
 sCK
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
 fyf
 fyf
 cuv
-fvF
+ccF
 rpu
 rkZ
 uCO
@@ -72971,7 +72505,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -73228,7 +72762,7 @@ erY
 cdc
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
@@ -73485,14 +73019,14 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 hCV
 fyf
 fyf
 cuv
-fvF
+ccF
 rpu
 rkZ
 uCO
@@ -73742,7 +73276,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 fyf
 gcK
@@ -73999,7 +73533,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 gcK
 gcK
@@ -74256,7 +73790,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 gcK
 gcK
@@ -74513,14 +74047,14 @@ erY
 cdc
 erY
 erY
-bml
+koD
 dMW
 gcK
 gcK
 gcK
 gcK
 sYX
-fvF
+ccF
 ioh
 rkZ
 uCO
@@ -74770,7 +74304,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 gcK
 gcK
@@ -75027,14 +74561,14 @@ erY
 xuL
 erY
 erY
-bml
+koD
 dMW
 gcK
 gcK
 gcK
 gcK
 eXw
-fvF
+ccF
 ioh
 rkZ
 uCO
@@ -75284,7 +74818,7 @@ erY
 erY
 erY
 erY
-bml
+koD
 dMW
 gcK
 gcK
@@ -75541,7 +75075,7 @@ erY
 erY
 cdc
 erY
-bml
+koD
 dMW
 gcK
 gcK
@@ -75798,7 +75332,7 @@ erY
 cdc
 erY
 erY
-bml
+koD
 dMW
 fyf
 gcK

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -38,6 +38,10 @@
 	icon_state = "horizontalbottombordertop2"
 	},
 /area/f13/wasteland)
+"acn" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "acs" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -227,6 +231,17 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/ncr)
+"ahD" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00";
+	tag = "icon-toilet00 (WEST)"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/village)
 "ahK" = (
 /obj/machinery/light{
 	dir = 4
@@ -240,7 +255,6 @@
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/rank/clown/sexy,
 /obj/item/clothing/mask/gas/sexyclown,
-/obj/item/clothing/neck/petcollar,
 /obj/item/clothing/suit/f13/sexymaid,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
@@ -351,10 +365,11 @@
 	},
 /area/f13/legion)
 "alN" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "alV" = (
 /obj/item/shard,
 /turf/open/floor/f13/wood,
@@ -660,10 +675,9 @@
 	},
 /area/f13/building)
 "awD" = (
-/obj/structure/billboard/ritas,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2top";
+	tag = "icon-verticalleftborderright2top"
 	},
 /area/f13/wasteland)
 "awK" = (
@@ -688,12 +702,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "axz" = (
-/obj/structure/chair/stool,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2";
+	tag = "icon-verticalinnermain2"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "ayJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/two_tire,
@@ -859,12 +872,6 @@
 /obj/structure/noticeboard,
 /turf/closed/wall/f13/wood,
 /area/f13/city)
-"aDB" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/obj/item/clothing/under/schoolgirl/orange,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "aDX" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt{
@@ -875,14 +882,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/ncr)
 "aEe" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1";
+	tag = "icon-verticalrightborderleft1"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "aFf" = (
 /obj/item/target{
 	pixel_x = 1
@@ -1091,6 +1095,12 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/wasteland)
+"aMw" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/village)
 "aMT" = (
 /obj/structure/chair/stool/retro,
 /turf/open/floor/f13/wood{
@@ -1125,6 +1135,10 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"aOc" = (
+/obj/structure/simple_door/dirtyglass,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aOx" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -1230,14 +1244,10 @@
 	},
 /area/f13/ncr)
 "aRd" = (
-/obj/machinery/light/small{
-	dir = 1
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2"
 	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
+/area/f13/ncr)
 "aRl" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/wasteland)
@@ -1441,6 +1451,25 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aYK" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken (NORTHEAST)"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
+"aYY" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "aZn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -1540,6 +1569,13 @@
 /mob/living/simple_animal/pet/dog/protectron,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
+"beA" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (EAST)"
+	},
+/area/f13/wasteland)
 "beG" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
@@ -1590,11 +1626,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "bgO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "innershade"
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
 	},
-/area/f13/ncr)
+/area/f13/wasteland)
 "bgR" = (
 /obj/structure/flora/tree/tall{
 	density = 0;
@@ -1643,16 +1679,18 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"bix" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "biU" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (NORTH)"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "bjg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -1731,10 +1769,10 @@
 	},
 /area/f13/village)
 "bml" = (
-/obj/structure/chair/f13chair2{
-	dir = 4
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
 	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "bmr" = (
 /obj/structure/chair{
@@ -1752,6 +1790,14 @@
 /obj/item/stack/f13Cash/random/ncr/high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"bmx" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "bmK" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -1759,9 +1805,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bmV" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2";
+	tag = "icon-verticalleftborderright2"
+	},
+/area/f13/wasteland)
+"bnf" = (
+/obj/structure/chair{
+	dir = 8;
+	icon_state = "chair";
+	tag = "icon-chair (WEST)"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "bnm" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -1853,6 +1910,17 @@
 /obj/structure/stone_tile/surrounding/burnt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bpb" = (
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
+	},
+/area/f13/wasteland)
 "bph" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
@@ -1890,6 +1958,11 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"bqB" = (
+/obj/structure/table/wood,
+/obj/item/paper,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bqC" = (
 /obj/machinery/jukebox,
 /obj/effect/decal/cleanable/dirt,
@@ -2097,6 +2170,13 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"bAJ" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 1;
+	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner (NORTH)"
+	},
+/area/f13/wasteland)
 "bAO" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -2120,11 +2200,12 @@
 	},
 /area/f13/village)
 "bAX" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHEAST)"
 	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/building)
+/area/f13/wasteland)
 "bBi" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -2208,15 +2289,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bDM" = (
-/obj/structure/girder,
-/obj/structure/decoration/warning{
-	layer = 3.5;
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (EAST)"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/ncr)
+/area/f13/wasteland)
 "bDO" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -2337,6 +2415,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"bHa" = (
+/obj/effect/decal/remains{
+	icon_state = "remains";
+	tag = "icon-remains"
+	},
+/obj/item/clothing/under/f13/tribal,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "bHo" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
@@ -2350,11 +2436,8 @@
 	},
 /area/f13/followers)
 "bIh" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
-	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/house,
+/area/f13/clinic)
 "bIV" = (
 /obj/structure/chair/bench,
 /obj/effect/landmark/start/f13/settler,
@@ -2369,15 +2452,11 @@
 	},
 /area/f13/wasteland)
 "bIZ" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain3";
+	tag = "icon-verticalinnermain3"
 	},
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "bJe" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2558,9 +2637,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "bQq" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft2";
+	tag = "icon-verticalrightborderleft2"
+	},
 /area/f13/wasteland)
 "bQr" = (
 /obj/structure/window/fulltile/house{
@@ -2597,11 +2677,12 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/city)
 "bSN" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
 	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/legion)
+/area/f13/wasteland)
 "bSR" = (
 /obj/machinery/autolathe,
 /turf/open/floor/f13{
@@ -2674,13 +2755,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bVY" = (
-/obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/flashlight/lantern,
-/obj/item/clothing/under/overalls,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (WEST)"
+	},
+/area/f13/wasteland)
 "bWb" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -2798,13 +2878,6 @@
 "cbr" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"ccl" = (
-/obj/structure/chair/bench,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "ccF" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -2843,6 +2916,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"ceI" = (
+/obj/structure/chair{
+	dir = 4;
+	icon_state = "chair";
+	tag = "icon-chair (EAST)"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "cfn" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood{
@@ -3103,6 +3184,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"cph" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "cps" = (
 /obj/machinery/light{
 	dir = 8;
@@ -3208,10 +3295,29 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"ctE" = (
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "cuv" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cuG" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (NORTH)"
+	},
+/area/f13/wasteland)
 "cuY" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/f13/ncrcorporal,
@@ -3282,6 +3388,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"cxF" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/village)
 "cxL" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -3549,11 +3661,11 @@
 	},
 /area/f13/village)
 "cLM" = (
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/wasteland)
 "cLP" = (
 /obj/item/paper,
 /obj/machinery/light/small{
@@ -3606,9 +3718,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "cOk" = (
-/obj/structure/cargocrate,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "cOE" = (
@@ -3641,10 +3754,10 @@
 	},
 /area/f13/wasteland)
 "cPH" = (
-/obj/structure/chair/f13chair2{
-	dir = 1
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2bottom";
+	tag = "icon-verticalleftborderright2bottom"
 	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "cPR" = (
 /obj/structure/chair/wood/fancy,
@@ -4145,10 +4258,11 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "dii" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft2bottom";
+	tag = "icon-verticalrightborderleft2bottom"
+	},
+/area/f13/wasteland)
 "dit" = (
 /turf/open/floor/f13{
 	icon_state = "floordirty"
@@ -4310,6 +4424,14 @@
 /obj/structure/sign/poster/contraband/pinup_funk,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
+"dol" = (
+/obj/structure/table,
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dop" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -4378,6 +4500,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/city)
+"dqc" = (
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "dqf" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -4660,9 +4786,11 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "dBH" = (
-/obj/item/stack/ore/iron,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0";
+	tag = "icon-verticalleftborderright0"
+	},
+/area/f13/wasteland)
 "dCa" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/wasteland)
@@ -4761,6 +4889,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"dGK" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dGL" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_7"
@@ -4941,14 +5074,11 @@
 	},
 /area/f13/wasteland)
 "dPc" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0";
+	tag = "icon-verticalinnermain0"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "dPe" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4995,6 +5125,16 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"dTG" = (
+/obj/structure/chair/stool{
+	dir = 2;
+	icon_state = "bench";
+	tag = "icon-bench"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dTT" = (
 /obj/structure/fence{
 	dir = 8
@@ -5137,8 +5277,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ebM" = (
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
+	},
 /area/f13/wasteland)
 "ebT" = (
 /obj/structure/table/wood,
@@ -5300,8 +5442,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "ekE" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/structure/fence/corner{
+	dir = 1;
+	icon_state = "corner"
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ekI" = (
@@ -5437,6 +5581,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"eqo" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
+	},
+/area/f13/wasteland)
 "eqv" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -5489,11 +5640,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eso" = (
-/obj/structure/chair{
-	dir = 4
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1";
+	tag = "icon-verticalinnermain1"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "esE" = (
 /obj/structure/rack,
 /obj/item/stack/f13Cash/random/banker,
@@ -5564,9 +5715,7 @@
 /area/f13/wasteland)
 "exj" = (
 /obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheethos"
-	},
+/obj/item/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "exm" = (
@@ -5922,6 +6071,10 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"eKN" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "eKP" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6038,10 +6191,16 @@
 	},
 /area/f13/wasteland)
 "eOK" = (
-/obj/structure/table,
-/obj/item/storage/firstaid,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/chair/wood/modern{
+	dir = 4;
+	icon_state = "wooden_chair_old";
+	tag = "icon-wooden_chair_old (EAST)"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eOX" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6049,10 +6208,10 @@
 	},
 /area/f13/wasteland)
 "eOZ" = (
-/obj/structure/table,
-/obj/item/gun/ballistic/shotgun/remington/scoped,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ePh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -6325,7 +6484,6 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/bundle/costume/chicken,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/dildo,
 /obj/item/clothing/suit/f13/sexymaid,
 /obj/item/clothing/head/helmet/f13/brahmincowboyhat,
 /obj/item/clothing/suit/armor/f13/brahmin_leather_duster,
@@ -6339,11 +6497,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "eXw" = (
-/obj/item/stack/ore/iron,
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
+/turf/closed/mineral/random/low_chance,
+/area/f13/building)
+"eXA" = (
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
 	},
-/area/f13/wasteland)
+/area/f13/village)
 "eXE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6389,10 +6550,8 @@
 	},
 /area/f13/village)
 "eZg" = (
-/obj/structure/chair/stool{
-	icon_state = "bench_center"
-	},
-/turf/open/floor/f13/wood,
+/obj/machinery/vending/cola/random,
+/turf/closed/mineral/random/low_chance,
 /area/f13/building)
 "eZI" = (
 /obj/structure/spirit_board,
@@ -6552,11 +6711,12 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "ffT" = (
-/obj/structure/rack,
-/obj/item/clothing/neck/petcollar,
-/obj/item/clothing/neck/petcollar,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2bottom";
+	tag = "icon-verticalleftborderright2bottom"
+	},
+/area/f13/wasteland)
 "ffY" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6771,6 +6931,14 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"fpF" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo";
+	tag = "icon-sheetcmo"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "fpY" = (
 /obj/structure/fence{
 	dir = 4;
@@ -6786,7 +6954,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fqg" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/rack,
+/obj/item/stack/cable_coil,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fqi" = (
@@ -6938,8 +7107,16 @@
 	},
 /area/f13/wasteland)
 "fuj" = (
-/obj/structure/table,
-/obj/item/clothing/neck/petcollar,
+/obj/structure/closet/cabinet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fuN" = (
@@ -6983,10 +7160,11 @@
 	},
 /area/f13/ncr)
 "fvF" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/pill/charcoal,
-/obj/item/reagent_containers/pill/charcoal,
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fwG" = (
@@ -7340,14 +7518,12 @@
 	},
 /area/f13/wasteland)
 "fKc" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "NCR"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "innershade"
-	},
-/area/f13/ncr)
+/area/f13/wasteland)
 "fKt" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -7401,11 +7577,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fMW" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "innershade"
+/obj/structure/fence/corner{
+	dir = 9;
+	icon_state = "corner"
 	},
-/area/f13/ncr)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "fNx" = (
 /obj/structure/chair,
 /turf/open/floor/f13/wood,
@@ -7435,12 +7612,11 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "fPN" = (
-/obj/structure/closet/cabinet,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/clothing/under/f13/blackdress,
-/obj/item/clothing/gloves/f13/lace,
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fPT" = (
@@ -7507,9 +7683,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "fQY" = (
-/obj/structure/ore_box,
+/obj/structure/closet/cabinet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "fRi" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
@@ -7523,12 +7708,13 @@
 	},
 /area/f13/building)
 "fRK" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "CHI1"
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "fSk" = (
 /obj/structure/closet/crate/bin{
 	anchorable = 0;
@@ -7659,6 +7845,14 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"fXj" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "fXO" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -7988,6 +8182,14 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"gkE" = (
+/obj/structure/chair{
+	dir = 1;
+	icon_state = "chair";
+	tag = "icon-chair (NORTH)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gkZ" = (
 /obj/structure/table/wood/poker,
 /obj/item/radio/intercom{
@@ -8086,6 +8288,13 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"gom" = (
+/obj/structure/fence/corner{
+	dir = 5;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "goC" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -8188,6 +8397,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"gsu" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench";
+	tag = "icon-bench (NORTH)"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "gsB" = (
 /obj/machinery/washing_machine,
 /obj/item/crafting/abraxo,
@@ -8211,6 +8431,12 @@
 /area/f13/building)
 "gts" = (
 /turf/closed/wall/f13/store,
+/area/f13/building)
+"gtv" = (
+/obj/machinery/icecream_vat,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "gtz" = (
 /obj/structure/table/wood,
@@ -8271,10 +8497,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gvN" = (
-/obj/structure/chair/bench,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/structure/closet/cabinet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "gvW" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
@@ -8328,10 +8561,14 @@
 	},
 /area/f13/legion)
 "gwB" = (
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/structure/table,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/item/clothing/under/f13/police,
+/obj/item/clothing/head/f13/police,
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "gwI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8341,6 +8578,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"gwJ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "gwW" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -8413,13 +8659,21 @@
 	},
 /area/f13/city)
 "gzQ" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/turf/open/floor/f13/wood,
 /area/f13/building)
+"gzW" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "gzY" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/f13/steak,
@@ -8613,13 +8867,10 @@
 	},
 /area/f13/building)
 "gEZ" = (
-/obj/structure/chair/bench,
-/obj/effect/spawner/lootdrop/f13/armor/tier2,
-/turf/open/floor/f13/wood,
-/area/f13/village)
-"gFg" = (
-/obj/item/stack/ore/slag,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2bottom";
+	tag = "icon-verticalinnermain2bottom"
+	},
 /area/f13/wasteland)
 "gFQ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8806,6 +9057,25 @@
 	name = "concrete wall"
 	},
 /area/f13/ncr)
+"gMV" = (
+/obj/structure/table/wood,
+/obj/item/pen,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/reagent_containers/syringe/medx,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"gNc" = (
+/obj/structure/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (EAST)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "gNA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 10;
@@ -8816,6 +9086,14 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gNL" = (
+/obj/structure/chair{
+	dir = 1;
+	icon_state = "chair";
+	tag = "icon-chair (NORTH)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "gOf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -9154,14 +9432,11 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "gYp" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/closet,
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "gYu" = (
 /obj/structure/flora/tree/tall{
@@ -9315,6 +9590,12 @@
 /obj/item/shovel/spade,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"hgm" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/village)
 "hgw" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/f13/rag,
@@ -9371,6 +9652,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"hiG" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "hiS" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -9489,11 +9779,10 @@
 /area/f13/wasteland)
 "hmy" = (
 /obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe,
-/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "hmP" = (
 /obj/structure/sign/poster/prewar/poster67{
 	pixel_y = 32
@@ -9828,12 +10117,11 @@
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/city)
 "hxp" = (
-/obj/item/stack/ore/iron,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/machinery/washing_machine,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "hxy" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pestspray,
@@ -9875,6 +10163,13 @@
 /obj/item/key/collar,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"hyf" = (
+/obj/structure/chair/stool,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "hyj" = (
 /obj/structure/closet/crate/large,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -9989,20 +10284,36 @@
 	},
 /area/f13/wasteland)
 "hCF" = (
-/obj/item/stack/ore/slag,
-/obj/item/stack/ore/slag,
-/turf/open/indestructible/ground/inside/subway,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"hCR" = (
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubblepillar";
+	tag = "icon-rubblepillar"
+	},
 /area/f13/wasteland)
 "hCV" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "Legion"
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"hDE" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/area/f13/legion)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "hDQ" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -10110,14 +10421,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "hHC" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
+/obj/structure/closet,
 /obj/machinery/light/small{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "hHD" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_south"
@@ -10140,9 +10452,12 @@
 	},
 /area/f13/wasteland)
 "hHY" = (
-/obj/item/pickaxe,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "hIB" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/structure/rack,
@@ -10216,6 +10531,12 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"hKY" = (
+/obj/structure/table/wood,
+/obj/item/folder/yellow,
+/obj/item/reagent_containers/pill/patch/jet,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hLm" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -10240,6 +10561,13 @@
 /obj/structure/stone_tile/block/burnt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"hMM" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "hMQ" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -10375,9 +10703,13 @@
 	},
 /area/f13/wasteland)
 "hTe" = (
-/obj/item/stack/ore/slag,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/wasteland)
+/obj/structure/chair/wood/modern{
+	dir = 1;
+	icon_state = "wooden_chair_new";
+	tag = "icon-wooden_chair_new (NORTH)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hTh" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10558,15 +10890,11 @@
 	},
 /area/f13/village)
 "hXP" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "Waster"
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "hXW" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -10957,13 +11285,9 @@
 	},
 /area/f13/ncr)
 "ioh" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2"
-	},
-/area/f13/wasteland)
+/obj/structure/chair/wood/modern,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ioU" = (
 /obj/structure/chair/stool,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -11004,6 +11328,13 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
+"iqJ" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "iqN" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -11044,6 +11375,13 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
+"isy" = (
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "isJ" = (
 /obj/structure/fence{
 	dir = 4;
@@ -11076,10 +11414,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
 "itm" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench"
-	},
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "itI" = (
@@ -11106,12 +11443,12 @@
 	},
 /area/f13/ncr)
 "iuS" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/chair/wood/modern{
+	dir = 4;
+	icon_state = "wooden_chair_old";
+	tag = "icon-wooden_chair_old (EAST)"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "ivi" = (
 /obj/structure/flora/tree/tall{
@@ -11219,6 +11556,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"iyR" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheethos";
+	tag = "icon-sheethos"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iyV" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/f13{
@@ -11261,13 +11606,17 @@
 	},
 /area/f13/building)
 "iAs" = (
-/obj/structure/campfire/stove,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/wood/modern{
+	dir = 8;
+	icon_state = "wooden_chair_new";
+	tag = "icon-wooden_chair_new (WEST)"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "iAz" = (
-/obj/item/shovel,
+/obj/structure/bed,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "iAB" = (
 /obj/structure/sink{
 	dir = 8;
@@ -11294,10 +11643,19 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
-"iBD" = (
-/obj/item/stack/ore/iron,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+"iBK" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench";
+	tag = "icon-bench (NORTH)"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "iBT" = (
 /obj/item/flag/oasis,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -11389,9 +11747,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "iGi" = (
-/obj/structure/nest/ghoul,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "iGt" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
@@ -11553,6 +11914,14 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
+"iKO" = (
+/obj/effect/decal/remains{
+	icon_state = "remains";
+	tag = "icon-remains"
+	},
+/obj/item/clothing/under/f13/female/tribal,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "iLc" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/city)
@@ -11772,14 +12141,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iRr" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -3
+/obj/structure/closet,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "iRv" = (
 /obj/structure/decoration/rag{
@@ -11844,6 +12211,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"iSB" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 4;
+	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner (WEST)"
+	},
+/area/f13/wasteland)
 "iSE" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -11878,10 +12252,10 @@
 	},
 /area/f13/ncr)
 "iTk" = (
-/obj/structure/chair/bench,
-/obj/machinery/light/small,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "iTy" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt,
@@ -11900,11 +12274,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iTJ" = (
-/obj/structure/cargocrate,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
+/obj/structure/table/wood,
+/obj/structure/bedsheetbin,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "iTL" = (
 /obj/structure/rack,
 /obj/item/clothing/under/assistantformal,
@@ -12045,18 +12420,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "jbw" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench"
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "jbx" = (
-/obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/flashlight/lantern,
+/obj/structure/simple_door/glass,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "jbI" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/broken{
@@ -12123,9 +12495,6 @@
 /area/f13/city)
 "jfu" = (
 /obj/structure/rack,
-/obj/item/clothing/neck/petcollar,
-/obj/item/clothing/neck/petcollar,
-/obj/item/clothing/neck/petcollar,
 /obj/item/reagent_containers/food/snacks/f13/dog,
 /obj/item/reagent_containers/food/snacks/f13/dog,
 /obj/effect/decal/cleanable/dirt,
@@ -12581,12 +12950,10 @@
 	},
 /area/f13/village)
 "jxk" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/flashlight/lantern,
-/obj/item/clothing/under/overalls,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "jxq" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -12659,6 +13026,16 @@
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"jAZ" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jBH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12809,10 +13186,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
-"jKS" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "jKV" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
@@ -12866,7 +13239,6 @@
 /obj/structure/table/wood/fancy,
 /obj/item/restraints/handcuffs,
 /obj/item/melee/chainofcommand/tailwhip/kitty,
-/obj/item/dildo,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "jMB" = (
@@ -12921,6 +13293,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"jOc" = (
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner"
+	},
+/area/f13/wasteland)
 "jOq" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -12937,11 +13315,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "jOA" = (
-/obj/item/stack/ore/iron,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/structure/chair{
+	dir = 4;
+	icon_state = "chair";
+	tag = "icon-chair (EAST)"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jOH" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/shovel,
@@ -13054,11 +13434,9 @@
 	},
 /area/f13/city)
 "jTZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/closet,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "jUb" = (
@@ -13098,6 +13476,18 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/tunnel)
+"jWa" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "jWb" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid,
@@ -13748,6 +14138,14 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13,
 /area/f13/building)
+"kqc" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "kqe" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -13787,11 +14185,14 @@
 	},
 /area/f13/city)
 "krm" = (
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken (NORTHEAST)"
 	},
-/area/f13/legion)
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "krJ" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13855,8 +14256,19 @@
 	},
 /area/f13/building)
 "kvb" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/sink{
+	dir = 1;
+	icon_state = "sink";
+	pixel_y = 16;
+	tag = "icon-sink (NORTH)"
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "kvT" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -13960,6 +14372,21 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/ncr)
+"kyC" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench";
+	tag = "icon-bench (NORTH)"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "kyT" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
@@ -14082,6 +14509,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"kEa" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	tag = "icon-tree_3"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "kEh" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/wasteland)
@@ -14156,6 +14590,13 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
+	},
+/area/f13/village)
+"kHs" = (
+/obj/structure/simple_door/room,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/village)
 "kHB" = (
@@ -14375,13 +14816,23 @@
 	},
 /area/f13/wasteland)
 "kUe" = (
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
+/obj/structure/toilet,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "kUk" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken (NORTHEAST)"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "kUs" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14473,8 +14924,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "kYz" = (
-/obj/structure/rack,
-/obj/item/clothing/neck/petcollar,
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench";
+	tag = "icon-bench (EAST)"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kYH" = (
@@ -14552,9 +15006,16 @@
 	},
 /area/f13/wasteland)
 "lda" = (
-/obj/item/pickaxe,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ldt" = (
 /obj/structure/closet/crate/large{
 	storage_capacity = 20
@@ -14821,6 +15282,16 @@
 "lmV" = (
 /turf/open/floor/plasteel/stairs/old,
 /area/f13/city)
+"lmY" = (
+/obj/structure/chair/comfy{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "lnc" = (
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
@@ -15175,9 +15646,12 @@
 	},
 /area/f13/ncr)
 "lyG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/f13/wood,
+/obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
 /area/f13/village)
 "lyY" = (
 /obj/structure/fence{
@@ -15501,6 +15975,14 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"lLv" = (
+/mob/living/simple_animal/hostile/wolf,
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 1;
+	icon_state = "rubble";
+	tag = "icon-rubble (NORTH)"
+	},
+/area/f13/wasteland)
 "lLB" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -15616,14 +16098,16 @@
 	},
 /area/f13/wasteland)
 "lRm" = (
-/obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe,
+/obj/structure/chair/stool{
+	dir = 2;
+	icon_state = "bench_center";
+	tag = "icon-bench_center"
+	},
 /obj/machinery/light/small{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "lRB" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -15659,11 +16143,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
 "lRZ" = (
-/obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe,
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "lSD" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -15798,12 +16284,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "lWX" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower";
+	tag = "icon-shower (EAST)"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "lWZ" = (
 /obj/structure/billboard/ritas,
@@ -15982,10 +16470,11 @@
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
 "mex" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2";
+	tag = "icon-horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "meL" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -16330,6 +16819,16 @@
 	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland)
+"msS" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"mtc" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "mtl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -16438,6 +16937,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"mxR" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "myh" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -16468,12 +16972,6 @@
 /area/f13/wasteland)
 "mzB" = (
 /obj/structure/table,
-/obj/item/clothing/neck/petcollar,
-/obj/item/clothing/neck/petcollar,
-/obj/item/clothing/neck/petcollar,
-/obj/item/clothing/neck/petcollar,
-/obj/item/clothing/neck/petcollar,
-/obj/item/clothing/neck/petcollar,
 /turf/open/floor/f13,
 /area/f13/building)
 "mzC" = (
@@ -16598,9 +17096,17 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
 "mGZ" = (
-/obj/structure/table/wood,
-/obj/item/stack/f13Cash/random/med,
-/turf/open/floor/f13/wood,
+/obj/structure/closet/crate/bin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"mHt" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	icon_state = "floor5-old";
+	tag = "icon-floor5-old"
+	},
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "mHv" = (
 /obj/structure/chair/booth{
@@ -16850,6 +17356,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"mSo" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "mSs" = (
 /obj/structure/decoration/rag{
 	icon_state = "flag_ncr";
@@ -17115,11 +17629,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "ncn" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/clothing_low,
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/structure/sink{
+	dir = 1;
+	icon_state = "sink";
+	pixel_y = 15;
+	tag = "icon-sink (NORTH)"
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "ncC" = (
@@ -17161,12 +17681,8 @@
 	},
 /area/f13/wasteland)
 "neZ" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/neck/petcollar,
-/obj/item/clothing/neck/petcollar,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "nfu" = (
 /turf/open/indestructible/ground/outside/desert,
@@ -17659,6 +18175,15 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/wasteland)
+"nCS" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "nDd" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17991,7 +18516,6 @@
 /area/f13/village)
 "nPV" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
 "nPX" = (
@@ -18094,10 +18618,16 @@
 	},
 /area/f13/city)
 "nUr" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00";
+	pixel_x = -3;
+	pixel_y = 0;
+	tag = "icon-toilet00 (EAST)"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "nUF" = (
 /obj/item/ammo_casing/c10mm,
@@ -18119,6 +18649,11 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/village)
+"nUT" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nVb" = (
 /obj/structure/closet/fridge,
 /turf/open/floor/f13/wood,
@@ -18220,13 +18755,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "oai" = (
-/obj/structure/mirror{
-	pixel_y = 30
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower";
+	tag = "icon-shower (WEST)"
 	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
+/obj/machinery/light/small,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -18412,6 +18946,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/city)
+"ohk" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ohx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/comfy/beige,
@@ -18535,9 +19077,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "olN" = (
-/obj/machinery/icecream_vat,
+/obj/machinery/light/small,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "olP" = (
@@ -18547,10 +19089,9 @@
 	},
 /area/f13/building)
 "olW" = (
-/obj/structure/chair/bench,
-/obj/item/clothing/under/overalls,
+/obj/machinery/light,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/building)
 "olZ" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/desert,
@@ -18847,11 +19388,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "owG" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "owK" = (
 /obj/structure/table/wood,
 /obj/structure/decoration/clock{
@@ -18944,6 +19486,13 @@
 /obj/structure/fireplace,
 /turf/open/floor/carpet/black,
 /area/f13/city)
+"oBc" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "oBh" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
@@ -18952,18 +19501,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "oBQ" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "oCg" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
@@ -19327,14 +19870,11 @@
 	},
 /area/f13/wasteland)
 "oOZ" = (
-/obj/structure/ladder/unbreakable{
-	desc = "A sturdy ladder that leads down deep into the earth... don't fall.";
-	height = 2;
-	id = "digsite";
-	name = "ladder to the depths"
+/obj/structure/toilet,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/wasteland)
+/area/f13/clinic)
 "oPO" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19566,13 +20106,27 @@
 /obj/effect/spawner/lootdrop/three_course_meal,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"oXa" = (
-/obj/structure/flora/tree/tall{
-	layer = 4;
-	pixel_y = 9
+"oWV" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"oXa" = (
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/structure/sink{
+	dir = 1;
+	icon_state = "sink";
+	pixel_y = 15;
+	tag = "icon-sink (NORTH)"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/clinic)
 "oXe" = (
 /obj/structure/rack,
 /obj/item/clothing/head/fedora,
@@ -19767,6 +20321,15 @@
 /obj/structure/mirror,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"peY" = (
+/obj/structure/chair{
+	dir = 1;
+	icon_state = "chair";
+	tag = "icon-chair (NORTH)"
+	},
+/obj/machinery/light,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "peZ" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/indestructible/ground/outside/desert,
@@ -19910,6 +20473,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/tunnel)
+"pkN" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "shadowright";
+	tag = "icon-shadowright"
+	},
+/area/f13/wasteland)
 "plq" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermainleft"
@@ -19938,6 +20507,12 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"pne" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/village)
 "pnw" = (
 /obj/machinery/light/sign/oasis_sign,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20157,12 +20732,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pud" = (
-/obj/item/stack/ore/iron,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood,
+/area/f13/clinic)
 "puP" = (
 /obj/structure/rack,
 /obj/item/seeds/cannabis,
@@ -20231,13 +20802,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "pxf" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/stack/cable_coil,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo";
+	tag = "icon-sheetcmo"
 	},
-/mob/living/simple_animal/pet/dog/protectron,
-/turf/open/floor/plating/f13/inside,
-/area/f13/building)
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "pxi" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20491,9 +21063,16 @@
 	},
 /area/f13/building)
 "pHi" = (
-/obj/structure/simple_door/dirtyglass,
+/obj/structure/bed,
+/obj/effect/decal/remains{
+	icon_state = "remains";
+	tag = "icon-remains"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "pHm" = (
 /obj/machinery/trading_machine/ammo,
 /turf/open/floor/f13/wood,
@@ -20642,11 +21221,12 @@
 	},
 /area/f13/followers)
 "pKP" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress4"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/obj/item/screwdriver,
+/obj/item/hatchet,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "pLn" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood{
@@ -20735,11 +21315,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "pOw" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2left"
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/clinic)
 "pOJ" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20860,6 +21439,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"pTE" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/pill/charcoal,
+/obj/item/reagent_containers/pill/charcoal,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pTM" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20948,15 +21534,9 @@
 	},
 /area/f13/wasteland)
 "pXo" = (
-/obj/structure/girder,
-/obj/structure/decoration/warning{
-	layer = 3.5;
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "innershade"
-	},
-/area/f13/ncr)
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pXq" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20973,11 +21553,9 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ncr)
 "pYa" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/f13/brahmin,
-/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/machinery/iv_drip,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "pYj" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20995,6 +21573,13 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
+"pZd" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 1;
+	icon_state = "rubble";
+	tag = "icon-rubble (NORTH)"
 	},
 /area/f13/wasteland)
 "pZl" = (
@@ -21021,12 +21606,24 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"qai" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qal" = (
 /turf/open/water,
 /area/f13/radiation)
 "qaW" = (
-/obj/structure/ore_box,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
+	},
 /area/f13/wasteland)
 "qbe" = (
 /obj/structure/table,
@@ -21172,6 +21769,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/city)
+"qeS" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 8;
+	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner (WEST)"
+	},
+/area/f13/wasteland)
 "qfh" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -21217,13 +21821,14 @@
 /obj/structure/chair/stool/retro,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"qhs" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "qij" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "qin" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/dirt{
@@ -21306,9 +21911,16 @@
 	},
 /area/f13/building)
 "qlv" = (
-/obj/machinery/mineral/ore_redemption,
+/obj/structure/table/wood,
+/obj/item/weldingtool,
+/obj/item/crowbar,
+/obj/item/wirecutters{
+	icon_state = "cutters";
+	tag = "icon-cutters"
+	},
+/obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/clinic)
 "qlE" = (
 /obj/structure/decoration/hatch{
 	dir = 8
@@ -21473,9 +22085,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qrw" = (
-/obj/structure/chair/wood/modern,
+/obj/structure/rack,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "qrL" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -21524,6 +22139,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"qtL" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "qul" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21658,11 +22280,12 @@
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/legion)
 "qzr" = (
-/obj/structure/chair/wood/modern{
-	dir = 8
-	},
+/obj/structure/rack,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "qzt" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21973,6 +22596,20 @@
 /obj/item/lighter,
 /turf/open/floor/carpet/black,
 /area/f13/city)
+"qMp" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 25
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"qMy" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "shadowleft";
+	tag = "icon-shadowleft"
+	},
+/area/f13/wasteland)
 "qMA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -22209,6 +22846,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"qXk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "qYg" = (
 /obj/structure/fence{
 	dir = 1;
@@ -22487,12 +23130,12 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "rja" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+/obj/structure/simple_door/room,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/clinic)
 "rjD" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
@@ -22637,6 +23280,13 @@
 /obj/structure/booth/middle,
 /turf/open/floor/carpet/black,
 /area/f13/city)
+"roR" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 4;
+	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner (EAST)"
+	},
+/area/f13/wasteland)
 "roX" = (
 /obj/structure/chair/wood{
 	dir = 1;
@@ -22720,6 +23370,12 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"rtl" = (
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate";
+	tag = "icon-rubbleplate"
+	},
+/area/f13/wasteland)
 "rtR" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/desert,
@@ -22733,13 +23389,21 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/ncr)
+"ruo" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 9;
+	icon_state = "rubble";
+	tag = "icon-rubble (NORTHWEST)"
+	},
+/area/f13/wasteland)
 "ruy" = (
-/obj/structure/chair/wood/modern{
+/obj/structure/chair{
 	dir = 4;
-	icon_state = "wooden_chair_old"
+	icon_state = "chair";
+	tag = "icon-chair (EAST)"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "ruN" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
@@ -22875,13 +23539,9 @@
 	},
 /area/f13/ncr)
 "rzV" = (
-/obj/structure/table/wood,
-/obj/item/pen,
-/obj/item/paper,
-/obj/item/pen,
-/obj/item/reagent_containers/syringe/medx,
+/mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "rAf" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -23003,9 +23663,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "rEB" = (
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "rEP" = (
 /obj/machinery/light{
 	dir = 4
@@ -23090,13 +23750,26 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"rJD" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+"rIZ" = (
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
+"rJD" = (
+/obj/structure/toilet{
+	pixel_y = 0
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/village)
 "rJO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -23139,12 +23812,13 @@
 	},
 /area/f13/ncr)
 "rLP" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/building)
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "rMq" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
@@ -23157,6 +23831,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"rML" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 4;
+	icon_state = "rubble";
+	tag = "icon-rubble (EAST)"
+	},
+/area/f13/wasteland)
 "rNa" = (
 /obj/structure/closet,
 /turf/open/floor/f13{
@@ -23455,6 +24136,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"rXF" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/village)
 "rYS" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23523,12 +24212,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"sbc" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/obj/item/clothing/under/schoolgirl,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "sbD" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23586,11 +24269,16 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "sem" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube"
+	},
 /obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/clothing/under/overalls,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/clinic)
 "sew" = (
 /obj/structure/table,
 /obj/structure/table,
@@ -23687,6 +24375,16 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
+"sic" = (
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower";
+	tag = "icon-shower (WEST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/village)
 "sif" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -24076,6 +24774,10 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/legion)
+"swx" = (
+/obj/item/mining_scanner,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "swH" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -24202,6 +24904,12 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"sCf" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sCh" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -24497,10 +25205,11 @@
 	},
 /area/f13/building)
 "sNk" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2";
+	tag = "icon-verticalleftborderright2"
 	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "sNz" = (
 /obj/machinery/light/small{
@@ -25018,11 +25727,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tem" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "teu" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "hole"
@@ -25042,9 +25752,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "tfA" = (
-/obj/machinery/mineral/wasteland_vendor/medical,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
+	},
+/area/f13/wasteland)
 "tfM" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
@@ -25083,6 +25795,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tis" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "tiu" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
@@ -25281,14 +26001,12 @@
 	},
 /area/f13/tunnel)
 "tpA" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 4
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical (NORTHEAST)"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "tpD" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25378,10 +26096,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"tsr" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "tsB" = (
-/obj/structure/chair/f13chair2,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/machinery/vending/coffee,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "tsH" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -25503,6 +26225,13 @@
 /obj/structure/billboard/cola/pristine,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"twY" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "txb" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/road{
@@ -25543,9 +26272,16 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
 "tym" = (
-/obj/item/stack/ore/slag,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/structure/chair/stool{
+	dir = 2;
+	icon_state = "bench_center";
+	tag = "icon-bench_center"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "tyw" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass{
@@ -25696,6 +26432,12 @@
 /obj/item/shovel,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tDX" = (
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate";
+	tag = "icon-rubbleplate"
+	},
+/area/f13/village)
 "tEp" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -25834,13 +26576,9 @@
 	},
 /area/f13/village)
 "tJx" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
+/obj/machinery/vending/medical,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "tJz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -25952,6 +26690,10 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"tPt" = (
+/obj/structure/simple_door/brokenglass,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "tPy" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain3"
@@ -26047,10 +26789,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "tSQ" = (
-/mob/living/simple_animal/hostile/retaliate/goat/bighorn,
-/mob/living/simple_animal/hostile/retaliate/goat/bighorn,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/closet,
+/obj/item/storage/box/gloves,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "tSV" = (
 /obj/item/ammo_casing/caseless{
 	dir = 4;
@@ -26243,12 +26985,9 @@
 	},
 /area/f13/building)
 "uar" = (
-/obj/structure/ore_box,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "ubd" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderrightbottom"
@@ -26654,6 +27393,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"upA" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 2;
+	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner (WEST)"
+	},
+/area/f13/wasteland)
 "upG" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -26704,11 +27450,10 @@
 	},
 /area/f13/legion)
 "urt" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
+/obj/structure/rack,
+/obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "uru" = (
 /obj/machinery/light{
 	dir = 1
@@ -26784,12 +27529,6 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building)
-"utK" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "utT" = (
 /obj/structure/barricade/wooden/strong,
@@ -26957,6 +27696,13 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
+"uzs" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	icon_state = "floor2-old";
+	tag = "icon-floor2-old"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "uzv" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27079,11 +27825,11 @@
 	},
 /area/f13/wasteland)
 "uDU" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/car,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0";
+	tag = "icon-verticalinnermain0"
+	},
 /area/f13/wasteland)
 "uDX" = (
 /obj/structure/simple_door/room,
@@ -27100,10 +27846,13 @@
 	},
 /area/f13/village)
 "uFp" = (
-/obj/structure/barricade/sandbags,
-/obj/item/candle/tribal_torch,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench_center";
+	tag = "icon-bench_center (EAST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "uFK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -27142,6 +27891,16 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
+	},
+/area/f13/building)
+"uGT" = (
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower";
+	tag = "icon-shower (WEST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "uGX" = (
@@ -27275,6 +28034,13 @@
 /obj/item/kitchen/knife/cosmicdirty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
+"uMb" = (
+/obj/structure/chair/comfy,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "uMQ" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
@@ -27300,6 +28066,10 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"uNQ" = (
+/obj/structure/closet/cabinet,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "uOr" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -27326,6 +28096,15 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"uPr" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "uPw" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -27473,13 +28252,12 @@
 	},
 /area/f13/wasteland)
 "uTA" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
-	pixel_x = -31;
-	pixel_y = -11
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/clinic)
 "uTG" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -27664,11 +28442,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uZg" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench";
+	tag = "icon-bench (NORTH)"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "uZj" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/floorgrime,
@@ -27727,9 +28507,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vbi" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "vbA" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife,
@@ -27814,6 +28597,15 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/wasteland)
+"veO" = (
+/obj/structure/closet/cabinet,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/clothing/under/f13/blackdress,
+/obj/item/clothing/gloves/f13/lace,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "veW" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
@@ -27910,9 +28702,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "viv" = (
-/obj/item/stack/ore/slag,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/clinic)
 "viS" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -27941,6 +28737,17 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
+"vjG" = (
+/obj/structure/chair/stool{
+	dir = 2;
+	icon_state = "bench";
+	tag = "icon-bench"
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "vjO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -28025,9 +28832,9 @@
 	},
 /area/f13/building)
 "vno" = (
-/obj/machinery/mineral/wasteland_vendor/clothing,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "voC" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28035,9 +28842,12 @@
 	},
 /area/f13/wasteland)
 "voS" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
+	},
+/area/f13/wasteland)
 "voV" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -28236,9 +29046,8 @@
 /area/f13/bar)
 "vwn" = (
 /obj/structure/table/wood,
-/obj/item/paper,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "vwt" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/cow/brahmin,
@@ -28459,7 +29268,8 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
-	icon_state = "dirt"
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHEAST)"
 	},
 /area/f13/wasteland)
 "vGA" = (
@@ -28637,6 +29447,13 @@
 /obj/item/defibrillator/loaded,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
+"vMR" = (
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "vMU" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2top"
@@ -28891,6 +29708,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"wcA" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wcO" = (
 /obj/structure/chair/stool,
 /mob/living/simple_animal/hostile/ghoul,
@@ -29182,9 +30007,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wpo" = (
-/obj/item/stack/ore/iron,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	termtag = "Business"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "wpx" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
@@ -29232,9 +30060,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "wqN" = (
-/obj/structure/nest/ghoul,
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
 "wqS" = (
@@ -29316,6 +30146,16 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/city)
+"wvq" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "wvV" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -29323,6 +30163,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"wwp" = (
+/obj/structure/chair/stool{
+	dir = 2;
+	icon_state = "bench_center";
+	tag = "icon-bench_center"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wwD" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/under/schoolgirl/orange,
@@ -29562,10 +30410,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "wFD" = (
-/obj/structure/table/wood,
-/obj/item/dildo,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (NORTH)"
+	},
+/area/f13/wasteland)
 "wFG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -29814,6 +30664,24 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wOw" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 8;
+	icon_state = "rubble";
+	tag = "icon-rubble (WEST)"
+	},
+/area/f13/wasteland)
+"wOA" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/village)
 "wOI" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -29857,12 +30725,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/city)
-"wPJ" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/obj/item/clothing/under/schoolgirl/red,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "wPS" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
@@ -29970,13 +30832,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "wSJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/wasteland)
+/obj/structure/simple_door/wood,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "wSP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/settler,
@@ -29992,6 +30850,12 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
+"wTm" = (
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
+	},
+/area/f13/wasteland)
 "wTJ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -30354,14 +31218,11 @@
 	},
 /area/f13/village)
 "xdG" = (
-/obj/structure/chair/stool{
-	icon_state = "bench"
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/table/wood,
+/obj/item/paper,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "xdL" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood{
@@ -30402,17 +31263,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
 "xeG" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/machinery/light/small{
+/obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "xeQ" = (
 /obj/structure/bed/mattress/pregame,
 /obj/item/clothing/head/fedora,
@@ -30533,6 +31388,14 @@
 	icon_state = "verticalinnermain2"
 	},
 /area/f13/wasteland)
+"xir" = (
+/obj/structure/chair/comfy/black{
+	dir = 8;
+	icon_state = "comfychair";
+	tag = "icon-comfychair (WEST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xiy" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -30801,7 +31664,6 @@
 "xrO" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
-/obj/item/clothing/under/schoolgirl/green,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xsd" = (
@@ -30821,7 +31683,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xsF" = (
@@ -30948,8 +31809,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xxf" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/legion)
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xxg" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/wood/f13/old,
@@ -30974,11 +31839,17 @@
 	},
 /area/f13/building)
 "xyo" = (
-/obj/structure/table/wood,
-/obj/item/folder/yellow,
-/obj/item/reagent_containers/pill/patch/jet,
+/obj/structure/chair{
+	dir = 1;
+	icon_state = "chair";
+	tag = "icon-chair (NORTH)"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube"
+	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "xys" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -31115,6 +31986,15 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xEZ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "xFv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
@@ -31149,6 +32029,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"xGD" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "xGH" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
@@ -31161,13 +32047,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xHw" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 25
+/obj/structure/fence/corner{
+	dir = 9;
+	icon_state = "corner"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xIo" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 1
@@ -31210,8 +32095,8 @@
 	},
 /area/f13/wasteland)
 "xJd" = (
-/obj/item/shovel,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/chair/stool,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "xJA" = (
 /obj/structure/chair/office/dark{
@@ -31534,9 +32419,19 @@
 	},
 /area/f13/wasteland)
 "xUc" = (
-/obj/structure/nest/ghoul,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/clinic)
+"xUq" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_2";
+	step_x = 0;
+	step_y = 0;
+	tag = "icon-tree_2"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xUO" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -31579,6 +32474,13 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
+"xVN" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	icon_state = "floor4-old";
+	tag = "icon-floor4-old"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "xVT" = (
 /obj/machinery/light{
 	dir = 1
@@ -31586,12 +32488,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xWu" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/chair,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "xWF" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13{
@@ -31620,12 +32519,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xXl" = (
-/obj/item/stack/ore/iron,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
+/obj/item/clothing/under/f13/police,
+/obj/item/clothing/head/f13/police,
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "xXp" = (
 /obj/machinery/workbench,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -31730,11 +32632,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "yaz" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old";
+	tag = "icon-floor5-old"
 	},
-/area/f13/ncr)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "yaA" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13{
@@ -31749,6 +32653,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"yaG" = (
+/obj/structure/chair/comfy{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "yaI" = (
 /obj/structure/table/wood,
 /obj/item/pickaxe,
@@ -31789,8 +32702,9 @@
 	},
 /area/f13/wasteland)
 "ybK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2right"
+	},
 /area/f13/ncr)
 "yci" = (
 /obj/structure/bed,
@@ -31912,6 +32826,12 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"yhv" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "yhB" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31953,10 +32873,12 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "ykq" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "ykD" = (
 /obj/structure/rack,
@@ -35780,7 +36702,7 @@ gcK
 gcK
 gcK
 fkU
-vbi
+mwp
 gcK
 gcK
 gcK
@@ -36446,12 +37368,12 @@ rCx
 evR
 uuI
 xeh
-fiB
-ybK
-ybK
-bgO
-fiB
-peO
+aRd
+fCO
+dyr
+dyr
+ixP
+evR
 uuI
 uuI
 xey
@@ -36704,11 +37626,11 @@ evR
 uuI
 uuI
 ybK
-yaz
-fKc
-fMW
-ybK
-uuI
+fCO
+dyr
+dyr
+ixP
+evR
 uuI
 uuI
 xey
@@ -36960,12 +37882,12 @@ jPH
 kmJ
 nMa
 nMa
-ybK
-bDM
+hkl
+fCO
 dyr
-pXo
-ybK
-nMa
+dyr
+ixP
+kmJ
 gFQ
 uuI
 xey
@@ -37217,11 +38139,11 @@ sZL
 hrQ
 hrQ
 hrQ
-fiB
+hkl
 fCO
 dyr
 dyr
-fiB
+ixP
 oBh
 evR
 uuI
@@ -41097,14 +42019,14 @@ fyf
 pis
 fyf
 fyf
-hAC
+bgO
 fyf
 qOV
-cWG
-daU
+fKc
+bAX
 bpD
 fyf
-hAC
+bgO
 fyf
 fyf
 fyf
@@ -41356,16 +42278,16 @@ fyf
 fyf
 fyf
 qOV
-daU
-aBH
-mfD
-hCg
+bAX
+fMW
+pXo
+vbi
+aUl
+uxC
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
+uxC
+sUv
 fyf
 fyf
 fyf
@@ -41613,16 +42535,16 @@ fyf
 fyf
 mtL
 tBN
-aBH
-hCg
+mvv
+fRK
+mvv
+xxf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -41870,16 +42792,16 @@ fyf
 fyf
 qOV
 vGg
+mvv
+fRK
+mvv
 bpD
 fyf
+ceI
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -42127,16 +43049,16 @@ fyf
 fyf
 tBN
 mvv
+mvv
+fRK
+mvv
 bpD
 fyf
+wrg
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -42384,16 +43306,16 @@ fyf
 rtR
 tBN
 mvv
-bpD
+mvv
+mvv
+bSN
+hCg
+fyf
+bnf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 gcK
@@ -42639,18 +43561,18 @@ jJb
 fyf
 fyf
 qOV
-daU
+bAX
 mvv
-bpD
+bSN
+mfD
+hCg
 fyf
 fyf
 fyf
 fyf
-sND
 fyf
 fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 gcK
@@ -42901,13 +43823,13 @@ mfD
 hCg
 fyf
 fyf
+yaz
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 gcK
@@ -43156,15 +44078,15 @@ fyf
 fyf
 fyf
 fyf
+hCV
+fyf
+tCq
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -43413,15 +44335,15 @@ fyf
 jJb
 fyf
 fyf
+hCV
 fyf
 fyf
+qOV
+fKc
+bDM
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -43670,15 +44592,15 @@ fyf
 fyf
 rtR
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
+qFk
+qFk
+qFk
+qFk
+lyG
+qFk
+qFk
+qFk
+qFk
 fyf
 pis
 fyf
@@ -43927,15 +44849,15 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qFk
+rJD
+rXF
+cbk
+gwJ
+cbk
+xGD
+wOA
+qFk
 fyf
 fyf
 fyf
@@ -44184,15 +45106,15 @@ fyf
 sqA
 fyf
 fyf
-sND
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
+krm
+cCf
+aMw
+qtL
+hgm
+qtL
+uRJ
+uRJ
+ndV
 fyf
 fyf
 fyf
@@ -44441,15 +45363,15 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qFk
+tlr
+sic
+cbk
+mtc
+cbk
+uMb
+hgm
+qFk
 fyf
 lQD
 fyf
@@ -44698,16 +45620,16 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qFk
+cbk
+cbk
+cbk
+kHs
+cbk
+uRJ
+cxF
+qFk
+iSB
 fyf
 olZ
 fyf
@@ -44955,16 +45877,16 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qFk
+jTq
+wvq
+mxR
+mtc
+cbk
+hgm
+faW
+faW
+pZd
 fyf
 fyf
 fyf
@@ -45209,19 +46131,19 @@ fyf
 fyf
 fyf
 qOV
-wDc
+bDM
 fyf
 qOV
-wDc
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kUk
+uRJ
+mtc
+mvJ
+mtc
+cbk
+cxF
+hCR
+ruo
+bAJ
 fyf
 fyf
 fyf
@@ -45469,15 +46391,15 @@ nlO
 hCg
 fyf
 tBN
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+lyG
+uRJ
+iFb
+mtc
+hgm
+cbk
+wTm
+ruo
+bAJ
 fyf
 fyf
 fyf
@@ -45726,14 +46648,14 @@ fyf
 fyf
 fyf
 nlO
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qFk
+rLP
+mtc
+yaG
+faW
+hCR
+faW
+lLv
 fyf
 fyf
 sND
@@ -45983,14 +46905,14 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
+qFk
+qFk
+qFk
+qFk
+rtl
+wTm
+ruo
+bAJ
 fyf
 fyf
 fyf
@@ -46243,10 +47165,10 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
+qeS
+wOw
+wOw
+bAJ
 fyf
 fyf
 fyf
@@ -50102,16 +51024,16 @@ fyf
 fyf
 fyf
 fyf
+kEa
+upA
+rML
+rML
+rML
+roR
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -50358,17 +51280,17 @@ fyf
 fyf
 fyf
 fyf
+qFk
+qFk
+qFk
+cov
+eXA
+cov
+qFk
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 gjP
@@ -50605,7 +51527,7 @@ nPX
 fyf
 pcG
 wcS
-lyG
+hVN
 uRJ
 uRJ
 seQ
@@ -50615,13 +51537,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qFk
+bmx
+xEZ
+eXA
+tDX
+lmY
+qFk
 fyf
 fyf
 fyf
@@ -50872,13 +51794,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+aYK
+mSo
+mtc
+oBc
+mtc
+tis
+qFk
 fyf
 fyf
 fyf
@@ -51129,13 +52051,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qFk
+iqJ
+mtc
+qFk
+qFk
+qFk
+qFk
 fyf
 fyf
 fyf
@@ -51386,13 +52308,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qFk
+mtc
+mtc
+oBc
+mtc
+hDE
+aYK
 fyf
 fyf
 fyf
@@ -51643,13 +52565,13 @@ cWG
 wDc
 sqA
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qFk
+qFk
+qFk
+qFk
+mtc
+gNc
+qFk
 fyf
 fyf
 fyf
@@ -51900,13 +52822,13 @@ mvv
 bpD
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+aYK
+cCf
+pne
+oBc
+mtc
+isy
+qFk
 fyf
 fyf
 fyf
@@ -52157,13 +53079,13 @@ mvv
 bpD
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qFk
+cSc
+ahD
+qFk
+mtc
+jWa
+qFk
 fyf
 fyf
 fyf
@@ -52414,14 +53336,14 @@ aBH
 hCg
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
+qFk
+qFk
+qFk
+qFk
+lyG
+qFk
+qFk
+xUq
 fyf
 fyf
 fyf
@@ -52671,13 +53593,13 @@ hCg
 fyf
 fyf
 fyf
-fyf
-sND
-fyf
+hCV
 fyf
 fyf
 fyf
 fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -52928,13 +53850,13 @@ fyf
 fyf
 hAC
 fyf
+hCV
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
+bpb
 fyf
 fyf
 fyf
@@ -53187,15 +54109,15 @@ fyf
 fyf
 fyf
 fyf
+sqA
 fyf
 fyf
 fyf
-fyf
-qOV
+rIZ
 cWG
 cWG
 cWG
-wDc
+bDM
 fyf
 fyf
 fyf
@@ -53446,9 +54368,9 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-tBN
+qOV
+cWG
+daU
 mvv
 mvv
 mvv
@@ -53699,14 +54621,14 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
 tBN
-aBH
+mvv
+mvv
+bSN
 mfD
 mfD
 hCg
@@ -53956,13 +54878,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
 nlO
+mfD
+mfD
 hCg
 fyf
 fyf
@@ -61246,11 +62168,11 @@ nlO
 mfD
 gcK
 gcK
-mrq
-mrq
-mrq
-mrq
-mrq
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 btN
 btN
@@ -61503,11 +62425,11 @@ fyf
 fyf
 fyf
 gcK
-mrq
-gEr
-pxf
-gEr
-mrq
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -61760,12 +62682,12 @@ fyf
 fyf
 fyf
 fyf
-mrq
-tfA
-nsE
-vno
-mrq
 fyf
+gcK
+gcK
+gcK
+gcK
+gcK
 fyf
 fyf
 fyf
@@ -62027,59 +62949,59 @@ igz
 igz
 igz
 igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
 bEw
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 gcK
@@ -62283,60 +63205,60 @@ ybI
 ybI
 ybI
 ybI
-nkp
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+alN
+beA
 dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 gcK
@@ -62540,60 +63462,60 @@ cdc
 idu
 idu
 idu
-koD
+awD
+bmV
+cPH
+dBH
+dBH
+awD
+bmV
+ffT
+dBH
+dBH
+dBH
+awD
+bmV
+mex
+dBH
+dBH
+dBH
+awD
+bmV
+cPH
+dBH
+sNk
+dBH
+dBH
+dBH
+dBH
+awD
+bmV
+cPH
+dBH
+dBH
+dBH
+awD
+bmV
+ffT
+dBH
+dBH
+dBH
+awD
+bmV
+mex
+dBH
+dBH
+dBH
+awD
+bmV
+cPH
+dBH
+sNk
+dBH
+dBH
+qMy
+bml
 dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rsE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 gcK
@@ -62797,62 +63719,62 @@ cdc
 ehN
 ehN
 hOl
-koD
+axz
+bIZ
+axz
+dPc
+eso
+axz
+bIZ
+axz
+gEZ
+dPc
+dPc
+dPc
+eso
+mex
+dPc
+dPc
+eso
+axz
+bIZ
+axz
+gEZ
+bIZ
+uDU
+dPc
+dPc
+eso
+axz
+bIZ
+axz
+gEZ
+dPc
+eso
+axz
+bIZ
+axz
+gEZ
+dPc
+dPc
+dPc
+eso
+mex
+dPc
+dPc
+eso
+axz
+bIZ
+axz
+gEZ
+bIZ
+dPc
+dPc
+dPc
+bml
 dMW
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-fyf
-fyf
-fyf
-fyf
-wjt
 gcK
 gcK
 gcK
@@ -63054,60 +63976,60 @@ ehN
 ehN
 ehN
 ehN
-koD
+aEe
+bQq
+dii
+ebM
+ebM
+aEe
+bQq
+dii
+ebM
+ebM
+aEe
+bQq
+bQq
+mex
+ebM
+ebM
+ebM
+aEe
+bQq
+dii
+ebM
+bQq
+ebM
+ebM
+ebM
+ebM
+aEe
+bQq
+dii
+ebM
+ebM
+ebM
+aEe
+bQq
+dii
+ebM
+ebM
+aEe
+bQq
+bQq
+mex
+ebM
+ebM
+ebM
+aEe
+bQq
+dii
+ebM
+bQq
+ebM
+eqo
+pkN
+bml
 dMW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-fyf
-fyf
 fyf
 fyf
 gcK
@@ -63311,60 +64233,60 @@ erY
 erY
 erY
 erY
-koD
+biU
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cLM
+cuG
 dMW
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rsE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 gcK
@@ -63557,7 +64479,7 @@ ptf
 ptf
 ptf
 ptf
-koD
+gNA
 unI
 erY
 erY
@@ -63568,63 +64490,63 @@ erY
 erY
 erY
 erY
-koD
-dMW
+bml
+sUX
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+owG
+oBQ
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+edA
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rsE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
 gcK
 gcK
 gcK
@@ -63814,7 +64736,7 @@ fyf
 fyf
 fyf
 fyf
-koD
+kGc
 unI
 erY
 erY
@@ -63825,7 +64747,7 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
 fyf
@@ -63845,14 +64767,6 @@ fyf
 fyf
 fyf
 fyf
-oFP
-oFP
-oFP
-oFP
-oFP
-oFP
-oFP
-oFP
 fyf
 fyf
 fyf
@@ -63872,7 +64786,6 @@ fyf
 fyf
 fyf
 fyf
-tSQ
 fyf
 fyf
 fyf
@@ -63881,7 +64794,16 @@ fyf
 fyf
 fyf
 fyf
-gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -64071,7 +64993,7 @@ fyf
 fyf
 fyf
 fyf
-koD
+kGc
 unI
 erY
 erY
@@ -64082,7 +65004,7 @@ erY
 cdc
 erY
 erY
-koD
+bml
 dMW
 fyf
 fyf
@@ -64092,39 +65014,6 @@ fyf
 fyf
 fyf
 fyf
-rsE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-iFr
-fyf
-oFP
-utK
-cbr
-cbr
-cbr
-cbr
-owG
-oFP
-fyf
-jxH
-jxH
-jxH
-jxH
-jxH
-uFp
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
 fyf
 fyf
 fyf
@@ -64135,11 +65024,44 @@ fyf
 fyf
 fyf
 fyf
+qOV
+cWG
+cWG
+cWG
+wDc
+xHw
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+ekE
 fyf
 fyf
 fyf
-gcK
-gcK
+fyf
+xHw
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+ekE
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -64325,10 +65247,10 @@ fyf
 fyf
 fyf
 fyf
-igz
-igz
-igz
-koD
+fyf
+fyf
+fyf
+kGc
 unI
 liv
 erY
@@ -64339,7 +65261,7 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
 fyf
@@ -64359,30 +65281,33 @@ fyf
 fyf
 fyf
 fyf
-oFP
-iAs
-cbr
-rja
-utK
-cbr
-pYa
-oFP
+tBN
+mvv
+mvv
+mvv
+voS
+gts
+gts
+gts
+gts
+gts
+gts
+fyf
+fyf
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-jxH
-fyf
-fyf
-rsE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -64398,9 +65323,6 @@ gcK
 gcK
 gcK
 gcK
-ktB
-ktB
-ktB
 ktB
 "}
 (127,1,1) = {"
@@ -64582,10 +65504,10 @@ fyf
 fyf
 fyf
 fyf
-cOk
-wGJ
-mmK
-koD
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -64596,55 +65518,58 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+ekE
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+ekE
 fyf
-fyf
-fyf
-fyf
-fyf
-oXa
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-iFr
-oFP
-cbr
-tem
-cbr
-jKS
-cbr
-cbr
-oFP
-qaW
+tBN
+mvv
+mvv
+mvv
+voS
+gts
+xXl
+fXj
+ctE
 gwB
-fyf
-hAC
-rsE
-hAC
-jxH
-sqA
+gts
 fyf
 fyf
+gts
+vYv
+vjG
+iBK
+vYv
+kIl
+gts
+gts
+gts
+gts
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-wjt
 fyf
 fyf
 fyf
@@ -64655,9 +65580,6 @@ gcK
 gcK
 gcK
 gcK
-ktB
-fRK
-ktB
 ktB
 "}
 (128,1,1) = {"
@@ -64839,10 +65761,10 @@ fyf
 fyf
 fyf
 fyf
-cdc
-cdc
-erY
-koD
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 cdc
@@ -64853,9 +65775,10 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
 fyf
 fyf
 fyf
@@ -64867,36 +65790,38 @@ fyf
 fyf
 fyf
 fyf
-uFp
-jxH
-jxH
-jxH
 fyf
 fyf
-oFP
-kvb
-pKP
-cbr
+fyf
+hCV
+fyf
+tBN
+mvv
+mvv
+mvv
 voS
-cbr
-owG
-oFP
-qaW
-gwB
+gts
+vYv
+vYv
+vYv
+vYv
+gts
 fyf
 fyf
-uey
+toB
+ouS
+olP
+ybq
+ouS
+vYv
+gts
+olP
+olP
+pjD
+gts
 fyf
-jxH
-jxH
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -64912,9 +65837,6 @@ gcK
 gcK
 gcK
 gcK
-ktB
-ktB
-ktB
 ktB
 "}
 (129,1,1) = {"
@@ -65085,21 +66007,21 @@ fyf
 fyf
 fyf
 fyf
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-pOw
-cdc
-cpK
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 cdc
@@ -65110,9 +66032,53 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+sYX
+sYX
+xIq
+sYX
+sYX
+xIq
+sYX
+sYX
+xIq
+sYX
+fyf
+fyf
+fyf
+hCV
+fyf
+tBN
+mvv
+mvv
+mvv
+voS
+gts
+gts
+gts
+vYv
+gts
+gts
+fyf
+fyf
+gts
+kqc
+vjG
+gsu
+vYv
+vYv
+gts
+qMp
+vYv
+dol
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -65124,50 +66090,6 @@ fyf
 fyf
 fyf
 fyf
-jxH
-bQq
-uDU
-eOK
-fyf
-fyf
-oFP
-oFP
-oFP
-hnB
-hnB
-oFP
-oFP
-oFP
-fyf
-hAC
-fyf
-bml
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -65342,21 +66264,21 @@ fyf
 fyf
 fyf
 fyf
-gts
-dPc
-tpA
-pjD
-gts
-vYv
-xdG
-xeG
-vYv
-kIl
-gts
-hbW
-erY
-iTJ
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 cdc
@@ -65367,9 +66289,53 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+cuv
+exj
+rpu
+gYp
+sYX
+rpu
+jxk
+jxk
+iAz
+sYX
+fyf
+fyf
+fyf
+hCV
+fyf
+tBN
+uRa
+mvv
+mvv
+voS
+toB
+ybq
+uKY
+vYv
+gts
+fyf
+fyf
+fyf
+mFe
+vYv
+vYv
+vYv
+vYv
+vYv
+olP
+vYv
+vYv
+vMR
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -65380,52 +66346,8 @@ fyf
 fyf
 fyf
 fyf
-dDC
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-qaW
-qaW
-ebM
-fyf
-fyf
-fyf
-fyf
-qaW
-fyf
-uey
-tsB
-wrg
-cPH
-fyf
-fyf
-iFr
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -65599,21 +66521,21 @@ fyf
 fyf
 fyf
 fyf
-gts
-xHw
-vYv
-ncn
-gts
-ouS
-olP
-ybq
-ouS
-vYv
-gts
-hbW
-erY
-wGJ
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -65624,47 +66546,53 @@ erY
 erY
 sCK
 erY
-koD
+bml
 dMW
 fyf
+hCV
 fyf
+sYX
+rpu
+klA
+hmy
+sYX
+iAz
+rpu
+rpu
+rpu
+sYX
+sYX
+sYX
+sYX
+hCV
 fyf
-oXa
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rtR
-fyf
-fyf
-qaW
-qaW
-fyf
-fyf
-rsE
-hAC
-fyf
-hAC
-iGi
-fyf
-fyf
-uZg
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
+tBN
+mvv
+mvv
+mvv
+wqN
+toB
+ykq
+vYv
+scY
+gts
 fyf
 rsE
 fyf
+mFe
+vYv
+vYv
+vYv
+iPf
+vYv
+olP
+vYv
+iPf
+pjD
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -65677,12 +66605,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
 gcK
 gcK
 gcK
@@ -65856,21 +66778,21 @@ fyf
 fyf
 fyf
 fyf
-olP
-vYv
-vYv
-iuS
-gts
-gzQ
-xdG
-gYp
-vYv
-vYv
-gts
-hbW
-erY
-wkd
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -65881,53 +66803,53 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+sYX
+eOK
+klA
+rpu
+sYX
+iRr
+rpu
+rpu
+iAz
+sYX
+ncn
+nUr
+sYX
+vxC
+fyf
+tBN
+mvv
+mvv
+mvv
+voS
+toB
+twY
+vYv
+vYv
+gts
 fyf
 fyf
 fyf
+gts
+vYv
+vjG
+gsu
+vYv
+vYv
+vMR
+gtv
+vYv
+qai
+gts
 fyf
 fyf
-fyf
-fyf
-fyf
-jxH
-fyf
-fyf
-fyf
-iGi
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -66113,21 +67035,21 @@ fyf
 fyf
 fyf
 fyf
-olP
-vYv
-iPf
-pjD
-gts
-vYv
-vYv
-vYv
-vYv
-vYv
-mFe
-hbW
-erY
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -66138,53 +67060,53 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+cuv
+eOZ
+fqg
+klA
+sYX
+iAz
+rpu
+rpu
+rpu
+jgq
+dhC
+oai
+sYX
+fyf
+fyf
+tBN
+mvv
+mvv
+mvv
+voS
+toB
+iHj
+vYv
+vYv
+gts
 fyf
 fyf
 fyf
+toB
+ouS
+onQ
+onQ
+hyf
+vYv
+rVK
+vYv
+vYv
+vYv
+gts
 fyf
 fyf
-fyf
-fyf
-fyf
-jxH
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-uHT
-fyf
-fyf
-uey
-qOV
-cWG
-cWG
-cWG
-cWG
-wDc
-hAC
-uey
-fyf
-rtR
-ulH
-fyf
-fyf
-jxH
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -66370,21 +67292,21 @@ fyf
 fyf
 fyf
 fyf
-xWu
-olN
-vYv
-biU
-gts
-vYv
-vYv
-vYv
-iPf
-vYv
-mFe
-hbW
-erY
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -66395,46 +67317,53 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+sYX
+sYX
+sYX
+sDp
+sYX
+iTk
+rpu
+rpu
+jxk
+uqa
+uqa
+sYX
+sYX
 fyf
 fyf
-fyf
-xtO
-fyf
-fyf
-fyf
-fyf
-jxH
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-qOV
-daU
+tBN
 mvv
 mvv
-wpo
 mvv
-pud
-cWG
-wDc
-uey
-fyf
-fyf
-hAC
-hAC
-jxH
+voS
+gts
+gts
+gts
+mFe
+gts
 fyf
 fyf
 fyf
+gts
+iPf
+dTG
+kyC
+vYv
+auU
+gts
+uPr
+uPr
+vYv
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -66446,13 +67375,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
 fyf
 gcK
 gcK
@@ -66627,21 +67549,21 @@ fyf
 fyf
 fyf
 fyf
-rVK
-vYv
-vYv
-vYv
-mFe
-vYv
-xdG
-gYp
-vYv
-vYv
-gts
-hbW
-erY
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 txb
 erY
@@ -66652,43 +67574,31 @@ erY
 cdc
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+rsE
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-jxH
 fyf
 rsE
 fyf
-uey
+sYX
+iAz
+rpu
+rpu
+iAz
+sYX
+qfh
+lWX
+sYX
 fyf
 fyf
-fyf
-fyf
-fyf
-uey
 tBN
 mvv
-iBD
-mvv
-hbt
 mvv
 mvv
-mvv
-doX
-wDc
-rsE
-fyf
-fyf
-fyf
-jxH
+voS
 fyf
 fyf
 fyf
@@ -66697,6 +67607,20 @@ fyf
 fyf
 fyf
 fyf
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+hCa
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -66709,9 +67633,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
+gcK
 gcK
 gcK
 ktB
@@ -66884,21 +67806,21 @@ fyf
 fyf
 fyf
 fyf
-gts
-aEe
-aEe
-vYv
-mFe
-ouS
-onQ
-onQ
-axz
-vYv
-gts
-hbW
-wGJ
-sCK
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -66909,60 +67831,53 @@ hsy
 hsy
 erY
 erY
-koD
+bml
 dMW
 fyf
-qOV
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-wDc
-qOV
-cWG
-cWG
-cWG
-cWG
-wDc
+hCV
 fyf
+fyf
+fyf
+sYX
+sYX
+sYX
+sYX
+sYX
+sDp
+sYX
+sYX
+ncn
+olN
+uqa
 fyf
 fyf
 tBN
 mvv
 mvv
-hbt
-hbt
-hbt
 mvv
-hbt
-mvv
-bpD
-fyf
-uey
-fyf
-uey
-jxH
+voS
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+rsE
 fyf
 fyf
 fyf
 fyf
 fyf
+gts
+pMz
+sCf
+wPl
+dGK
+olW
+gts
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -66970,6 +67885,13 @@ fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -67141,21 +68063,21 @@ fyf
 fyf
 fyf
 fyf
-gts
-vYv
-vYv
-vYv
-gts
-iPf
-bzb
-oBQ
-vYv
-auU
-gts
-hbW
-wGJ
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -67166,41 +68088,34 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
-tBN
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-bpD
-tBN
-mvv
-mvv
-mvv
-mvv
-doX
-wDc
-hAC
-uey
-tBN
-lda
-hbt
-hbt
-hCF
-hbt
-hbt
-mvv
-mvv
-doX
-wDc
+hCV
 fyf
-bml
+fyf
+fyf
+sYX
+hxp
+dhC
+iTJ
+jOA
+rpu
+rpu
+sYX
+uCO
+sDp
+uqa
+fyf
+fyf
+bVY
+tem
+mfD
+mfD
+wFD
+fyf
+fyf
+sju
 fyf
 fyf
 fyf
@@ -67210,6 +68125,16 @@ fyf
 fyf
 fyf
 fyf
+cuv
+rpu
+rpu
+rpu
+rpu
+rpu
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -67218,15 +68143,12 @@ fyf
 fyf
 fyf
 fyf
-sND
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -67398,21 +68320,21 @@ fyf
 fyf
 fyf
 fyf
-gts
-vYv
-jTZ
-iPf
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-box
-wGJ
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 fmW
 mmK
@@ -67423,43 +68345,25 @@ erY
 erY
 erY
 cdc
-koD
+bml
 dMW
 fyf
-tBN
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-bpD
-nlO
-xGH
-mvv
-mvv
-mvv
-mvv
-doX
-wDc
-hAC
-nlO
-xGH
-mvv
-hbt
-gFR
-oOZ
-hbt
-mvv
-mvv
-mvv
-bpD
+hCV
 fyf
-wrg
+rsE
 fyf
-iFr
+sYX
+hCF
+dhC
+dhC
+rpu
+rpu
+rpu
+rpu
+rpu
+rpu
+sYX
+mGZ
 fyf
 fyf
 fyf
@@ -67477,6 +68381,17 @@ fyf
 fyf
 fyf
 fyf
+mGZ
+gts
+klA
+rpu
+rkZ
+ohk
+rpu
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -67484,6 +68399,13 @@ fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -67655,21 +68577,21 @@ fyf
 fyf
 fyf
 fyf
-gts
-gts
-gts
-gts
-gts
-pMz
-eso
-wPl
-dii
-kUe
-gts
-ioh
-wGJ
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -67680,41 +68602,24 @@ erY
 erY
 erY
 erY
-koD
-dMW
+bml
+cOk
+dDC
+hCV
 fyf
-nlO
-xGH
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-aBH
-hCg
 fyf
-nlO
-xGH
-mvv
-mvv
-mvv
-mvv
-bpD
 fyf
-qOV
-daU
-hbt
-hTe
-gFR
-gFR
-hbt
-tym
-mvv
-wpo
-bpD
-fyf
-uZg
+sYX
+hHC
+dhC
+jbw
+rpu
+rpu
+rpu
+rpu
+rpu
+rpu
+wpx
 fyf
 fyf
 fyf
@@ -67724,11 +68629,26 @@ fyf
 fyf
 fyf
 fyf
+xJd
+fyf
+rsE
 fyf
 fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+acn
+rpu
+rpu
+bqB
+gkE
+rpu
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -67739,7 +68659,9 @@ fyf
 fyf
 fyf
 fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -67916,17 +68838,17 @@ fyf
 fyf
 fyf
 fyf
-cuv
-rpu
-rpu
-rpu
-rpu
-rpu
-gts
-dXy
-wGJ
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -67937,49 +68859,24 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
-fyf
-nlO
-mfD
-mfD
-mfD
-mfD
-mfD
-mfD
-hCg
-fyf
-fyf
-uey
-nlO
-mfD
-qij
-mfD
-mfD
-hCg
-fyf
-jOA
-bGM
-mvv
-hbt
-gFR
-hbt
-hTe
-hbt
-mvv
-mvv
-bpD
+hCV
 fyf
 fyf
 fyf
-dDC
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
+uqa
+hHY
+dhC
+dhC
+dhC
+rpu
+rpu
+rpu
+neZ
+olW
+sYX
 fyf
 fyf
 fyf
@@ -67989,6 +68886,7 @@ fyf
 fyf
 fyf
 fyf
+wrg
 fyf
 fyf
 fyf
@@ -67997,6 +68895,30 @@ fyf
 fyf
 fyf
 fyf
+fyf
+acn
+rpu
+rpu
+jAZ
+rpu
+rpu
+gts
+fyf
+fyf
+hCV
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+wjt
+fyf
+fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -68170,20 +69092,20 @@ fyf
 fyf
 fyf
 fyf
-gts
-gts
-gts
-gts
-klA
-rpu
-mGZ
-tJx
-rpu
-gts
-dXy
-apk
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -68194,41 +69116,34 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
 fyf
 fyf
 fyf
+uqa
+hxp
+dhC
+hxp
+jTZ
+rkZ
+rkZ
+rkZ
+rpu
+rpu
+cuv
 fyf
 fyf
 fyf
+tfA
+fKc
+fKc
+fKc
+wDc
 fyf
-fyf
-jxH
-fyf
-fyf
-fyf
-fyf
-rsE
-fyf
-fyf
-fyf
-wqN
-fyf
-tBN
-mvv
-mvv
-hbt
-hbt
 xJd
-hbt
-iBD
-mvv
-mvv
-bpD
-fyf
-uey
 fyf
 fyf
 fyf
@@ -68238,22 +69153,29 @@ fyf
 fyf
 fyf
 fyf
+gts
+kYz
+rpu
+bqB
+gkE
+rpu
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
 fyf
 fyf
+wjt
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -68427,20 +69349,20 @@ fyf
 fyf
 fyf
 fyf
-gts
-dhC
-iRr
-gts
-rpu
-rpu
-vwn
-ykq
-rpu
-mFe
-dXy
-tPy
-cdc
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -68451,44 +69373,32 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
 fyf
 fyf
 fyf
-xtO
+uqa
+sYX
+sYX
+sYX
+sYX
+sYX
+uqa
+xIq
+uqa
+sYX
+sYX
 fyf
 fyf
 fyf
-fyf
-jxH
-eOZ
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-nlO
-xXl
-mvv
-gFg
-hbt
+qaW
 mvv
 mvv
 mvv
-hbt
-aBH
-hCg
-uey
-fyf
-fyf
-fyf
-oXa
+voS
 fyf
 fyf
 fyf
@@ -68500,6 +69410,16 @@ fyf
 fyf
 fyf
 fyf
+cuv
+wwp
+rpu
+dGK
+rpu
+rpu
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -68510,7 +69430,9 @@ fyf
 fyf
 fyf
 fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -68684,20 +69606,20 @@ fyf
 fyf
 fyf
 fyf
-gts
-oai
-usW
-pHi
-rpu
-rpu
-bIZ
-rpu
-rpu
-mFe
-wSJ
-apk
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -68708,9 +69630,10 @@ hsy
 hsy
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
 fyf
 fyf
 fyf
@@ -68719,46 +69642,20 @@ fyf
 fyf
 fyf
 fyf
-jxH
-ekE
-rtR
-bml
-uey
 fyf
 fyf
-ulH
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 qaW
-qaW
-fyf
-tBN
 mvv
+pIn
 mvv
-mvv
-mvv
-aBH
-mfD
-mfD
-hCg
-iGi
-fyf
-eXw
-xtO
-jxH
-fyf
-fyf
-fyf
-fyf
-fyf
-rsE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
+voS
 fyf
 fyf
 fyf
@@ -68768,6 +69665,31 @@ fyf
 fyf
 fyf
 fyf
+fyf
+jOc
+gts
+lRZ
+rpu
+rpu
+rpu
+olW
+gts
+fyf
+fyf
+hCV
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+wjt
+fyf
+fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -68941,20 +69863,20 @@ fyf
 fyf
 fyf
 fyf
-gts
-gts
-gts
-gts
-itm
-rpu
-vwn
-ykq
-rpu
-gts
-hbW
-erY
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -68965,21 +69887,21 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+sYX
+sYX
+uqa
+uqa
 fyf
-fyf
-jxH
-fyf
-fyf
-wrg
 fyf
 fyf
 fyf
@@ -68987,21 +69909,10 @@ fyf
 fyf
 fyf
 qaW
-fyf
-nlO
-mfD
-mfD
-hxp
-mfD
-hCg
-uey
-hHY
-qaW
-ebM
-fyf
-fyf
-fyf
-jxH
+mvv
+mvv
+mvv
+voS
 fyf
 fyf
 fyf
@@ -69009,6 +69920,20 @@ fyf
 fyf
 fyf
 fyf
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+aOc
+rVK
+gts
+gts
+gts
+gts
+gts
 fyf
 fyf
 fyf
@@ -69019,12 +69944,9 @@ fyf
 fyf
 fyf
 fyf
-wjt
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -69201,17 +70123,17 @@ fyf
 fyf
 fyf
 fyf
-cuv
-eZg
-rpu
-dii
-rpu
-rpu
-gts
-hbW
-erY
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -69222,9 +70144,20 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+sYX
+dhC
+lWX
+uqa
 fyf
 fyf
 fyf
@@ -69232,31 +70165,11 @@ fyf
 fyf
 fyf
 fyf
-fyf
-jxH
-fyf
-fyf
-uZg
-fyf
-fyf
-fyf
-fyf
-bQV
-bQV
-bQV
-bQV
-uar
-uey
-fyf
-fyf
-rtR
-hAC
-fyf
-uar
-bQV
-bQV
-bQV
-bQV
+qaW
+mvv
+mvv
+mvv
+voS
 fyf
 fyf
 fyf
@@ -69264,14 +70177,20 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+veO
+rpu
+msS
+nUT
+gts
+iuS
+rpu
+rpu
+rpu
+sDp
+dhC
+nUr
+gts
 fyf
 fyf
 fyf
@@ -69282,7 +70201,10 @@ fyf
 fyf
 fyf
 fyf
-fyf
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -69458,18 +70380,18 @@ fyf
 fyf
 fyf
 fyf
-gts
-jbw
-rpu
-rpu
-rpu
-kUe
-gts
-hbW
-erY
-erY
-fLc
-onk
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
+unI
 erY
 erY
 erY
@@ -69479,41 +70401,32 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
 fyf
 fyf
 fyf
 fyf
-oXa
 fyf
 fyf
-fyf
-jxH
+sYX
+kvb
 iGi
+sYX
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-bQV
-lRZ
+fyf
 bVY
-bQV
-bQV
-sNk
-hAC
-fyf
-fyf
-fyf
-rEB
-bQV
-bQV
-hmy
-jbx
-bQV
+mfD
+mfD
+mfD
+wFD
 fyf
 fyf
 fyf
@@ -69521,15 +70434,20 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+tUf
+rpu
+rpu
+nUT
+gts
+pTE
+rpu
+rpu
+iuS
+gts
+ncn
+uGT
+gts
 fyf
 fyf
 fyf
@@ -69540,6 +70458,10 @@ fyf
 fyf
 fyf
 fyf
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -69711,22 +70633,22 @@ fyf
 fyf
 fyf
 fyf
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-pHi
-rVK
-gts
-gts
-hbW
-erY
-erY
-cpK
-erY
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
+unI
 erY
 erY
 erY
@@ -69736,46 +70658,27 @@ cdc
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+fyf
+sYX
+sYX
+xIq
+sYX
+sYX
+kUe
+dhC
+sYX
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-jxH
-jxH
-jxH
-fyf
-fyf
-iFr
-uey
-fyf
-bQV
-uRJ
-uRJ
-uRJ
-cLM
-dBH
-uRJ
-uRJ
-uRJ
-uRJ
-viv
-cLM
-uRJ
-uRJ
-uRJ
-bQV
-fyf
-fyf
-fyf
-fyf
-sND
+xJd
 fyf
 fyf
 fyf
@@ -69788,6 +70691,20 @@ fyf
 fyf
 fyf
 fyf
+gts
+rpu
+oWV
+rpu
+iyR
+rVK
+iAs
+jhp
+ioh
+rkZ
+gts
+gts
+gts
+gts
 fyf
 fyf
 fyf
@@ -69797,6 +70714,11 @@ fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -69968,22 +70890,22 @@ fyf
 fyf
 fyf
 fyf
-gts
-fPN
-rpu
-fqg
-mex
-gts
-ruy
-rpu
-rpu
-rpu
-gts
-hbW
-erY
-erY
-erY
-erY
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
+unI
 erY
 cdc
 erY
@@ -69993,9 +70915,27 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+fyf
+sYX
+fuj
+rpu
+rkZ
+uCO
+uCO
+sDp
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+xJd
+wrg
 fyf
 fyf
 fyf
@@ -70008,28 +70948,20 @@ fyf
 fyf
 fyf
 fyf
+gts
+vug
+gts
+gts
+gts
+gts
+aYG
+rpu
+ioh
+hKY
+gts
 fyf
 fyf
-fyf
-fyf
-bQV
-gvN
-uRJ
-uRJ
-bmV
-fQY
-dBH
-uRJ
-bmV
-uRJ
-iAz
-uRJ
-fQY
-uRJ
-olW
-bQV
-fyf
-rsE
+hCV
 fyf
 fyf
 fyf
@@ -70041,19 +70973,9 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -70120,7 +71042,7 @@ gcK
 gts
 oCg
 ckY
-neZ
+xtV
 vYv
 iXX
 boq
@@ -70225,22 +71147,22 @@ fyf
 fyf
 fyf
 fyf
-gts
-tUf
-rpu
-rpu
-mex
-gts
-fvF
-rpu
-rpu
-ruy
-gts
-hbW
-erY
-sCK
-erY
-erY
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
+unI
 erY
 erY
 erY
@@ -70250,9 +71172,27 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+fyf
+cuv
+fvF
+rpu
+rpu
+jbx
+rpu
+rpu
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+xJd
 fyf
 fyf
 fyf
@@ -70265,26 +71205,20 @@ fyf
 fyf
 fyf
 fyf
+cuv
+rpu
+iGO
+rkZ
+rpu
+gts
+rpu
+rpu
+ioh
+gMV
+gts
 fyf
 fyf
-xtO
-fyf
-bQV
-ccl
-uRJ
-uRJ
-dBH
-uRJ
-dBH
-sGL
-dBH
-uRJ
-uRJ
-uRJ
-uRJ
-uRJ
-iTk
-bQV
+hCV
 fyf
 fyf
 fyf
@@ -70296,21 +71230,9 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-wjt
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 ktB
 "}
@@ -70482,22 +71404,22 @@ fyf
 fyf
 fyf
 fyf
-gts
-rpu
-nUr
-rpu
-exj
-rVK
-qzr
-jhp
-qrw
-alN
-gts
-agH
-erY
-erY
-erY
-erY
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
+unI
 erY
 erY
 erY
@@ -70507,41 +71429,20 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-bQV
-gEZ
-uRJ
-uRJ
-fQY
-viv
-qlv
-xUc
-uRJ
-qlv
-viv
-bmV
-uRJ
-hRl
-ntv
-bQV
+sYX
+uCO
+uCO
+uCO
+uCO
+rpu
+rpu
+cuv
 fyf
 fyf
 fyf
@@ -70559,7 +71460,22 @@ fyf
 fyf
 fyf
 fyf
-sND
+fyf
+fyf
+gts
+aYG
+msS
+dpO
+rpu
+gts
+rpu
+rpu
+ioh
+rkZ
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -70567,6 +71483,12 @@ fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+gcK
+gcK
 gcK
 gcK
 ktB
@@ -70739,22 +71661,22 @@ fyf
 fyf
 fyf
 fyf
-gts
-vug
-gts
-gts
-gts
-gts
-aYG
-rpu
-qrw
-xyo
-gts
-hbW
-erY
-erY
-cpK
-erY
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
+unI
 erY
 erY
 erY
@@ -70764,41 +71686,20 @@ cdc
 erY
 cdc
 erY
-koD
+bml
 dMW
 fyf
+hCV
 fyf
 fyf
-fyf
-fyf
-rsE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-oXa
-fyf
-rsE
-fyf
-fyf
-bQV
-bQV
-bQV
-jxk
-uRJ
-uRJ
-viv
-uRJ
-viv
-viv
-viv
-uRJ
-sem
-bQV
-bQV
-bQV
+cuv
+fvF
+rpu
+rpu
+jbx
+rpu
+rpu
+sYX
 fyf
 fyf
 fyf
@@ -70818,11 +71719,32 @@ fyf
 fyf
 fyf
 fyf
+gts
+rpu
+wcA
+dGK
+rpu
+sDp
+rpu
+rpu
+rpu
+xir
+gts
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+gcK
 gcK
 gcK
 gcK
@@ -70996,22 +71918,22 @@ fyf
 fyf
 fyf
 fyf
-cuv
-rpu
-iGO
-mGZ
-rpu
-gts
-rpu
-rpu
-qrw
-rzV
-gts
-hbW
-liv
-erY
-geM
-muk
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
+unI
 erY
 erY
 liv
@@ -71021,9 +71943,20 @@ erY
 erY
 cdc
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+fyf
+sYX
+fPN
+hTe
+itm
+uCO
+kYz
+rpu
+sYX
 fyf
 fyf
 fyf
@@ -71042,32 +71975,21 @@ fyf
 fyf
 fyf
 fyf
-bQV
-bQV
-lRm
-uRJ
-viv
-dBH
-uRJ
-dBH
-uRJ
-hHC
-bQV
-bQV
+fyf
+cuv
+rpu
+oWV
+rpu
+rpu
+gts
+iGO
+iGO
+rpu
+olW
+gts
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -71253,21 +72175,21 @@ fyf
 fyf
 fyf
 fyf
-gts
-aYG
-fqg
-dpO
-rpu
-gts
-rpu
-rpu
-qrw
-rkZ
-gts
-hbW
-erY
-erY
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 pBv
 erY
 erY
@@ -71278,9 +72200,20 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+fyf
+sYX
+uCO
+uCO
+uCO
+uCO
+lda
+rpu
+cuv
 fyf
 fyf
 fyf
@@ -71300,31 +72233,20 @@ fyf
 fyf
 fyf
 fyf
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
-bQV
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
 fyf
 fyf
 fyf
@@ -71510,21 +72432,21 @@ fyf
 fyf
 fyf
 fyf
-gts
-rpu
-lWX
-dii
-rpu
-sDp
-rpu
-rpu
-rpu
-urt
-gts
-hbW
-erY
-wkd
-koD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 jIB
 erY
 cdc
@@ -71535,9 +72457,21 @@ erY
 sCK
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+fyf
+sYX
+fQY
+rpu
+rpu
+jbx
+jhp
+rpu
+sYX
+mGZ
 fyf
 fyf
 fyf
@@ -71569,6 +72503,7 @@ fyf
 fyf
 fyf
 fyf
+hCV
 fyf
 fyf
 fyf
@@ -71580,19 +72515,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-wjt
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-ivi
 fyf
 gcK
 gcK
@@ -71767,21 +72689,21 @@ fyf
 fyf
 fyf
 fyf
-cuv
-rpu
-nUr
-rpu
-rpu
-gts
-iGO
-iGO
-rpu
-kUe
-gts
-ees
-ees
-ees
-cpK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 ajD
 erY
 erY
@@ -71792,24 +72714,20 @@ erY
 sCK
 erY
 erY
-koD
+bml
 dMW
 fyf
-fyf
-oXa
-fyf
+hCV
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rsE
+cuv
+fvF
+rpu
+rkZ
+uCO
+bxl
+rpu
+sYX
 fyf
 fyf
 fyf
@@ -71822,13 +72740,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-oXa
+mGZ
 fyf
 fyf
 fyf
@@ -71839,6 +72751,16 @@ fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -72024,21 +72946,21 @@ fyf
 fyf
 fyf
 fyf
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-rRt
-cpK
-cpK
-cpK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+kGc
 unI
 erY
 erY
@@ -72049,53 +72971,53 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+fyf
+sYX
+uCO
+uCO
+uCO
+uCO
+rpu
+rpu
+wpx
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+bIh
+tpA
+pud
+bIh
+wSJ
+tpA
+bIh
+bIh
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rsE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+xHw
+uxC
+uxC
+uxC
+uxC
+uxC
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
 fyf
 fyf
 fyf
@@ -72306,27 +73228,20 @@ erY
 cdc
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+gvN
+rpu
+rpu
+jbx
+rpu
+rpu
+sYX
 fyf
 fyf
 fyf
@@ -72334,25 +73249,32 @@ fyf
 fyf
 fyf
 bIh
+tsB
+uFp
+uZg
+qij
+qij
+bix
+bIh
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
+qOV
+cWG
+cWG
+cWG
+cWG
+sYX
+eKN
+cbr
+cbr
+cbr
+mHt
+sYX
 fyf
 fyf
 fyf
@@ -72563,53 +73485,53 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+hCV
+fyf
+fyf
+cuv
+fvF
+rpu
+rkZ
+uCO
+rpu
+rpu
+cuv
 fyf
 fyf
 fyf
+bIh
+bIh
+bIh
+bIh
+tym
+qij
+qij
+qij
+qij
+peY
+bIh
+tpA
+bIh
+tpA
+pud
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rsE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
+tBN
+mvv
+mvv
+mvv
+mvv
+sYX
+uzs
+iKO
+cbr
+cbr
+swx
+sYX
 fyf
 fyf
 fyf
@@ -72820,9 +73742,53 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
 fyf
+gcK
+fyf
+fyf
+sYX
+uCO
+uCO
+uCO
+uCO
+rpu
+rpu
+sYX
+fyf
+fyf
+fyf
+bIh
+oOZ
+pOw
+pud
+tJx
+qij
+qij
+qij
+qij
+gNL
+bIh
+fpF
+nCS
+fpF
+pud
+fyf
+fyf
+hCV
+tBN
+mvv
+mvv
+mvv
+mvv
+sYX
+qXk
+cbr
+cbr
+cbr
+cbr
+sYX
 fyf
 fyf
 fyf
@@ -72832,52 +73798,8 @@ fyf
 fyf
 fyf
 fyf
-dWt
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-wjt
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-trW
 fyf
 fyf
 gcK
@@ -73077,53 +73999,53 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
+gcK
+gcK
+gcK
+fyf
+sYX
+gzQ
+rpu
+rpu
+jbx
+rpu
+rpu
+sYX
 fyf
 fyf
 fyf
+bIh
+oXa
+pOw
+rja
+qij
+qij
+qij
+qij
+qij
+qij
+bIh
+yhv
+qij
+rzV
+pud
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+tBN
+mvv
+mvv
+mvv
+mvv
+cbr
+cbr
+tsr
+cbr
+cbr
+cbr
+sYX
 fyf
 fyf
 fyf
@@ -73334,53 +74256,53 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
+gcK
+gcK
+gcK
+gcK
+sYX
+bxl
+rpu
+iuS
+uCO
+wPl
+jhp
+sYX
 fyf
 fyf
 fyf
+bIh
+pud
+pud
+bIh
+bIh
+bIh
+viv
+xdG
+xUc
+qij
+bIh
+qij
+qhs
+cph
+pud
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCV
+tBN
+mvv
+mvv
+mvv
+dqc
+sYX
+cbr
+cbr
+cbr
+bHa
+cbr
+sYX
 fyf
 fyf
 fyf
@@ -73591,59 +74513,59 @@ erY
 cdc
 erY
 erY
-koD
+bml
 dMW
+gcK
+gcK
+gcK
+gcK
+sYX
+fvF
+ioh
+rkZ
+uCO
+kYz
+rpu
+sYX
+fyf
+fyf
+fyf
+bIh
+pxf
+pYa
+ruy
+tSQ
+bIh
+vno
+xeG
+vwn
+qij
+bIh
+tPt
+pud
+pud
+pud
+pud
+fyf
+hCV
+tBN
+mvv
+mvv
+mvv
+mvv
+sYX
+cbr
+cbr
+cbr
+xVN
+cbr
+sYX
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-trW
 fyf
 fyf
 fyf
@@ -73848,60 +74770,60 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
+gcK
+gcK
+gcK
+gcK
+tKZ
+uCO
+uCO
+uCO
+uCO
+lRm
+rpu
+cuv
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+bIh
+pHi
+qij
+rzV
+qij
 uTA
+qij
+qij
+qij
+qij
+pud
+qij
+bIh
+gzW
+hMM
+bIh
+fyf
+hCV
+nlO
+mfD
+mfD
+mfD
+mfD
+sYX
+cbr
+cbr
+cbr
+cbr
+uNQ
+sYX
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -74105,53 +75027,53 @@ erY
 xuL
 erY
 erY
-koD
+bml
 dMW
+gcK
+gcK
+gcK
+gcK
+eXw
+fvF
+ioh
+rkZ
+uCO
+lRZ
+rpu
+sYX
 fyf
 fyf
 fyf
+bIh
+pKP
+qlv
+qij
+uar
+pud
+vwn
+qij
+qij
+qij
+tPt
+qij
+tPt
+qij
+qij
+bIh
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gom
+uxC
+uxC
+uxC
+uxC
+uxC
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
 fyf
 fyf
 fyf
@@ -74362,52 +75284,52 @@ erY
 erY
 erY
 erY
-koD
+bml
 dMW
-fyf
-fyf
-fyf
-uey
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gbL
-gcK
-gcK
-gcK
-gbL
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
 gcK
-gcK
+eXw
+eXw
+rpu
+iAs
+uCO
+rpu
+rpu
+kGD
+fyf
+fyf
+fyf
+bIh
+bIh
+bIh
+rEB
+bIh
+bIh
+wpo
+xyo
+xWu
+aYY
+pud
+qij
+bIh
+hiG
+fpF
+bIh
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+hCV
 fyf
 fyf
 fyf
@@ -74619,48 +75541,43 @@ erY
 erY
 cdc
 erY
-koD
-awD
+bml
+dMW
+gcK
+gcK
+gcK
+gcK
+eXw
+eXw
+eXw
+rpu
+jbx
+rpu
+rpu
+sYX
 fyf
 fyf
 fyf
 fyf
+bIh
+qrw
+qij
+qij
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
+bIh
 fyf
 fyf
 fyf
-gcK
-uey
-uey
 fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-gcK
-gcK
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
 fyf
 fyf
 fyf
@@ -74670,6 +75587,11 @@ fyf
 fyf
 gcK
 gcK
+gcK
+gcK
+gcK
+fyf
+fyf
 fyf
 fyf
 gcK
@@ -74876,9 +75798,36 @@ erY
 cdc
 erY
 erY
-koD
+bml
 dMW
 fyf
+gcK
+gcK
+gcK
+eZg
+eXw
+eXw
+tKZ
+sYX
+sYX
+sYX
+sYX
+fyf
+fyf
+fyf
+fyf
+bIh
+qzr
+sem
+urt
+bIh
+fyf
+gcK
+gcK
+gcK
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -74887,46 +75836,19 @@ gcK
 gcK
 gcK
 gcK
-fyf
-uey
-fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
 gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
 fyf
 gcK
 gcK
@@ -80760,10 +81682,10 @@ fyf
 kGc
 cpK
 unI
-dCV
-bAX
-rJD
-bAX
+mQj
+nFL
+nFL
+nFL
 bJB
 bJB
 gmX
@@ -81017,10 +81939,10 @@ gSt
 hgX
 uCW
 unI
-dCV
-mZD
-mZD
-dCV
+hbW
+erY
+liv
+erY
 ril
 erY
 gmX
@@ -81274,10 +82196,10 @@ gcK
 cpK
 cpK
 unI
-dCV
-aRd
-mZD
-dCV
+hbW
+erY
+erY
+erY
 cdc
 erY
 gmX
@@ -81531,10 +82453,10 @@ gcK
 uCW
 cpK
 unI
-dCV
-mZD
-mZD
-dCV
+hbW
+erY
+erY
+erY
 wGJ
 erY
 gmX
@@ -81788,10 +82710,10 @@ gcK
 uCW
 uCW
 unI
-dCV
+hbW
 hXP
-mZD
-dCV
+erY
+hXP
 cdc
 erY
 gmX
@@ -82045,10 +82967,10 @@ gcK
 gcK
 uCW
 unI
-dCV
-dCV
-dCV
-dCV
+hbW
+erY
+erY
+erY
 erY
 erY
 gmX
@@ -83898,10 +84820,10 @@ ata
 xNm
 hom
 gcK
-xxf
-xxf
-xxf
-xxf
+gcK
+gcK
+gcK
+gcK
 gcK
 hom
 ftz
@@ -84155,10 +85077,10 @@ qSM
 cbl
 hom
 gcK
-xxf
-krm
-hCV
-xxf
+gcK
+gcK
+gcK
+gcK
 gcK
 hom
 xaT
@@ -84412,10 +85334,10 @@ ata
 uIV
 hom
 gcK
-xxf
-krm
-krm
-xxf
+gcK
+gcK
+gcK
+gcK
 gcK
 hom
 nTm
@@ -84669,10 +85591,10 @@ dPe
 xNm
 hom
 gcK
-bSN
-kUk
-xxf
-xxf
+gcK
+gcK
+gcK
+gcK
 gcK
 hom
 hom
@@ -84926,8 +85848,8 @@ hom
 dvo
 hom
 gcK
-wPS
-wPS
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -85182,9 +86104,9 @@ oMY
 iJW
 xNm
 hom
-wPS
-ulU
-wPS
+gcK
+gcK
+gcK
 gcK
 syr
 gcK
@@ -85438,9 +86360,9 @@ hom
 pSu
 oMY
 xNm
-dvo
-wPS
-wPS
+hom
+gcK
+gcK
 gcK
 gcK
 syr
@@ -86645,7 +87567,7 @@ koD
 doP
 rkZ
 wYv
-sbc
+xrO
 sYX
 fyf
 fyf
@@ -87302,7 +88224,7 @@ gcK
 jNJ
 wJp
 pMh
-fuj
+dCU
 ptg
 gcK
 ktB
@@ -87361,8 +88283,8 @@ wSv
 svI
 dDn
 sYX
-kYz
-ffT
+cSH
+cSH
 kDx
 pim
 rpu
@@ -87671,7 +88593,7 @@ sQX
 sQX
 koD
 doP
-wFD
+rkZ
 wYv
 xrO
 tKZ
@@ -88701,7 +89623,7 @@ koD
 doP
 rkZ
 wYv
-aDB
+xrO
 sYX
 fyf
 fyf
@@ -89729,7 +90651,7 @@ koD
 doP
 rkZ
 wYv
-wPJ
+xrO
 sYX
 fyf
 fyf
@@ -95283,7 +96205,7 @@ dLO
 dLO
 gts
 kwV
-rLP
+xtV
 xtV
 gts
 gts

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -97,12 +97,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"as" = (
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/caves)
 "au" = (
 /obj/machinery/telecomms/server/presets/ncr,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -687,19 +681,6 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"cB" = (
-/obj/machinery/light/fo13colored/Red{
-	bulb_colour = "#008000";
-	desc = "A lighting fixture.";
-	dir = 8;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/tunnel)
 "cC" = (
 /obj/item/clothing/under/f13/recon,
 /obj/item/clothing/under/f13/recon,
@@ -897,16 +878,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
-"dg" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "BOS"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/caves)
 "di" = (
 /obj/machinery/light{
 	dir = 1
@@ -1757,16 +1728,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"ge" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -13
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/tunnel)
 "gf" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood,
@@ -2306,7 +2267,6 @@
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
 	},
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "hI" = (
@@ -2936,10 +2896,6 @@
 /area/f13/brotherhood)
 "jO" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
-"jP" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "jQ" = (
@@ -4407,12 +4363,6 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
-	},
-/area/f13/tunnel)
-"ot" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
 	},
 /area/f13/tunnel)
 "ou" = (
@@ -6164,9 +6114,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uJ" = (
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "uK" = (
 /turf/closed/wall,
 /area/f13/tunnel)
@@ -6846,13 +6793,6 @@
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"wQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/tunnel)
 "wR" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -7249,8 +7189,6 @@
 	name = "Slave whip"
 	},
 /obj/item/key/collar,
-/obj/item/clothing/neck/petcollar,
-/obj/item/clothing/neck/petcollar,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -7654,13 +7592,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood)
-"zG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/tunnel)
 "zH" = (
 /obj/effect/landmark/start/f13/followersguard,
 /turf/open/floor/f13{
@@ -8452,13 +8383,6 @@
 	dir = 9
 	},
 /area/f13/brotherhood)
-"Cy" = (
-/obj/structure/reagent_dispensers/compostbin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/tunnel)
 "Cz" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -8636,11 +8560,6 @@
 	icon_state = "floor2-old"
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
-"CV" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
 /area/f13/tunnel)
 "CW" = (
 /obj/structure/filingcabinet,
@@ -10590,13 +10509,6 @@
 /obj/machinery/telecomms/server/presets/vault,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"JN" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/tunnel)
 "JO" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
@@ -11036,13 +10948,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"Lq" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/tunnel)
 "Lr" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -11326,15 +11231,6 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
-"Ml" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/caves)
 "Mm" = (
 /turf/open/floor/plasteel/grimy,
 /area/f13/tunnel)
@@ -11450,12 +11346,6 @@
 /area/f13/bunker)
 "ME" = (
 /turf/closed/wall/f13/wood/house,
-/area/f13/tunnel)
-"MG" = (
-/obj/structure/legion_extractor,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
 /area/f13/tunnel)
 "MH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11914,12 +11804,6 @@
 	pixel_x = 17
 	},
 /turf/closed/wall/r_wall,
-/area/f13/tunnel)
-"NV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
 /area/f13/tunnel)
 "NW" = (
 /obj/structure/wreck/trash/two_barrels,
@@ -12784,12 +12668,6 @@
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"QQ" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/tunnel)
 "QR" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel/darkpurple/side{
@@ -13409,10 +13287,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"SN" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
 "SO" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/darkgreen/side{
@@ -13452,7 +13326,6 @@
 	},
 /area/f13/followers)
 "SU" = (
-/obj/item/jammer,
 /obj/structure/table,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
@@ -13609,7 +13482,6 @@
 /obj/structure/table,
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/legcuffs/bola,
-/obj/item/jammer,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -13679,12 +13551,6 @@
 /obj/item/paper_bin,
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"TD" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/caves)
 "TE" = (
 /obj/structure/chair/stool,
 /obj/machinery/button/door{
@@ -13933,15 +13799,6 @@
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"Uo" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/caves)
 "Up" = (
 /obj/machinery/door/window/southright,
 /turf/open/floor/plating/tunnel,
@@ -15381,12 +15238,6 @@
 	dir = 9
 	},
 /area/f13/brotherhood)
-"Zn" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/tunnel)
 "Zo" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/syringe/medx,
@@ -15877,19 +15728,19 @@ MA
 "}
 (2,1,1) = {"
 MA
-Kn
-Kn
-Kn
-Kn
-Kn
-Kn
-Kn
-Kn
-Kn
-Kn
-Kn
-Kn
-Kn
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -16134,19 +15985,19 @@ MA
 "}
 (3,1,1) = {"
 MA
-Kn
-ot
-CV
-cB
-ge
-NV
-NV
-NV
-NV
-cB
-ge
-NV
-Kn
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -16391,19 +16242,19 @@ MA
 "}
 (4,1,1) = {"
 MA
-Kn
-Lq
-NV
-Zn
-Zn
-CV
-Zn
-JN
-NV
-JN
-Zn
-CV
-Kn
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
 sS
 sS
 sS
@@ -16648,19 +16499,19 @@ MA
 "}
 (5,1,1) = {"
 MA
-Kn
-Cy
-NV
-CV
-CV
-CV
-CV
-CV
-CV
-CV
-CV
-NV
-Kn
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -16905,19 +16756,19 @@ MA
 "}
 (6,1,1) = {"
 MA
-Kn
-NV
-NV
-Zn
-JN
-wQ
-JN
-JN
-NV
-Zn
-Zn
-NV
-Kn
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -17162,19 +17013,19 @@ MA
 "}
 (7,1,1) = {"
 MA
-Kn
-NV
-NV
-CV
-CV
-CV
-CV
-CV
-CV
-CV
-CV
-CV
-Kn
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -17419,12 +17270,12 @@ MA
 "}
 (8,1,1) = {"
 MA
+Fz
+Fz
+Fz
 Kn
-MG
-zG
 Kn
 Kn
-QQ
 Kn
 Kn
 Kn
@@ -17676,9 +17527,9 @@ MA
 "}
 (9,1,1) = {"
 MA
-Kn
-Kn
-Kn
+Fz
+Fz
+Fz
 Kn
 DZ
 DZ
@@ -22065,7 +21916,7 @@ Fz
 Fz
 Fz
 Kn
-jP
+DZ
 DZ
 tY
 DZ
@@ -52776,7 +52627,7 @@ Fz
 Fz
 QC
 vP
-SN
+GY
 ri
 qc
 Jj
@@ -76060,9 +75911,9 @@ YK
 Lb
 eu
 NS
-uJ
-uJ
-uJ
+Fz
+Fz
+Fz
 Fz
 sS
 Fz
@@ -76316,10 +76167,10 @@ NT
 NT
 NT
 NT
-Kb
-TD
-Ml
-TD
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -76573,10 +76424,10 @@ RN
 Fr
 ag
 NT
-Kb
-as
-as
-Kb
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -76830,10 +76681,10 @@ Fr
 Fr
 ag
 NT
-Kb
-Uo
-as
-Kb
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -77087,10 +76938,10 @@ UJ
 Fr
 ag
 NT
-Kb
-as
-as
-Kb
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -77344,10 +77195,10 @@ Fr
 Fr
 rO
 NT
-Kb
-dg
-as
-Kb
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -77601,10 +77452,10 @@ UJ
 Fr
 Fr
 NT
-Kb
-Kb
-Kb
-Kb
+Fz
+Fz
+Fz
+Fz
 Fz
 Fz
 Fz


### PR DESCRIPTION
## About The Pull Request

Mapping changes.
Dust Bowl and entrances removed.
Ghoul Vault and surface section removed.
Pet collars and dildos removed.
High value and medium value caps spawned all over the map removed.
Nerfed the loot in that small bunker where the Funclaws used to be.
Added some old buildings back that got removed for no reason.
Removed radio jammers.
Removed the ladder down to the commie Vault.
Removed the hydroponics room in the wanamingo tunnels.
Removed the medical protectron vendor due to rampant LRP misuse, people can play our numerous medical roles/loadouts if they want to be a Doctor.


## Why It's Good For The Game

Because it is good for the game.

## Changelog
:cl:
add: some old buildings back: 
del: removed a shitload as listed in PR
/:cl:

