### PR TITLE
Explorer stuff buff and fulton removal but better.

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -8,7 +8,7 @@
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	hoodtype = /obj/item/clothing/head/hooded/explorer
-	armor = list("tier" = 3, "energy" = 20, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
+	armor = list("tier" = 4, "energy" = 20, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
 	flags_inv = HIDEJUMPSUIT|HIDETAUR
 	resistance_flags = FIRE_PROOF
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_SNEK_TAURIC|STYLE_PAW_TAURIC
@@ -21,7 +21,7 @@
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
 	cold_protection = HEAD
-	armor = list("tier" = 3, "energy" = 20, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50, "wound" = 10)
+	armor = list("tier" = 4, "energy" = 20, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50, "wound" = 10)
 	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/suit/hooded/explorer/standard
@@ -133,7 +133,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	hoodtype = /obj/item/clothing/head/hooded/explorer/seva
-	armor = list("tier" = 2, "energy" = 10, "bomb" = 35, "bio" = 50, "rad" = 25, "fire" = 100, "acid" = 25)
+	armor = list("tier" = 3, "energy" = 45, "bomb" = 35, "bio" = 75, "rad" = 75, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF | GOLIATH_WEAKNESS
 
 /obj/item/clothing/head/hooded/explorer/seva
@@ -142,7 +142,7 @@
 	icon_state = "seva"
 	item_state = "seva"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	armor = list("tier" = 2, "energy" = 10, "bomb" = 35, "bio" = 50, "rad" = 25, "fire" = 100, "acid" = 25)
+	armor = list("tier" = 3, "energy" = 45, "bomb" = 35, "bio" = 75, "rad" = 75, "fire" = 100, "acid" = 2505)
 	resistance_flags = FIRE_PROOF | GOLIATH_WEAKNESS
 
 /obj/item/clothing/mask/gas/seva
@@ -162,7 +162,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	hoodtype = /obj/item/clothing/head/hooded/explorer/exo
-	armor = list("linemelee" = 120, "linebullet" = 10, "linelaser" = 10, "energy" = 5, "bomb" = 40, "bio" = 25, "rad" = 10, "fire" = 0, "acid" = 0)
+	armor = list("tier" = 6, "energy" = 40, "bomb" = 40, "bio" = 40, "rad" = 40, "fire" = 35, "acid" = 35)
 	resistance_flags = FIRE_PROOF | GOLIATH_RESISTANCE
 
 /obj/item/clothing/head/hooded/explorer/exo
@@ -170,7 +170,7 @@
 	desc = "A robust helmet for fighting dangerous animals. Its design and material make it harder for a Goliath to keep their grip on the wearer."
 	icon_state = "exo"
 	item_state = "exo"
-	armor = list("linemelee" = 120, "linebullet" = 10, "linelaser" = 10, "energy" = 5, "bomb" = 40, "bio" = 25, "rad" = 10, "fire" = 0, "acid" = 0)
+	armor = list("tier" = 6, "energy" = 40, "bomb" = 40, "bio" = 40, "rad" = 40, "fire" = 35, "acid" = 35)
 	resistance_flags = FIRE_PROOF | GOLIATH_RESISTANCE
 
 /obj/item/clothing/mask/gas/exo

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -142,7 +142,7 @@
 	icon_state = "seva"
 	item_state = "seva"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	armor = list("tier" = 3, "energy" = 45, "bomb" = 35, "bio" = 75, "rad" = 75, "fire" = 100, "acid" = 2505)
+	armor = list("tier" = 3, "energy" = 45, "bomb" = 35, "bio" = 75, "rad" = 75, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF | GOLIATH_WEAKNESS
 
 /obj/item/clothing/mask/gas/seva

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -39,7 +39,7 @@
 		new /datum/data/mining_equipment("Advanced Scanner",			/obj/item/t_scanner/adv_mining_scanner,								800),
 		new /datum/data/mining_equipment("Resonator",					/obj/item/resonator,												800),
 		new /datum/data/mining_equipment("Mini Extinguisher",			/obj/item/extinguisher/mini,										1000),
-		new /datum/data/mining_equipment("Fulton Pack",					/obj/item/extraction_pack,											1000),
+//		new /datum/data/mining_equipment("Fulton Pack",					/obj/item/extraction_pack,											1000),
 //		new /datum/data/mining_equipment("Lazarus Injector",			/obj/item/lazarus_injector,											1000),
 		new /datum/data/mining_equipment("Silver Pickaxe",				/obj/item/pickaxe/silver,											1000),
 		new /datum/data/mining_equipment("Mining Conscription Kit",		/obj/item/storage/backpack/duffelbag/mining_conscript,				1000),


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffed explorer's gear, as well as Exo and SEVA to be useful not only for cosplaying purposes, but also for combat ones.
Explorer's suit's tier increased from 3 to 4 to correspond with OG "explorer's suit" aka Sunrise suit;
SEVA's tier increased from 2 to 3, with a slight increase of environmental resistances (energy 10 to 45, bio 50 to 75, acid 25 to 50) to correspond with OG SEVA suit;
Exosuit's tier increased from *pretty much none but cool melee resistance* to 6, with a slight increase of environmental resistances (energy 5 to 40, bio 25 to 40, rad 10 to 40, fire and acid from 0 to 35) to correspond with OG Exosuit.
Removed Fultons from vendor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

:thinking: Makes three cool suits even cooler and also *finally* quite useful, giving Vaulties/BoS/whoever gets the vendor access to totally-not-referencing-that-ukrainian-game equipment.
I don't really see any reason for Fultons to stay, since they're really game-breaking nor can they be used properly, since there's no beacons whatsoever.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Stalkeros
tweak: Improved Explorer suit, SEVA suit and Exosuit to match their referencing equipment. No more useless military-grade armor!
del: Removed Fulton packs from mining vendor. Why do we even have those here if we can't nor allowed to use them, anyways?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
