### PR TITLE
Fixes Ranger Poncho to be Trail Ranger Gear

### DIFF
--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -657,14 +657,13 @@ obj/item/clothing/suit/armor/f13/exile/cust0m
 	icon_state = "rigscustom_suit"
 	item_state = "rigscustom_suit"
 
-/obj/item/clothing/suit/toggle/armor/f13/cloakranger
+/obj/item/clothing/suit/toggle/armor/f13/cloakranger //Reskinned trail ranger gear
 	name = "ranger poncho"
 	desc = "(IV) A durable muslin poncho. Tough enough to bear the elements and serve as handy blanket."
 	icon_state = "ranger_cloak"
 	item_state = "ranger_cloak"
-	body_parts_covered = CHEST|GROIN|ARMS
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0) //Same armor as trail ranger gear
-	slowdown = -0.10 //Same speed boost as recon ranger gear. Lower than trail ranger speed to balance it protecting arms.
+	slowdown = -0.14 //Same speed buff as trail ranger gear
 
 /obj/item/clothing/suit/armor/f13/herbertranger //Armor wise, it's reskinned raider armor.
 	name = "weathered desert ranger armor"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the speed and armor covering values for trail ranger gear. I had mistakenly given it no leg protection without realizing that the standard ranger armors do have leg protection. The set is now a reskinned trail ranger vest.

## Changelog
:cl:
balance: Changes the Ranger Poncho to have the same values as the Ranger Vest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
