### PR TITLE
BoS ORM Input/Output Direction Swap + Missing Firelocks + Mismatched Floor tiles

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -35,6 +35,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"ag" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/flasher{
+	id = SW CELL;
+	pixel_x = -30
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
 "ah" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
@@ -46,10 +56,12 @@
 /area/f13/tunnel)
 "aj" = (
 /obj/machinery/button{
+	id = NW CELL;
 	pixel_x = -5;
 	pixel_y = 30
 	},
 /obj/machinery/button{
+	id = NE CELL;
 	pixel_x = 5;
 	pixel_y = 30
 	},
@@ -1566,7 +1578,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/darkred/side{
-	dir = 5
+	dir = 1
 	},
 /area/f13/brotherhood)
 "fi" = (
@@ -2078,6 +2090,7 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 5
 	},
@@ -2797,6 +2810,7 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 6
 	},
@@ -2987,6 +3001,16 @@
 	dir = 1
 	},
 /area/f13/brotherhood)
+"jp" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/flasher{
+	id = NE CELL;
+	pixel_x = -30
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/f13/brotherhood)
 "jq" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -3045,6 +3069,7 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/brotherhood)
 "jC" = (
@@ -4530,9 +4555,7 @@
 	req_access_txt = "120"
 	},
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
-	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "on" = (
 /obj/structure/window/fulltile/house{
@@ -7082,6 +7105,7 @@
 /area/f13/brotherhood)
 "wE" = (
 /obj/machinery/button{
+	id = SW CELL;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/darkred/side,
@@ -8327,6 +8351,12 @@
 "AD" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
+"AE" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 9
+	},
+/area/f13/brotherhood)
 "AF" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -13836,6 +13866,7 @@
 	dir = 8
 	},
 /obj/machinery/flasher{
+	id = NW CELL;
 	pixel_x = -30
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -15639,7 +15670,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "XM" = (
-/obj/machinery/mineral/ore_redemption,
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 2;
+	output_dir = 1
+	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
@@ -65964,7 +65998,7 @@ Fz
 Fz
 NT
 NT
-aJ
+AE
 sk
 Cp
 Dd
@@ -69834,7 +69868,7 @@ qF
 Rf
 IV
 DN
-Sk
+ag
 ES
 NT
 Fr
@@ -70599,7 +70633,7 @@ YC
 Nb
 NT
 ES
-Sk
+jp
 EG
 jo
 mP

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -35,16 +35,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"ag" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/flasher{
-	id = SW CELL;
-	pixel_x = -30
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/brotherhood)
 "ah" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
@@ -56,12 +46,10 @@
 /area/f13/tunnel)
 "aj" = (
 /obj/machinery/button{
-	id = NW CELL;
 	pixel_x = -5;
 	pixel_y = 30
 	},
 /obj/machinery/button{
-	id = NE CELL;
 	pixel_x = 5;
 	pixel_y = 30
 	},
@@ -1578,7 +1566,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/darkred/side{
-	dir = 1
+	dir = 5
 	},
 /area/f13/brotherhood)
 "fi" = (
@@ -2090,7 +2078,6 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 5
 	},
@@ -2810,7 +2797,6 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 6
 	},
@@ -3001,16 +2987,6 @@
 	dir = 1
 	},
 /area/f13/brotherhood)
-"jp" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/flasher{
-	id = NE CELL;
-	pixel_x = -30
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/brotherhood)
 "jq" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -3069,7 +3045,6 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/brotherhood)
 "jC" = (
@@ -4555,7 +4530,9 @@
 	req_access_txt = "120"
 	},
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 5
+	},
 /area/f13/brotherhood)
 "on" = (
 /obj/structure/window/fulltile/house{
@@ -7105,7 +7082,6 @@
 /area/f13/brotherhood)
 "wE" = (
 /obj/machinery/button{
-	id = SW CELL;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/darkred/side,
@@ -8351,12 +8327,6 @@
 "AD" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
-"AE" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 9
-	},
-/area/f13/brotherhood)
 "AF" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -13866,7 +13836,6 @@
 	dir = 8
 	},
 /obj/machinery/flasher{
-	id = NW CELL;
 	pixel_x = -30
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -15670,10 +15639,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "XM" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 2;
-	output_dir = 1
-	},
+/obj/machinery/mineral/ore_redemption,
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
@@ -65998,7 +65964,7 @@ Fz
 Fz
 NT
 NT
-AE
+aJ
 sk
 Cp
 Dd
@@ -69868,7 +69834,7 @@ qF
 Rf
 IV
 DN
-ag
+Sk
 ES
 NT
 Fr
@@ -70633,7 +70599,7 @@ YC
 Nb
 NT
 ES
-jp
+Sk
 EG
 jo
 mP

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2822,7 +2822,10 @@
 	},
 /area/f13/tunnel)
 "iI" = (
-/obj/structure/mirror,
+/obj/structure/mirror{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/brotherhood)
 "iJ" = (
@@ -10189,6 +10192,9 @@
 	color = "#845f58";
 	pixel_x = 31
 	},
+/obj/structure/window/reinforced/tinted{
+	pixel_y = -7
+	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 6
 	},
@@ -11488,6 +11494,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"KV" = (
+/obj/structure/window/reinforced/tinted{
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/darkred/side,
+/area/f13/brotherhood)
 "KW" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -11532,6 +11544,14 @@
 /obj/structure/closet,
 /obj/item/circlegame,
 /turf/open/floor/plating,
+/area/f13/brotherhood)
+"Lf" = (
+/obj/effect/spawner/structure/window/hollow,
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "Lh" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
@@ -70615,7 +70635,7 @@ Sk
 EG
 jo
 mP
-Ex
+KV
 ir
 Lk
 PZ
@@ -71129,7 +71149,7 @@ NT
 NT
 qm
 vn
-qm
+Lf
 xY
 Na
 Qs

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1566,7 +1566,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/darkred/side{
-	dir = 5
+	dir = 1
 	},
 /area/f13/brotherhood)
 "fi" = (
@@ -2078,6 +2078,7 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 5
 	},
@@ -2797,6 +2798,7 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 6
 	},
@@ -3045,6 +3047,7 @@
 	name = "Hydroponics";
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/brotherhood)
 "jC" = (
@@ -4530,9 +4533,7 @@
 	req_access_txt = "120"
 	},
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
-	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "on" = (
 /obj/structure/window/fulltile/house{
@@ -6629,6 +6630,7 @@
 	name = "brig";
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "vo" = (
@@ -11097,6 +11099,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/brotherhood)
+"JI" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 9
+	},
+/area/f13/brotherhood)
 "JJ" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -13894,6 +13902,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	req_access_txt = "120"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "St" = (
@@ -15639,7 +15648,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "XM" = (
-/obj/machinery/mineral/ore_redemption,
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 2;
+	output_dir = 1
+	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
@@ -65964,7 +65976,7 @@ Fz
 Fz
 NT
 NT
-aJ
+JI
 sk
 Cp
 Dd


### PR DESCRIPTION
As titled
### Changes
BoS ORM input/output values to coincide with new location
Mismatched floor tiles to proper ones
### Adds
Missing firelocks in hydroponics, brig entryway, armory door I totally didn't forget when I made it
Tinted windows I forgot to put into the brig

Increases
Severe anger of the mapper
A longing for the reformation of Yugoslavia