### PR TITLE
BoS Job Rename

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -659,23 +659,23 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	icon_state = "Head Scribe"
 
 /obj/effect/landmark/start/f13/seniorscribe
-	name = "Senior Scribe"
+	name = "Proctor"
 	icon_state = "Head Scribe"
 
 /obj/effect/landmark/start/f13/sentinel
-	name = "Sentinel"
+	name = "Head Paladin"
 	icon_state = "Paladin"
 
 /obj/effect/landmark/start/f13/knightcap
-	name = "Knight-Captain"
+	name = "Head Knight"
 	icon_state = "Initiate Knight"
 
 /obj/effect/landmark/start/f13/seniorknight
-	name = "Senior Knight"
+	name = "Star Knight"
 	icon_state = "Initiate Knight"
 
 /obj/effect/landmark/start/f13/seniorpaladin
-	name = "Senior Paladin"
+	name = "Star Paladin"
 	icon_state = "Knight"
 
 /obj/effect/landmark/start/f13/paladin

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -521,14 +521,14 @@
 	armor = list("tier" = 7, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/senior
-	name = "brotherhood senior knight helmet"
-	desc = "(VII) An improved combat helmet, bearing the symbol of a Senior Knight."
+	name = "brotherhood star knight helmet"
+	desc = "(VII) An improved combat helmet, bearing the symbol of a Star Knight."
 	icon_state = "brotherhood_helmet_senior"
 	item_state = "brotherhood_helmet_senior"
 
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/captain
-	name = "brotherhood knight-captain helmet"
-	desc = "(VII) An improved combat helmet, bearing the symbol of the Knight-Captain."
+	name = "brotherhood head knight helmet"
+	desc = "(VII) An improved combat helmet, bearing the symbol of the Head Knight."
 	icon_state = "brotherhood_helmet_captain"
 	item_state = "brotherhood_helmet_captain"
 

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -434,7 +434,7 @@
 	armor = list("tier" = 2, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/suit/f13/seniorscribe
-	name = "Brotherhood Senior Scribe's robe"
+	name = "Brotherhood Proctor's robe"
 	desc = "(II) A red cloth robe with silver gildings worn by the Brotherhood of Steel Senior Scribes."
 	icon_state = "seniorscribe"
 	item_state = "seniorscribe"
@@ -458,14 +458,14 @@
 	armor = list("tier" = 7, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/senior
-	name = "brotherhood senior knight armor"
-	desc = "(VII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Senior Knights. It bears a silver stripe."
+	name = "brotherhood star knight armor"
+	desc = "(VII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Star Knights. It bears a silver stripe."
 	icon_state = "brotherhood_armor_senior"
 	item_state = "brotherhood_armor_senior"
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/captain
-	name = "brotherhood knight-captain armor"
-	desc = "(VII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Knight-Captains. It bears golden embroidery."
+	name = "brotherhood head knight armor"
+	desc = "(VII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Head Knights. It bears golden embroidery."
 	icon_state = "brotherhood_armor_cap"
 	item_state = "brotherhood_armor_cap"
 

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -423,15 +423,15 @@
 	minimize_when_attached = TRUE
 
 /obj/item/clothing/accessory/bos/knightcaptain
-	name = "Knight-Captain pins"
-	desc = "A gold-plated, silver lined pin with one device and two outstretched wings on the side; a golden sword centered on blue-cloth. Worn by the Knight Captain."
+	name = "Head Knight pins"
+	desc = "A gold-plated, silver lined pin with one device and two outstretched wings on the side; a golden sword centered on blue-cloth. Worn by the Head Knight."
 	icon_state = "knight-captain"
 	item_color = "knight-captain"
 	minimize_when_attached = TRUE
 
 /obj/item/clothing/accessory/bos/seniorscribe
-	name = "Senior Scribe pins"
-	desc = "A silver pin with one device gilded in gold, little notches at the top end, and a golden sword in the center of red cloth; worn by the high-ranking Senior Scribe."
+	name = "Proctor pins"
+	desc = "A silver pin with one device gilded in gold, little notches at the top end, and a golden sword in the center of red cloth; worn by the high-ranking Proctor."
 	icon_state = "seniorscribe"
 	item_color = "seniorscribe"
 	minimize_when_attached = TRUE
@@ -444,15 +444,15 @@
 	minimize_when_attached = TRUE
 
 /obj/item/clothing/accessory/bos/seniorpaladin
-	name = "Senior Paladin pins"
-	desc = "A silver pin with one device gilded in gold, little notches at the top end, and a golden sword in the center of purple cloth; worn by the high-ranking Senior Paladin."
+	name = "Star Paladin pins"
+	desc = "A silver pin with one device gilded in gold, little notches at the top end, and a golden sword in the center of purple cloth; worn by the high-ranking Star Paladin."
 	icon_state = "seniorpaladin"
 	item_color = "seniorpaladin"
 	minimize_when_attached = TRUE
 
 /obj/item/clothing/accessory/bos/seniorknight
-	name = "Senior Knight pins"
-	desc = "A silver pin with one device gilded in gold, little notches at the top end, and a golden sword in the center of purple cloth; worn by the high-ranking Senior Knight."
+	name = "Star Knight pins"
+	desc = "A silver pin with one device gilded in gold, little notches at the top end, and a golden sword in the center of purple cloth; worn by the high-ranking Star Knight."
 	icon_state = "seniorknight"
 	item_color = "seniorknight"
 	minimize_when_attached = TRUE
@@ -472,15 +472,15 @@
 	minimize_when_attached = TRUE
 
 /obj/item/clothing/accessory/bos/headscribe
-	name = "Head-Scribe pins"
+	name = "Head Scribe pins"
 	desc = "A gold-plated, silver lined pin with one device and two outstretched wings on the side; a golden sword centered on red-cloth. Worn by the Head Scribe."
 	icon_state = "headscribe"
 	item_color = "headscribe"
 	minimize_when_attached = TRUE
 
 /obj/item/clothing/accessory/bos/sentinel
-	name = "Sentinel pins"
-	desc = "A gold-plated, silver lined pin with one device and two outstretched wings on the side; a golden sword centered on purple-cloth. Worn by the Sentinel."
+	name = "Head Paladin pins"
+	desc = "A gold-plated, silver lined pin with one device and two outstretched wings on the side; a golden sword centered on purple-cloth. Worn by the Head Paladin."
 	icon_state = "sentinel"
 	item_color = "sentinel"
 	minimize_when_attached = TRUE

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -81,11 +81,11 @@ Elder
 		/obj/item/gun/ballistic/automatic/pistol/n99=1)
 
 /*
-Sentinel
+Head Paladin
 */
 
 /datum/job/bos/f13sentinel
-	title = "Sentinel"
+	title = "Head Paladin"
 	flag = F13SENTINEL
 	faction = "BOS"
 	head_announce = list("Security")
@@ -124,7 +124,7 @@ Sentinel
 	ADD_TRAIT(H, TRAIT_IRONFIST, src)
 
 /datum/outfit/job/bos/f13sentinel
-	name = "Sentinel"
+	name = "Head Paladin"
 	jobtype = /datum/job/bos/f13sentinel
 	uniform = 		/obj/item/clothing/under/f13/recon
 	accessory = 	/obj/item/clothing/accessory/bos/sentinel
@@ -138,7 +138,7 @@ Sentinel
 		/obj/item/kitchen/knife/combat=1)
 
 /datum/outfit/loadout/sentstand
-	name = "Shock Sentinel"
+	name = "Shock Head Paladin"
 	l_hand = /obj/item/gun/energy/laser/scatter
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/mfc=3,
@@ -146,7 +146,7 @@ Sentinel
 		/obj/item/ammo_box/magazine/m10mm_adv=2)
 
 /datum/outfit/loadout/sentvet
