### PR TITLE
Fixes /structure bullets CanPass() to retain itself on its own scope

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -117,20 +117,19 @@
 				return  "<span class='warning'>It's falling apart!</span>"
 
 /obj/structure/rust_heretic_act()
-	take_damage(500, BRUTE, "melee", 1) 
+	take_damage(500, BRUTE, "melee", 1)
 
 /obj/structure/CanPass(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
-	if(barricade == FALSE)
-		return !density
-	else if(density == FALSE)
-		return 1
-	else if(istype(mover, /obj/item/projectile))
+	if(istype(mover, /obj/item/projectile)) // Treats especifically projectiles
 		var/obj/item/projectile/proj = mover
 		if(proj.firer && Adjacent(proj.firer))
 			return 1
-		if(prob(proj_pass_rate))
+		else if(prob(proj_pass_rate))
+			return 1
+		else if(barricade == FALSE)
+			return !density
+		else if(density == FALSE)
 			return 1
 		return 0
-	else
-		return !density
-
+	else // All other than projectiles should use the regular CanPass inheritance
+		return ..()


### PR DESCRIPTION
Posted by proxy for @lob0t#1951 on Discord.

This was causing the roller bed issue #40.
Tested locally. Both rollerbed and structures blocking projectiles(with it's chances and parameters) working just fine.
fixes #40

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was causing the roller bed issue #40.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Both rollerbed and structures blocking projectiles(with it's chances and parameters) working just fine.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: lob0t
fix: rollerbeds can now be pushed again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
