### PR TITLE
Dungeon Changes / QoL

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -257,7 +257,7 @@
 /area/f13/bunker)
 "auT" = (
 /obj/structure/spider/stickyweb,
-/turf/closed/mineral/random/low_chance,
+/turf/open/space/basic,
 /area/f13/bunker)
 "avm" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -1155,6 +1155,8 @@
 /mob/living/simple_animal/hostile/handy/sentrybot{
 	color = "#75FFE2";
 	desc = "A pre-war military robot armed with a deadly gatling laser and covered in thick, oddly blue armor plating, the name Lil' Chew-Chew scratched onto it's front armour.";
+	extra_projectiles = 6;
+	health = 700;
 	name = "Lil' Chew-Chew";
 	unique_name = 1
 	},
@@ -1447,7 +1449,6 @@
 	},
 /area/f13/bunker)
 "ccI" = (
-/mob/living/simple_animal/hostile/handy/securitron,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
@@ -4169,6 +4170,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker)
+"gdp" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/turf/open/floor/plasteel/barber{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "gdZ" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
@@ -4416,14 +4423,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/vault)
 "gte" = (
-/obj/structure/barricade/sandbags{
-	dir = 8
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "gtr" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/trash,
@@ -5007,6 +5010,11 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"hlb" = (
+/obj/structure/spider/stickyweb,
+/obj/effect/mine/stun,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "hlY" = (
 /obj/structure/window/reinforced{
 	color = "#000000";
@@ -5247,12 +5255,17 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"hER" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/mine/stun,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "hFk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/area/f13/radiation)
 "hGb" = (
 /obj/structure/closet/crate/radiation,
 /obj/item/stack/sheet/mineral/uranium{
@@ -7434,7 +7447,7 @@
 "laJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -8232,6 +8245,7 @@
 /area/space)
 "mnC" = (
 /obj/effect/decal/cleanable/blood/old,
+/mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
 "mnI" = (
@@ -8302,7 +8316,6 @@
 /area/f13/vault)
 "msa" = (
 /obj/item/kitchen/knife/combat,
-/mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "msi" = (
@@ -10149,9 +10162,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "pcr" = (
-/obj/structure/chair/stool,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "pdp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12067,8 +12080,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "rLU" = (
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/plating/tunnel,
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/bunker)
 "rLZ" = (
 /obj/item/storage/toolbox/electrical,
@@ -12209,6 +12225,10 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
+/area/f13/bunker)
+"rYU" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "rZP" = (
 /turf/closed/indestructible/opshuttle,
@@ -12705,6 +12725,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"sRk" = (
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "sRp" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -13222,6 +13248,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"tMd" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "tNM" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/barber{
@@ -14117,6 +14148,7 @@
 	dir = 1
 	},
 /obj/effect/decal/waste,
+/mob/living/simple_animal/hostile/handy/robobrain,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "vih" = (
@@ -15426,8 +15458,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
 "wRB" = (
-/mob/living/simple_animal/hostile/handy/securitron,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/robobrain,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
@@ -15687,6 +15719,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"xmg" = (
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "xmF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15851,6 +15887,10 @@
 /obj/structure/closet,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/vault)
+"xvw" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "xvC" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /obj/effect/decal/cleanable/dirt,
@@ -15886,6 +15926,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/vault)
+"xyj" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "xyU" = (
 /obj/structure/rack,
 /obj/machinery/button/door{
@@ -16184,9 +16228,11 @@
 	},
 /area/space)
 "xXr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/f13composite{
-	icon_state = "rubblepillar"
+/obj/machinery/door/airlock/hatch,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
 "xXG" = (
@@ -18475,7 +18521,7 @@ bsh
 bsh
 bsh
 bsh
-hFk
+bsh
 bsh
 bsh
 bsh
@@ -18732,7 +18778,7 @@ bsh
 bsh
 bsh
 bsh
-hFk
+bsh
 bsh
 bsh
 soK
@@ -18989,7 +19035,7 @@ bsh
 bsh
 bsh
 bsh
-hFk
+bsh
 bsh
 bsh
 soK
@@ -19245,8 +19291,8 @@ bsh
 bsh
 bsh
 bsh
-pcr
-hFk
+bsh
+bsh
 bsh
 bsh
 soK
@@ -19503,7 +19549,7 @@ bsh
 bsh
 bsh
 bsh
-hFk
+bsh
 bsh
 bsh
 soK
@@ -20227,7 +20273,7 @@ gic
 qvG
 qvG
 qvG
-qvG
+eoK
 iwT
 qvG
 qvG
@@ -21516,7 +21562,7 @@ qog
 qvG
 qvG
 jFj
-qvG
+goF
 qvG
 izh
 heT
@@ -21533,7 +21579,7 @@ rsj
 aUx
 kcw
 wII
-wII
+ozf
 wII
 efJ
 aUx
@@ -23326,7 +23372,7 @@ vOc
 aUx
 igu
 cDk
-gte
+wII
 wII
 cFS
 aUx
@@ -23831,7 +23877,7 @@ wII
 izh
 aUx
 ejJ
-wII
+rLU
 fVk
 aUx
 dUs
@@ -24602,12 +24648,12 @@ xzw
 cQv
 aUx
 fWt
-xzw
+wII
 hsq
 aUx
 voH
 xjU
-gte
+wII
 aUx
 aUx
 aUx
@@ -24859,7 +24905,7 @@ wII
 xrJ
 aUx
 aUx
-kbK
+xXr
 aUx
 aUx
 wII
@@ -32316,8 +32362,8 @@ heT
 heT
 lWj
 rzT
+gdp
 bue
-nGI
 heT
 aUx
 heT
@@ -34637,7 +34683,7 @@ heT
 heT
 heT
 bue
-bue
+odp
 odp
 bhv
 cll
@@ -46545,7 +46591,7 @@ eRb
 xph
 aUx
 fku
-cIT
+aUx
 diW
 tal
 gEI
@@ -47061,7 +47107,7 @@ wvj
 msD
 pqC
 diW
-aUx
+rYU
 bjT
 xzS
 cIT
@@ -47318,7 +47364,7 @@ aUx
 iJV
 nBV
 iCR
-aUx
+rYU
 uXT
 uau
 kOH
@@ -47575,7 +47621,7 @@ aUx
 uGH
 diW
 diW
-aUx
+rYU
 iOE
 gEI
 nmg
@@ -47835,7 +47881,7 @@ diW
 aUx
 xYP
 ggC
-koh
+cIT
 aUx
 tCc
 vPZ
@@ -48091,8 +48137,8 @@ jru
 aUx
 aUx
 aUx
-koh
-koh
+aUx
+aUx
 aUx
 gQm
 azq
@@ -48346,7 +48392,7 @@ wvj
 vwf
 vId
 bcE
-koh
+cIT
 rwc
 oRq
 xhC
@@ -48355,7 +48401,7 @@ fRE
 ulM
 gEI
 aUd
-azq
+ulM
 vPZ
 heT
 heT
@@ -48603,7 +48649,7 @@ xeO
 ryR
 rKG
 vNb
-vPZ
+cIT
 koh
 bcE
 rKG
@@ -48861,8 +48907,8 @@ lPR
 nSi
 uNn
 gKr
-xXr
-koh
+rwc
+cIT
 rag
 aUx
 aUd
@@ -49118,7 +49164,7 @@ qPJ
 hnU
 jUG
 azq
-azq
+cIT
 koh
 bQs
 aUx
@@ -71376,7 +71422,7 @@ heT
 heT
 izh
 hjg
-sSH
+tMd
 cIT
 cIT
 heT
@@ -71399,7 +71445,7 @@ izh
 cIT
 cIT
 cIT
-rar
+xyj
 ghm
 bVk
 bSx
@@ -71657,7 +71703,7 @@ cIT
 cIT
 okW
 okW
-rLU
+kRy
 rJm
 slg
 izh
@@ -71882,7 +71928,7 @@ heT
 wYe
 tPc
 plg
-gCF
+gte
 tAP
 wYe
 heT
@@ -72147,7 +72193,7 @@ heT
 heT
 izh
 cIT
-sSH
+hlb
 hjg
 cIT
 heT
@@ -72158,7 +72204,7 @@ okW
 okW
 okW
 mib
-okW
+xvw
 heT
 heT
 heT
@@ -72669,7 +72715,7 @@ izh
 izh
 fxm
 kRy
-okW
+xvw
 okW
 nnW
 fgp
@@ -72926,7 +72972,7 @@ hSq
 hjg
 okW
 sGb
-okW
+xmg
 okW
 okW
 okW
@@ -74196,7 +74242,7 @@ wYe
 ktv
 olb
 gCF
-nxD
+hFk
 wYe
 heT
 heT
@@ -74727,7 +74773,7 @@ heT
 heT
 izh
 tWT
-wsi
+hER
 cIT
 cIT
 izh
@@ -75497,7 +75543,7 @@ heT
 heT
 izh
 izh
-nmg
+sRk
 oid
 izh
 cIT
@@ -76271,7 +76317,7 @@ wKk
 eej
 gQm
 nZr
-okW
+uCw
 cIT
 heT
 cIT
@@ -76517,7 +76563,7 @@ wYe
 kGP
 iLq
 wII
-wII
+rLU
 iII
 wYe
 izh
@@ -78055,7 +78101,7 @@ heT
 heT
 mnI
 rJm
-kRy
+pcr
 wYe
 kcw
 lTw

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -10323,6 +10323,18 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "hJd" = (
@@ -10514,7 +10526,6 @@
 /area/f13/village)
 "hSC" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
@@ -20968,6 +20979,7 @@
 /obj/machinery/light,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "pSj" = (
@@ -24486,7 +24498,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/generic,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -25319,12 +25330,9 @@
 	},
 /area/f13/building)
 "tkm" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "tkS" = (
 /obj/structure/table/wood,
 /obj/item/mining_scanner,
@@ -29574,12 +29582,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
-"wqv" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "wqL" = (
 /obj/item/stack/f13Cash/random/low,
 /turf/open/indestructible/ground/outside/dirt,
@@ -50138,14 +50140,14 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -50395,6 +50397,19 @@ gcK
 gcK
 gcK
 gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -50433,20 +50448,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 ezX
 cpK
@@ -50680,6 +50682,9 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -50690,19 +50695,16 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
+ktB
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 ezX
@@ -50939,6 +50941,7 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
@@ -50955,8 +50958,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -51164,6 +51166,7 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
@@ -51193,26 +51196,25 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
+gcK
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -51420,6 +51422,8 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -51434,6 +51438,7 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
@@ -51446,6 +51451,7 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
@@ -51454,13 +51460,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -51675,6 +51677,8 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -51691,6 +51695,10 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -51699,13 +51707,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -51929,6 +51931,8 @@ ktB
 (77,1,1) = {"
 ktB
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -51954,6 +51958,12 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -51976,16 +51986,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
 gcK
 gMR
 oIu
@@ -52243,7 +52245,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gMR
 aDY
 tcj
@@ -64541,7 +64543,7 @@ ggK
 dCV
 tYt
 hhx
-wqv
+tYt
 dCV
 gcK
 gcK
@@ -71464,7 +71466,7 @@ gcK
 gcK
 oFP
 gQy
-tkm
+gQy
 sYV
 sYV
 tul
@@ -73217,7 +73219,7 @@ pud
 tJx
 qij
 qij
-qij
+tkm
 qij
 nRc
 bIh

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -500,6 +500,15 @@
 	icon_state = "floor6-old"
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw/legendary{
+	bare_wound_bonus = 10;
+	health = 1250;
+	melee_damage_lower = 85;
+	melee_damage_upper = 90;
+	name = "Alpha Deathclaw";
+	speed = -1.25;
+	wound_bonus = 10
+	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "bA" = (
@@ -558,6 +567,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"bN" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "bO" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/terminal{
@@ -804,6 +824,13 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"cA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "cB" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -1380,9 +1407,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "et" = (
-/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/f13/tunnel)
 "eu" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall/f13/vault,
@@ -1606,6 +1635,13 @@
 	},
 /turf/open/floor/plasteel/neutral,
 /area/f13/brotherhood)
+"ff" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
 "fg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -1750,6 +1786,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
+"fD" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "fE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1774,11 +1816,8 @@
 /area/f13/tunnel)
 "fJ" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw/mother{
-	obj_damage = 100
-	},
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "fK" = (
@@ -1948,6 +1987,7 @@
 /area/f13/tunnel)
 "gj" = (
 /obj/effect/decal/cleanable/blood/old,
+/mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -2179,8 +2219,12 @@
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
 	},
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "gJ" = (
@@ -2335,7 +2379,6 @@
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor1-old"
 	},
-/mob/living/simple_animal/hostile/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "hh" = (
@@ -2953,6 +2996,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"iV" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "iW" = (
 /obj/structure/billboard/cola/pristine,
 /obj/effect/decal/cleanable/dirt,
@@ -3448,8 +3497,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "kF" = (
@@ -4190,6 +4243,7 @@
 	name = "shutters button";
 	pixel_x = 32
 	},
+/obj/machinery/vending/medical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mT" = (
@@ -4273,7 +4327,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "ng" = (
-/mob/living/simple_animal/hostile/deathclaw,
+/mob/living/simple_animal/hostile/deathclaw{
+	name = "Rock Claw"
+	},
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "nh" = (
@@ -5156,10 +5212,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pS" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "pU" = (
@@ -5902,6 +5960,12 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/tunnel)
+"so" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
 "sp" = (
 /obj/item/trash/f13/dog,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5989,6 +6053,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"sF" = (
+/obj/structure/table/wood,
+/obj/item/clothing/glasses/heat,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "sG" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -6658,9 +6730,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood)
 "uS" = (
-/obj/structure/barricade/wooden,
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8
+	},
+/area/f13/tunnel)
 "uT" = (
 /obj/machinery/mineral/ore_redemption,
 /obj/effect/decal/cleanable/dirt,
@@ -7578,9 +7652,12 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
 "xJ" = (
-/obj/effect/mine/stun,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/mob/living/simple_animal/hostile/centaur,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
 "xK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -8210,8 +8287,13 @@
 /area/f13/followers)
 "zB" = (
 /obj/structure/table,
+/obj/item/roller,
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "zC" = (
@@ -8481,6 +8563,12 @@
 /obj/structure/grille,
 /turf/open/floor/wood,
 /area/f13/brotherhood)
+"Ay" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "Az" = (
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
@@ -8610,6 +8698,12 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"AT" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "AU" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood{
@@ -8819,6 +8913,7 @@
 /area/f13/tunnel)
 "BD" = (
 /obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
@@ -9508,6 +9603,12 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"DE" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "DF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/can,
@@ -9644,10 +9745,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "Ed" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "Ee" = (
@@ -10242,10 +10342,8 @@
 	},
 /area/f13/clinic)
 "FX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw/mother,
-/turf/open/floor/plating/tunnel,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "FZ" = (
 /obj/machinery/smartfridge/bottlerack/gardentool,
@@ -10349,9 +10447,9 @@
 	},
 /area/f13/tunnel)
 "Gr" = (
-/obj/structure/barricade/wooden,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/water,
+/area/f13/tunnel)
 "Gs" = (
 /obj/structure/chair/stool/f13stool{
 	pixel_x = -7;
@@ -10370,10 +10468,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Gv" = (
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
 /obj/structure/table,
+/obj/item/book/granter/trait/chemistry,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "Gw" = (
@@ -10568,13 +10666,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"Hd" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+"Hc" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"Hd" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "He" = (
@@ -10610,6 +10717,12 @@
 	dir = 8
 	},
 /area/f13/brotherhood)
+"Hj" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "Hk" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -10747,6 +10860,13 @@
 "HI" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
+"HJ" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "HK" = (
 /obj/machinery/light{
 	dir = 8
@@ -10840,10 +10960,9 @@
 /area/f13/brotherhood)
 "HZ" = (
 /obj/structure/closet/crate,
-/obj/item/clothing/suit/armor/f13/power_armor/t45d,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/helmet/f13/power_armor/t45d,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/armor/tier5,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -11329,6 +11448,12 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"Jx" = (
+/obj/effect/decal/cleanable/blood/splats,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "Jy" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -12473,6 +12598,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"Nh" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "Ni" = (
 /turf/open/floor/plasteel/darkgreen/side,
 /area/f13/brotherhood)
@@ -12719,7 +12850,6 @@
 /area/f13/tunnel)
 "NO" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw/mother,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -12931,6 +13061,11 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/sewer)
+"Ot" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
 "Ou" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -13014,9 +13149,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "OH" = (
-/obj/structure/chair/stool,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/handy/sentrybot,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/clinic)
 "OI" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -13268,7 +13408,7 @@
 "Pt" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "Pu" = (
@@ -13701,6 +13841,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/supermart,
 /area/f13/tunnel)
+"QM" = (
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "QN" = (
 /obj/structure/closet/crate/large,
 /obj/structure/closet/crate/large,
@@ -13752,6 +13898,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -13842,15 +13989,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "Rk" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
 "Rl" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw/mother,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "Rm" = (
@@ -14374,6 +14522,13 @@
 	dir = 8
 	},
 /area/f13/brotherhood)
+"ST" = (
+/obj/effect/decal/cleanable/blood/innards,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "SU" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/floorgrime,
@@ -14612,6 +14767,12 @@
 /obj/item/paper_bin,
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"TD" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "TE" = (
 /obj/structure/chair/stool,
 /obj/machinery/button/door{
@@ -14726,7 +14887,7 @@
 /area/f13/tunnel)
 "TS" = (
 /obj/machinery/door/airlock/abandoned,
-/turf/closed/wall/rust,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "TT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15089,14 +15250,6 @@
 /obj/docking_port/stationary/bosaway,
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
-"UY" = (
-/mob/living/simple_animal/hostile/deathclaw/mother{
-	obj_damage = 100
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/bunker)
 "UZ" = (
 /obj/structure/closet/crate/rcd,
 /obj/item/construction/rld,
@@ -15108,6 +15261,15 @@
 	dir = 6
 	},
 /area/f13/brotherhood)
+"Va" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
 "Vb" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/floor/f13/wood,
@@ -15116,6 +15278,7 @@
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
 	},
+/obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -15342,6 +15505,12 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
+"VK" = (
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
 "VL" = (
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/indestructible/ground/inside/subway,
@@ -16201,9 +16370,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "Yh" = (
-/obj/item/storage/trash_stack,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/machinery/vending/medical,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/bunker)
 "Yi" = (
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -16273,7 +16444,7 @@
 "Ys" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "Yt" = (
@@ -16412,8 +16583,11 @@
 /obj/effect/decal/remains{
 	icon_state = "remains"
 	},
+/mob/living/simple_animal/hostile/raider/ranged/legendary{
+	name = "John Doe"
+	},
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
 "YQ" = (
@@ -19760,8 +19934,8 @@ HI
 HW
 MQ
 xG
+Wd
 MQ
-BX
 MQ
 eL
 HI
@@ -21262,7 +21436,7 @@ ek
 pn
 dO
 Zx
-Zx
+hy
 nF
 Zx
 ee
@@ -23086,7 +23260,7 @@ Ob
 rG
 Ls
 Gy
-tN
+OH
 CQ
 rh
 Oc
@@ -24130,7 +24304,7 @@ wC
 Fz
 Fz
 Fz
-OH
+Fz
 ki
 Fz
 Fz
@@ -24617,7 +24791,7 @@ al
 rG
 Te
 rG
-rG
+Zw
 wH
 Gy
 tN
@@ -31056,7 +31230,7 @@ ku
 ku
 Fz
 Fz
-Rk
+Fz
 Fz
 Fz
 Fz
@@ -31311,7 +31485,7 @@ KR
 KR
 ku
 Fz
-Gr
+Fz
 Fz
 Fz
 Fz
@@ -32596,7 +32770,7 @@ Fz
 Fz
 Fz
 Fz
-Gr
+Fz
 Fz
 sS
 Fz
@@ -33879,9 +34053,9 @@ Fz
 ku
 Fz
 Fz
-Yh
 Fz
-Gr
+Fz
+Fz
 Fz
 sS
 Fz
@@ -34137,8 +34311,8 @@ Dx
 Fz
 Fz
 Fz
-Gr
-uS
+Fz
+sS
 Fz
 Fz
 Fz
@@ -34394,7 +34568,7 @@ ku
 Fz
 Fz
 Fz
-Gr
+Fz
 Fz
 Fz
 Fz
@@ -34910,7 +35084,7 @@ Fz
 FI
 Fz
 Fz
-Rk
+Fz
 Fz
 sS
 Fz
@@ -35336,7 +35510,7 @@ DZ
 Ao
 DZ
 we
-ol
+xJ
 Oo
 cj
 sK
@@ -36193,7 +36367,7 @@ BF
 ku
 Fz
 Fz
-Gr
+Fz
 Fz
 Fz
 Fz
@@ -36453,7 +36627,7 @@ Fz
 Fz
 Fz
 Fz
-Gr
+Fz
 Fz
 Fz
 Fz
@@ -36964,8 +37138,8 @@ Fz
 Fz
 Fz
 Fz
-uS
-uS
+Fz
+sS
 sS
 sS
 Fz
@@ -37221,7 +37395,7 @@ Fz
 Fz
 Fz
 Fz
-uS
+Fz
 sS
 sS
 sS
@@ -37995,7 +38169,7 @@ Fz
 sS
 Fz
 sS
-uS
+Fz
 Fz
 Fz
 Fz
@@ -38251,7 +38425,7 @@ Fz
 Fz
 Fz
 Fz
-xJ
+Fz
 Fz
 Fz
 Fz
@@ -38930,7 +39104,7 @@ DZ
 nT
 KU
 DZ
-DZ
+Ao
 yt
 jK
 sK
@@ -39022,7 +39196,7 @@ Rg
 Fz
 Fz
 Fz
-Gr
+Fz
 Fz
 Fz
 Fz
@@ -39279,8 +39453,8 @@ ku
 ku
 ku
 Fz
-Gr
-Gr
+Fz
+Fz
 Fz
 Fz
 Fz
@@ -39354,7 +39528,7 @@ pt
 Wj
 jR
 Jo
-zt
+VK
 zt
 pt
 Xn
@@ -39537,7 +39711,7 @@ ku
 ku
 ku
 ku
-Gr
+Fz
 Fz
 Fz
 Fz
@@ -40727,13 +40901,13 @@ ap
 kJ
 kJ
 dp
-kJ
+et
 wf
 kJ
 ij
 sW
 GY
-GY
+FX
 fd
 GY
 GY
@@ -40993,7 +41167,7 @@ GY
 GY
 fd
 GY
-Wo
+GY
 GY
 GY
 GY
@@ -41241,13 +41415,13 @@ JY
 Sv
 Sv
 cx
-Sv
+uS
 xz
 Sv
 NL
 BY
 GY
-GY
+FX
 fd
 GY
 GY
@@ -42865,13 +43039,13 @@ Fz
 Fz
 Fz
 Fz
-Fz
-Fz
-Fz
-Fz
-Fz
-Fz
-Fz
+MA
+MA
+MA
+MA
+MA
+MA
+MA
 Fz
 QC
 OC
@@ -43122,13 +43296,13 @@ Fz
 Fz
 Fz
 Fz
-Fz
+MA
 UH
 UH
 UH
 UH
 UH
-Fz
+MA
 Fz
 QC
 ct
@@ -43377,15 +43551,15 @@ Fz
 Fz
 Fz
 Fz
-Fz
-Fz
-Fz
+MA
+MA
+MA
 UH
 sh
 xs
 Lt
 UH
-Fz
+MA
 Fz
 QC
 FU
@@ -43634,7 +43808,7 @@ Fz
 Fz
 Fz
 Fz
-Fz
+MA
 UH
 UH
 UH
@@ -43642,7 +43816,7 @@ ou
 DX
 ZK
 UH
-Fz
+MA
 Fz
 QC
 Wx
@@ -43831,7 +44005,7 @@ uA
 Wu
 dC
 kw
-FX
+Hb
 To
 Wu
 Fz
@@ -43888,10 +44062,10 @@ Fz
 Fz
 Fz
 Fz
-Fz
-Fz
-Fz
-Fz
+MA
+MA
+MA
+MA
 UH
 qq
 xk
@@ -43899,7 +44073,7 @@ ZK
 ZK
 Gd
 UH
-Fz
+MA
 Fz
 QC
 OC
@@ -44145,7 +44319,7 @@ Fz
 Fz
 Fz
 Fz
-Fz
+MA
 UH
 UH
 UH
@@ -44156,7 +44330,7 @@ UH
 xk
 UH
 UH
-Fz
+MA
 Fz
 QC
 OC
@@ -44402,7 +44576,7 @@ Fz
 sS
 Fz
 Fz
-Fz
+MA
 UH
 Gu
 ZK
@@ -44413,7 +44587,7 @@ By
 Vb
 sX
 UH
-Fz
+MA
 Fz
 QC
 OC
@@ -44659,7 +44833,7 @@ Fz
 sS
 Fz
 Fz
-Fz
+MA
 UH
 UH
 UH
@@ -44670,7 +44844,7 @@ Bo
 ZK
 lA
 UH
-Fz
+MA
 Fz
 QC
 yO
@@ -44916,7 +45090,7 @@ Fz
 sS
 Fz
 Fz
-Fz
+MA
 UH
 hU
 ZK
@@ -44927,7 +45101,7 @@ sX
 ZK
 ZK
 UH
-Fz
+MA
 Fz
 QC
 FU
@@ -45173,7 +45347,7 @@ Fz
 sS
 Fz
 Fz
-Fz
+MA
 UH
 vq
 ZK
@@ -45184,7 +45358,7 @@ hU
 ZK
 xA
 UH
-Fz
+MA
 Fz
 QC
 OC
@@ -45430,7 +45604,7 @@ Fz
 Fz
 Fz
 Fz
-Fz
+MA
 UH
 UH
 xk
@@ -45441,7 +45615,7 @@ UH
 UH
 UH
 UH
-Fz
+MA
 Fz
 QC
 OC
@@ -45694,11 +45868,11 @@ ku
 Fz
 Fz
 Fz
-Fz
-Fz
-Fz
-Fz
-Fz
+MA
+MA
+MA
+MA
+MA
 Fz
 QC
 OC
@@ -46917,7 +47091,7 @@ ku
 Yx
 Yx
 ku
-ku
+IR
 Fz
 Fz
 MA
@@ -47163,7 +47337,7 @@ MA
 Fz
 ku
 Yx
-Yx
+Gr
 ku
 Fz
 MA
@@ -47174,7 +47348,7 @@ Yx
 Yx
 Yx
 Yx
-IR
+uA
 ku
 Fz
 Fz
@@ -47420,9 +47594,9 @@ Fz
 ku
 ku
 Yx
-GD
+Yx
 ku
-et
+Fz
 MA
 Fz
 ku
@@ -47431,7 +47605,7 @@ Yx
 Yx
 Yx
 Yx
-ku
+bc
 ku
 ku
 Fz
@@ -47678,7 +47852,7 @@ ku
 Yx
 Yx
 Yx
-ku
+uA
 Fz
 Fz
 ku
@@ -48204,7 +48378,7 @@ Yx
 Yx
 Yx
 ku
-ku
+IR
 Fz
 MA
 Fz
@@ -48459,7 +48633,7 @@ Yx
 Yx
 Yx
 Yx
-GD
+Yx
 ku
 ku
 Fz
@@ -48716,7 +48890,7 @@ Yx
 Yx
 Yx
 Yx
-ku
+bc
 ku
 Fz
 Fz
@@ -59605,7 +59779,7 @@ Fz
 Fz
 Wh
 lg
-PO
+Rk
 Hd
 lg
 lg
@@ -59863,7 +60037,7 @@ Fz
 lg
 pS
 Ys
-RF
+ff
 gI
 lg
 lg
@@ -60119,10 +60293,10 @@ Fz
 Fz
 lg
 kE
-mT
+Pt
 fJ
-PO
-UY
+Ed
+Ys
 fV
 PO
 lg
@@ -60377,8 +60551,8 @@ Fz
 lg
 Ed
 YP
-PO
-wL
+Ot
+so
 Pt
 Jp
 wL
@@ -60633,14 +60807,14 @@ sS
 Fz
 lg
 lg
-PO
+Yh
 zB
 Gv
 rD
 Jp
 wL
 RF
-PO
+fD
 lg
 lg
 QC
@@ -60896,8 +61070,8 @@ rD
 rD
 Jp
 If
-Jp
 PO
+HJ
 RF
 lg
 uK
@@ -61152,10 +61326,10 @@ rD
 rD
 mT
 Jp
-Jp
-Jp
-Jp
-RF
+iV
+ST
+DE
+cA
 lg
 uK
 uK
@@ -61408,10 +61582,10 @@ Fk
 PO
 gj
 wL
-PO
-fV
-PO
 Jp
+PO
+PO
+PO
 wL
 lg
 Fz
@@ -61663,13 +61837,13 @@ Fz
 lg
 WS
 PO
-RP
+PO
 wL
 Vc
-Jp
-wL
-Jp
 PO
+Hj
+Jx
+QM
 lg
 Fz
 Fz
@@ -61919,13 +62093,13 @@ QC
 Fz
 lg
 PO
-wL
+Ay
 mT
+TD
+Jp
 PO
-Jp
-Jp
-wL
-Jp
+QM
+PO
 cv
 lg
 Fz
@@ -62178,11 +62352,11 @@ Wh
 lg
 lg
 ci
-PC
+Va
 Jp
 cv
 PO
-Jp
+iV
 PO
 lg
 sS
@@ -62435,12 +62609,12 @@ Fz
 Fz
 lg
 Jp
-PC
+Hc
 Jp
+sF
+Nh
 PO
-Jp
-Jp
-fV
+PO
 lg
 Fz
 sS
@@ -62694,10 +62868,10 @@ lg
 DU
 KA
 Jp
+bN
+AT
 PO
-wL
-PO
-PO
+QM
 lg
 Fz
 sS
@@ -62954,7 +63128,7 @@ Jp
 Jp
 Jp
 Ce
-PO
+Jx
 lg
 Fz
 sS


### PR DESCRIPTION
### **WE CALL THIS A DIFFICULTY TWEAK**

Dungeon Changes/QoL

### Changelog:
- Adds MedTek vendor to Oasis Doctor
- Changes the Double-Momma bunker to a mini raider cannibal bunker with main reward being medical things and main challenge being a legendary raider at the end
- Changes NSB's Claw-Cave to be more difficult with a var-edited Legendary Claw at the end
- Removes some in-the-wall things made by mapping mistakes
- Gives the NCR Armoury some facewraps and NCR Headsets
- Scatters some legendary muties and ghouls around the main bunkers rooms
- Difficulty increase for nearly all bunkers
- Fixes the weld-through-wall meta for the claw-house
- Changes NSB T-45d Spawn to a T-5 armour spawn as a result of the difficulty change
- Adds a second sentry bot to the end-room of North Bunker
- Adds a sentry bot to the end room of Big Claw Bunker
- Gives the followers a reloading bench finally

(This was done on-stream in DR General, should be good, got some feedback while i did so. Doesn't make things impossible, just makes it harder and fixes some things which needed fixing. Now, not every bunker will be cleared by 1:30 every round. Probably.)