-	name = "Veteran Sentinel"
+	name = "Veteran Head Paladin"
 	backpack_contents = list(
 		/obj/item/gun/energy/ionrifle=1,
 		/obj/item/stock_parts/cell/ammo/mfc=3,
@@ -155,7 +155,7 @@ Sentinel
 		)
 
 /datum/outfit/loadout/sentheavy
-	name = "Heavy Sentinel"
+	name = "Heavy Head Paladin"
 	backpack_contents = list(
 		/obj/item/minigunpack=1,
 		)
@@ -230,17 +230,17 @@ Head Scribe
 		)
 
 /*
-Knight-Captain
+Head Knight
 */
 
 /datum/job/bos/f13knightcap
-	title = "Knight-Captain"
+	title = "Head Knight"
 	flag = F13KNIGHTCAPTAIN
 	head_announce = list("Security")
 	faction = "BOS"
 	total_positions = 1
 	spawn_positions = 1
-	description = "You are the Knight-Captain, head of the Knight division in the Chapter. Your knowledge of pre-war materials and engineering is almost unparalleled, and you have basic combat training and experience. You are in charge of the Chapter's engineering Corps, and your Knights. Delegate to them as necessary. As Chief Armorer, you are also in charge of the armory."
+	description = "You are the Head Knight, leader of your respective division in the Chapter. Your knowledge of pre-war materials and engineering is almost unparalleled, and you have basic combat training and experience. You are in charge of the Chapter's engineering Corps, and your Knights. Delegate to them as necessary. As Chief Armorer, you are also in charge of the armory."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Sentinel"
@@ -266,7 +266,7 @@ Knight-Captain
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 
 /datum/outfit/job/bos/f13knightcap
