### PR TITLE
HOTFIX Bos Elevator Is In Space + ORM Input/Output Direction

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -15639,7 +15639,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "XM" = (
-/obj/machinery/mineral/ore_redemption,
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 2;
+	output_dir = 1
+	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},

--- a/_maps/shuttles/Brotherhood_of_Steel_base.dmm
+++ b/_maps/shuttles/Brotherhood_of_Steel_base.dmm
@@ -6,32 +6,34 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/bos_foyer)
 "e" = (
-/obj/machinery/computer/shuttle/bos,
+/obj/docking_port/mobile/elevator/bos,
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/bos_foyer)
 "f" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "SW";
-	move_me = 1
-	},
+/obj/item/flag/bos,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/bos_foyer)
 "h" = (
 /turf/template_noop,
 /area/template_noop)
 "i" = (
-/obj/item/flag/bos,
+/turf/closed/indestructible/rock,
+/area/template_noop)
+"j" = (
+/turf/closed/indestructible/rock,
+/area/space)
+"s" = (
+/obj/machinery/computer/shuttle/bos,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/bos_foyer)
-"j" = (
-/obj/docking_port/mobile/elevator/bos,
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
+"t" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "SE";
+	move_me = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/bos_foyer)
@@ -52,83 +54,128 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/bos_foyer)
 "D" = (
+/turf/open/space/basic,
+/area/space)
+"X" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
 /obj/structure/ladder/unbreakable{
 	height = 2;
-	id = "SE";
+	id = "SW";
 	move_me = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/bos_foyer)
 
 (1,1,1) = {"
-a
 j
-a
-h
-h
-h
+j
+j
+j
+j
+D
+D
+D
 "}
 (2,1,1) = {"
+j
 a
-c
+e
 a
+i
 h
 h
-h
+D
 "}
 (3,1,1) = {"
+j
+a
+c
+a
+i
+i
+i
+j
+"}
+(4,1,1) = {"
+j
 a
 c
 a
 a
 a
 a
+j
 "}
-(4,1,1) = {"
+(5,1,1) = {"
+j
 a
 c
 c
 u
-f
+X
 a
-"}
-(5,1,1) = {"
-a
-c
-c
-c
-c
-a
+j
 "}
 (6,1,1) = {"
+j
+a
+c
+c
+c
+c
+a
+j
+"}
+(7,1,1) = {"
+j
 a
 c
 c
 w
-D
+t
 a
-"}
-(7,1,1) = {"
-a
-c
-c
-c
-c
-a
+j
 "}
 (8,1,1) = {"
+j
 a
-i
 c
 c
-e
+c
+c
 a
+j
 "}
 (9,1,1) = {"
+j
+a
+f
+c
+c
+s
+a
+j
+"}
+(10,1,1) = {"
+j
 a
 a
 a
 a
 a
 a
+j
+"}
+(11,1,1) = {"
+j
+j
+j
+j
+j
+j
+j
+j
 "}


### PR DESCRIPTION
### Issue
BoS Elevator, unlike legacy, no longer spawns with dense rock surrounding it before it is surfaced. Therefore, if someone were to break down a wall, the only thing behind the wall is space. As in, outer space.

### Adds
Dense rock surrounding the elevator completely on the BoS elevator map.

### Changes
Overlooked the input/output directions on the BoS ORM, swapped the values to represent the new location it's at.

![dasdasd](https://user-images.githubusercontent.com/60239538/110197433-a0ae6d00-7e19-11eb-9965-2ed40cc244eb.JPG)
