### PR TITLE
Fixes, Changes and Legion Stuff

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1148,7 +1148,7 @@
 	loot = list(
 				/obj/item/gun/energy/laser/plasma,
 				/obj/item/gun/ballistic/automatic/tommygun,
-				/obj/item/gun/ballistic/automatic/shotgun/riot,
+				/obj/item/gun/ballistic/shotgun/automatic/combat/citykiller,
 				/obj/item/gun/energy/laser/scatter,
 				/obj/item/gun/ballistic/revolver/sequoia/scoped,
 				/obj/item/gun/ballistic/automatic/bozar,
@@ -1176,7 +1176,7 @@
 			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2 = 14,
 			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3 = 4,
 			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4 = 1,
-			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5 = 1
+			///obj/effect/spawner/lootdrop/f13/weapon/gun/tier5 = 1 //no more generic school locker bozar 4 u
 			)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -137,6 +137,7 @@ Centurion
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13centurion
 	id =			/obj/item/card/id/dogtag/legcenturion
 	mask =			/obj/item/clothing/mask/bandana/legcenturion
+    neck =          /obj/item/storage/belt/holster
 	glasses = 		/obj/item/clothing/glasses/legionpolarizing
 	ears = 			/obj/item/radio/headset/headset_legion
 	r_pocket =      /obj/item/restraints/handcuffs
@@ -167,7 +168,7 @@ Centurion
 	head = 			/obj/item/clothing/head/helmet/f13/legion/rangercent
 	suit_store = /obj/item/gun/ballistic/shotgun/antimateriel
 	backpack_contents = list(
-		/obj/item/ammo_box/a50MG=2,	
+		/obj/item/ammo_box/a50MG=2,
 		/obj/item/gun/ballistic/automatic/pistol/deagle=1,
 		/obj/item/ammo_box/magazine/m44=1
 	)
@@ -198,12 +199,13 @@ Orator
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13orator
 	name = "Legion Orator"
-	suit = 	/obj/item/clothing/suit/armor/f13/legion/vet/orator
-	ears =	/obj/item/radio/headset/headset_legion
-	id = /obj/item/card/id/dogtag/legorator
-	belt = /obj/item/claymore/machete/spatha
+	suit = 	     /obj/item/clothing/suit/armor/f13/legion/vet/orator
+	ears =	     /obj/item/radio/headset/headset_legion
+	neck =		 /obj/item/storage/belt/holster
+	id =         /obj/item/card/id/dogtag/legorator
+	belt =       /obj/item/claymore/machete/spatha
 	suit_store = /obj/item/gun/ballistic/automatic/pistol/type17