-	name = "Knight-Captain"
+	name = "Head Knight"
 	jobtype = /datum/job/bos/f13knightcap
 	gunsmith_one = TRUE
 	gunsmith_two = TRUE
@@ -285,7 +285,7 @@ Knight-Captain
 		)
 
 /datum/outfit/loadout/capstand
-	name = "Knight-Captain"
+	name = "Standard"
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/aer14=1,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
@@ -312,19 +312,19 @@ Knight-Captain
 		)
 
 /*
-Senior Paladin
+Star Paladin
 */
 
 /datum/job/bos/f13seniorpaladin
-	title = "Senior Paladin"
+	title = "Star Paladin"
 	flag = F13SENIORPALADIN
 	faction = "BOS"
-	total_positions = 1
-	spawn_positions = 1
-	description = "As the Chapter's Senior offensive warrior, you have proven your service and dedication to the Brotherhood over your time as a Paladin. As your skills gained, however, you were deigned to be more useful as a commander and trainer. Now you have your trusty powerfist, and were recently given a suit of T-51b power armor. Your job is to coordinate the Paladins and ensure they work as a team, instilling discipline as you go."
+	total_positions = 2
+	spawn_positions = 2
+	description = "As the Chapter's senior offensive warrior, you have proven your service and dedication to the Brotherhood over your time as a Paladin. As your skills gained, however, you were deigned to be more useful as a commander and trainer. Now you have your trusty powerfist, and were recently given a suit of T-51b power armor. Your job is to coordinate the Paladins and ensure they work as a team, instilling discipline as you go."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
-	supervisors = "the Sentinel"
+	supervisors = "the Head Paladin"
 	selection_color = "#95a5a6"
 
 	loadout_options = list(
@@ -350,7 +350,7 @@ Senior Paladin
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 
 /datum/outfit/job/bos/f13seniorpaladin
-	name = "Senior Paladin"
+	name = "Star Paladin"
 	jobtype = /datum/job/bos/f13seniorpaladin
 	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/t51b
 	head = 			/obj/item/clothing/head/helmet/f13/power_armor/t51b
@@ -363,7 +363,7 @@ Senior Paladin
 		)
 
 /datum/outfit/loadout/spaladina
-	name = "Long-Range Support Senior-Paladin"
+	name = "Long-Range Support Star Paladin"
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/m72=1,
 		/obj/item/ammo_box/magazine/m2mm=3,
@@ -372,7 +372,7 @@ Senior Paladin
 		)
 
 /datum/outfit/loadout/spaladinc
-	name = "Mainline Senior-Paladin"
+	name = "Mainline Star Paladin"
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/aer14=1,
 		/obj/item/stock_parts/cell/ammo/mfc=2,
@@ -390,10 +390,10 @@ Paladin
 	faction = "BOS"
 	total_positions = 2
 	spawn_positions = 2
