### PR TITLE
BoS ORM Input/Output Direction Swap, Missing Firelocks, Brig Flashers Fix

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -35,6 +35,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"ag" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/flasher{
+	id = SW CELL;
+	pixel_x = -30
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
 "ah" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
@@ -46,10 +56,12 @@
 /area/f13/tunnel)
 "aj" = (
 /obj/machinery/button{
+	id = NW CELL;
 	pixel_x = -5;
 	pixel_y = 30
 	},
 /obj/machinery/button{
+	id = NE CELL;
 	pixel_x = 5;
 	pixel_y = 30
 	},
@@ -1566,7 +1578,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/darkred/side{
-	dir = 5
+	dir = 1
 	},
 /area/f13/brotherhood)
 "fi" = (
@@ -2078,6 +2090,7 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 5
 	},
@@ -2797,6 +2810,7 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 6
 	},
@@ -2987,6 +3001,16 @@
 	dir = 1
 	},
 /area/f13/brotherhood)
+"jp" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/flasher{
+	id = NE CELL;
+	pixel_x = -30
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
 "jq" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -3045,6 +3069,7 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/brotherhood)
 "jC" = (
@@ -4530,9 +4555,7 @@
 	req_access_txt = "120"
 	},
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
-	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "on" = (
 /obj/structure/window/fulltile/house{
@@ -7082,6 +7105,7 @@
 /area/f13/brotherhood)
 "wE" = (
 /obj/machinery/button{
+	id = SW CELL;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/darkred/side,
@@ -8327,6 +8351,12 @@
 "AD" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
+"AE" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 9
+	},
+/area/f13/brotherhood)
 "AF" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -13836,6 +13866,7 @@
 	dir = 8
 	},
 /obj/machinery/flasher{
+	id = NW CELL;
 	pixel_x = -30
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -15639,7 +15670,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "XM" = (
-/obj/machinery/mineral/ore_redemption,
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 2;
+	output_dir = 1
+	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
@@ -65964,7 +65998,7 @@ Fz
 Fz
 NT
 NT
-aJ
+AE
 sk
 Cp
 Dd
@@ -69834,7 +69868,7 @@ qF
 Rf
 IV
 DN
-Sk
+ag
 ES
 NT
 Fr
@@ -70599,7 +70633,7 @@ YC
 Nb
 NT
 ES
-Sk
+jp
 EG
 jo
 mP


### PR DESCRIPTION
As titled.

### Changes
Swaps input/output directions for the BoS' ORM, to reflect its new location.
Fixes a few mismatched floor tiles, one in hydro, two in the armory.

### Adds
ID variables to the flashers + their corresponding buttons in the BoS brig, so they'll work now.
Missing firelocks in hydroponics I totally didn't forget to add.




I hate ladders, Z levels, elevators, and everything about the destruction of Yugoslavia.