### PR TITLE
Hotfix: Head Knight Armor Missing Sprite

### DIFF
--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -193,7 +193,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola, /obj/item/twohanded)
 	armor = list("tier" = 3, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 20, "fire" = 50, "acid" = 0)
-	
+
 /obj/item/clothing/suit/armor/f13/legion/recruit
 	name = "legion recruit armor"
 	desc = "(III) Legion recruit armor is a common light armor, supplied to recruit legionaries and to recruit decanus units. Like most Legion armor, it is made from repurposed sports equipment, consisting of a football player's protective shoulder and chest pads reinforced with additional leather padding and worn over a baseball catcher's vest."
@@ -466,8 +466,8 @@
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/captain
 	name = "brotherhood knight-captain armor"
 	desc = "(VII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Knight-Captains. It bears golden embroidery."
-	icon_state = "brotherhood_armor_cap"
-	item_state = "brotherhood_armor_cap"
+	icon_state = "brotherhood_armor_captain"
+	item_state = "brotherhood_armor_captain"
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate
 	name = "initiate armor"


### PR DESCRIPTION
When the new Brotherhood armor was added, the icon name was incorrect in the KC's armor's code, causing a missing sprite in-game.

This fixes it.