-	description = "You answer directly to the Sentinel. You are this Chapter's main line of defense and offense; highly trained in combat and weaponry though with little practical field experience, you are eager to prove your worth to the Brotherhood. Your primary duties are defense and surface operations. You may also be assigned a trainee Initiate."
+	description = "You answer directly to the Star Paladin. You are this Chapter's main line of defense and offense; highly trained in combat and weaponry though with little practical field experience, you are eager to prove your worth to the Brotherhood. Your primary duties are defense and surface operations. You may also be assigned a trainee Initiate."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
-	supervisors = "the Sentinel, or Senior Paladin"
+	supervisors = "the Star Paladin, or Head Paladin"
 	selection_color = "#95a5a6"
 
 	loadout_options = list(
@@ -473,16 +473,16 @@ Paladin
 		)
 
 /*
-Senior Scribe
+Proctor
 */
 
 /datum/job/bos/f13seniorscribe
-	title = "Senior Scribe"
+	title = "Proctor"
 	flag = F13SENIORSCRIBE
 	faction = "BOS"
 	total_positions = 2
 	spawn_positions = 2
-	description = "You are the bunker's seniormost medical and scientific expert in the bunker, sans the Headscribe themselves. You are trained in both medicine and engineering, while also having extensive studies of the old world to assist in pinpointing what technology would be useful to the Brotherhood and its interests."
+	description = "You are the bunker's seniormost medical and scientific expert in the bunker, sans the Head Scribe themselves. You are trained in both medicine and engineering, while also having extensive studies of the old world to assist in pinpointing what technology would be useful to the Brotherhood and its interests."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Head Scribe"
@@ -500,7 +500,7 @@ Senior Scribe
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 
 /datum/outfit/job/bos/f13seniorscribe
-	name = "Senior Scribe"
+	name = "Proctor"
 	jobtype = /datum/job/bos/f13seniorscribe
 	chemwhiz = TRUE
 	uniform =		/obj/item/clothing/under/syndicate/brotherhood
@@ -527,10 +527,10 @@ Scribe
 	faction = "BOS"
 	total_positions = 3
 	spawn_positions = 3
-	description = "You answer directly to the Head Scribe, tasked with researching and reverse-engineering recovered technologies from the old world, while maintaining the brotherhoods scientific archives. You may also be given a trainee to assign duties to."
+	description = "You answer directly to the Proctor, tasked with researching and reverse-engineering recovered technologies from the old world, while maintaining the brotherhoods scientific archives. You may also be given a trainee to assign duties to."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
-	supervisors = "the Head Scribe"
+	supervisors = "the Proctor, or Head Scribe"
 	selection_color = "#95a5a6"
 
 	loadout_options = list(
@@ -578,19 +578,19 @@ Scribe
 		)
 
 /*
-Senior Knight
+Star Knight
 */
 
 datum/job/bos/f13seniorknight
-	title = "Senior Knight"
+	title = "Star Knight"
 	flag = F13SENIORKNIGHT
 	faction = "BOS"
 	total_positions = 2
 	spawn_positions = 2