-	l_pocket = 		/obj/item/flashlight/lantern
+	l_pocket = 	 /obj/item/flashlight/lantern
 	backpack_contents = list(
 		/obj/item/reagent_containers/pill/patch/healpoultice=1,
 		/obj/item/ammo_box/magazine/m9mm=3,
@@ -366,6 +368,7 @@ Decanii
 	suit = 			/obj/item/clothing/suit/armor/f13/legion/heavy
 	head = 			/obj/item/clothing/head/helmet/f13/legion/heavy
 	mask =			/obj/item/clothing/mask/bandana/legdecan
+	neck =			/obj/item/storage/belt/holster
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
 	ears = 			/obj/item/radio/headset/headset_legion
 	suit_store = 	/obj/item/gun/ballistic/automatic/service/r82
@@ -410,6 +413,7 @@ Decanii
 	suit =			/obj/item/clothing/suit/armor/f13/legion/vet
 	head =			/obj/item/clothing/head/helmet/f13/legion/prime/decan
 	mask =			/obj/item/clothing/mask/bandana/legdecan
+	neck =			/obj/item/storage/belt/holster
 	glasses = 		/obj/item/clothing/glasses/sunglasses
 	ears = 			/obj/item/radio/headset/headset_legion
 	suit_store =	/obj/item/gun/ballistic/automatic/m1garand
@@ -454,6 +458,7 @@ Decanii
 	suit = 			/obj/item/clothing/suit/armor/f13/legion/vet
 	head = 			/obj/item/clothing/head/helmet/f13/legion/recruit/decan
 	mask =			/obj/item/clothing/mask/bandana/legdecan
+	neck =			/obj/item/storage/belt/holster
 	glasses = 		/obj/item/clothing/glasses/legiongoggles
 	ears = 			/obj/item/radio/headset/headset_legion
 	suit_store = 	/obj/item/gun/ballistic/automatic/mini_uzi
@@ -504,6 +509,7 @@ Vexillarius
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13vexillarius
 	id = 			/obj/item/card/id/dogtag/legveteran
 	mask =			/obj/item/clothing/mask/bandana/legvet
+	neck =			/obj/item/storage/belt/holster
 	suit = 			/obj/item/clothing/suit/armor/f13/legion/vet/vexil
 	glasses = 		/obj/item/clothing/glasses/sunglasses
 	ears = 			/obj/item/radio/headset/headset_legion
@@ -610,6 +616,7 @@ Veteran Legionary
 	id = 			/obj/item/card/id/dogtag/legveteran
 	mask =			/obj/item/clothing/mask/bandana/legvet
 	head = 			/obj/item/clothing/head/helmet/f13/legion/vet
+	neck =			/obj/item/storage/belt/holster
 	suit = 			/obj/item/clothing/suit/armor/f13/legion/vet
 	glasses = 		/obj/item/clothing/glasses/sunglasses
 	ears	=		/obj/item/radio/headset/headset_legion
@@ -674,6 +681,7 @@ Prime Legionairy
 	id = 			/obj/item/card/id/dogtag/legprime
 	mask =			/obj/item/clothing/mask/bandana/legprime
 	head = 			/obj/item/clothing/head/helmet/f13/legion/prime
+	neck =			/obj/item/storage/belt/holster
 	suit = 			/obj/item/clothing/suit/armor/f13/legion/prime
 	glasses = 		/obj/item/clothing/glasses/legiongoggles
 	ears	=		/obj/item/radio/headset/headset_legion
@@ -773,7 +781,7 @@ Venator
 
 	loadout_options = list(
 	/datum/outfit/loadout/vensniper, //.308 sniper and gladius
-	/datum/outfit/loadout/venassault //Bulldog assault shotgun and C4
+	/datum/outfit/loadout/venassault //Neostead Shotgun + Gladius
 	)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13venator/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -791,6 +799,7 @@ Venator
 	suit 		= 	/obj/item/clothing/suit/armor/f13/legion/venator
 	head 		= 	/obj/item/clothing/head/helmet/f13/legion/venator
 	mask 		=	/obj/item/clothing/mask/bandana/legdecan
+	neck        =	/obj/item/storage/belt/holster
 	glasses 	=	/obj/item/clothing/glasses/night
 	ears		=	/obj/item/radio/headset/headset_legion
 	r_pocket 	= 	/obj/item/binoculars
@@ -808,9 +817,9 @@ Venator
 
 /datum/outfit/loadout/venassault
 	name = "Venator Assault"
-	suit_store	=	/obj/item/gun/ballistic/automatic/shotgun/bulldog
+	suit_store	=	/obj/item/gun/ballistic/shotgun/neostead
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m12g=2,
+	    /obj/item/storage/fancy/ammobox/lethalshot=2,
 		/obj/item/claymore/machete/gladius=1)
 
 /*
@@ -848,6 +857,7 @@ Explorer
 	id = 		/obj/item/card/id/dogtag/legprime
 	suit = 		/obj/item/clothing/suit/armor/f13/legion/vet/explorer
 	head = 		/obj/item/clothing/head/helmet/f13/legion/vet/explorer
+	neck =		/obj/item/storage/belt/holster
 	glasses = 	/obj/item/clothing/glasses/legiongoggles
 	ears	=	/obj/item/radio/headset/headset_legion
 	r_pocket = /obj/item/binoculars
@@ -861,18 +871,18 @@ Explorer
 
 /datum/outfit/loadout/explinfil
 	name = "Infiltrator Explorer"
-	suit_store = /obj/item/gun/ballistic/revolver/m29
+	suit_store = /obj/item/gun/ballistic/revolver/revolver45
 	backpack_contents = list(
-		/obj/item/ammo_box/m44=2,
+		/obj/item/ammo_box/c45rev=2,
 		/obj/item/grenade/plastic=1,
 		/obj/item/storage/belt/utility/full/engi=1,
 		/obj/item/clothing/glasses/welding=1)
 
 /datum/outfit/loadout/explscout
 	name = "Scout Explorer"
-	suit_store = /obj/item/gun/ballistic/shotgun/automatic/hunting/trail/scoped
+	suit_store = /obj/item/gun/ballistic/shotgun/kar98k/scoped
 	backpack_contents = list(
-		/obj/item/ammo_box/tube/m44=2)
+	    /obj/item/ammo_box/a762/doublestacked=2)
 
 /*
 Auxilia
@@ -1086,5 +1096,5 @@ Slave
 	belt = /obj/item/hatchet
 	backpack_contents = list(
 		/obj/item/storage/bag/plants=1,
-		/obj/item/clothing/under/f13/legslavef=1,		
+		/obj/item/clothing/under/f13/legslavef=1,
 		/obj/item/radio=1)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -800,7 +800,7 @@
 	fire_sound = 'sound/f13weapons/hunting_rifle.ogg'
 	fire_delay = 10
 	burst_size = 1
-//	projectile_speed = 0 //basically hitscan
+	projectile_speed = 0.2
 	can_bayonet = FALSE
 
 /obj/item/gun/ballistic/automatic/m1garand/republicspride
@@ -889,7 +889,7 @@
 	zoom_out_amt = 13
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
-//	projectile_speed = 0
+	projectile_speed = 0.2
 	recoil = 2
 
 /obj/item/gun/ballistic/automatic/marksman/sniper/gold
@@ -1041,7 +1041,7 @@
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 	update_icon()
 	return
-	
+
 /obj/item/gun/ballistic/automatic/p90
 	name = "FN P90c"
 	desc = "The Fabrique Nationale P90c was just coming into use at the time of the war. The weapon's bullpup layout, and compact design, make it easy to control. The durable P90c is prized for its reliability, and high firepower in a ruggedly-compact package. Chambered in 10mm."
@@ -1155,9 +1155,12 @@
 	item_state = "fnfal"
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
 	burst_size = 2
+	burst_shot_delay = 1
 	automatic = 1
-	can_attachments = TRUE
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 	suppressed = 1
+	can_attachments = TRUE
 	can_suppress = FALSE
 	can_unsuppress = FALSE
 

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -417,7 +417,7 @@
 	icon_state = "lever"
 	item_state = "trenchgun"
 	//can_scope = TRUE //why tho
-	//scopestate = "AEP7_scope"	
+	//scopestate = "AEP7_scope"
 	//scope_x_offset = 8
 	//scope_y_offset = 19
 	//can_bayonet = TRUE
@@ -446,7 +446,8 @@
 	desc = "An advanced shotgun with two separate magazine tubes, allowing you to quickly toggle between ammo types."
 	icon_state = "neostead"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 	var/toggled = FALSE
 	var/obj/item/ammo_box/magazine/internal/shot/alternate_magazine
 
@@ -616,7 +617,7 @@
 	weapon_weight = WEAPON_HEAVY
 	recoil = 1 //have fun
 	fire_delay = 6
-//	projectile_speed = 0 //basically hitscan
+	projectile_speed = 0.2
 
 /obj/item/gun/ballistic/shotgun/kar98k
 	name = "\improper karabiner 98k"


### PR DESCRIPTION
**Fixes, Changes and Legion Stuff**

Decided to go ahead and do something i've been meaning to do, even if it gets reverted another time - by that, i mean Nerf the MP5 as the 180 was nerfed, allow the Neostead to go on your back, give the Legion shoulderholsters, edit the Explorer and Venator loadouts slightly, and fix T5 spawn logic. Also removed the stinky breacher from T5, it's a T4 >:(

Most of this is QoL and easily changeable, and the Legion Changes are there since NCR pretty much all has Holsters but legion never did for reasons beyond me, and explorer/venator loadouts were kinda meh but going to change anyways, so i changed them in a way which still makes them good while sticking to the 'no automatics' rule

Changelog:
- Nerfs MP5
- Changes projectile speed of Gauss, AMR and Sniper to 0.2 from 1 (pre-rebase it was 0)
- Fixes the Neostead being unable to go in suit storage
- Swaps Venator Bulldog for Neostead
- Swaps Explorer .44 for .45
- Swaps Explorer Trail Carbine for Kar98k
- Gives most Legion roles Shoulder Holsters
- Added Citykiller to T5 spawnpool
- Removed Breacher from T5 spawnpool
- Re-added Kelo's T5 hotfix from pre-rebase (_no more overworld locker Bozar for you_)