-	description = "You report directly to the Knight-Captain. You are the Brotherhood Senior Knight. Having served the Knight Caste for some time now, you are versatile and experienced in both basic combat and repairs, and also a primary maintainer of the Bunker's facilities. As your seniormost Knight, you may be assigned initiates or Junior Knights to mentor."
+	description = "You report directly to the Head Knight. You are the Brotherhood Star Knight. Having served the Knight Caste for some time now, you are versatile and experienced in both basic combat and repairs, and also a primary maintainer of the Bunker's facilities. As your seniormost Knight, you may be assigned initiates or Junior Knights to mentor."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
-	supervisors = "the Knight-Captain"
+	supervisors = "the Head Knight"
 	selection_color = "#95a5a6"
 
 	loadout_options = list(
@@ -604,7 +604,7 @@ datum/job/bos/f13seniorknight
 	minimal_access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
 
 /datum/outfit/job/bos/f13seniorknight
-	name = "Senior Knight"
+	name = "Star Knight"
 	jobtype = /datum/job/bos/f13seniorknight
 	suit = 			/obj/item/clothing/suit/armor/f13/combat/brotherhood/senior
 	accessory = 	/obj/item/clothing/accessory/bos/seniorknight
@@ -653,7 +653,7 @@ Knight
 	description = " You are the Brotherhood Knight, the veritable lifeblood of your organization. You are a versatile and adaptably trained person: from your primary duties of weapon & armor repair to basic combat, survival and stealth skills, the only thing you lack is proper experience. You are also in charge of Initiates."
 	forbids = "TheBrotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
-	supervisors = "the Knight-Captain, or Senior Knight"
+	supervisors = "the Star Knight, or Head Knight"
 	selection_color = "#95a5a6"
 
 	loadout_options = list(
@@ -798,16 +798,16 @@ Off-Duty
 	loadout_options = list(
 	/datum/outfit/loadout/offa, //Junior Knight
 	/datum/outfit/loadout/offb, //Knight
-	/datum/outfit/loadout/offc, //Senior Knight
-	/datum/outfit/loadout/offd, //Knight-Captain
+	/datum/outfit/loadout/offc, //Star Knight
+	/datum/outfit/loadout/offd, //Head Knight
 	/datum/outfit/loadout/offe, //Junior Scribe
 	/datum/outfit/loadout/offf, //Scribe
 	/datum/outfit/loadout/offg, //Senior Scribe
 	/datum/outfit/loadout/offh, //Head Scribe
 	/datum/outfit/loadout/offi, //Junior Paladin
 	/datum/outfit/loadout/offj, //Paladin
-	/datum/outfit/loadout/offk, //Senior Paladin
-	/datum/outfit/loadout/offl, //Sentinel
+	/datum/outfit/loadout/offk, //Star Paladin
+	/datum/outfit/loadout/offl, //Head Paladin
 	)
 
 	outfit = /datum/outfit/job/bos/f13offdutybos

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -46,8 +46,8 @@ GLOBAL_LIST_INIT(nonhuman_positions, list(
 GLOBAL_LIST_INIT(command_positions, list(
 	"Elder",
 	"Head Scribe",
-	"Sentinel",
-	"Knight-Captain",
+	"Head Paladin",
+	"Head Knight",
 
 	"Legion Centurion",
 	"Legion Orator",
@@ -79,14 +79,14 @@ GLOBAL_LIST_INIT(silicon_whitelist_positions, list(
 GLOBAL_LIST_INIT(faction_whitelist_positions, list(
 "Head Scribe",
 "Elder",
-"Sentinel",
-"Knight-Captain",
+"Head Paladin",
+"Head Knight",
 "Head Scribe",
-"Senior Paladin",
+"Star Paladin",
 "Paladin",
-"Senior Knight",
+"Star Knight",
 "Knight",
-"Senior Scribe",
+"Proctor",
 "Scribe",
 "BoS Off-Duty",
 
@@ -138,11 +138,11 @@ GLOBAL_LIST_INIT(faction_whitelist_positions, list(
 ))
 
 GLOBAL_LIST_INIT(faction_player_positions, list(
-"Senior Paladin",
+"Star Paladin",
 "Paladin",
-"Senior Knight",
+"Star Knight",
 "Knight",
-"Senior Scribe",
+"Proctor",
 "Scribe",
 "BoS Off-Duty",
 
@@ -185,17 +185,17 @@ GLOBAL_LIST_INIT(antagonist_whitelist_positions, list(
 
 GLOBAL_LIST_INIT(brotherhood_command_positions, list(
 	"Elder",
-	"Sentinel",
-	"Knight-Captain",
+	"Head Paladin",
+	"Head Knight",
 	"Head Scribe"
 ))
 
 GLOBAL_LIST_INIT(brotherhood_positions, list(
-	"Senior Paladin",
+	"Star Paladin",
 	"Paladin",
-	"Senior Knight",
+	"Star Knight",
 	"Knight",
-	"Senior Scribe",
+	"Proctor",
 	"Scribe",
 	"Initiate",
 	"BoS Off-Duty"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This renames a few jobs in the Brotherhood. Senior Scribe to Proctor, Senior Paladin to Star Paladin, Senior Knight to Star Knight, etc etc. Head Paladin finally exists. Senior paladin slots raised to two. tested extensively.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We're changing the rank names, and the BoS loremasters want it. Therefore it is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
- senior paladin changed to star paladin
- senior knight changed to star knight
- senior scribe changed to proctor
- knight-captain changed to head knight
- pins changed to reflect renamed ranks
- senior knight armor changed to reflect renamed ranks
- knight-captain armor changed to reflect renamed ranks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
