### PR TITLE
BoS Bunker Revamp

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -1978,8 +1978,7 @@
 /turf/closed/wall/f13/store,
 /area/f13/city)
 "brJ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/workbench,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -13248,7 +13247,8 @@
 	},
 /area/f13/wasteland)
 "jIN" = (
-/obj/machinery/workbench,
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -32,6 +32,10 @@
 	icon_state = "verticalleftborderright2top"
 	},
 /area/f13/wasteland)
+"abM" = (
+/obj/structure/table,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "abN" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -48,6 +52,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/city)
+"acN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "acW" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/f13{
@@ -120,16 +131,27 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"aff" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, poorly filtered gardening water.";
+	name = "stagnant water"
+	},
+/area/f13/brotherhood)
 "afj" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pda,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"afF" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/caves)
 "afL" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -141,6 +163,17 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
 	},
+/area/f13/wasteland)
+"aga" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"agc" = (
+/obj/structure/flora/grass/wasteland{
+	pixel_x = 9;
+	pixel_y = 14
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "agr" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -206,6 +239,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"ahE" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ahK" = (
 /obj/machinery/light{
 	dir = 4
@@ -228,6 +265,13 @@
 /obj/item/storage/backpack/spearquiver,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"aiI" = (
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_x = 33
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "aji" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -321,6 +365,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"alh" = (
+/obj/structure/simple_door/interior{
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "all" = (
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/outside/dirt{
@@ -408,6 +458,19 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
+"aoO" = (
+/obj/structure/wreck/car/bike{
+	pixel_x = -12;
+	pixel_y = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "aoV" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "shadowleft"
@@ -422,10 +485,18 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"apX" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+"aqf" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"aqh" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/vending/sustenance{
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "aqD" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
@@ -475,15 +546,11 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"arH" = (
-/obj/structure/fence/wooden,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "arS" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/obj/structure/bonfire/dense,
+/obj/item/stack/rods,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "arT" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/f13{
@@ -523,6 +590,14 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"ath" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/brotherhood)
 "atL" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/desert,
@@ -548,17 +623,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"auA" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "auH" = (
 /obj/structure/table,
 /obj/item/ammo_casing/shotgun/buckshot,
@@ -645,13 +709,17 @@
 /obj/effect/landmark/start/f13/auxilia,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"axi" = (
+/obj/structure/wreck/trash/halftire,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "ayz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ayJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/two_tire,
@@ -691,6 +759,11 @@
 	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland)
+"aAz" = (
+/obj/structure/barricade/bars,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "aAD" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
@@ -748,15 +821,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"aBK" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/obj/machinery/light/small{
-	dir = 8
+"aBW" = (
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
+"aCf" = (
+/obj/machinery/button/door{
+	id = "bosvillage";
+	pixel_x = 30;
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
 "aCn" = (
 /obj/structure/ladder/unbreakable{
@@ -774,6 +849,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"aCQ" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
+"aCY" = (
+/obj/structure/decoration/vent,
+/turf/closed/wall/f13/wood/house,
+/area/f13/brotherhood)
 "aDb" = (
 /obj/effect/landmark/start/f13/slave,
 /turf/open/floor/f13/wood{
@@ -839,6 +922,16 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
+"aFy" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = -11;
+	pixel_y = 2
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "aFF" = (
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/dirt,
@@ -895,12 +988,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/city)
-"aHC" = (
-/obj/structure/sign/warning/nosmoking/circle{
-	icon_state = "bluecross"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/building)
 "aHH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/destructible/tribal_torch/lit,
@@ -1147,22 +1234,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"aRl" = (
-/obj/effect/turf_decal/stripes/red/line{
+"aRu" = (
+/turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "warningline_red"
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10;
-	icon_state = "warningline_red"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "NE"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
 "aRF" = (
@@ -1203,6 +1278,13 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
+"aTG" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "aTI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/prewar/poster86{
@@ -1230,10 +1312,6 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"aUC" = (
-/obj/structure/chair/wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "aUV" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -1261,6 +1339,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"aVy" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "aVC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
@@ -1347,9 +1430,13 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"aYw" = (
-/obj/structure/simple_door/interior,
-/turf/open/indestructible/ground/outside/ruins,
+"aYD" = (
+/obj/effect/turf_decal/caution/stand_clear/red{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/brotherhood)
 "aYG" = (
 /obj/structure/decoration/clock{
@@ -1399,6 +1486,10 @@
 "aZJ" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"aZW" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "baS" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/f13/stage_tr,
@@ -1455,6 +1546,12 @@
 "bcM" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"bdc" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "bdN" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1506,16 +1603,6 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland)
-"bfV" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibtorso"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "bgd" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -1660,6 +1747,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"blf" = (
+/obj/structure/closet/crate/wicker,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "blp" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 10
@@ -1786,6 +1877,12 @@
 /obj/item/shard,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"boJ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "boN" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -1802,6 +1899,18 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"bpi" = (
+/obj/machinery/button/door{
+	id = "locustgarage";
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"bpk" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "bpn" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/f13/wood,
@@ -1858,12 +1967,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"bqW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "brE" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -1913,6 +2016,12 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/wasteland)
+"buy" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "buD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -1937,6 +2046,12 @@
 /obj/machinery/recharger,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bvh" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "bvs" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2094,12 +2209,13 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/ncr)
-"bAO" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+"bAz" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "bAS" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -2131,18 +2247,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"bBK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "bBY" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
-"bCQ" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/caves)
 "bDb" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/decal/cleanable/dirt,
@@ -2163,11 +2279,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"bDv" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "bDO" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -2510,21 +2621,6 @@
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/city)
-"bSu" = (
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9;
-	icon_state = "warningline_red"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "SE"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "bSR" = (
 /obj/machinery/autolathe,
 /turf/open/floor/f13{
@@ -2572,16 +2668,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/ncr)
-"bUL" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/under/f13/combat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "bVq" = (
 /obj/structure/table/wood,
 /obj/item/toner,
@@ -2637,6 +2723,14 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"bXS" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/caves)
 "bYY" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
@@ -2677,27 +2771,12 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
-"can" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "cbf" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
-"cbj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
 "cbk" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/village)
@@ -2828,13 +2907,6 @@
 	icon_state = "verticalleftborderleft2bottom"
 	},
 /area/f13/wasteland)
-"cix" = (
-/obj/item/ammo_casing/caseless{
-	dir = 4;
-	icon_state = "sS-casing"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "ciH" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -2854,6 +2926,13 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/ncr)
+"cjE" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/brotherhood)
 "cjG" = (
 /obj/structure/chair{
 	dir = 1
@@ -2888,6 +2967,15 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/village)
+"cks" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "ckt" = (
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2976,17 +3064,6 @@
 	name = "temple wall"
 	},
 /area/f13/caves)
-"cot" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red";
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "cov" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/village)
@@ -2996,19 +3073,15 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"coJ" = (
+/obj/structure/bonfire,
+/obj/item/stack/rods,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "coQ" = (
 /obj/machinery/smartfridge/drying_rack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"coW" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "coZ" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -3041,6 +3114,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"cpW" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2"
+	},
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "cqe" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light{
@@ -3128,6 +3208,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"ctJ" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/brotherhood)
 "cuv" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
@@ -3310,20 +3394,44 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"cBW" = (
-/obj/structure/flora/grass/wasteland,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "cCf" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"cCK" = (
+/obj/item/flag/bos,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "cDd" = (
 /obj/structure/chair/stool/bar,
 /mob/living/simple_animal/hostile/raider/thief,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"cDg" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "SW";
+	move_me = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
+"cEg" = (
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "cFe" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/destructible/tribal_torch/lit,
@@ -3450,6 +3558,18 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/legion)
+"cKH" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "SE";
+	move_me = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "cKN" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -3465,6 +3585,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"cLv" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/brotherhood)
+"cLz" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/wasteland)
 "cLP" = (
 /obj/item/paper,
 /obj/machinery/light/small{
@@ -3498,6 +3629,11 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"cNG" = (
+/obj/structure/rack,
+/obj/item/flashlight/seclite,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "cNH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -3527,17 +3663,6 @@
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"cPc" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "cPg" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
@@ -3601,6 +3726,12 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
+"cRT" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "cRX" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -3642,6 +3773,13 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"cSR" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4";
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "cST" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/floor/f13{
@@ -3678,13 +3816,14 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
-"cUT" = (
-/obj/structure/fence{
+"cUC" = (
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/brotherhood)
 "cVw" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -3708,6 +3847,13 @@
 	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
+"cVL" = (
+/obj/structure/simple_door/metal/fence{
+	door_type = "fence_wood";
+	icon_state = "fence_wood"
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "cVS" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3783,6 +3929,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"cYa" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, poorly filtered gardening water.";
+	name = "stagnant water"
+	},
+/area/f13/brotherhood)
 "cYz" = (
 /obj/item/target,
 /turf/open/floor/f13{
@@ -3949,6 +4107,21 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"ddz" = (
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"ddG" = (
+/obj/structure/car/rubbish3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ddR" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal";
@@ -3971,14 +4144,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"deO" = (
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "deQ" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
@@ -3987,6 +4152,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2"
 	},
+/area/f13/wasteland)
+"dfd" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "dfx" = (
 /obj/structure/destructible/tribal_torch{
@@ -4027,6 +4198,11 @@
 /obj/item/storage/box/matches,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"dgy" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "dgB" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4047,18 +4223,6 @@
 /obj/item/reagent_containers/food/condiment/ketchup,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"dgX" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/obj/structure/sign/poster/prewar/poster69{
-	pixel_x = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "dhh" = (
 /obj/item/stack/sheet/animalhide/human,
 /turf/open/indestructible/ground/outside/ruins{
@@ -4089,11 +4253,27 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"dii" = (
+/obj/structure/closet/crate/miningcar,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "dit" = (
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
 /area/f13/building)
+"diE" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "diF" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
@@ -4280,6 +4460,10 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"doA" = (
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "doB" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4367,6 +4551,10 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"drA" = (
+/obj/item/flag/bos,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "dsh" = (
 /obj/structure/rack,
 /obj/item/clothing/head/sombrero,
@@ -4386,6 +4574,21 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dsw" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, poorly filtered gardening water.";
+	name = "stagnant water"
+	},
+/area/f13/brotherhood)
+"dsD" = (
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "dsW" = (
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4484,12 +4687,22 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"dvC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
+"dvx" = (
+/obj/structure/lattice{
+	layer = 3
 	},
-/area/f13/wasteland)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, poorly filtered gardening water.";
+	name = "stagnant water"
+	},
+/area/f13/brotherhood)
+"dvX" = (
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "dwx" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/f13/wood,
@@ -4544,6 +4757,10 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"dxK" = (
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "dyg" = (
 /obj/machinery/light{
 	dir = 8
@@ -4630,17 +4847,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"dBi" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
-"dBE" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
 "dCl" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13{
@@ -4718,15 +4924,23 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"dFw" = (
-/obj/structure/fermenting_barrel,
+"dFE" = (
+/obj/effect/landmark/start/f13/pusher,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland)
 "dFQ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"dGo" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/brotherhood)
 "dGK" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -4773,6 +4987,16 @@
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
+"dIw" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = -6
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "dIN" = (
@@ -4872,6 +5096,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"dMw" = (
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "dMI" = (
 /obj/structure/chair/comfy,
 /obj/machinery/light/small/broken{
@@ -4906,6 +5137,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dOu" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "dOA" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
@@ -4922,6 +5157,12 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"dPu" = (
+/obj/structure/table/wood,
+/obj/structure/fluff/paper/stack,
+/obj/item/pen,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "dQf" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -4935,6 +5176,10 @@
 "dRs" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/legion)
+"dSb" = (
+/obj/structure/simple_door/interior,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "dSd" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -5050,13 +5295,10 @@
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"dXZ" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+"dZo" = (
+/obj/structure/ore_box,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "dZE" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -5065,13 +5307,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/legion)
-"dZI" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "dZK" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/indestructible/ground/outside/desert,
@@ -5119,20 +5354,36 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/tunnel)
+"ecO" = (
+/obj/effect/landmark/start/f13/pusher,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/wasteland)
+"edc" = (
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/brotherhood)
 "edA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
+"edI" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "edO" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
 "eeo" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "ees" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -5186,6 +5437,11 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"ehG" = (
+/obj/machinery/light/small,
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "ehI" = (
 /obj/structure/fence/corner/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -5225,12 +5481,6 @@
 /obj/structure/sign/poster/prewar/poster88,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
-"eiw" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/caves)
 "ejl" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/cleanable/oil,
@@ -5259,15 +5509,6 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
-"ejH" = (
-/obj/structure/barricade/wooden,
-/obj/structure/destructible/tribal_torch{
-	layer = 4.5;
-	pixel_x = 1;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/caves)
 "ekn" = (
 /obj/effect/landmark/start/f13/ncrmedofficer,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -5362,6 +5603,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"eos" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
+/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
+/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "eou" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13{
@@ -5454,10 +5702,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"ery" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "erY" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -5548,15 +5792,22 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
-"exz" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/pill/patch/turbo,
+"exK" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "exL" = (
 /turf/open/floor/wood/f13/carpet,
 /area/f13/village)
+"exQ" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "exS" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/ruins{
@@ -5578,6 +5829,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"eyw" = (
+/obj/machinery/vending/hydronutrients,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "eyI" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/wood,
@@ -5652,6 +5910,10 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
 	},
+/area/f13/wasteland)
+"eBm" = (
+/obj/structure/chair/f13foldupchair,
+/turf/open/indestructible/ground/outside/wood,
 /area/f13/wasteland)
 "eBu" = (
 /obj/structure/table/wood/fancy/royalblack,
@@ -5766,13 +6028,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"eGx" = (
-/obj/effect/decal/remains/human,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "eGX" = (
 /obj/item/trash/f13/steak,
 /turf/open/floor/f13/wood,
@@ -6125,6 +6380,12 @@
 /obj/machinery/microwave/stove,
 /turf/open/floor/wood/f13,
 /area/f13/building)
+"eSd" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/head/hardhat,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "eSh" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -6156,10 +6417,11 @@
 	icon_state = "horizontaltopbordertopright"
 	},
 /area/f13/wasteland)
-"eSY" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/building)
+"eSZ" = (
+/obj/structure/car/rubbish1,
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "eTg" = (
 /obj/structure/barricade/bars,
 /obj/structure/decoration/rag,
@@ -6207,12 +6469,6 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/city)
-"eUy" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "eUI" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -6238,6 +6494,13 @@
 /obj/machinery/door/morgue,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"eVk" = (
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_x = -33
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "eVQ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/bundle/costume/chicken,
@@ -6247,6 +6510,11 @@
 /obj/item/clothing/suit/armor/f13/brahmin_leather_duster,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"eVY" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "eWk" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -6325,30 +6593,10 @@
 /obj/machinery/vending/cola/random,
 /turf/closed/mineral/random/low_chance,
 /area/f13/building)
-"eZi" = (
-/obj/structure/barricade/sandbags,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "eZI" = (
 /obj/structure/spirit_board,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"faC" = (
-/obj/structure/destructible/tribal_torch{
-	layer = 4.5;
-	pixel_x = 1;
-	pixel_y = 20
-	},
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "post_wood"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "faI" = (
 /obj/structure/girder,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6396,16 +6644,9 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"fbN" = (
-/obj/item/book/granter/crafting_recipe/gunsmith_two,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "fck" = (
 /turf/open/water,
 /area/f13/wasteland)
-"fcF" = (
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "fcH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
@@ -6459,6 +6700,21 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"fer" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, poorly filtered gardening water.";
+	name = "stagnant water"
+	},
+/area/f13/brotherhood)
 "feC" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13{
@@ -6529,12 +6785,20 @@
 /obj/structure/bed,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"fhi" = (
+/obj/structure/window/fulltile/house,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "fhm" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"fiw" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "fiB" = (
 /turf/closed/wall/mineral/sandstone,
 /area/f13/ncr)
@@ -6576,15 +6840,6 @@
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"fkr" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "fkU" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/remains/human,
@@ -6671,6 +6926,13 @@
 /obj/structure/fluff/fokoff_sign,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"fov" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/vending/coffee,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "foz" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -6703,15 +6965,6 @@
 /obj/item/gun/ballistic/automatic/tribalbow,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
-"fps" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood)
 "fpt" = (
 /obj/item/clothing/suit/armor/f13/kit,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6727,13 +6980,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"fpY" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "post_wood"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "fqa" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -6864,14 +7110,6 @@
 /obj/item/pda,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
-"ftr" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = 25;
-	pixel_y = 18
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "ftz" = (
 /obj/structure/table,
 /obj/item/kitchen/knife,
@@ -6907,6 +7145,11 @@
 /obj/item/clothing/gloves/color/white,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fuw" = (
+/obj/structure/table,
+/obj/item/flashlight/lantern,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "fuN" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7050,10 +7293,8 @@
 	},
 /area/f13/wasteland)
 "fAA" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowdestroyed"
-	},
-/turf/open/indestructible/ground/outside/ruins,
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "fAP" = (
 /obj/structure/chair/wood{
@@ -7110,6 +7351,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"fCt" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "fCA" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/wood/f13/carpet,
@@ -7169,6 +7416,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/city)
+"fEk" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "fEP" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -7189,6 +7440,9 @@
 "fFu" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"fFx" = (
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "fFB" = (
 /obj/structure/barricade/wooden,
@@ -7225,6 +7479,11 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/city)
+"fGb" = (
+/obj/machinery/workbench,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "fGh" = (
 /obj/structure/sink{
 	dir = 4;
@@ -7303,12 +7562,11 @@
 	icon_state = "verticalleftborderrightbottom"
 	},
 /area/f13/wasteland)
-"fJP" = (
-/obj/structure/sign/warning/nosmoking/circle{
-	icon_state = "monkey_painting"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/building)
+"fKk" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "fKt" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -7473,13 +7731,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"fRX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "fSz" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_7"
@@ -7558,6 +7809,12 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/city)
+"fVO" = (
+/obj/structure/simple_door/tent,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "fVT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/soymilk,
@@ -7584,6 +7841,13 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"fWN" = (
+/obj/structure/table/glass,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "fXj" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -7669,11 +7933,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"gbu" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
 "gbL" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
@@ -7696,31 +7955,21 @@
 /obj/structure/punching_bag,
 /turf/open/floor/f13,
 /area/f13/building)
-"gcC" = (
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/structure/table/wood,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "gcK" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"gdb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermainbottom"
-	},
-/area/f13/wasteland)
 "gdu" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/kebab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"gdH" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "gdN" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/desert,
@@ -7738,12 +7987,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"gec" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "gez" = (
 /obj/structure/chair{
 	dir = 1
@@ -7859,16 +8102,6 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"gix" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "giD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/ammo,
@@ -7886,18 +8119,10 @@
 "giZ" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
-"gjw" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = 25;
-	pixel_y = 18
-	},
-/obj/structure/flora/tree/tall{
-	layer = 2;
-	pixel_y = 9
-	},
+"gjd" = (
+/obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "gjB" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/dirt{
@@ -7969,11 +8194,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
-"glM" = (
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
 "glZ" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -8059,12 +8279,6 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"goJ" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "goK" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8111,6 +8325,12 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/ncr)
+"gpI" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "gpL" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -8173,6 +8393,16 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
+"grG" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, poorly filtered gardening water.";
+	name = "stagnant water"
+	},
+/area/f13/brotherhood)
 "gsd" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -8253,6 +8483,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"guk" = (
+/obj/structure/wreck/trash/five_tires,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "gun" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -8308,11 +8542,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"gwc" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/cloth/ten,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "gwi" = (
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/outside/desert,
@@ -8324,14 +8553,6 @@
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
-"gwr" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "gws" = (
@@ -8393,13 +8614,34 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"gyZ" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+"gyC" = (
+/obj/structure/fence/post{
+	desc = "A wooden post.";
+	icon_state = "end_wood";
+	name = "pole"
 	},
-/area/f13/wasteland)
+/obj/structure/sign/warning{
+	pixel_y = 22
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
+"gyV" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
+"gzn" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "gzq" = (
 /obj/machinery/hydroponics/soil{
 	mutmod = 2;
@@ -8536,6 +8778,15 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"gDy" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "gDP" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
@@ -8552,9 +8803,11 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
 "gEv" = (
-/obj/item/reagent_containers/glass/bucket,
+/obj/structure/chair/wood{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland)
 "gEA" = (
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8585,6 +8838,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"gFl" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/brotherhood)
 "gFR" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
@@ -8630,18 +8890,27 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/village)
-"gGY" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+"gGA" = (
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/tunnel)
 "gHt" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"gHu" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"gHC" = (
+/obj/structure/table,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "gHI" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -8725,10 +8994,6 @@
 "gKG" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
-"gKI" = (
-/obj/effect/spawner/lootdrop/f13/cash_legion_low,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "gKP" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -8867,6 +9132,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"gQm" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall/rust,
+/area/f13/brotherhood)
 "gQp" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin/towel,
@@ -8908,6 +9180,12 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"gRe" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "gRf" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -8986,18 +9264,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"gUi" = (
-/obj/structure/simple_door/interior,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "gUq" = (
 /obj/structure/statue/sandstone/mars{
 	pixel_x = -1
@@ -9023,21 +9289,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gVz" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/item/storage/belt/military/assault,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "gVE" = (
 /obj/structure/chair{
 	dir = 4
@@ -9083,6 +9334,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"gWN" = (
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "gXm" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -9174,29 +9430,20 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"gYK" = (
-/obj/effect/decal/cleanable/generic,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "gZD" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"haO" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "haP" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"hbt" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/item/clothing/under/f13/combat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "hbx" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/sneakers/black{
@@ -9205,6 +9452,14 @@
 /obj/item/clothing/shoes/sneakers/black,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hbC" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "hbK" = (
 /obj/machinery/light{
 	dir = 4
@@ -9293,10 +9548,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
-"hfy" = (
-/obj/effect/decal/waste,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "hfz" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -9306,6 +9557,9 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"hfO" = (
+/turf/closed/wall/f13/tunnel,
+/area/f13/brotherhood)
 "hfV" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -9522,10 +9776,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"hmR" = (
-/mob/living/simple_animal/cow/brahmin/calf,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "hna" = (
 /obj/structure/closet/cabinet/anchored,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9618,20 +9868,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "hpM" = (
-/obj/item/ammo_casing/caseless{
-	dir = 10;
-	icon_state = "sS-casing"
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "hpY" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/city)
+"hqb" = (
+/obj/structure/fence/corner/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "hqr" = (
 /obj/machinery/vending/games,
 /turf/open/floor/f13/wood,
@@ -9651,17 +9903,6 @@
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"hrn" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "hrx" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/f13/wood,
@@ -9687,6 +9928,12 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"hsA" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "hsD" = (
 /obj/structure/chair,
 /obj/effect/decal/remains/human,
@@ -9694,6 +9941,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"hsG" = (
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "hsI" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13{
@@ -9732,6 +9983,12 @@
 /obj/item/book/granter/crafting_recipe/blueprint/r84,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"htH" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "htQ" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -9763,8 +10020,9 @@
 	},
 /area/f13/village)
 "huY" = (
+/obj/structure/simple_door/interior,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/caves)
+/area/f13/brotherhood)
 "hvk" = (
 /obj/effect/landmark/start/f13/auxilia,
 /turf/open/floor/f13{
@@ -9959,6 +10217,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"hzR" = (
+/obj/structure/closet/crate/freezer/blood{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/brotherhood)
 "hAC" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33"
@@ -10040,6 +10307,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"hDb" = (
+/obj/structure/wreck/trash/halftire,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hDE" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -10079,14 +10350,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"hEL" = (
-/obj/item/lighter,
-/obj/structure/table/wood,
-/obj/item/phone,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "hET" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/dirt,
@@ -10198,6 +10461,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"hIq" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "hIB" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/structure/rack,
@@ -10218,11 +10485,10 @@
 /obj/item/clothing/mask/ncr_facewrap,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"hIV" = (
-/obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/cigar,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+"hIN" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
 "hJd" = (
@@ -10249,6 +10515,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"hJm" = (
+/obj/structure/wreck/trash/halftire,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "hJv" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -10362,10 +10632,6 @@
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"hOR" = (
-/obj/effect/spawner/lootdrop/f13/cash_legion_low,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "hPA" = (
 /obj/structure/sign/poster/prewar/poster73{
 	pixel_x = 31
@@ -10392,6 +10658,13 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"hPZ" = (
+/obj/structure/closet/crate/secure/hydroponics{
+	name = "gardening toolbox"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "hQr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerturn"
@@ -10472,6 +10745,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"hUb" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	pixel_x = -11;
+	pixel_y = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "hUe" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -10483,6 +10767,10 @@
 /obj/effect/landmark/start/f13/recleg,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"hUj" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "hUk" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/ruins{
@@ -10626,6 +10914,13 @@
 /obj/item/clothing/shoes/laceup,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hYl" = (
+/obj/item/flag/bos,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "hYv" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -10742,9 +11037,12 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "ibX" = (
-/obj/effect/spawner/lootdrop/trash,
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland)
 "ibZ" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/road{
@@ -10806,19 +11104,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"ifi" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj/item/clothing/shoes/f13/military,
-/obj/item/clothing/under/f13/combat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "ifq" = (
 /obj/structure/table/wood,
 /obj/item/restraints/handcuffs/cable{
@@ -10829,6 +11114,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"ifQ" = (
+/obj/structure/simple_door/interior{
+	req_access_txt = "120"
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "igc" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -10863,6 +11154,17 @@
 /obj/effect/landmark/start/f13/shopkeeper,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"ihL" = (
+/obj/structure/closet/secure_closet/hydroponics{
+	desc = "A locker that smells of soil.";
+	name = "gardening locker";
+	req_access = list(120)
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "iik" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -10906,6 +11208,10 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
+"ijM" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ijO" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -10916,6 +11222,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"ikB" = (
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ilb" = (
 /obj/machinery/chem_heater,
 /obj/machinery/light{
@@ -11019,17 +11332,6 @@
 	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland)
-"iod" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
-	},
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "ioh" = (
 /obj/structure/chair/wood/modern,
 /turf/open/floor/f13/wood,
@@ -11099,17 +11401,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
 "irn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/rack,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"irx" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/closed/wall/f13/wood/house,
-/area/f13/building)
+"irv" = (
+/obj/structure/flora/grass/wasteland{
+	layer = 4.2;
+	pixel_x = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "irP" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13/wood,
@@ -11163,6 +11466,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"itw" = (
+/obj/structure/wreck/trash/halftire,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "itI" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -11174,10 +11484,24 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"itO" = (
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "itY" = (
 /obj/structure/table/wood,
 /obj/item/lighter,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"iug" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "iul" = (
 /obj/machinery/light{
@@ -11206,6 +11530,10 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ivu" = (
+/obj/structure/wreck/trash/halftire,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "ivJ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/helmet/f13/raider/eyebot,
@@ -11217,6 +11545,12 @@
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"ivM" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ivZ" = (
 /obj/structure/table,
 /obj/item/phone,
@@ -11261,17 +11595,26 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
-"ixt" = (
-/obj/structure/simple_door/metal/fence{
-	door_type = "fence_wood";
-	icon_state = "fence_wood"
+"ixi" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
-"ixR" = (
-/obj/effect/landmark/start/f13/pusher,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/brotherhood)
+"ixs" = (
+/obj/item/flag/bos,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
+"iyf" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "iyg" = (
 /mob/living/simple_animal/hostile/wolf/alpha,
 /turf/open/indestructible/ground/outside/desert,
@@ -11312,16 +11655,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"izi" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
-"izn" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+"izg" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/storage/belt/medical,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/brotherhood)
 "izB" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/glass/mortar{
@@ -11363,6 +11707,13 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"iBi" = (
+/obj/structure/lattice/catwalk,
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, poorly filtered gardening water.";
+	name = "stagnant water"
+	},
+/area/f13/brotherhood)
 "iBv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence{
@@ -11404,16 +11755,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"iEL" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = -11;
-	pixel_y = 2
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
 "iFb" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -11531,6 +11872,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"iHG" = (
+/obj/structure/fence/post{
+	desc = "A wooden post.";
+	icon_state = "end_wood";
+	name = "pole"
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "iHO" = (
 /obj/structure/rack,
 /obj/item/mining_scanner,
@@ -11567,6 +11916,10 @@
 	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland)
+"iIv" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "iIz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11621,6 +11974,12 @@
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"iKv" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/tentwall,
+/area/f13/building)
 "iKD" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -11668,6 +12027,10 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"iMd" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "iMi" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11676,10 +12039,15 @@
 	},
 /area/f13/wasteland)
 "iMS" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/closet{
+	pixel_x = -9;
+	pixel_y = 13
+	},
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
 /area/f13/brotherhood)
 "iMV" = (
@@ -11718,6 +12086,10 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"iNB" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "iNC" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -11837,20 +12209,21 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
+"iQc" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "iQs" = (
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood/f13,
 /area/f13/building)
-"iQw" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+"iQx" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
 "iQK" = (
 /obj/structure/table/wood/poker,
@@ -11876,6 +12249,15 @@
 /obj/structure/displaycase,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"iRg" = (
+/obj/structure/sink/well{
+	pixel_x = -15
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "iRr" = (
 /obj/structure/closet,
 /obj/machinery/light/small{
@@ -11982,10 +12364,6 @@
 /mob/living/simple_animal/hostile/raider/tribal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"iTy" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "iTB" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontaldegraded"
@@ -12019,22 +12397,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/ncr)
-"iUD" = (
-/obj/structure/simple_door/metal/store,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old";
-	pixel_x = 20
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "iVd" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12076,6 +12438,16 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"iWA" = (
+/obj/machinery/button/door{
+	id = "bosgarage";
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"iXj" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/brotherhood)
 "iXz" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/floor/f13{
@@ -12132,15 +12504,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"jaJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/brotherhood)
 "jaU" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/lights/bulbs,
@@ -12181,6 +12544,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"jbR" = (
+/obj/structure/simple_door/interior,
+/turf/closed/wall/f13/wood/house,
+/area/f13/brotherhood)
 "jbV" = (
 /obj/structure/chair/wood/modern{
 	dir = 4;
@@ -12325,10 +12692,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
-"jiv" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/f13/tunnel,
-/area/f13/wasteland)
 "jiP" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -12373,12 +12736,6 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"jkv" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "jkB" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -12499,19 +12856,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"jnO" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"jnP" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermaintop"
-	},
-/area/f13/wasteland)
 "jnX" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -12551,6 +12895,10 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/building)
+"jqh" = (
+/obj/structure/flora/grass/wasteland,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "jqp" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -12577,11 +12925,24 @@
 	icon_state = "horizontalbottombordertop2"
 	},
 /area/f13/wasteland)
+"jsz" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, poorly filtered gardening water.";
+	name = "stagnant water"
+	},
+/area/f13/brotherhood)
 "jsP" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"jsS" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "jtm" = (
 /obj/structure/chair/wood/fancy,
 /turf/open/floor/f13/wood,
@@ -12623,6 +12984,12 @@
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jvn" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "jvw" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -12633,6 +13000,13 @@
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"jvO" = (
+/obj/structure/tires/five,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "jvT" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -12711,11 +13085,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"jxE" = (
-/obj/structure/simple_door,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/brotherhood)
 "jxH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
@@ -12810,18 +13179,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
-"jEC" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "jEX" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12951,9 +13308,9 @@
 	},
 /area/f13/building)
 "jLO" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
+	dir = 4;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -12982,6 +13339,14 @@
 /obj/effect/landmark/start/f13/explorer,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"jMn" = (
+/obj/structure/simple_door/interior{
+	req_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/brotherhood)
 "jMz" = (
 /obj/structure/table/wood/fancy,
 /obj/item/restraints/handcuffs,
@@ -13019,6 +13384,12 @@
 /obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"jNw" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "jNJ" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -13059,6 +13430,15 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
+"jPH" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "jPN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13094,6 +13474,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jQY" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "jRn" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/autolathe/ammo,
@@ -13182,13 +13566,6 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
-"jVB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 1;
-	icon_state = "rubble"
-	},
-/area/f13/wasteland)
 "jVC" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
@@ -13237,6 +13614,13 @@
 "jXj" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
+"jXn" = (
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "jXu" = (
 /obj/item/instrument/guitar,
 /turf/open/floor/f13/wood{
@@ -13306,13 +13690,6 @@
 /obj/structure/bed/dogbed,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jZN" = (
-/obj/item/ammo_casing/caseless{
-	dir = 10;
-	icon_state = "sS-casing"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "kas" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -13449,6 +13826,12 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kdH" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "kdJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop"
@@ -13487,6 +13870,12 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"kff" = (
+/obj/structure/fence/corner/wooden{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kfh" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "followershutters";
@@ -13496,6 +13885,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"kfk" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "kfo" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -13949,6 +14343,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"kvN" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kvT" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -14110,6 +14510,10 @@
 "kBU" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
+"kCm" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kCs" = (
 /obj/item/ammo_casing/a50MG,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14235,6 +14639,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"kHX" = (
+/obj/structure/chair/wood,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "kIl" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/f13{
@@ -14256,6 +14664,20 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kJG" = (
+/obj/structure/fence/post{
+	desc = "A wooden post.";
+	icon_state = "end_wood";
+	name = "pole"
+	},
+/obj/structure/sign/warning{
+	pixel_y = 22
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "kKe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -14382,6 +14804,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kQA" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "kQC" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt{
@@ -14403,6 +14831,11 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"kRL" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kSd" = (
 /obj/structure/closet/crate,
 /turf/open/indestructible/ground/outside/dirt,
@@ -14499,6 +14932,10 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kWB" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "kWC" = (
 /obj/structure/table/wood,
 /obj/item/storage/backpack/satchel/leather,
@@ -14512,6 +14949,13 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"kXe" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kXj" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -14522,11 +14966,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"kXq" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/caves)
 "kXv" = (
 /obj/structure/fence{
 	dir = 8
@@ -14544,15 +14983,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"kYh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/wasteland)
 "kYv" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain,
@@ -14624,6 +15054,24 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/grimy,
 /area/f13/village)
+"lay" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"lbl" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"lbu" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = -4;
+	pixel_y = 13
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "lcx" = (
 /obj/machinery/alchemy_table,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14638,20 +15086,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ldt" = (
-/obj/structure/closet/crate/large{
-	storage_capacity = 20
-	},
-/obj/item/clothing/shoes/sneakers/green,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/purple,
-/obj/item/clothing/shoes/sneakers/red,
-/obj/item/clothing/shoes/sneakers/yellow,
-/obj/item/clothing/shoes/sneakers/brown,
-/obj/item/clothing/shoes/sneakers/blue,
-/obj/item/clothing/shoes/sneakers/black,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "ldy" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14697,6 +15131,13 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lff" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "lgg" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -14743,14 +15184,6 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"lhm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood)
 "lhz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15039,6 +15472,9 @@
 	icon_state = "rubbleslab"
 	},
 /area/f13/wasteland)
+"lsg" = (
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "lsm" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -15066,6 +15502,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"lsT" = (
+/obj/structure/fence/corner{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ltl" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -15086,6 +15528,12 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
+"ltL" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "ltZ" = (
 /obj/machinery/light{
 	dir = 8
@@ -15134,6 +15582,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lva" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "lvp" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/wood,
@@ -15411,6 +15865,11 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"lED" = (
+/obj/structure/table/wood,
+/obj/item/clothing/glasses/f13/biker,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "lEG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15575,10 +16034,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/village)
-"lMW" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "lNa" = (
 /obj/structure/closet/fridge/standard,
 /turf/open/floor/f13/wood,
@@ -15736,6 +16191,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lTK" = (
+/obj/structure/bed/mattress{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "lTZ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -15774,21 +16238,6 @@
 	icon_state = "verticalleftborderleft2top"
 	},
 /area/f13/wasteland)
-"lUh" = (
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5;
-	icon_state = "warningline_red"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "SW"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "lUk" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/store,
@@ -15820,6 +16269,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"lVb" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "lVe" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -15831,6 +16286,16 @@
 /obj/item/clothing/under/f13/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lVx" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, poorly filtered gardening water.";
+	name = "stagnant water"
+	},
+/area/f13/brotherhood)
 "lWj" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15854,19 +16319,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"lXR" = (
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Security"
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "lYi" = (
 /obj/item/ammo_casing/c10mm/ap,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15883,10 +16335,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "lZu" = (
-/obj/structure/bookcase,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/curtain,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
 /area/f13/brotherhood)
 "lZP" = (
@@ -15969,11 +16421,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
-"mdk" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/matches,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "mdv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
@@ -16019,6 +16466,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"mez" = (
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "meL" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -16144,11 +16601,11 @@
 /turf/closed/wall/f13/wood,
 /area/f13/village)
 "mkJ" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/f13/store{
-	desc = "A pre-War wall made of solid concrete.";
-	name = "concrete wall"
+/obj/item/stock_parts/cell,
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "mkP" = (
 /obj/machinery/workbench,
@@ -16166,6 +16623,13 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mlI" = (
+/obj/machinery/deepfryer,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "mmj" = (
 /obj/structure/fence/corner{
 	dir = 5
@@ -16283,6 +16747,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
+"mqj" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/tunnel)
 "mqy" = (
 /obj/machinery/mineral/wasteland_trader/general{
 	icon_state = "trade_idle"
@@ -16313,6 +16781,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mro" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "mrq" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/building)
@@ -16320,6 +16794,11 @@
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"mrG" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "mrS" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16459,11 +16938,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"mxl" = (
-/obj/structure/table/wood,
-/obj/item/clothing/glasses/f13/biker,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "mxR" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -16485,11 +16959,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "myX" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6"
+/obj/structure/simple_door/metal/fence{
+	door_type = "fence_wood";
+	icon_state = "fence_wood"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland)
 "mzs" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16519,6 +16994,10 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
 	},
+/area/f13/wasteland)
+"mCv" = (
+/obj/structure/wreck/trash/bus_door,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mCG" = (
 /obj/structure/fence{
@@ -16688,10 +17167,6 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
-"mJW" = (
-/obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "mKe" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -16750,6 +17225,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/city)
+"mMy" = (
+/obj/machinery/vending/dinnerware,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "mMI" = (
 /obj/structure/simple_door/house{
 	icon_state = "glassclosing"
@@ -16768,6 +17250,9 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"mNA" = (
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "mNB" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/f13{
@@ -16808,13 +17293,6 @@
 /obj/structure/tires/five,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"mOU" = (
-/obj/effect/decal/waste,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "mPa" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -17001,6 +17479,17 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"mXX" = (
+/mob/living/simple_animal/hostile/wolf{
+	desc = "The dogs that survived the Great War are a larger, and tougher breed, size of a wolf.<br>This one looks mangy, with mud stuck to his hair and flies buzzing around him.";
+	faction = list("neutral");
+	health = 200;
+	maxHealth = 200;
+	name = "Guerrilla";
+	tame = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mYi" = (
 /obj/structure/fence{
 	dir = 4
@@ -17010,13 +17499,6 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
-"mYk" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "mYl" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -17139,6 +17621,14 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
+"ncx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "ndx" = (
 /obj/structure/chair/booth{
 	dir = 4
@@ -17163,6 +17653,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nev" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench"
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "neN" = (
 /obj/structure/destructible/tribal_torch{
 	pixel_x = 10
@@ -17289,6 +17786,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"niV" = (
+/obj/structure/wreck/trash/two_tire,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"njU" = (
+/obj/structure/chair/stool{
+	icon_state = "bench"
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "nkp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -17379,6 +17886,13 @@
 	icon_state = "verticalleftborderleft1"
 	},
 /area/f13/wasteland)
+"nop" = (
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "noH" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/rollingpin,
@@ -17464,6 +17978,12 @@
 "nsE" = (
 /turf/closed/indestructible/fakeglass,
 /area/f13/building)
+"nsP" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "ntg" = (
 /obj/structure/flora/ausbushes/grassybush,
 /mob/living/simple_animal/opossum/poppy{
@@ -17501,8 +18021,8 @@
 	},
 /area/f13/legion)
 "ntZ" = (
-/obj/item/ammo_casing/caseless{
-	dir = 6
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -17601,6 +18121,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"nyv" = (
+/obj/structure/flora/grass/wasteland{
+	pixel_x = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "nyM" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -17658,6 +18184,18 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"nAs" = (
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
+/obj/structure/fence/wooden{
+	density = 0;
+	dir = 4;
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "nAz" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -17723,18 +18261,6 @@
 	icon_state = "shadowleft"
 	},
 /area/f13/wasteland)
-"nFX" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/obj/item/clothing/under/f13/combat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "nGc" = (
 /obj/structure/toilet{
 	dir = 4
@@ -17793,6 +18319,18 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"nGM" = (
+/obj/structure/wreck/car/bike{
+	pixel_x = -12;
+	pixel_y = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "nHi" = (
 /obj/machinery/vending/snack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17827,15 +18365,6 @@
 "nIp" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
-"nIs" = (
-/obj/structure/simple_door{
-	icon_state = "brokenglass"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "nIz" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/machinery/light/small/broken{
@@ -17881,6 +18410,12 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"nJJ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "nJM" = (
 /obj/item/clothing/head/cone{
 	anchored = 1
@@ -17963,18 +18498,6 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
-"nOH" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj/item/storage/belt/military/assault,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "nOR" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -18075,11 +18598,31 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
-"nRK" = (
-/obj/item/flag/bos,
-/obj/effect/decal/cleanable/dirt,
+"nRV" = (
+/obj/structure/table/optable,
+/obj/structure/table/optable,
+/obj/structure/table/optable,
+/obj/machinery/iv_drip{
+	pixel_x = -7;
+	pixel_y = 16
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/brotherhood)
+"nSe" = (
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 31
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/brotherhood)
 "nSf" = (
@@ -18095,15 +18638,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"nSP" = (
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/obj/structure/fence/post{
-	icon_state = "end_wood"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "nTm" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/f13{
@@ -18206,7 +18740,8 @@
 	},
 /area/f13/ncr)
 "nYt" = (
-/obj/item/ammo_casing/caseless,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/sunset,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nYI" = (
@@ -18224,6 +18759,12 @@
 	icon_state = "verticalleftborderleftbottom"
 	},
 /area/f13/wasteland)
+"nZa" = (
+/obj/structure/simple_door/metal/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "nZr" = (
 /mob/living/simple_animal/hostile/wolf,
 /turf/open/indestructible/ground/outside/desert,
@@ -18267,6 +18808,11 @@
 	icon_state = "verticalleftborderright2bottom"
 	},
 /area/f13/wasteland)
+"obb" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "obd" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/road{
@@ -18394,12 +18940,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ofd" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "ofe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil{
@@ -18474,6 +19014,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"oih" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "NW";
+	move_me = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "oil" = (
 /obj/machinery/computer/shuttle/northbunkerelevator,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18495,10 +19047,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"ojV" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "okc" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
+"okd" = (
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall/rust,
+/area/f13/brotherhood)
 "okt" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_t,
@@ -18645,6 +19207,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"onY" = (
+/obj/structure/wreck/trash/one_barrel,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ooa" = (
 /obj/item/clothing/suit/armor/f13/leatherarmor,
 /obj/effect/decal/remains/human,
@@ -18672,12 +19238,6 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"opc" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "opW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -18743,18 +19303,13 @@
 /obj/machinery/light/sign,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/city)
-"orP" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+"orX" = (
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 12
 	},
-/area/f13/wasteland)
-"osf" = (
-/obj/structure/bonfire/dense,
-/obj/item/stack/rods,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "osj" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -18783,17 +19338,21 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"otg" = (
-/obj/effect/turf_decal/stripes/red/line,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+"ote" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "otr" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"otA" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "otQ" = (
 /obj/structure/urinal,
 /turf/closed/wall/f13/wood/house,
@@ -18804,6 +19363,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"otZ" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/brotherhood)
+"oui" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "ouS" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13{
@@ -18890,19 +19459,6 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"oyd" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = 12;
-	pixel_y = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/tunnel)
 "oyx" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13{
@@ -18950,10 +19506,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "oAo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "oAS" = (
 /obj/structure/fireplace,
@@ -19044,10 +19599,6 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"oEX" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "oFp" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/rust,
@@ -19067,10 +19618,6 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/wasteland)
-"oGF" = (
-/obj/machinery/vending/nukacolavend,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/caves)
 "oGS" = (
 /obj/structure/chair{
 	dir = 8
@@ -19249,17 +19796,19 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"oMT" = (
+/obj/structure/curtain,
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/brotherhood)
 "oMY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"oNj" = (
-/obj/effect/turf_decal/caution/stand_clear/red,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "oNC" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood{
@@ -19354,13 +19903,6 @@
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ncr)
-"oRf" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3"
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "oRq" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/road{
@@ -19462,6 +20004,14 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"oUp" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "oUu" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -19552,10 +20102,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"oWq" = (
-/obj/structure/reagent_dispensers/barrel,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "oWC" = (
 /obj/structure/decoration/rag,
 /obj/structure/simple_door/wood,
@@ -19718,10 +20264,6 @@
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"pdI" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "pea" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -19803,6 +20345,10 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"phx" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "phy" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -19844,8 +20390,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "piv" = (
-/obj/structure/simple_door,
-/turf/open/indestructible/ground/outside/ruins,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "piw" = (
 /obj/structure/chair/bench,
@@ -19856,6 +20402,11 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"piF" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "pjD" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -19879,6 +20430,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"pkl" = (
+/obj/structure/window/fulltile/house/broken,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "pku" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -19901,26 +20456,10 @@
 	icon_state = "horizontalinnermainleft"
 	},
 /area/f13/wasteland)
-"pls" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "plt" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"plY" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/tunnel)
 "pmt" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19933,6 +20472,18 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"pnr" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "NE";
+	move_me = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "pnw" = (
 /obj/machinery/light/sign/oasis_sign,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19980,6 +20531,12 @@
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/water,
 /area/f13/radiation)
+"poQ" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "poX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -20014,12 +20571,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"pqq" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "pqs" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
@@ -20098,6 +20649,12 @@
 /obj/effect/landmark/start/f13/legionary,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
+"psQ" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/brotherhood)
 "psR" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
@@ -20121,32 +20678,17 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"ptl" = (
+/obj/structure/toilet,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "ptP" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"ptT" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "pud" = (
 /turf/closed/wall/f13/wood,
 /area/f13/clinic)
-"puy" = (
-/obj/structure/sign/poster/prewar/poster69{
-	dir = 1;
-	pixel_y = null
-	},
-/turf/closed/wall/f13/store{
-	desc = "A pre-War wall made of solid concrete.";
-	name = "concrete wall"
-	},
-/area/f13/brotherhood)
 "puP" = (
 /obj/structure/rack,
 /obj/item/seeds/cannabis,
@@ -20178,26 +20720,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"pwe" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "pww" = (
 /obj/machinery/chem_dispenser/low_power,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"pwZ" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2"
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "pxd" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/chem_tin/radx,
@@ -20306,6 +20832,13 @@
 	},
 /turf/open/floor/plating,
 /area/f13/caves)
+"pBl" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "pBp" = (
 /mob/living/simple_animal/hostile/wolf{
 	aggro_vision_range = 0;
@@ -20358,6 +20891,15 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13,
 /area/f13/building)
+"pCN" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "pDd" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -20369,6 +20911,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"pDs" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "pDR" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -20409,13 +20957,6 @@
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"pEy" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outermaincornerouter"
-	},
-/area/f13/wasteland)
 "pED" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -20432,15 +20973,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
-"pEK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "pFa" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20483,19 +21015,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"pHK" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/item/clothing/shoes/f13/military,
-/obj/item/clothing/under/f13/combat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "pHM" = (
 /obj/machinery/light{
 	dir = 1
@@ -20710,10 +21229,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/clinic)
-"pOJ" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "pOL" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -20733,12 +21248,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"pPy" = (
-/obj/structure/closet/crate/bin{
-	anchorable = 0
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "pPF" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -20747,6 +21256,12 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pQi" = (
+/obj/structure/table/wood,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "pQx" = (
 /obj/structure/toilet{
 	dir = 8
@@ -20832,6 +21347,10 @@
 /obj/item/trash/popcorn,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pSS" = (
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "pTa" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13{
@@ -20895,6 +21414,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"pVG" = (
+/obj/structure/wreck/trash/one_tire,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "pVT" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13{
@@ -20995,6 +21518,13 @@
 "qal" = (
 /turf/open/water,
 /area/f13/radiation)
+"qaw" = (
+/obj/machinery/door/poddoor/gate{
+	id = "bosvillage";
+	name = "gate"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "qbe" = (
 /obj/structure/table,
 /obj/item/storage/box/drinkingglasses,
@@ -21314,6 +21844,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qmD" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/brotherhood)
 "qmP" = (
 /obj/structure/toilet{
 	dir = 8
@@ -21369,6 +21902,12 @@
 	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland)
+"qpw" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "qpJ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -21396,15 +21935,13 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"qqh" = (
-/obj/structure/sign/poster/prewar/poster69{
-	pixel_x = -32
+"qpZ" = (
+/obj/structure/closet/crate/bin{
+	anchorable = 0
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/item/storage/bag/trash,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qqK" = (
 /obj/structure/chair/stool/f13stool{
 	pixel_x = -8
@@ -21497,14 +22034,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"quW" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_8";
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "qva" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21601,10 +22130,6 @@
 /obj/item/toy/cattoy,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"qyA" = (
-/obj/structure/sink/puddle,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "qyH" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
@@ -21633,17 +22158,23 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"qAb" = (
-/obj/structure/simple_door/tent,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
+"qAa" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/cloth/ten,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qAc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
+"qAg" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "qAA" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/f13/wood{
@@ -21659,6 +22190,11 @@
 /obj/effect/landmark/start/f13/farmer,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
+"qBo" = (
+/obj/structure/table/wood,
+/obj/item/flashlight,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qBq" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -21680,6 +22216,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"qCH" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "qDe" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table/wood,
@@ -21845,6 +22388,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"qIx" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	layer = 6;
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "qIE" = (
 /obj/effect/decal/waste{
 	pixel_x = -4;
@@ -21870,12 +22422,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"qJI" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/caves)
 "qJR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21950,6 +22496,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/building)
+"qMF" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "qMQ" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/small/broken{
@@ -22133,6 +22685,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"qTx" = (
+/obj/machinery/vending/hydroseeds,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "qTP" = (
 /obj/effect/landmark/start/f13/Hhunter,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22191,12 +22750,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "qYg" = (
-/obj/structure/fence{
-	dir = 1;
-	icon_state = "post_wood"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland)
 "qZy" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/f13/tunnel,
@@ -22270,13 +22828,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
-"rbV" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
+"rcc" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/brotherhood)
+/turf/closed/wall/f13/wood,
+/area/f13/wasteland)
 "rco" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -22343,10 +22901,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"rea" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "rec" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
@@ -22369,10 +22923,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"rfc" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "rfP" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/barber{
@@ -22380,23 +22930,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"rgh" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
-"rgq" = (
-/obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "rgu" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
@@ -22521,6 +23054,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"rkM" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "rkO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22629,6 +23170,13 @@
 "rpu" = (
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"rpv" = (
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "rpF" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -22662,11 +23210,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"rsm" = (
-/obj/item/clothing/suit/armor/f13/combatrusted,
-/obj/item/clothing/head/helmet/f13/hoodedmask,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "rss" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
@@ -22694,6 +23237,17 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/ncr)
+"ruf" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
+"ruM" = (
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "ruN" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
@@ -22728,13 +23282,6 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"rwE" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "rwO" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -22813,6 +23360,16 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"rzg" = (
+/obj/machinery/light/small,
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 5
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "rzn" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22858,13 +23415,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"rAH" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "rAM" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -22877,6 +23427,20 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/wood/f13,
 /area/f13/building)
+"rBC" = (
+/obj/structure/closet/crate/large{
+	storage_capacity = 20
+	},
+/obj/item/clothing/shoes/sneakers/green,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/purple,
+/obj/item/clothing/shoes/sneakers/red,
+/obj/item/clothing/shoes/sneakers/yellow,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/shoes/sneakers/blue,
+/obj/item/clothing/shoes/sneakers/black,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "rBD" = (
 /obj/structure/rack,
 /obj/item/cultivator,
@@ -22892,10 +23456,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"rBO" = (
-/obj/structure/reagent_dispensers/barrel/four,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "rCt" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road,
@@ -22917,11 +23477,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"rDr" = (
-/obj/effect/decal/remains/human,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "rDT" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/melee/chainofcommand{
@@ -23153,6 +23708,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"rOR" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_2"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "rPM" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23179,6 +23740,11 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"rQB" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "rQG" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -23225,9 +23791,9 @@
 	},
 /area/f13/wasteland)
 "rRE" = (
-/turf/closed/wall/f13/store{
-	desc = "A pre-War wall made of solid concrete.";
-	name = "concrete wall"
+/obj/structure/ore_box,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
 "rRR" = (
@@ -23299,17 +23865,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"rUm" = (
-/mob/living/simple_animal/hostile/wolf{
-	desc = "The dogs that survived the Great War are a larger, and tougher breed, size of a wolf.<br>This one looks mangy, with mud stuck to his hair and flies buzzing around him.";
-	faction = list("neutral");
-	health = 200;
-	maxHealth = 200;
-	name = "Guerrilla";
-	tame = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "rUp" = (
 /obj/machinery/shower{
 	dir = 4
@@ -23405,19 +23960,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"rXU" = (
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "rYS" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
 	},
-/area/f13/wasteland)
-"rYT" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rZf" = (
 /obj/structure/decoration/clock{
@@ -23494,6 +24044,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
+"scx" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = -33
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "scB" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood{
@@ -23528,6 +24084,11 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"sdQ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "sed" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet/black,
@@ -23654,6 +24215,19 @@
 /obj/structure/decoration/warning,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"six" = (
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/tato,
+/obj/item/seeds/potato,
+/obj/item/seeds/potato,
+/obj/item/seeds/potato/sweet,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "siE" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
@@ -23764,12 +24338,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"smG" = (
-/obj/structure/fence/end,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainright"
-	},
-/area/f13/wasteland)
 "smU" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -23819,12 +24387,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plating/tunnel,
 /area/f13/village)
-"soC" = (
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermainbottom"
-	},
-/area/f13/wasteland)
 "soY" = (
 /obj/structure/fence{
 	dir = 4
@@ -23840,17 +24402,6 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
-"spl" = (
-/obj/structure/closet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "spx" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -23858,6 +24409,13 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/village)
+"spz" = (
+/obj/structure/flora/grass/wasteland{
+	pixel_x = 9;
+	pixel_y = 14
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "spC" = (
 /obj/structure/bed/dogbed,
 /turf/open/floor/f13/wood,
@@ -23911,12 +24469,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"srk" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "srp" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -23970,10 +24522,6 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
-"suo" = (
-/mob/living/simple_animal/hostile/mirelurk/baby,
-/turf/open/water,
-/area/f13/caves)
 "suq" = (
 /obj/structure/fence{
 	dir = 4
@@ -24071,6 +24619,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"swT" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/brotherhood)
 "swU" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/wood,
@@ -24153,6 +24711,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"sAk" = (
+/obj/structure/simple_door/tent,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/building)
 "sAH" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
@@ -24162,6 +24724,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"sBd" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "sBk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2"
@@ -24218,6 +24784,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"sDb" = (
+/obj/structure/closet/crate/miningcar,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "sDc" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -24295,6 +24868,10 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"sHh" = (
+/obj/structure/barricade/bars,
+/turf/open/water,
+/area/f13/caves)
 "sIa" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -24311,8 +24888,8 @@
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/turf/open/water,
+/area/f13/wasteland)
 "sIN" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -24371,6 +24948,14 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"sKY" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "sLm" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
@@ -24476,15 +25061,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"sOg" = (
-/obj/item/ammo_casing/caseless{
-	dir = 4;
-	icon_state = "sS-casing"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "sOD" = (
 /obj/effect/landmark/observer_start,
 /obj/effect/decal/cleanable/dirt,
@@ -24504,11 +25080,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"sPD" = (
-/obj/structure/table/wood,
-/obj/item/flashlight,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "sPJ" = (
 /obj/machinery/mineral/wasteland_vendor/mining,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -24595,20 +25166,22 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"sSX" = (
+/obj/machinery/vending/nukacolavend,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/wasteland)
 "sTa" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
 "sTb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "sTk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -24632,6 +25205,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"sTM" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "sUd" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -24745,14 +25324,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"sWD" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/tunnel)
 "sWI" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -24950,6 +25521,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"tdP" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/brotherhood)
 "tdU" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -24968,6 +25544,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"teZ" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "tfn" = (
 /obj/structure/sink{
 	pixel_y = 28
@@ -25064,14 +25646,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "tjq" = (
-/obj/structure/fence/wooden{
-	dir = 1
-	},
-/obj/structure/fence/post{
-	icon_state = "end_wood"
+/obj/structure/chair/f13chair1{
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland)
 "tjy" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
@@ -25104,6 +25683,10 @@
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"tkq" = (
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "tkS" = (
 /obj/structure/table/wood,
 /obj/item/mining_scanner,
@@ -25176,6 +25759,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"tmQ" = (
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "tnu" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -25263,6 +25850,11 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/city)
+"tpO" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "tqu" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -25278,6 +25870,9 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
+"tri" = (
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "trr" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -25313,16 +25908,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"tsm" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/item/storage/belt/military/assault,
-/obj/item/clothing/under/f13/combat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "tsr" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/dirt,
@@ -25368,6 +25953,10 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"ttB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "ttU" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
@@ -25376,11 +25965,13 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"tul" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/closed/wall/f13/tentwall,
-/area/f13/building)
+"tus" = (
+/obj/item/flag/bos,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "tvl" = (
 /obj/effect/landmark/latejoin,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25520,6 +26111,10 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"tyW" = (
+/obj/structure/fence/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tzf" = (
 /obj/item/clothing/under/f13/police,
 /obj/item/clothing/head/f13/police,
@@ -25585,6 +26180,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"tBO" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tBP" = (
 /obj/structure/sign/poster/prewar/poster93{
 	pixel_x = 32
@@ -25592,6 +26191,11 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"tCb" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/vending/nukacolavendfull,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "tCc" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -3
@@ -25612,14 +26216,6 @@
 "tCq" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"tCr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
 /area/f13/wasteland)
 "tCu" = (
 /obj/structure/kitchenspike,
@@ -25683,14 +26279,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"tFv" = (
-/mob/living/simple_animal/hostile/mirelurk,
-/turf/open/water,
-/area/f13/caves)
 "tFA" = (
-/mob/living/simple_animal/hostile/supermutant/rangedmutant,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/closed/wall/f13/tentwall,
+/area/f13/building)
 "tFM" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/structure/table/wood/fancy,
@@ -25734,12 +26331,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"tGb" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "tHw" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -25807,17 +26398,33 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tJE" = (
-/obj/structure/closet/crate/bin{
-	anchorable = 0
+"tJA" = (
+/obj/structure/fence/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
-/obj/item/storage/bag/trash,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/brotherhood)
 "tJQ" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"tKd" = (
+/obj/structure/window/fulltile/wood/broken{
+	desc = "Feed me! FEED ME!";
+	layer = 2;
+	name = "feed trough"
+	},
+/obj/structure/fence/wooden{
+	density = 0;
+	dir = 4;
+	pixel_y = 16
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	layer = 2.1
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "tKk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -25830,6 +26437,28 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"tKp" = (
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "tKw" = (
 /obj/structure/chair{
 	dir = 4
@@ -25886,12 +26515,6 @@
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"tNZ" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/caves)
 "tOd" = (
 /obj/structure/table/wood,
 /obj/structure/decoration/rag{
@@ -25906,15 +26529,6 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tOv" = (
-/obj/structure/barricade/sandbags,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermaintop"
-	},
-/area/f13/wasteland)
 "tOH" = (
 /mob/living/simple_animal/hostile/cazador/young,
 /turf/open/indestructible/ground/outside/desert,
@@ -25956,13 +26570,6 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
-"tPZ" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "tQk" = (
 /obj/structure/table/wood,
 /obj/item/stack/f13Cash/aureus,
@@ -26000,6 +26607,11 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
+"tQy" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "tQU" = (
 /obj/structure/mirror,
 /turf/closed/wall/f13/wood,
@@ -26016,6 +26628,13 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"tRG" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 11
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "tRX" = (
 /obj/structure/chair{
 	dir = 4
@@ -26034,13 +26653,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tRZ" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "tSd" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26053,6 +26665,9 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"tSx" = (
+/turf/closed/wall/f13/wood,
+/area/f13/brotherhood)
 "tSQ" = (
 /obj/structure/closet,
 /obj/item/storage/box/gloves,
@@ -26157,15 +26772,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"tWX" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "tXe" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigars/cohiba,
@@ -26221,6 +26827,15 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/tcoms)
+"tZk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "tZI" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards,
@@ -26359,6 +26974,10 @@
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"udC" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "udY" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13,
@@ -26405,6 +27024,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"ufe" = (
+/obj/structure/fence/wooden{
+	density = 0;
+	dir = 4;
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/brotherhood)
 "uff" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -26434,12 +27061,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/water,
 /area/f13/caves)
-"ufV" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
 "ugm" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26458,17 +27079,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/bar)
-"ugT" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "uhi" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/water,
@@ -26514,6 +27124,13 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uik" = (
+/obj/machinery/microwave/stove,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "uit" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 1;
@@ -26528,13 +27145,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"ujU" = (
-/obj/structure/sign/poster/prewar/poster67,
-/turf/closed/wall/f13/store{
-	desc = "A pre-War wall made of solid concrete.";
-	name = "concrete wall"
-	},
-/area/f13/brotherhood)
 "uke" = (
 /obj/structure/closet/cabinet/anchored,
 /turf/open/indestructible/ground/outside/dirt,
@@ -26593,6 +27203,10 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/caves)
+"umk" = (
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "umD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -26682,6 +27296,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"upk" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "upG" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -26825,15 +27443,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"utZ" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib1-old"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "uug" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -26877,10 +27486,21 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"uvA" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2"
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "uvC" = (
 /obj/item/shovel,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"uvT" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "uvW" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -26929,14 +27549,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"uyc" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "uyg" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -26993,6 +27605,15 @@
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"uzh" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "uzn" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/floorgrime,
@@ -27116,10 +27737,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"uDN" = (
-/obj/structure/window/fulltile/ruins,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/brotherhood)
 "uEK" = (
 /obj/item/cigbutt,
 /obj/item/cigbutt,
@@ -27182,12 +27799,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"uFW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/wasteland)
 "uGc" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -27252,6 +27863,12 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13,
 /area/f13/ncr)
+"uHI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "uHT" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/desert,
@@ -27260,6 +27877,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"uIw" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "uIK" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/wooden,
@@ -27293,6 +27918,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"uJK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "uJP" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/dirt,
@@ -27406,18 +28037,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"uOX" = (
-/obj/item/folder/yellow,
-/obj/item/folder/yellow,
-/obj/item/folder/yellow,
-/obj/structure/table/wood,
-/obj/structure/table/wood,
-/obj/machinery/light/small/broken,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "uPj" = (
 /obj/structure/fence{
 	dir = 4
@@ -27479,6 +28098,10 @@
 /obj/machinery/microwave,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"uQG" = (
+/obj/machinery/grill,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "uRa" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
@@ -27510,6 +28133,10 @@
 /obj/item/flashlight,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"uSl" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "uSm" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27629,12 +28256,6 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"uVf" = (
-/obj/structure/fence/corner/wooden{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "uVo" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop3"
@@ -27713,6 +28334,10 @@
 "uXj" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"uXo" = (
+/obj/structure/simple_door/metal/fence,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "uXU" = (
 /obj/structure/table/wood,
 /obj/item/papercutter,
@@ -27762,10 +28387,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"uYW" = (
-/obj/structure/campfire/stove,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "uZg" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -27828,15 +28449,6 @@
 /obj/item/kitchen/knife,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vbO" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/f13/armor/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "vcJ" = (
 /obj/structure/sink{
 	dir = 4;
@@ -27873,6 +28485,9 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vdk" = (
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "vdE" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/trophy/gold_cup,
@@ -27982,6 +28597,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"vht" = (
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood)
+"vhB" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "vhC" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -28074,6 +28699,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
+"vlh" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vlz" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/f13/raiderrags,
@@ -28164,13 +28795,6 @@
 "vqM" = (
 /turf/open/floor/f13,
 /area/f13/building)
-"vqQ" = (
-/obj/item/ammo_casing/caseless{
-	dir = 4;
-	icon_state = "sS-casing"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "vrc" = (
 /obj/structure/rack,
 /obj/item/cultivator,
@@ -28190,16 +28814,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"vrM" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/item/clothing/shoes/f13/military,
-/obj/item/clothing/under/f13/combat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "vsm" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/fence/wooden{
@@ -28209,10 +28823,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "vsu" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/wasteland)
 "vsU" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/broken,
@@ -28543,6 +29156,15 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"vFQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "vGg" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/dirt{
@@ -28652,13 +29274,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"vIM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/wasteland)
 "vJb" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -28677,6 +29292,10 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
+"vJr" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vJB" = (
 /obj/machinery/button/door{
 	id = "bargambling";
@@ -28686,6 +29305,12 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/city)
+"vJO" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "locustgarage"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "vJP" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/desert,
@@ -28808,6 +29433,11 @@
 "vPY" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"vQv" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/f13Cash/random/low,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "vQE" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -28860,12 +29490,13 @@
 	},
 /area/f13/building)
 "vUj" = (
-/obj/structure/chair/wood/fancy{
-	icon_state = "officechair_dark"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
 /area/f13/brotherhood)
 "vUA" = (
@@ -28958,6 +29589,19 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
+"vXC" = (
+/obj/item/kirbyplants,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
+"vXZ" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vYe" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -29036,14 +29680,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wcK" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "wcO" = (
 /obj/structure/chair/stool,
 /mob/living/simple_animal/hostile/ghoul,
@@ -29067,10 +29703,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"wdE" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "wdJ" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
@@ -29086,18 +29718,6 @@
 	anchored = 1
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/caves)
-"wdX" = (
-/obj/structure/fence/post{
-	icon_state = "end_wood"
-	},
-/obj/structure/barricade/wooden,
-/obj/structure/destructible/tribal_torch{
-	layer = 4.5;
-	pixel_x = 1;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/wood,
 /area/f13/caves)
 "wef" = (
 /obj/effect/decal/remains/human,
@@ -29117,6 +29737,11 @@
 	icon_state = "horizontaloutermainright"
 	},
 /area/f13/wasteland)
+"wfY" = (
+/obj/structure/closet/crate/internals,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "wgf" = (
 /obj/machinery/light/sign/oasis_sign{
 	layer = 5
@@ -29253,32 +29878,14 @@
 /obj/item/clothing/suit/armor/bulletproof,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wmP" = (
+/obj/structure/wreck/trash/autoshaft,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "wnA" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wnG" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/building)
 "wnT" = (
 /obj/structure/decoration/vent,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29353,13 +29960,8 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/black,
 /area/f13/city)
-"wqo" = (
-/obj/structure/closet,
-/obj/item/clothing/under/f13/combat,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+"wqp" = (
+/turf/closed/wall/f13/wood/house/broken,
 /area/f13/brotherhood)
 "wqs" = (
 /obj/structure/chair/wood{
@@ -29431,6 +30033,14 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wtz" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 25;
+	pixel_y = 18
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wuk" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verylittleshadowleft"
@@ -29544,6 +30154,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"wyX" = (
+/obj/structure/table/wood,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "wzh" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13/wood{
@@ -29616,17 +30232,22 @@
 	},
 /area/f13/building)
 "wCb" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/structure/destructible/tribal_torch,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/building)
 "wCA" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 5
 	},
 /area/f13/village)
+"wCI" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "wDc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -29712,6 +30333,11 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/carpet/black,
 /area/f13/city)
+"wFP" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "wGc" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_north_middle"
@@ -29727,6 +30353,13 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"wHl" = (
+/obj/machinery/workbench,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "wHu" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -29762,11 +30395,18 @@
 /obj/structure/chair/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/ncr)
+"wIQ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/brotherhood)
 "wJp" = (
-/obj/structure/closet,
-/obj/item/clothing/under/f13/rag,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/sink/puddle,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wJz" = (
 /obj/structure/closet/crate/medical,
 /obj/item/storage/pill_bottle/chem_tin/fixer,
@@ -29776,18 +30416,36 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
+"wJJ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "wKo" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"wKw" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/brotherhood)
 "wKC" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
 /area/f13/caves)
+"wKG" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bosgarage";
+	name = "shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "wLu" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -29859,15 +30517,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/city)
-"wMG" = (
-/obj/structure/simple_door/interior,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "wML" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
@@ -30056,12 +30705,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"wSf" = (
-/obj/structure/bookcase,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "wSj" = (
 /obj/machinery/light/small,
 /obj/structure/table/wood/settler,
@@ -30118,22 +30761,20 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"wTJ" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "wTU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/city)
+"wUn" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/syringe/medx,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/brotherhood)
 "wUv" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/dirt,
@@ -30152,6 +30793,12 @@
 /obj/machinery/smartfridge/bottlerack,
 /turf/closed/wall/r_wall/rust,
 /area/f13/city)
+"wVm" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wVn" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
@@ -30211,15 +30858,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/village)
-"wXf" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "wXl" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -30301,15 +30939,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"wZS" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibdown1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "wZV" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -30332,12 +30961,19 @@
 "xaG" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"xaY" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood)
 "xbk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/caves)
+/area/f13/brotherhood)
 "xbA" = (
 /obj/structure/sign/poster/prewar/poster83,
 /turf/closed/wall/f13/supermart,
@@ -30410,24 +31046,13 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/ncr)
-"xdr" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+"xdf" = (
+/obj/structure/wreck/trash/one_tire,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
-	icon_state = "warningline_red"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "NW"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xdt" = (
 /obj/structure/rack,
 /obj/item/shovel,
@@ -30471,6 +31096,24 @@
 "xes" = (
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/legion)
+"xet" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
+"xeC" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "xeG" = (
 /obj/structure/chair{
 	dir = 8
@@ -30495,12 +31138,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xfd" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "xff" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -30537,6 +31174,12 @@
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xfW" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "xgB" = (
 /obj/structure/chair{
 	dir = 4
@@ -30556,15 +31199,6 @@
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/wasteland)
-"xgR" = (
-/obj/structure/fence/end{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
 "xgV" = (
@@ -30623,6 +31257,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xiG" = (
+/obj/structure/wreck/car/bike{
+	pixel_x = -12;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xiH" = (
 /obj/structure/rack,
 /obj/item/clothing/under/lawyer/female{
@@ -30679,6 +31320,20 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xkz" = (
+/obj/machinery/light/small,
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_y = -33
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/button/door{
+	id = "bosvillage";
+	pixel_x = -30;
+	req_access_txt = "120"
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "xkC" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -30689,11 +31344,6 @@
 /obj/structure/stone_tile/surrounding_tile,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"xkT" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/warning,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "xlb" = (
 /obj/structure/sink/well{
 	pixel_x = -15
@@ -30745,16 +31395,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xnn" = (
-/obj/structure/chair/wood/worn{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "xnp" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -30803,6 +31443,13 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/village)
+"xoh" = (
+/obj/machinery/button/door{
+	id = "bosgarage";
+	pixel_y = 30
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "xor" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
@@ -30890,15 +31537,6 @@
 /obj/structure/sign/poster/contraband/pinup_pink,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
-"xrp" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "xrA" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30908,6 +31546,13 @@
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xrP" = (
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "xsd" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedvertical"
@@ -30954,22 +31599,6 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
-"xtw" = (
-/obj/structure/table/wood,
-/obj/item/lighter/greyscale{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/pill/patch/jet{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/pill/patch/jet,
-/obj/item/candle{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "xtV" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -31072,13 +31701,6 @@
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xzI" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	obj_integrity = 800
-	},
-/turf/open/water,
-/area/f13/caves)
 "xzM" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
@@ -31121,6 +31743,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xBb" = (
+/obj/machinery/smartfridge/bottlerack/gardentool,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "xBC" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -31145,6 +31775,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"xDz" = (
+/obj/structure/window/fulltile,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "xDA" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/f13{
@@ -31221,6 +31857,14 @@
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
+"xFV" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xGr" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -31229,12 +31873,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"xGt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
 "xGy" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/window/fulltile/wood{
@@ -31540,6 +32178,12 @@
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"xQh" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "xQo" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -31597,15 +32241,11 @@
 	},
 /area/f13/wasteland)
 "xSI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xTj" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
@@ -31628,6 +32268,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
+"xTs" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "xTB" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table/wood,
@@ -31723,6 +32373,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xWm" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "xWu" = (
 /obj/structure/chair,
 /turf/open/floor/f13/wood,
@@ -31797,6 +32451,11 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/legion)
+"xZc" = (
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/brotherhood)
 "xZu" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
@@ -31890,6 +32549,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/city)
+"yaY" = (
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/wood,
+/area/f13/tunnel)
 "ybg" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -31938,23 +32601,32 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/village)
+"yco" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
+"ycw" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/sunset{
+	pixel_y = 17
+	},
+/obj/item/reagent_containers/food/drinks/bottle/sunset,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ycD" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_south"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"ycI" = (
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+"ydC" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
 	},
-/obj/item/pen,
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
 "ydH" = (
 /obj/structure/musician/piano{
@@ -31990,15 +32662,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"yeu" = (
-/obj/structure/closet,
-/obj/item/clothing/under/f13/combat,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "yeJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
@@ -32090,21 +32753,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"yiO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"yiY" = (
-/obj/structure/reagent_dispensers/barrel/three,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
 "yjA" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/dirt,
@@ -60981,10 +61629,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -61234,10 +61882,10 @@ gbL
 gcK
 gcK
 gcK
-gcK
-gcK
-gbL
-gcK
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -61489,8 +62137,8 @@ gcK
 gcK
 gbL
 gbL
+ktB
 gbL
-gbL
 gcK
 gcK
 gcK
@@ -61499,8 +62147,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -61746,7 +62394,7 @@ gcK
 gcK
 gcK
 gcK
-gbL
+ktB
 gcK
 gcK
 gcK
@@ -61757,7 +62405,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -61995,16 +62643,6 @@ ktB
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
 gbL
 gcK
 gcK
@@ -62012,9 +62650,19 @@ gcK
 gcK
 gcK
 gcK
-gbL
+ktB
+ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
 gcK
 gcK
 gcK
@@ -62259,6 +62907,7 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
@@ -62269,10 +62918,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -62514,22 +63162,22 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -62769,25 +63417,25 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
+gcK
+gcK
+ktB
+ktB
 gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gcK
 gcK
 gcK
 gcK
@@ -63024,27 +63672,27 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
+gcK
+gcK
+gcK
+ktB
 ktB
 gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+lsg
+oih
+lsg
+cDg
+qmD
+gcK
+gcK
+gcK
+ktB
 gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -63060,7 +63708,7 @@ gcK
 gcK
 cpK
 cpK
-gcK
+ggK
 gcK
 gcK
 gcK
@@ -63284,26 +63932,21 @@ gcK
 gcK
 gcK
 ktB
-gcK
-gcK
-gcK
-ktB
-gbL
-gbL
-gcK
 ktB
 gcK
 gcK
 gcK
-ktB
 gcK
 gcK
-ktB
 gcK
-ktB
+qmD
+lsg
+xfW
+lsg
+pSS
+qmD
 gcK
 gcK
-ktB
 gbL
 gcK
 gcK
@@ -63314,10 +63957,15 @@ gcK
 gcK
 gcK
 gcK
+gbL
 gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+ggK
+ggK
 gcK
 gcK
 uIh
@@ -63537,31 +64185,31 @@ ktB
 gcK
 gcK
 gcK
-ktB
-ktB
 gcK
 gcK
 gcK
 ktB
-ktB
-ktB
-ktB
-ktB
 gcK
 gcK
-ktB
-ktB
 gcK
 gcK
-ktB
-gbL
-ktB
 gcK
-ktB
-gbL
-ktB
-ktB
-ktB
+gcK
+gcK
+qmD
+uHI
+pnr
+lsg
+cKH
+qmD
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -63792,10 +64440,6 @@ ktB
 (124,1,1) = {"
 ktB
 gcK
-gbL
-gcK
-gbL
-ktB
 gcK
 gcK
 gcK
@@ -63809,16 +64453,20 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+qmD
+lsg
+lsg
+lsg
+dvX
+qmD
 gcK
 gbL
 gcK
 ktB
+ktB
+gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -64049,35 +64697,35 @@ ktB
 (125,1,1) = {"
 ktB
 gcK
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+gRe
+qmD
+gRe
+qmD
+qmD
+qmD
+qmD
+qmD
+gcK
+ktB
+gcK
+gbL
+gcK
+gcK
+gcK
 gbL
 gcK
 gcK
@@ -64307,34 +64955,34 @@ ktB
 ktB
 gcK
 gcK
-ktB
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gcK
 ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+aYD
+tdP
+aYD
+qmD
+aga
+edI
+cNG
+qmD
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gcK
 gcK
@@ -64564,34 +65212,34 @@ ktB
 ktB
 gcK
 gcK
-gbL
-gcK
-gcK
-gcK
-gcK
-rDr
-fyf
-fyf
-fyf
-fyf
-apX
-apX
-apX
-fyf
-tVV
-yeJ
-yeJ
-yeJ
-ssm
-iFr
-jJb
-iFr
-fyf
-iFr
-gcK
-gbL
-gbL
 ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+tdP
+tdP
+tdP
+qmD
+aga
+edI
+aga
+qmD
+gcK
+gcK
+gbL
+gcK
+gbL
+gbL
+gcK
 gcK
 gcK
 gcK
@@ -64819,36 +65467,36 @@ ktB
 "}
 (128,1,1) = {"
 ktB
-gcK
-gcK
-ktB
 ktB
 ktB
 gcK
 gcK
-rRE
-rRE
-rRE
-puy
-rRE
-rRE
-rRE
-rRE
-rRE
-jnP
-uCW
-uCW
-uCW
-nPX
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
-ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+rRE
+tdP
+tdP
+qmD
+sdQ
+edI
+ivM
+qmD
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -65079,32 +65727,32 @@ ktB
 gcK
 gcK
 gcK
-ktB
 gcK
 gcK
 gcK
-rRE
-wSf
-oAo
-aBK
-gcC
-coW
-oAo
-ycI
-rRE
-kdJ
-uCW
-gdY
-uCW
-nPX
-fyf
-fyf
-fyf
-fyf
-ofd
 gcK
+gcK
+gcK
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
+dGo
+tdP
+tdP
+qmD
+ivM
+edI
+vQv
+qmD
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gbL
@@ -65335,30 +65983,30 @@ ktB
 ktB
 gcK
 gcK
-gbL
 gcK
 gcK
 gcK
 gcK
-rRE
-wSf
-oAo
+gcK
+gcK
+gcK
+qmD
 vUj
-hIV
-xnn
-oAo
-uOX
-rRE
-kdJ
-uCW
-pjQ
-pjQ
-nPX
-iFr
-apX
-xfd
-fyf
-iFr
+edc
+gFl
+gFl
+qmD
+tdP
+tdP
+tdP
+qmD
+bvh
+edI
+edI
+qmD
+gcK
+ktB
+gcK
 gcK
 gbL
 gcK
@@ -65591,35 +66239,35 @@ ktB
 (131,1,1) = {"
 ktB
 gbL
-gbL
 gcK
 gcK
 gcK
 gcK
 gcK
-rRE
-goJ
-oAo
-oAo
-hEL
-oAo
-oAo
-iMS
-rRE
-kdJ
-uaf
-jPN
-cNE
-nPX
-fyf
-fyf
-iFr
-fyf
-fyf
 gcK
 gcK
+gcK
+qmD
+izg
+edc
+edc
+edc
+qmD
+tdP
+tdP
+tdP
+qmD
+qmD
+qmD
+fiw
+qmD
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -65850,33 +66498,33 @@ ktB
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+qmD
+qmD
+qmD
+hzR
+edc
+edc
+qmD
+tdP
+tdP
+tdP
+qmD
+tdP
+tdP
+tdP
+qmD
+gcK
 ktB
 gcK
-gcK
-gcK
-rRE
-goJ
-oAo
-oAo
-oAo
-oAo
-oAo
-lXR
-rRE
-kdJ
-pjQ
-uCW
-uCW
-nPX
-fyf
-fyf
-fyf
-fyf
-kpM
 gcK
 gbL
 gcK
-ktB
+gcK
 gcK
 gcK
 gbL
@@ -66106,33 +66754,33 @@ ktB
 ktB
 gcK
 gcK
-ktB
-ktB
 gcK
 gcK
 gcK
-rRE
+gcK
+gcK
+qmD
 iMS
-oAo
+edc
 lZu
-fRX
-lZu
-oAo
-rgq
-rRE
-kdJ
-pjQ
-uCW
-pjQ
-nPX
-fyf
-fyf
-hAC
-fyf
-iFr
-gcK
+edc
+edc
+edc
+ixi
+tdP
+tdP
+tdP
+ixi
+tdP
+tdP
+cjE
+qmD
 gcK
 ktB
+ktB
+gcK
+gcK
+gcK
 gbL
 gcK
 gcK
@@ -66363,34 +67011,34 @@ ktB
 ktB
 gcK
 gcK
-gbL
-csk
 gcK
 gcK
 gcK
-rRE
-rRE
-aYw
-rRE
-nIs
-rRE
-rRE
-rRE
-rRE
-tOv
-thW
-uCW
-pjQ
-nPX
-pEv
-quW
-fyf
-fyf
-fyf
 gcK
+gcK
+qmD
+nRV
+edc
+lZu
+edc
+swT
+wUn
+qmD
+cUC
+tdP
+tdP
+qmD
+ath
+cUC
+cLv
+qmD
 gcK
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -66620,33 +67268,33 @@ ktB
 ktB
 gbL
 gcK
-gbL
-csk
-csk
 gcK
 gcK
-rRE
-wcK
-fRX
-rRE
-xGt
-uDN
-vIM
-uFW
-mji
-kdJ
-eZi
-uCW
-uCW
-nPX
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
+gcK
+gcK
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
+kWB
+kWB
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
 ktB
+ktB
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -66877,32 +67525,32 @@ ktB
 ktB
 gbL
 gcK
-ktB
-csk
-csk
 gcK
 gcK
-rRE
-cPc
-oAo
-piv
-xGt
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+cSR
+edI
 piv
 xSI
 sTb
-nHP
-kdJ
-uCW
-uaf
-pjQ
-nPX
-fyf
-fyf
-fyf
-fyf
-iFr
+qmD
+edI
+edI
+aga
+qmD
+udC
+edI
+haO
+ote
+qmD
 gcK
 ktB
+gcK
 gcK
 gcK
 gcK
@@ -67134,32 +67782,32 @@ ktB
 ktB
 gcK
 gcK
-gbL
-csk
-csk
 gcK
 gcK
-rRE
-wcK
-oAo
-rRE
-cbj
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+edI
+edI
 fAA
-vIM
+edI
 ayz
-jVB
-kdJ
-cNE
-uCW
-pjQ
-nPX
-fyf
-fyf
-fyf
-fyf
-fyf
+qmD
+dxK
+edI
+aga
+qmD
+mro
+edI
+edI
+phx
+qmD
 gcK
 ktB
+gcK
 gcK
 kex
 xKr
@@ -67390,33 +68038,33 @@ ktB
 (138,1,1) = {"
 ktB
 gcK
-ktB
-gbL
-csk
-csk
-ggK
 gcK
-rRE
-yeu
-oAo
-jxE
-xGt
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
 piv
-kYh
-sTb
-nHP
-kdJ
-uCW
-uCW
-pjQ
-nPX
-fyf
-sTv
-fyf
-fyf
-fyf
+piv
+piv
+edI
+edI
+qmD
+mro
+edI
+edI
+poQ
+edI
+edI
+edI
+edI
+qmD
 gcK
-ktB
+gcK
+gcK
 gcK
 ggK
 nHC
@@ -67647,33 +68295,33 @@ ktB
 (139,1,1) = {"
 ktB
 gcK
-ktB
 gcK
-csk
-csk
-ggK
 gcK
-rRE
-spl
-oAo
-rRE
-glM
-uDN
-tCr
-uFW
-aqD
-kdJ
-pls
-uaf
-cNE
-nPX
-fyf
-fyf
-fyf
-fyf
-iFr
 gcK
-ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+edI
+edI
+fAA
+edI
+edI
+kWB
+edI
+edI
+edI
+poQ
+edI
+edI
+edI
+ijM
+qmD
+gcK
+gbL
+gcK
 gcK
 gcK
 ggK
@@ -67904,34 +68552,34 @@ ktB
 (140,1,1) = {"
 ktB
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+cSR
+edI
+aAz
+edI
+lay
+qmD
+edI
+edI
+gHC
+qmD
+tZk
+edI
+edI
+edI
+qmD
+gcK
+gcK
 ktB
 gcK
-csk
-csk
-gcK
-gcK
-rRE
-wqo
-oAo
-rRE
-aYw
-rRE
-rRE
-rRE
-rRE
-tOv
-eZi
-uCW
-lEG
-nPX
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gbL
-ktB
 gcK
 gcK
 xRg
@@ -67939,9 +68587,9 @@ wnA
 ggK
 ggK
 gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -68160,50 +68808,50 @@ ktB
 "}
 (141,1,1) = {"
 ktB
+tSx
+tSx
+otZ
+ctJ
+tSx
 gcK
-gbL
+gcK
+gcK
+gcK
+qmD
+qmD
+qmD
+qmD
+edI
+oAo
+qmD
+edI
+edI
+fuw
+qmD
+edI
+ddG
+edI
+niV
+qmD
+gcK
+gcK
 ktB
-csk
-csk
-gcK
-gcK
-rRE
-ujU
-oAo
-oAo
-oAo
-lhm
-jaJ
-oAo
-rRE
-kdJ
-pjQ
-uCW
-uCW
-nPX
-fyf
-fyf
-fyf
-fyf
-jJb
+ktB
 gcK
 gcK
 gcK
+ktB
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
-gcK
-ggK
-ggK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -68417,51 +69065,51 @@ ktB
 "}
 (142,1,1) = {"
 ktB
+otZ
+blf
+ojV
+tri
+itO
+spz
+gcK
+gcK
+gcK
+gcK
+gcK
+qmD
+qmD
+kWB
+qmD
+qmD
+poQ
+poQ
+qmD
+qmD
+edI
+edI
+edI
+guk
+qmD
+gcK
+gcK
 gcK
 ktB
-gcK
-csk
-csk
-gcK
-gcK
-rRE
-rRE
-rRE
-rRE
-rRE
-rRE
-rRE
-xrp
-rRE
-kdJ
-pjQ
-pjQ
-pjQ
-nPX
-fyf
-uey
-lRT
-fyf
-fyf
-gcK
-gcK
+ktB
+ktB
 ktB
 ktB
 gcK
 gcK
 gcK
-ggK
-ggK
-gcK
-fyf
-fyf
+cLz
+cLz
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -68674,52 +69322,52 @@ ktB
 "}
 (143,1,1) = {"
 ktB
+tSx
+tri
+hUj
+tri
+mez
+qpw
+bdc
+gcK
+gcK
+gcK
+gcK
+qmD
+wJJ
+edI
+wJJ
+qmD
+aCQ
+scx
+qmD
+qmD
+qmD
+edI
+edI
+phx
+qmD
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+hsG
+fyf
+fyf
+wmP
+gdN
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 ktB
-gbL
-tFv
-csk
-gcK
-gcK
-rRE
-irn
-irn
-fps
-rbV
-oAo
-oAo
-oAo
-rRE
-kdJ
-pjQ
-cNE
-uaf
-nPX
-fyf
-fyf
-lHo
-ghx
-fyf
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-ggK
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -68931,32 +69579,32 @@ ktB
 "}
 (144,1,1) = {"
 ktB
+ctJ
+tri
+tri
+tri
+cVL
+rXU
+aRu
+mNA
 gcK
 gcK
-ggK
-csk
-csk
 gcK
-gcK
-rRE
-nRK
-irn
-rRE
-rRE
+qmD
 mkJ
-rRE
-rRE
-rRE
-kdJ
-uCW
-cNE
-uCW
-nPX
-fyf
-fyf
-ghx
-ghx
-uey
+edI
+qmD
+qmD
+rXU
+rXU
+xet
+hfO
+qmD
+pVG
+edI
+edI
+qmD
+gcK
 gcK
 gcK
 gcK
@@ -68977,8 +69625,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -69188,46 +69836,46 @@ ktB
 "}
 (145,1,1) = {"
 ktB
+otZ
+hUj
+tri
+tri
+ruM
+rXU
+aRu
+mNA
+mNA
+rOR
 gcK
-gcK
-csk
-csk
-csk
-gcK
-gcK
-rRE
+qmD
 irn
-oNj
-ptT
-auA
-irn
-irn
-nRK
-rRE
-kdJ
-uCW
-pjQ
-uCW
-nPX
-cTp
-ghx
-ghx
-fyf
-cTp
+qmD
+qmD
+hfO
+rXU
+rXU
+aRu
+hfO
+qmD
+iWA
+edI
+edI
+qmD
 gcK
 gcK
-ktB
+gcK
+gcK
 gcK
 gcK
 gcK
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+lbl
+xhh
+xhh
+xhh
+oFP
+oFP
+oFP
 ntZ
 fyf
 fyf
@@ -69235,7 +69883,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -69445,55 +70093,55 @@ ktB
 "}
 (146,1,1) = {"
 ktB
+otZ
+nJJ
+tri
+tmQ
+ruM
+rXU
+aRu
+mNA
+mNA
+gjd
+gcK
+qmD
+qmD
+qmD
+hfO
+hfO
+rXU
+rXU
+aRu
+rOR
+qmD
+wKG
+wKG
+wKG
+qmD
+gcK
+gcK
+gcK
+gbL
+gbL
+gcK
+fyf
+fyf
+fyf
+iKv
+oUp
+sYV
+lTK
+sYV
+oFP
+fyf
+fyf
+fyf
+fyf
+gcK
 gcK
 gcK
 ktB
-csk
-csk
-gcK
-gcK
-rRE
-pwe
-irn
-rRE
-irn
-xdr
-irn
-lUh
-rRE
-kdJ
-uCW
-pjQ
-uCW
-nPX
-cTp
-ghx
-mJW
-fyf
-cTp
-gcK
-gcK
-gbL
-gbL
-gcK
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -69702,55 +70350,55 @@ ktB
 "}
 (147,1,1) = {"
 ktB
+ctJ
+tKd
+ufe
+tKd
+nAs
+rXU
+dMw
+iXj
+iXj
+iXj
+iXj
+iXj
+iXj
+iXj
+iXj
+aVy
+rXU
+rXU
+uzh
+mNA
+qmD
+xoh
+rXU
+rXU
+qmD
 gcK
 gcK
 gcK
-csk
-csk
 gcK
 gcK
-rRE
-irn
-oNj
-ptT
-yiO
-iQw
-yiO
-otg
-rRE
-kdJ
-uCW
-cNE
-uCW
-nPX
-cTp
-ghx
+gcK
+irv
+mCv
+fyf
+shF
+sYV
+sYV
+sYV
+rzg
+oFP
 fyf
 fyf
-cTp
+sqA
+fyf
+pEv
+gcK
 gcK
 gcK
 ktB
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-qOV
-cWG
-cWG
-wDc
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -69959,56 +70607,56 @@ ktB
 "}
 (148,1,1) = {"
 ktB
+tSx
+tJA
+tJA
+tJA
+hqb
+rXU
+rXU
+jbR
+dsD
+dsD
+mMy
+dsD
+njU
+nev
+iXj
+cCK
+rXU
+rXU
+aRu
+mNA
+nGM
+rXU
+rXU
+rXU
+aoO
 gcK
-ktB
-gcK
-csk
-csk
 gcK
 gcK
-rRE
-nRK
-irn
-rRE
-cot
-aRl
-irn
-bSu
-rRE
-kdJ
-uCW
-cNE
-uCW
-gdb
-ghx
-rYT
+gcK
+gcK
+gcK
 fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-cix
 fyf
 fyf
 tFA
-fyf
-qOV
+sYV
+sYV
 hpM
-mvv
-mvv
-dXZ
-cWG
-wDc
+sYV
+oFP
 fyf
 fyf
 fyf
+fyf
+pEv
+pEv
 gcK
 gcK
-gcK
-gcK
+ktB
+ktB
 gcK
 gbL
 gbL
@@ -70217,55 +70865,55 @@ ktB
 (149,1,1) = {"
 ktB
 gcK
-gbL
-ktB
-csk
-csk
-ggK
+mNA
+cRT
+mNA
+aVy
+rXU
+rpv
+iXj
+uik
+dsD
+abM
+dsD
+abM
+abM
+iXj
+aVy
+rXU
+rXU
+aRu
+mNA
+aVy
+rXU
+rXU
+rXU
+aRu
+dOu
+vaA
 gcK
-rRE
-rRE
-rRE
-rRE
-rRE
-rRE
-rRE
-rRE
-rRE
-jnP
-pjQ
-pjQ
-cNE
-nPX
+gcK
+gcK
+vaA
+xdf
+iGM
+fyf
+shF
+fVO
+oFP
+oFP
+oFP
+oFP
+upk
+fyf
+lHo
+ahE
+fyf
 pEv
-fyf
-uey
-fyf
-gix
+pEv
 gcK
 gcK
 ktB
-gcK
-fyf
-fyf
-hAC
-fyf
-sOg
-cWG
-daU
-mvv
-hfy
-mvv
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
 gcK
 gcK
 gbL
@@ -70474,56 +71122,56 @@ ktB
 (150,1,1) = {"
 ktB
 gcK
-gbL
-ktB
-csk
-csk
-ggK
-wnA
-tFR
-xkT
-rBO
-fyf
-fyf
-tVV
-yeJ
-yeJ
-yeJ
-lae
-pjQ
-jPN
-pjQ
-soC
-sYX
-sYX
-sYX
-sYX
-sYX
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-qOV
+aZW
+jsS
+aZW
+aVy
+rXU
+aRu
+iXj
+tRG
+dsD
+abM
+dsD
+njU
+xeC
+iXj
+cks
+rXU
+rXU
+sTM
+qpw
+iQc
+rXU
+rXU
+rXU
+sTM
+nop
+vaA
+vaA
+vaA
+vaA
+vaA
+tus
+cWG
+cWG
 jLO
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-bpD
-fyf
-upX
-fyf
-fyf
+cWG
+cWG
+cWG
+cWG
+cWG
+cWG
+cWG
+cWG
+cWG
+cWG
+wDc
+pEv
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gbL
@@ -70731,57 +71379,57 @@ ktB
 (151,1,1) = {"
 ktB
 gcK
-gcK
-gcK
-csk
-csk
-ggK
-gcK
-sYX
-sYX
-sYX
-sYX
-sYX
-sYX
-uCW
-uCW
-uCW
-uCW
-cNE
-pjQ
-pjQ
-nPX
-iUD
-tWX
-wZS
-qqh
-sYX
+aZW
+jsS
+aZW
+aVy
+rXU
+aRu
+iXj
+wFP
+dsD
+abM
+dsD
+dsD
+dsD
+huY
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+lbu
+rXU
+rXU
+rXU
+rXU
+ydC
+rXU
+qaw
+eVk
+rXU
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+fEk
+bpD
+fyf
+uHT
 gcK
 gcK
 ktB
-gcK
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-rsm
-mvv
-oWq
-mvv
-aBH
-rgh
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gbL
 gbL
@@ -70988,39 +71636,44 @@ ktB
 (152,1,1) = {"
 ktB
 gcK
-gcK
-ktB
-csk
-csk
-gcK
-gcK
-sYX
-ugT
-dgX
-deO
-dZI
-sYX
-uCW
-pjQ
-bFJ
-pjQ
-uCW
-uaf
-pjQ
-nPX
-sYX
-bqW
-bqW
-mYk
-sYX
-gcK
-gcK
-ktB
-gcK
-upX
-fyf
-qOV
-gwr
+aZW
+jsS
+aZW
+aVy
+rXU
+aRu
+iXj
+iQx
+dsD
+abM
+dsD
+njU
+xeC
+iXj
+xbk
+rXU
+rXU
+ivu
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 mvv
 mvv
 mvv
@@ -71028,14 +71681,9 @@ mvv
 mvv
 mvv
 bpD
-cix
 fyf
-fWI
-fyf
-fyf
-fyf
-fyf
-fyf
+sim
+gcK
 gcK
 gcK
 gcK
@@ -71245,59 +71893,59 @@ ktB
 (153,1,1) = {"
 ktB
 gcK
-gcK
-ktB
-csk
-csk
-gcK
-gcK
-sYX
-bqW
-utZ
-fkr
-fkr
-gUi
-uCW
-pjQ
-uCW
-uyc
-uCW
-uaf
-uCW
-nPX
-sYX
-bqW
-bqW
-iod
-sYX
-gcK
-gcK
-ktB
-gcK
-fyf
-tFA
-tBN
-mvv
-oWq
+aZW
+jsS
+aZW
+aVy
+rXU
+aRu
+iXj
+yco
+dsD
+abM
+dsD
+abM
+abM
+iXj
+aVy
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+aiI
+rXU
+rXU
+aCf
+rXU
 mvv
 mvv
-vqQ
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 mvv
 mvv
 bpD
 fyf
+dDC
 fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-tFA
+sim
 gcK
 gcK
-gcK
-gcK
+ktB
+ktB
 gcK
 gbL
 gbL
@@ -71501,61 +72149,61 @@ ktB
 "}
 (154,1,1) = {"
 ktB
-gbL
 gcK
-ktB
-csk
-csk
-gcK
-gcK
-sYX
-wXf
-fkr
-jEC
-jEC
-wMG
-uCW
-uaf
-uCW
-pjQ
-orP
-fZm
-cNE
-nPX
-sYX
-sYX
-sYX
-sYX
-sYX
-gcK
-gcK
-ktB
-gcK
-gcK
-rtR
-tBN
-mvv
-mvv
-mvv
-aBH
+ixs
+mNA
+mNA
+aVy
+rXU
+aRu
+iXj
+mlI
+orX
+nsP
+dsD
+njU
+nev
+iXj
+aVy
+rXU
+rXU
+hIN
+fCt
+vFQ
+fCt
+fCt
+fCt
+vFQ
+fCt
+vaA
+vaA
+vaA
+vaA
+vaA
+hYl
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
 xGH
 mvv
-wdE
+mvv
+mvv
 bpD
 fyf
 fyf
-qOV
-cWG
-cWG
-cWG
-wDc
-fyf
-fyf
-fyf
+sim
+dDC
 gcK
 gcK
 gcK
-gcK
+ktB
+ktB
 gbL
 gbL
 gbL
@@ -71759,61 +72407,61 @@ ktB
 (155,1,1) = {"
 ktB
 gcK
+qpw
+qpw
+qpw
+iQc
+rXU
+sTM
+iXj
+iXj
+iXj
+iXj
+iXj
+iXj
+iXj
+iXj
+iQc
+rXU
+rXU
+aRu
+iXj
+iXj
+fhi
+mrG
+fhi
+iXj
+iXj
+vaA
+gcK
+gcK
+gcK
+vaA
+jvO
+cTp
+fyf
+fyf
+qIx
+cTp
+gCh
+gCh
+xhh
+oFP
+wCI
+mvv
+mvv
+mvv
+bpD
+fyf
+uHT
+fyf
+fyf
+dDC
+gcK
+gcK
+gcK
 ktB
-gbL
-csk
-csk
-gcK
-gcK
-sYX
-bUL
-hbt
-bqW
-tsm
-sYX
-pEK
-uCW
-cNE
-uCW
-uCW
-uaf
-uCW
-nPX
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-qOV
-rwE
-mvv
-vbO
-mfD
-hCg
-tBN
-hfy
-mvv
-bpD
-eGx
-fyf
-tBN
-izn
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
+ktB
 gbL
 gbL
 gcK
@@ -72016,61 +72664,61 @@ ktB
 (156,1,1) = {"
 ktB
 gcK
+rXU
+rXU
+gpI
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+gpI
+rXU
+rXU
+rXU
+uXo
+rXU
+rXU
+rXU
+dMw
+iXj
+fov
+dsD
+gyV
+abM
+xkz
+iXj
 gcK
 gcK
-csk
-csk
 gcK
-gcK
-sYX
-wXf
-bqW
-bqW
-bqW
-sYX
-uCW
-uaf
-uaf
-pjQ
-uaf
-jPN
-uCW
-soC
-sYX
-sYX
-sYX
-sYX
-fyf
-gcK
-gcK
-ktB
 gbL
 gcK
-nlO
-mOU
-mfD
-hCg
+pEv
+cTp
 fyf
+coJ
 fyf
-nlO
-mfD
-mfD
-hCg
-fyf
-fyf
+cTp
+gCh
+wHl
+sYV
+oFP
 tBN
 mvv
-wdE
+mvv
 mvv
 bpD
 fyf
 fyf
 fyf
+uHT
 fyf
-fyf
+uHT
 gcK
 gcK
 gcK
+ktB
 gcK
 gbL
 gbL
@@ -72273,61 +72921,61 @@ ktB
 (157,1,1) = {"
 ktB
 gcK
-gcK
-ktB
-csk
-csk
-gYK
-gcK
-sYX
-bUL
-vrM
-bqW
-gVz
-sYX
-uCW
-uCW
-uCW
-pjQ
-jPN
-dvC
-uCW
-nPX
-aHC
-mYk
-tPZ
-sYX
-fyf
-gcK
-gcK
-ktB
+rXU
+qmD
+qmD
+xDz
+xDz
+qmD
+lVb
+qmD
+lVb
+qmD
+xDz
+xDz
+qmD
+qmD
+xbk
+rXU
+rXU
+rXU
+ifQ
+dsD
+dsD
+dsD
+dsD
+dsD
+iXj
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+cTp
+jqh
 fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hJm
+cTp
+oFP
+iyf
+sYV
+sAk
 tBN
-hfy
 mvv
-aBH
-hCg
+mvv
+mvv
+doX
+cWG
+cWG
+cWG
+wDc
 fyf
-fyf
-fyf
-fyf
-fyf
+dDC
+uHT
 gcK
 gcK
-gcK
+ktB
 gcK
 gbL
 gbL
@@ -72530,61 +73178,61 @@ ktB
 (158,1,1) = {"
 ktB
 gcK
-gbL
-ktB
-csk
-csk
-gcK
-gcK
-fJP
-wXf
-bfV
-bqW
-bqW
-sYX
-uaf
-cNE
-pjQ
-cam
-uCW
-pjQ
-uCW
-nPX
-aHC
-rAH
-tPZ
-sYX
-pEv
-gcK
-gcK
-ktB
-ktB
+aBW
+okd
+cYa
+jsz
+cYa
+grG
+iBi
+iBi
+iBi
+grG
+jsz
+cYa
+cYa
+okd
+aVy
+rXU
+rXU
+rXU
+ifQ
+dsD
+dsD
+dsD
+kHX
+dPu
+iXj
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+eos
 fyf
 fyf
 fyf
-fyf
-fyf
+oFP
 eeo
-jZN
-fyf
-fyf
-sND
-nlO
-mfD
-mfD
-hCg
-fyf
-fyf
-rsE
+sYV
+shF
+tBN
+mvv
+hDb
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
 fyf
 fyf
 fyf
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gbL
@@ -72787,61 +73435,61 @@ ktB
 (159,1,1) = {"
 ktB
 gcK
-gbL
-gbL
-csk
-csk
+rXU
+xDz
+cYa
+vXC
+lva
+uSl
+aqh
+bpk
+tCb
+uSl
+vht
+lva
+cYa
+xDz
+aVy
+jNw
+rXU
+rpv
+iXj
+drA
+dsD
+nsP
+kHX
+obb
+iXj
 gcK
 gcK
-sYX
-nOH
-nFX
-ifi
-pHK
-sYX
-cam
-uCW
-pjQ
-uaf
-pjQ
-pjQ
-uCW
-nPX
-jkv
-bqW
-exz
-sYX
 gcK
 gcK
 gcK
-ktB
-ktB
 gcK
-gbL
 gcK
 gcK
 nYt
+ycw
 fyf
+oFP
+oFP
+oFP
+shF
+tBN
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+dIw
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+eSZ
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
@@ -73044,61 +73692,61 @@ ktB
 (160,1,1) = {"
 ktB
 gcK
+rXU
+xDz
+dvx
+pBl
+lva
+gzn
+lva
+xTs
+aTG
+ihL
+lva
+lva
+lVx
+xDz
+aVy
+rXU
+rXU
+aRu
+iXj
+iXj
+fhi
+iXj
+fhi
+iXj
+iXj
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+tFR
+tFR
+onY
+fyf
+tBN
+mvv
+mvv
+gdH
+mvv
+mvv
+mvv
+mvv
+bpD
+fyf
+fyf
+gcK
+gcK
+gcK
 ktB
-ktB
-csk
-csk
-gcK
-gcK
-sYX
-sYX
-sYX
-sYX
-sYX
-sYX
-yiY
-uCW
-uCW
-uCW
-uCW
-uCW
-gyZ
-nPX
-sYX
-sYX
-sYX
-sYX
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-qTY
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -73301,61 +73949,61 @@ ktB
 (161,1,1) = {"
 ktB
 gcK
+rXU
+qmD
+jsz
+lva
+lva
+lva
+lva
+lva
+lva
+lva
+lva
+lva
+jsz
+qmD
+aVy
+rXU
+rXU
+sTM
+qpw
+qpw
+qpw
+pCN
+qpw
+lff
+tSx
+tSx
+tSx
+tSx
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
+nlO
+mfD
+mfD
+mfD
+xGH
+mvv
+mvv
+mvv
+bpD
+dDC
+gcK
+gcK
+gcK
+gcK
 ktB
-gbL
-csk
-csk
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-pEy
-wfe
-wfe
-wfe
-smG
-trd
-uCW
-qGZ
-xgR
-uxC
-uxC
-uxC
-uxC
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -73558,61 +74206,61 @@ ktB
 (162,1,1) = {"
 ktB
 gcK
+rXU
+qmD
+jsz
+lva
+lva
+lva
+lva
+jvn
+fWN
+htH
+lva
+lva
+jsz
+qmD
+aVy
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+qCH
+aRu
+fKk
+dsD
+fGb
+tSx
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fFu
+dhD
+wCI
+mvv
+mvv
+mvv
+bpD
+fyf
+gcK
+gcK
 gcK
 ktB
-csk
-csk
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-jJb
-fyf
-fyf
-fyf
-fyf
-kdJ
-uCW
-nPX
-fyf
-rsE
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -73815,35 +74463,35 @@ ktB
 (163,1,1) = {"
 ktB
 gcK
+rXU
+xDz
+aff
+pBl
+lva
+pBl
+lva
+lva
+lva
+lva
+lva
+lva
+lVx
+xDz
+aVy
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+aRu
+dsD
+dsD
+ehG
+tSx
 gcK
-gbL
-csk
-csk
-gcK
-gcK
-gcK
-gbL
-gcK
-gcK
-gcK
-pEv
-fyf
-hAC
-dDC
-fyf
-kdJ
-uaf
-nPX
-fyf
-fyf
-uey
-gjw
-fyf
-fyf
-ktB
-ktB
-ktB
-ktB
 gcK
 gcK
 gcK
@@ -73860,15 +74508,15 @@ gcK
 gcK
 mcN
 mcN
-fyf
-fyf
-fyf
+mvv
+mvv
+mvv
 mcN
 mcN
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -74072,39 +74720,39 @@ ktB
 (164,1,1) = {"
 ktB
 gcK
-ktB
+rXU
+xDz
+cYa
+vXC
+lva
+lva
+lva
+lva
+eyw
+qTx
+acN
+lva
+jsz
+xDz
+kdH
+fCt
+fCt
+fCt
+fCt
+fCt
+teZ
+rXU
+rXU
+aRu
+iHG
+dsD
+iMd
+tSx
 gcK
-csk
-csk
-csk
 gcK
 gcK
 gcK
 gcK
-gbL
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-kdJ
-uaf
-nPX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-srk
-jxH
-jxH
-fyf
-fyf
-sND
 gcK
 gcK
 gcK
@@ -74117,9 +74765,9 @@ gcK
 gcK
 gcK
 mcN
-fyf
-fyf
-fyf
+mvv
+mvv
+mvv
 mcN
 gcK
 gcK
@@ -74329,54 +74977,54 @@ ktB
 (165,1,1) = {"
 ktB
 gcK
+aBW
+okd
+iBi
+iBi
+iBi
+dsw
+jsz
+iBi
+cYa
+fer
+jsz
+jsz
+cYa
+okd
+mNA
+iXj
+iXj
+aCY
+iXj
+iXj
+cks
+rXU
+rXU
+aRu
+mNA
+mNA
+mNA
+mNA
+axi
+otA
+mNA
+mNA
+mNA
+rOR
+tQy
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
 gcK
 ktB
-csk
-csk
-ggK
-gcK
-gcK
-gbL
-gcK
-gbL
-gcK
-gcK
-pEv
-ftr
-fyf
-fyf
-ilu
-mKu
-jMC
-fyf
-fyf
-gGY
-tRZ
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-tRZ
-cWG
-cWG
-wDc
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
 mcN
-fyf
-hAC
-fyf
+mvv
+mvv
+mvv
 mcN
 gcK
 gcK
@@ -74586,55 +75234,55 @@ ktB
 (166,1,1) = {"
 ktB
 gcK
-gcK
+rXU
+qmD
+qmD
+qmD
+gQm
+psQ
+qmD
+xQh
+psQ
+qmD
+okd
+qmD
+qmD
+qmD
+mNA
+iXj
+wIQ
+xZc
+xZc
+jMn
+rXU
+rXU
+rXU
+sTM
+qpw
+hUb
+qpw
+qpw
+qpw
+qpw
+gyC
+qpw
+qpw
+sDb
+xaY
 ktB
-csk
-csk
-ggK
-gcK
-gcK
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-lFX
-oen
-mvv
-oen
-mvv
-mvv
-mvv
-lFX
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
 mcN
 qZy
-fyf
-fyf
-fyf
-jiv
+mvv
+mvv
+mvv
+qZy
 mcN
 fyf
 fyf
@@ -74843,55 +75491,55 @@ ktB
 (167,1,1) = {"
 ktB
 gcK
+rXU
+ltL
+rXU
+qmD
+hPZ
+ttB
+ttB
+ttB
+ttB
+ncx
+ttB
+qmD
+gjd
+buy
+mNA
+iXj
+nSe
+xZc
+oMT
+iXj
+teZ
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+dii
+xaY
+dgy
+ktB
+ktB
+ktB
+ktB
 gcK
-csk
-csk
-ggK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gbL
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-xaF
-mfD
-mfD
-mfD
-mfD
-mfD
-xaF
-xaF
-xGH
+tBN
+mvv
+mvv
 mvv
 bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -75100,55 +75748,55 @@ ktB
 (168,1,1) = {"
 ktB
 gcK
-gcK
-csk
-csk
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-pEv
-fyf
-fyf
-fbN
-fyf
-jxH
-fyf
-fyf
-fyf
-fyf
-ftr
-uey
-fyf
-tBN
+fCt
+teZ
+rXU
+qmD
+six
+exK
+jXn
+jXn
+gWN
+xBb
+wfY
+qmD
+gjd
+buy
+mNA
+iXj
+iXj
+iXj
+iXj
+iXj
+cCK
+rXU
+rXU
+hIN
+jPH
+rXU
+hIN
+fCt
+fCt
+fCt
+kJG
+teZ
+rXU
+sTM
+qpw
+bXS
+ktB
+ktB
+uIw
+cWG
+cWG
+cWG
+cWG
+cWG
+daU
+mvv
+mvv
 mvv
 doX
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
 cWG
 cWG
 cWG
@@ -75356,46 +76004,46 @@ ktB
 "}
 (169,1,1) = {"
 ktB
+gcK
+gcK
+aVy
+rXU
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
+qmD
+mNA
+buy
+piF
+qpw
+qpw
+qpw
+qpw
+qpw
+iQc
+rXU
+rXU
+aRu
+iXj
+ifQ
+wqp
+iXj
+pkl
+iXj
+iXj
+hbC
+rXU
+rXU
+exQ
 ktB
 ktB
-tFv
-csk
-gcK
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-oEX
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-mvv
-mvv
-lFX
-lFX
-mvv
+kRL
 mvv
 mvv
 mvv
@@ -75614,45 +76262,45 @@ ktB
 (170,1,1) = {"
 ktB
 gcK
+gcK
+aVy
+rXU
+ltL
+rXU
+rXU
+rXU
+rXU
+rXU
+rXU
+aRu
+boJ
+mNA
+rkM
+iQc
+hIN
+fCt
+fCt
+itw
+fCt
+fCt
+teZ
+rXU
+aRu
+iXj
+dsD
+dsD
+dsD
+dsD
+uvT
+iXj
+cCK
+rXU
+rXU
+sKY
 ktB
-csk
-csk
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 ktB
 ktB
-ktB
-ktB
-fyf
-nlO
-mfD
-mfD
-mfD
-mfD
-mfD
-mfD
-xaF
-mfD
+xFV
 mfD
 mfD
 mfD
@@ -75872,44 +76520,44 @@ ktB
 ktB
 gcK
 gcK
-csk
-csk
-gcK
-gcK
-gcK
+kdH
+fCt
+fCt
+fCt
+teZ
+rXU
+rXU
+rXU
+rXU
+aRu
+mNA
+mNA
+nZa
+rXU
+xrP
+iXj
+iXj
+iXj
+iXj
+iXj
+cks
+rXU
+aRu
+iXj
+uJK
+dsD
+dsD
+dsD
+umk
+iXj
+kdH
+fCt
+fCt
+kQA
 ktB
 ktB
 ktB
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-ktB
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-jxH
-fyf
+tpO
 fyf
 fyf
 sqA
@@ -76130,43 +76778,43 @@ ktB
 gcK
 gcK
 gcK
-csk
-csk
+gcK
+oui
+mNA
+aVy
+xWm
+iIv
+iIv
+xWm
+aRu
+axi
+mNA
+gDy
+fCt
+wKw
+iXj
+aqf
+diE
+edI
+alh
+rXU
+rXU
+aRu
+iXj
+uvA
+dsD
+qAg
+dsD
+pDs
+iXj
+mNA
+pQi
+mNA
+tQy
 ktB
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-gcK
-gcK
-ktB
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
-sqA
-jxH
-fyf
+tpO
 fyf
 fyf
 fyf
@@ -76386,45 +77034,45 @@ ktB
 ktB
 gcK
 gcK
+gcK
+gcK
+gjd
+uQG
+aVy
+xWm
+iIv
+iIv
+xWm
+aRu
+mNA
+mNA
+buy
+mNA
+mNA
+iXj
+niV
+edI
+ijM
+iXj
+teZ
+rXU
+aRu
+iXj
+iXj
+iXj
+iXj
+wqp
+iXj
+iXj
+bBK
+eSd
+mNA
+tQy
 ktB
-csk
-csk
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 ktB
-ktB
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+tpO
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -76643,48 +77291,48 @@ ktB
 ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+hIq
+aVy
+xWm
+iIv
+iIv
+xWm
+aRu
+cRT
+mNA
+buy
+mNA
+mNA
+iXj
+vhB
+edI
+edI
+vJO
+aVy
+rXU
+sTM
+qpw
+pCN
+qpw
+bdc
+mNA
+mNA
+mNA
+mNA
+dZo
+mNA
+tQy
 ktB
-csk
-csk
-gcK
-gcK
 ktB
-ktB
-gcK
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+tpO
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -76902,48 +77550,48 @@ gcK
 gcK
 gcK
 gcK
-csk
+gcK
+gcK
+kdH
+vFQ
+fCt
+fCt
+vFQ
+wKw
+mNA
+mNA
+buy
+iNB
+mNA
+iXj
+xiG
+bvh
+bpi
+vJO
+aVy
+rXU
+rXU
+rXU
+rXU
+rXU
+iRg
+mNA
+dZo
+wyX
+hsA
+mNA
+tQy
 ktB
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 ktB
 ktB
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+tpO
+fyf
+fyf
+fyf
+fyf
+fyf
+sqA
 fyf
 fyf
 fyf
@@ -77157,50 +77805,50 @@ ktB
 ktB
 gcK
 gcK
-ktB
-ktB
-ktB
 gcK
 gcK
 gcK
 gcK
 gcK
+hBr
+hBr
+hBr
+hBr
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+oui
+mNA
+buy
+gjd
+mNA
+iXj
+iXj
+iXj
+iXj
+iXj
+kdH
+fCt
+fCt
+fCt
+fCt
+fCt
+wKw
+mNA
+nyv
+mNA
+mNA
+mNA
+tQy
 ktB
 ktB
 ktB
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
+tpO
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -77413,7 +78061,6 @@ ktB
 (177,1,1) = {"
 ktB
 gcK
-ktB
 gcK
 gcK
 gcK
@@ -77426,20 +78073,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
+oui
+buy
+gjd
+oui
 gcK
 gcK
 gcK
@@ -77450,15 +78087,26 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+oui
+mNA
+mNA
+mNA
+mNA
+mNA
+ruf
+rQB
 ktB
 ktB
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+tpO
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -77683,22 +78331,6 @@ gcK
 gcK
 gcK
 gcK
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
 gcK
 gcK
 gcK
@@ -77712,12 +78344,28 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+oui
+gjd
+mNA
+tQy
+dgy
 ktB
+ktB
+ktB
+ktB
+tpO
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
-gcK
-gcK
-gcK
-gcK
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -77926,40 +78574,30 @@ ktB
 "}
 (179,1,1) = {"
 ktB
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-csk
-mTd
-mTd
-sjX
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-bcM
-bcM
-myX
-bcM
-myX
-bcM
-bcM
-bcM
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -77971,6 +78609,16 @@ gcK
 gcK
 gcK
 ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -78184,42 +78832,32 @@ ktB
 (180,1,1) = {"
 ktB
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
-csk
-csk
-csk
-csk
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-bcM
-bcM
-myX
-bcM
-myX
-bcM
-bcM
-bcM
-hOR
-myX
-bcM
-myX
-myX
-bcM
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -78228,6 +78866,16 @@ gcK
 gcK
 gcK
 ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -78442,42 +79090,31 @@ ktB
 ktB
 gcK
 gcK
+ktB
 gcK
 gcK
-mTd
-csk
-csk
-csk
-csk
-fcF
-fcF
-sjX
-myX
-bcM
-bcM
-bcM
-myX
-izi
-gwc
-bcM
-gCh
-uqa
-gCh
-sWd
-sYX
-sYX
-bcM
-bcM
-myX
-bcM
-bcM
-myX
-bcM
-bcM
-fcF
-fcF
-fcF
-fcF
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -78486,6 +79123,17 @@ gcK
 gcK
 gcK
 ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -78701,41 +79349,16 @@ gcK
 gcK
 gcK
 gcK
-csk
-csk
-csk
-csk
-sjX
-myX
-usx
-usx
-usx
-usx
-gCh
-bBY
-gCh
-sWd
-jNJ
-bcM
-sWd
-aGb
-sYV
-cfn
-hul
-jNJ
-bcM
-bcM
-bcM
-uqa
-oFP
-oFP
-oFP
-oFP
-bcM
-bcM
-fcF
-fcF
-fcF
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -78744,6 +79367,31 @@ gcK
 gcK
 gcK
 ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -78956,53 +79604,53 @@ emz
 ktB
 gcK
 gcK
-mTd
-csk
-csk
-csk
-ggK
-gcK
-gcK
-ibX
-aay
-lxS
-sWx
-nOR
-fvm
-fvm
-fvm
-mST
-wgr
-bcM
-sYX
-xXp
-sYV
-sYV
-aqZ
-ptg
-bcM
-bcM
-gCh
-uqa
-vUF
-hyj
-vcO
-oFP
-ptg
-bcM
-myX
-fcF
-fcF
-fcF
 gcK
 gcK
 gcK
+gcK
+ktB
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
 ktB
 gcK
 gcK
 gcK
 ktB
 ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -79213,44 +79861,25 @@ emz
 ktB
 gcK
 gcK
-sjX
-csk
-csk
-ggK
 gcK
 gcK
 gcK
-bcM
-cio
-lxS
-aOE
-xQo
-xQo
-fvm
-lxS
-yaA
-sYX
-bcM
-sYX
-oPZ
-sYV
-sYV
-kpG
-wgr
-bcM
-bcM
-uqa
-scB
-sYV
-sYV
-sYV
-sYV
-cio
-myX
-myX
-bcM
-fcF
-fcF
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -79261,8 +79890,27 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
 ktB
 ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -79469,50 +80117,7 @@ emz
 (185,1,1) = {"
 ktB
 gcK
-mTd
-csk
-csk
-ggK
-ggK
 gcK
-gcK
-gcK
-gcK
-ptg
-vWL
-lxS
-lxS
-lxS
-lxS
-pHh
-rSq
-sYX
-bcM
-jNJ
-tgB
-sYV
-sYV
-ppg
-sYX
-bcM
-bcM
-oFP
-gQy
-sYV
-qka
-sYV
-sYV
-gnk
-bcM
-myX
-bcM
-fcF
-fcF
-gcK
-gcK
-gcK
-gcK
-ktB
 gcK
 gcK
 gcK
@@ -79521,6 +80126,49 @@ gcK
 gcK
 gcK
 ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -79726,45 +80374,28 @@ emz
 (186,1,1) = {"
 ktB
 gcK
-mTd
-csk
-csk
-ggK
 gcK
 gcK
 gcK
 gcK
 gcK
-aay
-lxS
-rXa
-xQo
-dCX
-fvm
-sWd
-lzZ
-sWd
-bcM
-ptg
-gCh
-klB
-sWd
-gnk
-sWd
-bcM
-bcM
-oFP
-ntB
-sYV
-sYV
-sYV
-uGR
-ptg
-myX
-bcM
-myX
-fcF
-fcF
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -79780,6 +80411,23 @@ gcK
 gcK
 ktB
 ktB
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -79984,45 +80632,25 @@ emz
 ktB
 gcK
 gcK
-csk
-csk
-csk
 gcK
 gcK
 gcK
 gcK
-bcM
-usx
-tFU
-iJo
-rGs
-dCX
-fvm
-lzZ
-pqq
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-iTy
-sIp
-bcM
-oFP
-uqa
-vuZ
-cbr
-sYV
-uqa
-ptg
-bcM
-bcM
-bcM
-fcF
-fcF
-fcF
+gcK
+ktB
+ktB
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -80031,15 +80659,35 @@ gcK
 gcK
 ktB
 ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
 ktB
 gcK
 gcK
 gcK
 gcK
 gcK
-ktB
-ktB
-ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -80241,45 +80889,27 @@ emz
 ktB
 gcK
 gcK
-ggK
-csk
-csk
-ggK
 gcK
 gcK
 gcK
-bcM
-usx
-fvm
-lxS
-rGs
-fvm
-lxS
-vjg
-bcM
-huY
-bcM
-bcM
-huY
-bcM
-huY
-bcM
-bcM
-bcM
-bcM
-bcM
-ptg
-oFP
-cnt
-oFP
-uqa
-bcM
-bcM
-myX
-bcM
-bcM
-fcF
-fcF
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+uXj
+gcK
 mTd
 gcK
 gcK
@@ -80289,15 +80919,33 @@ gcK
 gcK
 gcK
 gcK
-ktB
-ktB
-ktB
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
 gcK
 gcK
 ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -80498,46 +81146,32 @@ emz
 ktB
 gcK
 gcK
-ggK
-csk
-csk
-ggK
 gcK
 gcK
 gcK
-bcM
-usx
-sXO
-rXa
-rGs
-qMD
-lxS
-pVX
-huY
-huY
-huY
-bcM
-cBW
-bcM
-bcM
-huY
-bcM
-huY
-huY
-bcM
-bcM
-bcM
-bcM
-ixR
-bcM
-bcM
-cBW
-bcM
-bcM
-bcM
-fcF
-fcF
-sjX
+gcK
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+gcK
 mTd
 gcK
 gcK
@@ -80554,8 +81188,22 @@ gcK
 gcK
 gcK
 gcK
+ktB
+gcK
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -80754,51 +81402,39 @@ mGC
 (190,1,1) = {"
 ktB
 gcK
-ggK
-csk
-csk
-sjX
 gcK
 gcK
 gcK
 gcK
 gcK
-sYX
-eou
-rXa
-hnh
-dCX
-bUo
-jNJ
-oGF
-bcM
-bcM
-bcM
-huY
-huY
-bcM
-bcM
-bcM
-huY
-bcM
-bcM
-huY
-bcM
-huY
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-fcF
-fcF
-nSP
-bcM
-bcM
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fck
+fck
+fck
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+gcK
 gcK
 mTd
+gcK
 gcK
 gcK
 gcK
@@ -80817,8 +81453,20 @@ ktB
 gcK
 gcK
 gcK
-iwR
-wDc
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
 fyf
 kGc
 rxa
@@ -81011,60 +81659,6 @@ ktB
 (191,1,1) = {"
 ktB
 gcK
-ggK
-csk
-csk
-mTd
-gcK
-gcK
-gcK
-gcK
-gcK
-sYX
-sYX
-sYX
-gCh
-uqa
-sWd
-jNJ
-pqq
-bcM
-bcM
-bcM
-bcM
-ixR
-bcM
-huY
-huY
-bcM
-bcM
-huY
-cBW
-bcM
-bcM
-bcM
-huY
-huY
-bcM
-bcM
-wdX
-mTd
-arH
-arH
-mTd
-ejH
-bcM
-dnA
-icu
-dBE
-mTd
-mTd
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -81073,9 +81667,63 @@ gcK
 ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fck
+fck
+fck
+fck
+fck
+fck
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+gcK
 mTd
-bGM
-bpD
+gcK
+gcK
+gcK
+gcK
+uXj
+uXj
+uXj
+uXj
+mTd
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
 fyf
 kGc
 unI
@@ -81268,10 +81916,6 @@ ktB
 (192,1,1) = {"
 ktB
 gcK
-ggK
-csk
-csk
-ggK
 gcK
 gcK
 gcK
@@ -81279,60 +81923,64 @@ gcK
 gcK
 gcK
 gcK
-pwZ
-bcM
-sIp
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-ibX
-iTy
-bcM
-bcM
-bcM
-bcM
-huY
-bcM
-huY
-ibX
-bcM
-bcM
-huY
-huY
-huY
-huY
-huY
-huY
-huY
-dnA
-dnA
-sWD
-dnA
-dnA
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 mTd
-ufV
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+fck
+fck
+fck
+fck
+fck
+mvv
+mvv
+mvv
+mvv
+mvv
+uRa
+mvv
+mvv
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
 gcK
 gcK
 ktB
 gcK
 gcK
-wdV
-ilT
-bpD
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
 fyf
 kGc
 pBv
@@ -81526,10 +82174,9 @@ ktB
 ktB
 gcK
 gcK
-csk
-csk
-csk
-ggK
+gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -81537,59 +82184,60 @@ gcK
 gcK
 gcK
 gcK
-gcK
-ibX
-bcM
-oFP
-oFP
-gOO
-oFP
-tJE
-pqq
-sIp
-cBW
-bcM
-bcM
-bcM
-rUm
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-huY
-huY
-huY
-huY
-huY
-huY
-huY
-huY
-dnA
-jVC
-oyd
-dnA
-dnA
-dnA
-ovt
-dnA
-sjX
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-vGC
-bWF
-bGM
+fck
+fck
+fck
+fck
+fck
+fck
 mvv
-bpD
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+oen
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
 fyf
 kGc
 ajD
@@ -81783,70 +82431,70 @@ ktB
 ktB
 gcK
 gcK
-csk
-csk
-csk
-ggK
-ggK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fck
+fck
+fck
+fck
+sIp
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
 gcK
 ktB
 gcK
 gcK
 gcK
-sIp
-oFP
-vYv
-cbr
-xhh
-uqa
-eYn
-eYn
-uqa
-rea
-mxl
-bcM
-bcM
-gec
-eUy
-bcM
-bcM
-bcM
-huY
-huY
-bcM
-huY
-huY
-huY
-huY
-huY
-huY
-huY
-bcM
-dnA
-dnA
-plY
-dnA
-dnA
-dnA
-dnA
-dnA
-dnA
-jVC
-dBE
-mTd
 gcK
-sjX
-ovt
-dnA
-dnA
-pku
-mvv
-mvv
-mvv
-bpD
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
 fyf
 kGc
 oPO
@@ -82040,70 +82688,70 @@ ktB
 ktB
 gcK
 gcK
-sjX
-csk
-csk
-csk
-ggK
-ggK
-gcK
-gcK
-gcK
+ktB
+ktB
 gcK
 ktB
 gcK
 gcK
 gcK
-xuv
-cbr
-vYv
-usx
-qkP
-iap
-vdO
-uqa
-ptg
-sPD
-bcM
-lMW
-eiw
-bCQ
-xbk
-pOJ
-bcM
-bcM
-bcM
-bcM
-bcM
-wdX
-mTd
-arH
-arH
-mTd
-ejH
-bcM
-dnA
 gcK
-vGC
-sjX
-tcp
-dnA
-dnA
-dnA
-dnA
-dnA
-dnA
-dnA
-dnA
-icu
-dnA
-dnA
-dnA
-rdy
+fck
+fck
+fck
+fck
+fck
+mvv
+mvv
+uqa
+gCh
+uqa
+bWF
 mvv
 mvv
 mvv
-bpD
+oFP
+oFP
+gOO
+oFP
+qpZ
+gVp
+ofL
+odZ
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
+uXj
+mvv
+mvv
+uXj
+uXj
+uXj
+uXj
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
 fyf
 kGc
 ofX
@@ -82297,70 +82945,70 @@ ktB
 ktB
 gcK
 gcK
-gcK
-mTd
-csk
-csk
-csk
-csk
-ggK
-gcK
-gcK
-gcK
-gcK
-ktB
 ktB
 gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+fck
+fck
+fck
+fck
+fck
+oen
+mvv
+mvv
 uqa
-chM
-scY
-usx
-hmP
-aqK
+ptl
+dSb
+mvv
+mvv
+mvv
+mvv
+oFP
 vYv
-pHh
-tbq
-mdk
-bcM
-lMW
-bAO
-osf
-kXq
-can
-bcM
-bcM
-huY
-bcM
-bcM
-bcM
-bcM
-fcF
-fcF
-nSP
-bcM
-bcM
-gcK
-gcK
-gcK
-gcK
-mTd
-mTd
-gcK
-icu
-dnA
-dnA
-ovt
-dnA
-dnA
-dnA
-dnA
-icu
-mTd
-iEL
-fnP
+cbr
+xhh
+uqa
+eYn
+eYn
+uqa
+pSC
+lED
 mvv
 mvv
-bpD
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
 fyf
 kGc
 unI
@@ -82554,47 +83202,52 @@ ktB
 ktB
 gcK
 gcK
-gcK
-gcK
-gcK
-csk
-csk
-csk
-csk
-csk
-mTd
-gcK
-gcK
-gcK
+ktB
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+fck
+fck
+fck
+fck
+mvv
+mvv
+mvv
+mvv
+uqa
+uqa
 gCh
-obj
-cSE
+uRa
+mvv
+mvv
+mvv
+xuv
+cbr
+vYv
 usx
-ilb
-fvm
-lxS
-pHh
-shF
-bcM
-bcM
-bcM
-qJI
-xyS
-tNZ
-bcM
-bcM
-huY
-bcM
-bcM
-bcM
-bcM
-bcM
-fcF
-fcF
-sjX
-mTd
+qkP
+iap
+vdO
+uqa
+ptg
+qBo
+mvv
+bWF
+gCh
+uqa
+gCh
+sWd
+sYX
+sYX
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
 mTd
 gcK
 ktB
@@ -82605,19 +83258,14 @@ gcK
 gcK
 gcK
 gcK
-mTd
-sjX
-tcp
-wRK
-jVC
-dBE
 gcK
 gcK
 gcK
-mTd
-iwR
-ilT
-bpD
+gcK
+gcK
+gcK
+gcK
+fyf
 fyf
 kGc
 unI
@@ -82812,69 +83460,69 @@ ktB
 gcK
 gcK
 gcK
-gcK
-gcK
-ggK
-ggK
-csk
-csk
-csk
-csk
-sjX
-mTd
-gcK
-gcK
 ktB
-gCh
-uqa
-uqa
-gCh
-rlU
-vYv
-dit
-vYv
-qWX
-huY
-bcM
-myX
-dBi
-dBi
-bcM
-iTy
-bcM
-huY
-bcM
-bcM
-bcM
-bcM
-bcM
-fcF
-fcF
-fcF
-gcK
-ktB
-ktB
-gcK
-gcK
-gcK
-ktB
-ktB
-ktB
-gcK
 gcK
 gcK
 gcK
 gcK
 mTd
-mTd
-gcK
-gcK
-ktB
-gcK
-ktB
-gcK
+fck
+fck
+fck
+lPT
 mvv
-bpD
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+uqa
+chM
+scY
+usx
+hmP
+aqK
+vYv
+pHh
+tbq
+eVY
+mvv
+mvv
+sWd
+aGb
+sYV
+cfn
+hul
+jNJ
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
+gcK
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
 fyf
 kGc
 unI
@@ -83068,70 +83716,70 @@ ktB
 ktB
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-mTd
-sjX
-ggK
-csk
-csk
-csk
-ggK
-ggK
-gcK
-gcK
+ktB
 ktB
 gcK
 gcK
-uqa
-ulL
-pVT
-dit
-dit
+gcK
+gcK
+gcK
+fck
+fck
+fck
+fFx
+fFx
+usx
+usx
+usx
+usx
+gCh
+bBY
+gCh
+sWd
+jNJ
+mvv
+gCh
+obj
+cSE
+usx
+ilb
+fvm
+lxS
+pHh
 shF
-afF
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-huY
-bcM
-cBW
-bcM
-sjX
-fcF
-fcF
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+mvv
+mvv
+mvv
+sYX
+xXp
+sYV
+sYV
+aqZ
+ptg
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
 gcK
 gcK
 ktB
 ktB
-ktB
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-ktB
 gcK
-ktB
 gcK
-sjX
-hCg
+gcK
+gcK
+gcK
+gcK
+fyf
 fyf
 kGc
 unI
@@ -83325,54 +83973,53 @@ ktB
 ktB
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ggK
-csk
-csk
-csk
-ggK
-gcK
-gcK
 ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+fFx
+fck
+fck
+fck
+fFx
+aay
+lxS
+sWx
+nOR
+fvm
+fvm
+fvm
+mST
+wgr
+mvv
+gCh
 uqa
-jIN
+uqa
+gCh
+rlU
 vYv
-kLQ
-uqa
-ptg
-bcM
-bcM
-huY
-bcM
-bcM
-bcM
-huY
-huY
-bcM
-ibX
-bcM
-bcM
-bcM
-bcM
-gcK
-gcK
-fcF
-fcF
-gcK
-gcK
-gcK
-ktB
-ktB
-ktB
-ktB
+dit
+vYv
+qWX
+oen
+mvv
+mvv
+sYX
+oPZ
+sYV
+sYV
+kpG
+wgr
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
 gcK
 gcK
 gcK
@@ -83380,12 +84027,13 @@ gcK
 gcK
 gcK
 gcK
-ktB
-ktB
-ktB
 gcK
 gcK
-ktB
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 fyf
@@ -83590,49 +84238,48 @@ gcK
 gcK
 gcK
 gcK
-ggK
-csk
-csk
-ggK
-sjX
-gcK
-ktB
-gcK
-gcK
-usx
-brJ
-hPA
-bSR
+fFx
+fck
+fck
+fFx
+cio
+lxS
+aOE
+xQo
+xQo
+fvm
+lxS
+yaA
+sYX
+mvv
+mvv
+mvv
+mvv
 uqa
-tGb
-pqq
-bcM
-bcM
-bcM
-huY
-bcM
-ixR
-bcM
-bcM
-huY
-bcM
-bcM
-bcM
-bcM
-gcK
-gcK
-fcF
-fcF
-gcK
-ktB
-ktB
-gcK
-gcK
+ulL
+pVT
+dit
+dit
+shF
+eBm
+mvv
+agc
+jNJ
+tgB
+sYV
+sYV
+ppg
+sYX
+mvv
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
 gcK
 gcK
 ktB
-ktB
-ktB
 gcK
 gcK
 gcK
@@ -83641,7 +84288,8 @@ gcK
 gcK
 gcK
 gcK
-ktB
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -83839,53 +84487,52 @@ ktB
 ktB
 gcK
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-mTd
-csk
-csk
-ggK
-mTd
-gcK
-gcK
-gcK
-gcK
-usx
-usx
-usx
-usx
-usx
-oRf
-gcK
-sjX
-pPy
-bcM
-huY
-huY
-bcM
-bcM
-bcM
-bcM
-huY
-ibX
-bcM
-bcM
-bcM
-sjX
-fcF
-fcF
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+lPT
+fck
+fck
+cLz
+ptg
+vWL
+lxS
+lxS
+lxS
+lxS
+pHh
+rSq
+sYX
+mvv
+oen
+mvv
+mvv
+uqa
+jIN
+vYv
+kLQ
+uqa
+ptg
+mvv
+mvv
+mvv
+ptg
+gCh
+klB
+sWd
+gnk
+sWd
+mvv
+mvv
+mvv
+mvv
+mvv
+uXj
 gcK
 gcK
 gcK
@@ -83895,10 +84542,11 @@ gcK
 gcK
 gcK
 gcK
-ktB
 gcK
 gcK
-ktB
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -84096,66 +84744,66 @@ ktB
 ktB
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-sjX
-ggK
-csk
-csk
-ggK
-ggK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-mTd
-qYg
-qYg
-qYg
-qYg
-qYg
-uVf
-bcM
-huY
-bcM
-huY
-bcM
-bcM
-bcM
-fcF
-fcF
-fcF
-sjX
-gcK
-gcK
-sjX
-fcF
-fcF
-mTd
-mTd
-gcK
-gcK
 ktB
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+lPT
+fFx
+fck
+fck
+mvv
+aay
+lxS
+rXa
+xQo
+dCX
+fvm
+sWd
+lzZ
+sWd
+mvv
+mvv
+agc
+mvv
+usx
+brJ
+hPA
+bSR
+uqa
+qYg
+gVp
+mvv
+mvv
+mvv
+bWF
+mvv
+mvv
+oen
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
+gcK
+gcK
+gcK
+ktB
 ktB
 gcK
 gcK
-ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -84352,58 +85000,57 @@ ktB
 (204,1,1) = {"
 ktB
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
+lPT
+fFx
+fFx
+fck
+fck
+fck
+mvv
+usx
+tFU
+iJo
+rGs
+dCX
+fvm
+lzZ
+kCm
+qAa
+mvv
+oen
+oen
+mvv
+uqa
+uqa
+uqa
+uqa
+uqa
+mvv
+mvv
+oen
+oen
+dFE
+mvv
+oen
+mvv
+gdH
+mvv
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
+uXj
+uXj
 gcK
-gcK
-sjX
-ggK
-ggK
-csk
-csk
-csk
-ggK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-mTd
-bcM
-pqq
-pdI
-bcM
-bcM
-fpY
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-bcM
-fcF
-fcF
-fcF
-mTd
-mTd
-fcF
-fcF
-fcF
-fcF
-fcF
-sjX
 gcK
 gcK
 ktB
@@ -84412,7 +85059,8 @@ gcK
 gcK
 gcK
 gcK
-ktB
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -84614,62 +85262,62 @@ gcK
 gcK
 gcK
 gcK
-mTd
-ggK
-csk
-csk
-csk
-csk
-ggK
-ggK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-bcM
-bcM
-bcM
-arS
-cBW
-ixt
-bcM
-bcM
-bcM
-huY
-bcM
-bcM
-bcM
-bcM
-bcM
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-mTd
-gcK
-gcK
-gcK
-gcK
-gcK
+lPT
+fFx
+fck
+fck
+fck
+fck
+fFx
+mvv
+usx
+fvm
+lxS
+rGs
+fvm
+lxS
+vjg
+mvv
+oen
+mvv
+oen
+mvv
+mvv
+bWF
+mvv
+mvv
+mvv
+mvv
+oen
+mvv
+oen
+uRa
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
+uXj
+uXj
 gcK
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -84866,67 +85514,67 @@ ktB
 (206,1,1) = {"
 ktB
 gcK
+ktB
 gcK
 gcK
 gcK
-gcK
-mTd
-ggK
-csk
-csk
-sjX
-csk
-csk
-ggK
-gcK
-gcK
-gcK
-gcK
-mTd
-mTd
-sjX
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-mTd
-bcM
-hmR
-bcM
-bcM
-faC
-bcM
-bcM
-bcM
-bcM
-huY
-bcM
-bcM
-bcM
-iwR
-mTd
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-sjX
-gcK
-gcK
-gcK
+lPT
+fFx
+fck
+fck
+lPT
+fck
+fck
+fFx
+mvv
+usx
+sXO
+rXa
+rGs
+qMD
+lxS
+pVX
+oen
+oen
+mvv
+mvv
+oen
+amc
+mvv
+mXX
+mvv
+oen
+mvv
+mvv
+mvv
+mvv
+mvv
+gdH
+mvv
+uqa
+oFP
+oFP
+oFP
+uqa
+mvv
+mvv
+mvv
+cEg
+vXZ
+vXZ
+vXZ
+vXZ
+vlh
+uXj
 gcK
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -85123,67 +85771,67 @@ ktB
 (207,1,1) = {"
 ktB
 gcK
+ktB
 gcK
 gcK
 gcK
-gcK
-sjX
-csk
-csk
-csk
-csk
-csk
-csk
-ggK
-ggK
-gcK
-gcK
-gcK
-ggK
-ggK
-ckt
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+lPT
+fck
+fck
+fck
+fck
+fck
+fck
+fFx
+mvv
+sYX
+eou
+rXa
+hnh
+dCX
+bUo
+jNJ
+sSX
+mvv
+mvv
+mvv
+wtz
+mvv
+mvv
+mvv
 gEv
-bcM
-pqq
-bcM
-fpY
-pqq
-tGb
-bcM
-bcM
-bcM
-bcM
-huY
-bcM
-wCb
-mTd
-sjX
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-mTd
-gcK
-gcK
+wVm
+mvv
+mvv
+mvv
+oen
+oen
+mvv
+gCh
+uqa
+vUF
+hyj
+vcO
+oFP
+ptg
+mvv
+mvv
+ucA
+mvv
+mvv
+mvv
+mvv
+ucA
+uXj
 gcK
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -85380,67 +86028,67 @@ ktB
 (208,1,1) = {"
 ktB
 gcK
-gcK
-gcK
-gcK
-gcK
-csk
-csk
-csk
-ggK
-csk
-csk
-csk
-csk
-ggK
-sjX
-mTd
-ggK
-ggK
-ggK
-ggK
-ggK
-ptg
-gCh
-uqa
-sYX
-sYX
-gcK
-gcK
-gcK
-sjX
-bcM
-pdI
-bcM
-gCh
-uqa
-gnk
-gCh
-bcM
-bcM
-huY
-bcM
-bcM
-wCb
-wCb
-cBW
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-mTd
-gcK
-gcK
-gcK
-gcK
 ktB
+gcK
+gcK
+gcK
+fck
+fck
+fck
+fFx
+fck
+fck
+fFx
+fFx
+mvv
+sYX
+sYX
+sYX
+gCh
+uqa
+sWd
+jNJ
+cpW
+mvv
+mvv
+oen
+mvv
+mvv
+mvv
+hxO
+aBH
+mfD
+xGH
+tBO
+mvv
+mvv
+mvv
+mvv
+uqa
+scB
+sYV
+sYV
+sYV
+wCb
+cio
+mvv
+mvv
+iWi
+mvv
+mvv
+mvv
+mvv
+ucA
+uXj
+uXj
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -85636,68 +86284,68 @@ ktB
 "}
 (209,1,1) = {"
 ktB
+ktB
+ktB
 gcK
 gcK
-gcK
-gcK
-mTd
-csk
-csk
-ggK
-ggK
-ggK
-ggK
-csk
-csk
-csk
-ggK
-ggK
-ggK
-csk
-csk
-ggK
-ggK
-gbu
-bDv
-vsu
-jnO
-jNJ
-gcK
-gcK
-gcK
-mTd
-arS
-bcM
-oFP
-oFP
-sLs
-kDI
+lPT
+fck
+fck
+mvv
 gCh
-kgD
-bcM
-bcM
-huY
-pqq
-bcM
-qyA
-hrn
-bcM
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-gKI
-gcK
-gcK
-gcK
+uqa
+gnk
+gCh
+mvv
+bWF
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+vsu
+mvv
+mvv
+dFE
+mvv
+hxO
+bpD
+arS
+tBN
+dfd
+mvv
+mvv
+oen
+mvv
+oFP
+gQy
+sYV
+qka
+sYV
+sYV
+gnk
+mvv
+mvv
+iWi
+mvv
+mvv
+mvv
+mvv
+ucA
+uXj
+uXj
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -85897,64 +86545,64 @@ gcK
 gcK
 gcK
 gcK
-sjX
-csk
-csk
-ggK
-ggK
-mTd
-sjX
-ggK
-csk
-csk
-csk
-ggK
-csk
-csk
-csk
-csk
-ggK
-tul
-klA
-rpu
-rpu
-irx
-sWd
-gcK
-gcK
-bcM
-pqq
-bcM
-uqa
-bvO
+lPT
+fck
+fck
+oFP
+oFP
+sLs
+kDI
+gCh
+kgD
+mvv
+mvv
+mvv
+mvv
+ikB
+mvv
+mvv
+oen
+mvv
+mvv
+lPT
+cLz
+mvv
+mvv
+mvv
+mvv
+doX
+cWG
+daU
+mvv
+mvv
+oen
+mvv
+mvv
+oFP
+ntB
 sYV
 sYV
 sYV
-qND
-ixR
-bcM
-huY
-bcM
-bcM
-wCb
-wCb
-bcM
-iwR
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-mTd
-gcK
-gcK
-gcK
+uGR
+ptg
+mvv
+mvv
+ucA
+mvv
+mvv
+mvv
+mvv
+ucA
+uXj
+uXj
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 fyf
@@ -86150,67 +86798,67 @@ ktB
 "}
 (211,1,1) = {"
 ktB
+ktB
 gcK
 gcK
 gcK
-gcK
-csk
-csk
-ggK
-ggK
-mTd
-gcK
-mTd
-ggK
-ggK
-csk
-csk
-csk
-suo
-csk
-tFv
-csk
-ggK
-qAb
-pMh
-rpu
-rpu
-ery
-wgr
-gcK
-sjX
-tjq
-tjq
-tjq
-gCh
-sew
+fck
+fck
+fFx
+uqa
+bvO
 sYV
 sYV
+sYV
+qND
+dFE
+mvv
+mvv
+mvv
+ikB
+ikB
+odZ
+mvv
+mvv
+mvv
+mvv
+lPT
+oen
+mvv
+mvv
+amc
+tjq
+tjq
+mvv
+bWF
+mvv
+oen
+mvv
+mvv
+oFP
+uqa
+vuZ
 cbr
-shF
-bcM
-bcM
-bcM
-bcM
-wCb
-bcM
-rfc
-wCb
-cBW
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-sjX
-gcK
-gcK
+sYV
+uqa
+ptg
+mvv
+mvv
+kvN
+vXZ
+vXZ
+vXZ
+vXZ
+lsT
+uXj
 gcK
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -86407,67 +87055,67 @@ ktB
 "}
 (212,1,1) = {"
 ktB
+ktB
 gcK
 gcK
 gcK
-gcK
-csk
-csk
-ggK
-ggK
-gcK
-gcK
-gcK
-ggK
-ggK
-ggK
-csk
-csk
-csk
-csk
-csk
-csk
-ggK
-tul
-uYW
-rpu
-aUC
-xtw
-wgr
-gcK
-mTd
-myX
-myX
-bcM
-eYn
-oJR
+fck
+fck
+fFx
+gCh
+sew
 sYV
 sYV
 cbr
+shF
+mvv
+mvv
+oen
+mvv
+mvv
+wJp
+ddz
+mvv
+mvv
+mvv
+mvv
+agc
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+oen
+mvv
+ptg
+oFP
 cnt
-huY
-huY
-bcM
-bcM
-wCb
-wCb
-bcM
-qyA
-wCb
-fcF
-fcF
-fcF
-fcF
-fcF
-fcF
-mTd
-gcK
-gcK
-gcK
+oFP
+uqa
+mvv
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
+uXj
+uXj
+uXj
 gcK
 gcK
 gcK
 ktB
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -86667,56 +87315,53 @@ ktB
 gcK
 gcK
 gcK
-sjX
-csk
-csk
-ggK
-ggK
-gcK
-gcK
-gcK
-gcK
-sjX
-opc
-ggK
-csk
-csk
-csk
-csk
-ggK
-ggK
-gCh
-uqa
-itJ
-gCh
-gCh
-uqa
-gcK
-gcK
+lPT
+fck
+fck
+fFx
+eYn
+oJR
+sYV
+sYV
+cbr
+cnt
+oen
+mvv
+mvv
+ikB
+ikB
+mvv
+bAz
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+oen
+mvv
+ecO
+mvv
+agc
+mvv
+oen
+oen
+mvv
+uRa
+mvv
+mvv
+bWF
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 mTd
-myX
-myX
-oFP
-dTl
-sYV
-sYV
-eEI
-shF
-bcM
-huY
-bcM
-bcM
-qyA
-cBW
-wCb
-wCb
-wCb
-fcF
-fcF
-fcF
-fcF
-fcF
-sjX
+uXj
+uXj
+uXj
+mTd
 gcK
 gcK
 gcK
@@ -86724,7 +87369,10 @@ gcK
 gcK
 gcK
 gcK
-ktB
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -86923,64 +87571,64 @@ ktB
 ktB
 gcK
 gcK
-mTd
-csk
-csk
-ggK
-ggK
-ggK
-mTd
-gcK
-gcK
-gcK
-mTd
-ggK
-ggK
-csk
-csk
-csk
-csk
-ggK
-sjX
-uqa
-rpu
-rpu
-pMh
-cio
-gcK
-gcK
-gcK
-gcK
-ibX
-myX
+lPT
+fck
+fck
+fFx
+fFx
 oFP
-uqa
+dTl
 sYV
 sYV
-gCh
-cio
-bcM
-bcM
-bcM
-huY
-bcM
-wCb
-bcM
-wCb
-bcM
-cBW
-fcF
-fcF
-fcF
-fcF
-fcF
+eEI
+shF
+mvv
+mvv
+mvv
+mvv
+uRa
+amc
+mvv
+agc
+mvv
+wtz
+mvv
+bWF
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+dFE
+mvv
+wtz
+mvv
+mvv
+amc
+mvv
+mvv
+mvv
+mvv
+mvv
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
 gcK
 ktB
 gcK
-ktB
+gcK
 gcK
 gcK
 gcK
@@ -87180,67 +87828,67 @@ ktB
 ktB
 gcK
 gcK
-sjX
-csk
-csk
-ggK
-ggK
-sjX
-gcK
-gcK
-gcK
-gcK
-gcK
-ckt
-ggK
-ggK
-csk
-csk
-ggK
-ggK
-gcK
-wgr
-wTJ
-rpu
-klA
-cio
-gcK
-ktB
-gcK
-gcK
-gcK
-myX
-bcM
-gCh
+lPT
+fck
+fck
+fFx
+fFx
 oFP
 uqa
-uqa
-tGb
-bcM
-ixR
-bcM
-bcM
-pqq
-bcM
-wCb
-tGb
-bcM
-sjX
-fcF
-fcF
-fcF
-fcF
-fcF
+sYV
+sYV
+gCh
+cio
+mvv
+mvv
+mvv
+mvv
+mvv
+gHu
+ikB
+mvv
+ttW
+ikB
+odZ
+mvv
+kff
+tyW
+tyW
+tyW
+tyW
+tyW
+tyW
+tyW
+psR
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mTd
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
 gcK
 ktB
 gcK
-ktB
 gcK
 gcK
-gcK
+rcc
+wDc
 gcK
 fyf
 trW
@@ -87438,66 +88086,66 @@ ktB
 gcK
 gcK
 gcK
-csk
-csk
-ggK
-ggK
-mTd
-gcK
-gcK
-gcK
-gcK
-gcK
-sjX
-xrA
-ggK
-tFv
-csk
-ggK
-ckt
-gcK
-jNJ
-wJp
-pMh
-dCU
-ptg
-gcK
-ktB
-gcK
-gcK
-gcK
-myX
-bcM
-ibX
-myX
-bcM
-cUT
-bcM
-bcM
+fck
+fck
+fFx
+fFx
+mvv
 gCh
-wqS
-wqS
-bcM
-wCb
-sjX
+oFP
+uqa
+uqa
+qYg
+mvv
+mvv
+dFE
+mvv
+oen
+gVp
+ikB
+ikB
+mvv
+wJp
+ikB
+mvv
+ibX
+mvv
+mvv
+qPQ
+mvv
+mvv
+mvv
+gVp
+ibX
+mvv
+mvv
+mvv
+mvv
+oen
+oen
+mvv
+mvv
+bGM
+kfk
+vdk
+vdk
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
 gcK
 gcK
 mTd
-fcF
-fcF
-fcF
-sjX
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
+bGM
+bpD
 fyf
 fyf
 fyf
@@ -87694,55 +88342,56 @@ ktB
 ktB
 gcK
 gcK
-mTd
-csk
-csk
-csk
-ggK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-mTd
-ggK
-ggK
-ggK
-ggK
-ggK
-gcK
-gcK
-sWd
-sWd
-sYX
-sYX
-cio
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-ldt
+lPT
+fck
+fck
+fck
+fFx
+mvv
+uRa
+amc
+mvv
+kXe
+mvv
+mvv
+mvv
+gCh
+wqS
+mvv
+mvv
+wJp
+odZ
+ikB
+ikB
+ikB
+mvv
 myX
-bcM
+oen
+gVp
+doA
+mvv
+mvv
+qPQ
+mvv
 myX
-cUT
-dFw
-dFw
-uqa
-rBD
-wnG
-eSY
+mvv
+mvv
+amc
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+pku
+dnA
+dnA
+gcK
+vdk
+qMF
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-mTd
-mTd
 gcK
 gcK
 gcK
@@ -87750,11 +88399,10 @@ gcK
 gcK
 ktB
 gcK
-ktB
 gcK
-gcK
-gcK
-gcK
+wdV
+ilT
+bpD
 fyf
 fyf
 fyf
@@ -87949,69 +88597,69 @@ ktB
 "}
 (218,1,1) = {"
 ktB
-gcK
-gcK
-gcK
-sjX
-csk
-csk
-ggK
-ggK
-gcK
-gcK
-gcK
-gcK
 ktB
 gcK
 gcK
-ggK
-ggK
-ggK
-sjX
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+lPT
+fck
+fck
+fFx
+rBC
+amc
+mvv
+amc
+kXe
+gNB
+gNB
+mvv
 uqa
-uqa
-uqa
-gCh
+rBD
+tKp
+iug
+mvv
+ikB
+mvv
+ikB
+mvv
+odZ
+ibX
+mvv
+mvv
+mvv
+mvv
+oen
+mvv
+mvv
+ibX
+oen
+mvv
+mvv
+mvv
+mvv
+dFE
+mvv
+mvv
+uRa
+rdy
+gGA
+dnA
+dnA
+ovt
+dnA
+jQY
 gcK
 gcK
 gcK
-ktB
-ktB
-ktB
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-ktB
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
+vGC
+bWF
+bGM
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -88206,21 +88854,15 @@ ktB
 "}
 (219,1,1) = {"
 ktB
+ktB
 gcK
 gcK
 gcK
-gcK
-csk
-csk
-csk
+fck
+fck
+fck
+fFx
 ggK
-ggK
-sjX
-mTd
-sjX
-gcK
-ktB
-gcK
 mTd
 mTd
 mTd
@@ -88229,46 +88871,52 @@ gcK
 gcK
 gcK
 gcK
+uqa
+gCh
+mvv
+mvv
+ikB
+qYg
+mvv
+cLz
+ibX
+mvv
+gVp
+mvv
+qPQ
+mvv
+doA
+mvv
+ibX
+mvv
+mvv
+mvv
+oen
+mvv
+mvv
+mvv
+mvv
+mvv
+aFy
+dnA
+gGA
+dnA
+dnA
+dnA
+gGA
+jVC
+kfk
+vdk
 gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
+jQY
+ovt
+dnA
+dnA
+dnA
+mvv
+mvv
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -88464,15 +89112,15 @@ ktB
 (220,1,1) = {"
 ktB
 gcK
+ktB
 gcK
 gcK
-gcK
-sjX
+lPT
+fck
+fck
+fck
 csk
-csk
-csk
-csk
-xzI
+sHh
 csk
 csk
 mTd
@@ -88481,51 +89129,51 @@ ktB
 ktB
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+mvv
+mvv
+ikB
+sBd
+mvv
+mvv
+mvv
+ibX
+mvv
+vJr
+mvv
+gVp
+mvv
+mvv
+mvv
+ibX
+bWF
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mTd
+yaY
+jQY
+tcp
+dnA
+dnA
+gGA
+dnA
+dnA
+dnA
+dnA
+dnA
+mqj
+dnA
+gGA
+dnA
+dnA
+mvv
+mvv
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -88721,32 +89369,43 @@ ktB
 (221,1,1) = {"
 ktB
 gcK
+ktB
+gcK
+gcK
+gcK
+lPT
+fck
+fck
+csk
+sHh
+csk
+csk
+csk
+mTd
+gcK
+gcK
+ktB
+ktB
+gcK
+sjX
+mTd
+mTd
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
 gcK
 sjX
-csk
-csk
-csk
-xzI
-csk
-csk
-csk
-sjX
-gcK
-gcK
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-ktB
-ktB
-ktB
+mTd
 gcK
 gcK
 gcK
@@ -88754,35 +89413,24 @@ gcK
 gcK
 gcK
 gcK
+vdk
+vdk
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+icu
+dnA
+dnA
+ovt
+dnA
+gGA
+dnA
+dnA
+icu
+vdk
+dnA
+fnP
+mvv
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -88986,7 +89634,7 @@ gcK
 gcK
 gcK
 gcK
-sjX
+mTd
 ggK
 csk
 csk
@@ -88999,11 +89647,11 @@ ktB
 ktB
 ktB
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 ktB
@@ -89019,17 +89667,6 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
 ktB
 ktB
 gcK
@@ -89038,8 +89675,19 @@ gcK
 gcK
 gcK
 gcK
+vdk
+jQY
+tcp
+wRK
+jVC
+kfk
 gcK
-fyf
+gcK
+gcK
+mTd
+iwR
+ilT
+bpD
 fyf
 fyf
 fyf
@@ -89237,19 +89885,19 @@ ktB
 gcK
 gcK
 gcK
+ktB
+ktB
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-sjX
+mTd
 ggK
 csk
 csk
 ggK
-sjX
+mTd
 gcK
 gcK
 gcK
@@ -89290,13 +89938,13 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
+ktB
+ktB
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
+mvv
+bpD
 fyf
 fyf
 fyf
@@ -89496,10 +90144,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
 gcK
 mTd
 ggK
@@ -89543,17 +90191,17 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
+ktB
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
+cLz
+hCg
 fyf
 fyf
 fyf
@@ -91753,7 +92401,7 @@ gcK
 gcK
 gcK
 pIz
-pIz
+tkq
 pIz
 okZ
 hge

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -69582,7 +69582,7 @@ ktB
 ctJ
 tri
 tri
-tri
+tmQ
 cVL
 rXU
 aRu

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1,7 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aam" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/plating/tunnel,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "aao" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22,10 +25,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "abN" = (
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red";
+	pixel_y = 0
 	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "acc" = (
 /obj/structure/sink{
@@ -75,8 +82,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "adR" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
+/obj/structure/mopbucket{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "adY" = (
 /obj/structure/chair/stool,
@@ -95,10 +106,12 @@
 /turf/open/water,
 /area/f13/brotherhood)
 "aeM" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/shower{
+	dir = 4
 	},
+/obj/structure/decoration/vent,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "aeN" = (
 /obj/structure/lattice/catwalk,
@@ -109,17 +122,12 @@
 /turf/open/water,
 /area/f13/tunnel)
 "aeR" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/line{
+	pixel_y = -6
 	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/shreds,
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "aeS" = (
 /obj/structure/frame/machine,
@@ -160,14 +168,9 @@
 	},
 /area/f13/tunnel)
 "agy" = (
-/obj/structure/table/wood,
-/obj/item/lighter{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "agR" = (
 /obj/structure/table/wood/poker,
@@ -185,10 +188,8 @@
 	},
 /area/f13/followers)
 "ahx" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
-	},
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ahB" = (
@@ -196,21 +197,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"aic" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
 "ajd" = (
-/obj/structure/chair/office/light,
-/obj/machinery/button/door{
-	id = "bosengineaccess";
-	name = "Engineering Lockdown";
-	pixel_x = 34;
-	pixel_y = -4
+/obj/structure/bookcase/manuals/engineering,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "ajk" = (
 /obj/structure/decoration/vent/rusty,
@@ -267,37 +260,36 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "amV" = (
-/obj/machinery/computer/secure_data{
-	dir = 4;
-	icon_state = "computer"
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
-"anf" = (
-/obj/machinery/workbench/forge{
-	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
-	icon_state = "generator_on";
-	name = "superheating forge"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood)
 "anO" = (
-/obj/structure/chair/stool/retro,
+/obj/structure/target_stake{
+	anchored = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "aoj" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "aoq" = (
-/obj/structure/closet/crate/trashcart{
-	storage_capacity = 10
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 4;
+	name = "light fixture"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "aoC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -338,11 +330,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ash" = (
-/obj/structure/chair/bench,
-/obj/structure/sign/poster/contraband/smoke{
-	pixel_y = -32
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/vent{
+	pixel_x = 15;
+	pixel_y = -17
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
+	},
 /area/f13/brotherhood)
 "ask" = (
 /obj/machinery/light/fo13colored/Red{
@@ -358,8 +353,10 @@
 	},
 /area/f13/tcoms)
 "atn" = (
-/obj/structure/chair/left,
-/turf/open/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
+	},
 /area/f13/brotherhood)
 "ato" = (
 /obj/effect/decal/cleanable/dirt,
@@ -403,12 +400,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/tunnel)
-"awF" = (
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "awR" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -453,11 +444,21 @@
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/brotherhood)
 "azX" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = null;
-	req_access_txt = "120"
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "NW"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1;
+	icon_state = "warningline_red"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood)
 "aBb" = (
 /turf/closed/mineral/random/high_chance,
@@ -597,17 +598,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"aIX" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "aJR" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/f13/stage_t,
@@ -646,57 +636,61 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "aNH" = (
-/obj/structure/table/glass,
-/obj/item/storage/book/bible,
-/turf/open/floor/f13/wood,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1;
+	icon_state = "warningline_red"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood)
 "aNI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "aOr" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood)
-"aPa" = (
-/obj/structure/simple_door/bunker{
-	req_access = 120;
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whiterustysolid"
 	},
 /area/f13/brotherhood)
+"aPa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
+	},
+/area/f13/brotherhood)
 "aQg" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
 	},
 /area/f13/brotherhood)
 "aQN" = (
-/obj/item/target,
-/obj/structure/target_stake,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/pool/ladder,
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, filtered pool water.";
+	name = "pool water"
 	},
 /area/f13/brotherhood)
 "aRj" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/simple_door/bunker{
+	name = "Locker Room"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood)
 "aRn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -728,9 +722,11 @@
 	},
 /area/f13/brotherhood)
 "aSI" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "aSJ" = (
 /obj/machinery/vending/wallmed{
@@ -740,22 +736,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "aSW" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "SW"
 	},
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5;
+	icon_state = "warningline_red"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
 "aSZ" = (
-/obj/structure/lattice{
-	density = 1
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "aTP" = (
 /turf/open/floor/f13{
@@ -763,13 +763,17 @@
 	},
 /area/f13/brotherhood)
 "aUc" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/target_stake{
+	anchored = 1
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "aUo" = (
 /obj/structure/simple_door/metal/dirtystore,
@@ -808,47 +812,49 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "aXh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/rag/towel{
+	pixel_x = -19;
+	pixel_y = -3
 	},
-/obj/structure/bookcase/manuals/engineering,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/item/reagent_containers/glass/rag/towel{
+	pixel_x = -19
+	},
+/obj/item/reagent_containers/glass/rag/towel{
+	pixel_x = -19;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/rag/towel{
+	pixel_x = -19;
+	pixel_y = 7
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood)
 "baZ" = (
 /obj/structure/fence/handrail{
-	pixel_y = 16
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	density = 0;
 	dir = 4;
-	layer = 2.9
+	layer = 3.1;
+	pixel_x = -16
 	},
 /obj/structure/lattice{
 	layer = 3
 	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "bbd" = (
-/obj/machinery/artillerycontrol{
-	desc = "A seldom-used machine that activates an anti-air relay during Vertibird raids, capable of downing most Vertibirds in the surrounding area with a wide-range EMP created by Tesla relay, using the bases power for its powerful blast. Warning; likely to cause base-wide power issues on activation.";
-	name = "Tesla Anti-Air Relay Control"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker{
+	name = "Pool"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/circuit,
 /area/f13/brotherhood)
 "bbI" = (
 /obj/structure/handrail/g_end{
@@ -929,11 +935,13 @@
 	},
 /area/f13/tunnel)
 "bdP" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch{
+	name = "Dorms";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
 "bdV" = (
@@ -948,15 +956,19 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "beL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "Emergency Power";
-	req_access_txt = "120"
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "beY" = (
 /obj/machinery/light/small{
@@ -967,12 +979,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "bfh" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
 	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/stage_t,
+/area/f13/brotherhood)
 "bfL" = (
 /obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt,
@@ -1009,20 +1023,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "bik" = (
-/obj/structure/rack,
-/obj/item/bot_assembly/medbot,
-/obj/item/bodypart/r_arm/robot,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "bio" = (
-/obj/effect/decal/cleanable/shreds,
-/obj/structure/lattice{
-	layer = 3
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "bis" = (
 /obj/structure/chair/office/dark{
@@ -1032,20 +1050,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"biy" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/camera/autoname{
-	dir = 9;
-	icon_state = "camera"
-	},
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/grimy,
-/area/f13/brotherhood)
 "bje" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -1090,12 +1094,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "bki" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/railing{
+	dir = 4;
+	pixel_x = 4
 	},
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
 "bkU" = (
@@ -1104,15 +1109,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "blk" = (
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/camera/autoname{
+	dir = 5;
+	icon_state = "camera"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plating/tunnel,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "blo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner,
+/obj/machinery/door/airlock/wood{
+	name = "Sauna"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
+	},
 /area/f13/brotherhood)
 "blH" = (
 /obj/structure/table,
@@ -1135,26 +1151,22 @@
 /turf/open/floor/wood,
 /area/f13/tunnel)
 "bmF" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/turf/open/water,
-/area/f13/brotherhood)
-"bmK" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "bnT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/falsewall/wood{
+	layer = 3;
+	name = "steam generator shutter"
 	},
+/obj/machinery/smoke_machine{
+	desc = "An old world machine with a centrifuge installed into it. It produces steam with any reagents you put into the machine.";
+	name = "Steam Generator"
+	},
+/turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
 "boc" = (
 /obj/machinery/door/airlock/medical{
@@ -1166,10 +1178,13 @@
 	},
 /area/f13/followers)
 "boe" = (
-/obj/structure/simple_door,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/shower{
+	pixel_y = 24
 	},
+/obj/structure/decoration/vent,
+/obj/structure/window/reinforced/tinted/frosted,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "bof" = (
 /obj/structure/chair/f13chair1{
@@ -1179,21 +1194,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/followers)
-"bor" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "boG" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -1205,9 +1205,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "bpg" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table/wood/poker,
+/obj/item/toy/eightball,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "bpj" = (
 /obj/structure/table,
@@ -1215,8 +1215,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bpv" = (
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/wood,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/obj/structure/fluff/railing,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "bpW" = (
 /obj/structure/table{
@@ -1264,9 +1274,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "bri" = (
-/obj/effect/temp_visual/steam_release,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/structure/table/wood/poker,
+/obj/item/dice/d20,
+/turf/open/floor/wood,
+/area/f13/brotherhood)
 "brp" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -1304,12 +1315,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "btq" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice{
 	density = 1
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "btB" = (
@@ -1321,24 +1331,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "btL" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/turf/open/water,
 /area/f13/brotherhood)
 "btM" = (
 /turf/closed/wall/rust,
@@ -1401,26 +1400,6 @@
 /obj/item/storage/fancy/rollingpapers,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bvC" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood)
-"bxo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "bxz" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -1432,20 +1411,23 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bxX" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "byA" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 4;
+	name = "light fixture"
 	},
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "bzt" = (
@@ -1500,10 +1482,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "bCf" = (
-/obj/item/flag/bos,
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
+/obj/item/toy/beach_ball,
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, filtered pool water.";
+	name = "pool water"
 	},
 /area/f13/brotherhood)
 "bCh" = (
@@ -1558,27 +1540,11 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"bFa" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood)
 "bFi" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/structure/rack,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "bGf" = (
 /obj/machinery/light/small{
@@ -1618,12 +1584,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bHC" = (
-/obj/structure/table/glass,
-/obj/structure/table/reinforced,
-/obj/item/documents{
-	desc = "Documents and maps concerning the local NCR presence."
-	},
-/turf/open/floor/f13/wood,
+/obj/structure/chair/f13chair1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "bIh" = (
 /obj/machinery/light/small{
@@ -1632,17 +1595,20 @@
 /turf/open/water,
 /area/f13/tunnel)
 "bIz" = (
-/obj/machinery/libraryscanner{
-	desc = "This device scans books and other documents for entry into the Archives.";
-	name = "archive scanner"
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
-"bJh" = (
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/railing{
+	dir = 8
 	},
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "bJn" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -1658,12 +1624,6 @@
 /obj/item/paper_bin/bundlenatural,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"bKF" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "bKX" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -1673,8 +1633,14 @@
 	},
 /area/f13/tunnel)
 "bLY" = (
-/obj/effect/decal/remains/robot,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/item/flag/bos,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "bMq" = (
 /obj/structure/bed/mattress{
@@ -1699,15 +1665,17 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "bNO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "bOf" = (
-/obj/machinery/rnd/production/protolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/bookcase/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood)
 "bPh" = (
 /obj/structure/simple_door/metal/dirtystore,
@@ -1741,20 +1709,21 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "bQD" = (
+/obj/structure/rack,
+/obj/item/crafting/turpentine,
+/obj/item/crafting/wonderglue,
+/obj/item/crafting/wonderglue,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "bRf" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bRE" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "bSL" = (
 /obj/structure/table,
@@ -1766,12 +1735,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"bTG" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "bTH" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -1786,20 +1749,9 @@
 	},
 /area/f13/brotherhood)
 "bTW" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
-	},
-/obj/item/paper/crumpled,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "bUh" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -1810,11 +1762,23 @@
 /turf/open/water,
 /area/f13/tunnel)
 "bUw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/brotherhood)
 "bUR" = (
 /obj/structure/decoration/vent,
@@ -1832,12 +1796,14 @@
 	},
 /area/f13/tunnel)
 "bVN" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/fulltile/store,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/area/f13/brotherhood)
 "bVO" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -1847,8 +1813,8 @@
 	},
 /area/f13/brotherhood)
 "bVY" = (
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_right"
 	},
 /area/f13/brotherhood)
 "bWk" = (
@@ -1909,12 +1875,12 @@
 	},
 /area/f13/tunnel)
 "cbU" = (
-/obj/effect/decal/marking{
-	pixel_x = -16
+/obj/structure/simple_door/bunker{
+	name = "Firing Range";
+	req_one_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "ccq" = (
@@ -2010,9 +1976,11 @@
 	},
 /area/f13/tunnel)
 "cko" = (
-/turf/open/floor/f13{
-	icon_state = "rampupbottom"
-	},
+/obj/structure/rack,
+/obj/item/crafting/transistor,
+/obj/item/crafting/abraxo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ckx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2029,37 +1997,42 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "cmj" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/structure/table/wood/bar,
+/obj/machinery/chem_dispenser/drinks/beer{
+	pixel_y = 23
 	},
-/area/f13/brotherhood)
-"cmy" = (
-/obj/structure/flora/junglebush/b,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
-"cmM" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1;
+	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "cmZ" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table/wood/bar,
+/obj/machinery/reagentgrinder{
+	pixel_x = -7;
+	pixel_y = 16
+	},
+/obj/item/crafting/coffee_pot{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = -16;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/shamblers_juice{
+	pixel_y = 31
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "cnf" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/item/reagent_containers/food/drinks/mug/coco{
-	pixel_y = 5
-	},
 /obj/machinery/light/small{
 	dir = 8;
 	light_color = "#d8b1b1"
@@ -2103,17 +2076,16 @@
 	},
 /area/f13/tunnel)
 "col" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+/obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
+	pixel_y = 6
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 1;
+	name = "light fixture"
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "coX" = (
 /obj/structure/simple_door/wood,
@@ -2143,19 +2115,31 @@
 	},
 /area/f13/tunnel)
 "cqm" = (
-/obj/structure/simple_door,
-/obj/structure/decoration/rag,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/structure/table/wood,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1;
+	pixel_y = 6
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/clock/active{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "cqo" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/rock/jungle,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/brotherhood)
 "cqF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2213,17 +2197,12 @@
 	},
 /area/f13/bunker)
 "ctL" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/item/kirbyplants/photosynthetic,
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "cuj" = (
 /obj/structure/noticeboard{
@@ -2270,10 +2249,10 @@
 	},
 /area/f13/tunnel)
 "cwq" = (
-/obj/item/pickaxe,
-/obj/item/clothing/head/hardhat,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "cxb" = (
 /obj/structure/wreck/car/bike,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -2295,12 +2274,9 @@
 /turf/open/floor/plating/f13,
 /area/f13/followers)
 "cxQ" = (
-/turf/open/floor/circuit/f13_blue{
-	icon_state = "bcircuit4";
-	light_color = "#5c8eb4";
-	light_power = 2;
-	light_range = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "cyG" = (
 /obj/structure/table/glass,
@@ -2322,9 +2298,12 @@
 	},
 /area/f13/sewer)
 "cBm" = (
-/obj/structure/debris/v3,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/poolnoodle/blue,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "cBH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2346,26 +2325,22 @@
 /area/f13/clinic)
 "cCr" = (
 /obj/effect/decal/cleanable/shreds,
-/obj/machinery/vending/wallmed{
-	pixel_y = 30;
-	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 10, /obj/item/reagent_containers/pill/patch/silver_sulf = 10, /obj/item/reagent_containers/medspray/styptic = 4, /obj/item/reagent_containers/medspray/silver_sulf = 4, /obj/item/reagent_containers/pill/charcoal = 2, /obj/item/reagent_containers/medspray/sterilizine = 2)
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker{
+	name = "Locker Room"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
 "cCE" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1;
+	pixel_y = 6
 	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/item/flashlight/lamp,
-/obj/item/trash/cheesie,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "cDp" = (
@@ -2375,34 +2350,27 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood)
 "cDx" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
-"cEm" = (
-/obj/item/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"cEF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
+/obj/structure/curtain{
+	color = "#5c131b";
+	open = 0
 	},
-/area/f13/brotherhood)
-"cEK" = (
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
-	},
+/obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
+/area/f13/brotherhood)
+"cEF" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/brotherhood)
+"cEK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "cFE" = (
 /obj/structure/table/optable/abductor,
@@ -2435,37 +2403,28 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "cGO" = (
-/obj/structure/showcase/machinery/microwave{
-	pixel_y = 8
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "cHx" = (
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/chair/middle{
+	dir = 8
 	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "cHA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"cHK" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/item/paper/crumpled/ruins,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -2489,17 +2448,28 @@
 	},
 /area/f13/sewer)
 "cIQ" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/light_emitter,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "cIS" = (
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/water,
 /area/f13/brotherhood)
 "cJp" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -2518,11 +2488,14 @@
 	},
 /area/f13/tunnel)
 "cKI" = (
-/obj/structure/chair/wood{
-	dir = 1;
-	icon_state = "wooden_chair_settler"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/wood,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "cLN" = (
 /obj/structure/simple_door/metal/barred,
@@ -2562,12 +2535,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "cOm" = (
-/obj/structure/closet,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/lattice{
+	layer = 3
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "cOn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2584,7 +2558,10 @@
 	},
 /area/f13/brotherhood)
 "cPq" = (
-/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker{
+	name = "Locker Room"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "cPA" = (
@@ -2604,8 +2581,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "cQU" = (
-/obj/structure/sign/poster/contraband/pinup_ride,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "cQW" = (
 /obj/item/clothing/under/f13/rag,
@@ -2622,11 +2608,19 @@
 	},
 /area/f13/tunnel)
 "cRy" = (
-/turf/open/floor/f13,
-/area/f13/brotherhood)
-"cRN" = (
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/left{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "cRX" = (
 /obj/structure/closet{
@@ -2663,10 +2657,17 @@
 /turf/open/water,
 /area/f13/caves)
 "cTh" = (
-/obj/structure/chair/bench{
-	icon_state = "dropshipleft"
+/obj/machinery/door/poddoor/shutters{
+	id = "bosdoors";
+	name = "brotherhood shutters"
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
 /area/f13/brotherhood)
 "cTp" = (
 /obj/machinery/light/small{
@@ -2685,16 +2686,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "cTM" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+/obj/machinery/door/poddoor/shutters{
+	id = "bosdoors";
+	name = "brotherhood shutters"
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "darkrusty"
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
 "cUk" = (
@@ -2711,31 +2709,37 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "cUF" = (
-/obj/machinery/workbench/forge{
-	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
-	icon_state = "generator_on";
-	name = "superheating forge"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "cVj" = (
-/obj/structure/rack,
-/obj/item/crafting/transistor,
-/obj/item/crafting/abraxo,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "cVA" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood)
 "cVH" = (
-/obj/structure/rack,
-/obj/item/bot_assembly/floorbot,
-/obj/item/bodypart/r_arm/robot,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "cWd" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -2750,23 +2754,43 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "cWR" = (
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/rack,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "cWS" = (
-/obj/structure/rack,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/air,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/oxygen/red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -11;
+	pixel_y = 13
+	},
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "cXl" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "cXG" = (
-/obj/item/flag/bos,
-/turf/open/floor/carpet/black,
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_y = 19
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "cYr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2775,46 +2799,32 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"cZm" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood)
 "cZu" = (
-/obj/structure/table/wood,
-/obj/item/trash/f13/bubblegum,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/closet/fridge/standard,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "cZA" = (
 /obj/machinery/telecomms/server/presets/vault,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "cZI" = (
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 4;
-	light_color = "#800080";
-	name = "light fixture"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/deepfryer,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "cZT" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "dbk" = (
@@ -2846,23 +2856,22 @@
 	},
 /area/f13/brotherhood)
 "dcF" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/processor/chopping_block{
+	pixel_x = -4;
+	pixel_y = 16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/side{
-	dir = 9
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "dcI" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/machinery/jukebox,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/shreds,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "dcV" = (
@@ -2874,14 +2883,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ddJ" = (
-/obj/structure/table/survival_pod,
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable{
+	pixel_y = 16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "dek" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2945,30 +2951,28 @@
 	},
 /area/f13/tunnel)
 "diM" = (
-/obj/structure/chair/stool/f13stool{
-	pixel_x = -8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
+/obj/machinery/smartfridge/food,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "djc" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "djn" = (
-/obj/structure/chair/brass{
-	dir = 8
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtysolid"
-	},
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "djs" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/brotherhood)
 "djR" = (
@@ -2979,10 +2983,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "dkT" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/bus_door,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/left{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "dlz" = (
 /obj/structure/toilet{
 	pixel_y = 10
@@ -2996,21 +3002,24 @@
 	},
 /area/f13/bunker)
 "dlT" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
+/obj/machinery/door/poddoor/gate{
+	id = "boscheckpoint";
+	name = "Checkpoint";
+	req_access_txt = "120";
+	req_one_access_txt = "120";
+	state_open = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "dmp" = (
-/obj/effect/decal/cleanable/robot_debris/limb,
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_x = 4;
+	pixel_y = 9
 	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dmH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3023,29 +3032,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dny" = (
-/obj/structure/rack,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"dnH" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+	dir = 8
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"dnH" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "doi" = (
@@ -3118,11 +3118,12 @@
 /area/f13/tunnel)
 "dsy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/grenades{
+	pixel_x = 5;
+	pixel_y = 9
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dsB" = (
 /obj/item/trash/cheesie,
@@ -3135,35 +3136,33 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"dtm" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster69"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
 "dtH" = (
 /obj/structure/table/reinforced{
 	req_access_txt = "120"
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
+/obj/structure/barricade/bars{
+	layer = 5
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "due" = (
-/turf/closed/indestructible/riveted,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13foldupchair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dur" = (
-/obj/structure/flora/grass/wasteland,
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/item/book/granter/crafting_recipe/blueprint/aep7,
+/obj/item/book/granter/crafting_recipe/blueprint/aer9,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/area/f13/brotherhood)
 "dvP" = (
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "120"
@@ -3173,11 +3172,14 @@
 	},
 /area/f13/brotherhood)
 "dwd" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "dxj" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -3343,34 +3345,23 @@
 /obj/item/clothing/mask/gas/explorer{
 	pixel_y = 11
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"dyO" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dyQ" = (
 /obj/structure/ore_box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dyR" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "dze" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 1;
-	name = "light fixture"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtysolid"
-	},
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "dzJ" = (
 /obj/machinery/light{
@@ -3383,9 +3374,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dBy" = (
-/obj/structure/table/wood/poker,
-/obj/item/dice/d20,
-/turf/open/floor/wood,
+/obj/effect/decal/cleanable/flour,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "dCf" = (
 /obj/structure/campfire/barrel,
@@ -3394,14 +3384,11 @@
 	},
 /area/f13/tunnel)
 "dDj" = (
-/obj/effect/decal/cleanable/robot_debris/up,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/machinery/reagentgrinder{
+	pixel_y = 9
 	},
-/area/f13/brotherhood)
-"dDE" = (
-/obj/structure/sign/poster/prewar/poster93,
-/turf/closed/wall/r_wall,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "dEa" = (
 /obj/machinery/telecomms/server/presets/den,
@@ -3416,15 +3403,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dEk" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
-	},
-/obj/item/pen/fourcolor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/brotherhood)
 "dEm" = (
 /obj/effect/decal/remains/human,
@@ -3456,15 +3441,9 @@
 	},
 /area/f13/followers)
 "dFd" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red";
-	pixel_y = 0
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "dFz" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -3477,17 +3456,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"dGu" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "dGD" = (
 /obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
+	pixel_x = -16;
+	pixel_y = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -3501,34 +3476,24 @@
 	},
 /area/f13/clinic)
 "dGU" = (
-/obj/machinery/power/am_control_unit{
-	anchored = 1;
-	dir = 4;
-	pixel_y = 16
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dHm" = (
-/obj/structure/chair/brass{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dHn" = (
 /obj/structure/sign/poster/prewar/poster85,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "dIf" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/side,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dID" = (
 /obj/structure/sign/warning/biohazard,
@@ -3593,29 +3558,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dKo" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dKx" = (
 /obj/item/chair,
@@ -3664,14 +3609,26 @@
 	},
 /area/f13/bunker)
 "dLO" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
 	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/brotherhood)
 "dLP" = (
 /obj/structure/table/wood,
@@ -3697,13 +3654,11 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/tunnel)
 "dNh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/kirbyplants/photosynthetic,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dNu" = (
 /obj/structure/closet/crate{
@@ -3753,21 +3708,14 @@
 	},
 /area/f13/bunker)
 "dQy" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "dQA" = (
 /obj/machinery/light/small{
@@ -3779,9 +3727,14 @@
 	},
 /area/f13/clinic)
 "dQB" = (
-/obj/structure/sign/poster/ripped,
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dRM" = (
 /turf/open/floor/f13{
@@ -3796,15 +3749,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"dSr" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
-/area/f13/brotherhood)
 "dSs" = (
-/obj/structure/table/wood/bar,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/trash/f13/electronic/toaster{
+	pixel_x = -5;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
@@ -3845,35 +3794,24 @@
 	},
 /area/f13/tunnel)
 "dTN" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood)
+"dUm" = (
+/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/revolver{
+	pixel_y = 32
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood)
-"dUm" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/filingcabinet/filingcabinet,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "dUn" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dUu" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood)
 "dUC" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -3882,20 +3820,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"dUG" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "A console used by the scribes of the Brotherhood of Steel.";
-	dir = 8;
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal";
-	name = "Archive Terminal"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "dUL" = (
 /obj/structure/curtain{
 	color = "#5c131b"
@@ -3936,10 +3860,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "dWT" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "dWV" = (
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3955,11 +3882,18 @@
 /turf/closed/wall/rust,
 /area/f13/caves)
 "dYf" = (
-/obj/machinery/computer/shuttle/boselevator{
-	dir = 1
+/obj/structure/rack,
+/obj/item/twohanded/sledgehammer/supersledge,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "dYr" = (
@@ -4016,18 +3950,23 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/tunnel)
-"dZj" = (
-/obj/structure/fence/end/wooden{
-	density = 0;
-	pixel_x = -16;
-	pixel_y = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
 "dZz" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_left"
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "dZF" = (
@@ -4041,19 +3980,39 @@
 	},
 /area/f13/tunnel)
 "eaR" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "ebN" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "engine"
+/obj/machinery/light/small{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "ede" = (
 /obj/machinery/shower{
@@ -4085,24 +4044,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "eet" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "eey" = (
-/obj/machinery/door/airlock/wood,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "eeG" = (
 /obj/structure/noticeboard{
@@ -4135,17 +4089,19 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
 "efw" = (
-/obj/structure/sign/poster/prewar/poster69{
-	dir = 1;
-	pixel_y = null
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "efS" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "efX" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4184,66 +4140,43 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
-"eiZ" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "ejr" = (
 /obj/structure/barricade/wooden,
 /obj/effect/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ejF" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "ejM" = (
 /obj/structure/simple_door/bunker,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "ejY" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Business"
-	},
-/turf/open/floor/f13/wood,
+/obj/machinery/workbench/advanced,
+/obj/item/stack/sheet/prewar/five,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ekv" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/side{
-	dir = 4
+/obj/machinery/hydroponics/constructable{
+	anchored = 0
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "ekD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/sign/poster/prewar/poster66,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "ekK" = (
 /obj/structure/decoration/vent{
@@ -4263,27 +4196,12 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/tunnel)
-"ekN" = (
-/obj/machinery/rnd/production/protolathe,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
 "ekY" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood)
-"ele" = (
-/obj/machinery/plantgenes{
-	layer = 2.8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "elU" = (
 /obj/effect/decal/cleanable/blood/splats,
@@ -4292,11 +4210,12 @@
 	},
 /area/f13/bunker)
 "emn" = (
-/obj/structure/simple_door/bunker{
-	req_access = 120;
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "emX" = (
 /obj/structure/table/glass,
@@ -4306,13 +4225,12 @@
 	},
 /area/f13/followers)
 "eod" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	pixel_x = 6;
-	pixel_y = -4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosaccesscontrol";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "eom" = (
 /obj/structure/wreck/trash/three_barrels,
@@ -4350,13 +4268,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "epW" = (
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosarmoryacc";
+	name = "Armory";
+	req_access_txt = "120"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "epZ" = (
 /obj/structure/sign/warning{
@@ -4374,13 +4292,15 @@
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "eqw" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/machinery/button/door{
+	id = "bosarmoryacc";
+	normaldoorcontrol = 1;
+	pixel_y = -22;
+	specialfunctions = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "eqz" = (
@@ -4406,16 +4326,6 @@
 /obj/structure/sign/poster/prewar/poster60,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
-"etu" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "etN" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -4432,14 +4342,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "euI" = (
-/obj/structure/sign/poster/contraband/pinup_couch,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
-"euS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/machinery/light/small,
+/obj/machinery/autolathe,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "euY" = (
@@ -4452,15 +4358,12 @@
 	},
 /area/f13/followers)
 "ewy" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/bookcase/manuals/engineering{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Brotherhood Archives"
 	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "exq" = (
@@ -4479,12 +4382,13 @@
 	},
 /area/f13/tunnel)
 "eyt" = (
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
+/obj/structure/window/fulltile/store,
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/grille,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "eyW" = (
 /obj/machinery/door/airlock/abandoned,
@@ -4537,7 +4441,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "eAw" = (
-/obj/machinery/vending/coffee,
+/obj/structure/wreck/trash/secway,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "eAO" = (
@@ -4575,13 +4480,8 @@
 	},
 /area/f13/followers)
 "eBz" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 2
-	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "eBK" = (
 /obj/machinery/shower{
@@ -4625,10 +4525,6 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "eDv" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/lighter,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -4652,16 +4548,20 @@
 	},
 /area/f13/brotherhood)
 "eDB" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
+/obj/item/toy/plush/nukeplushie{
+	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
+	name = "Knight-Captain Aryom";
+	pixel_x = 9
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "eDT" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/hydroponics/constructable{
+	anchored = 0
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "eDV" = (
 /obj/structure/closet,
@@ -4681,38 +4581,9 @@
 	},
 /area/f13/sewer)
 "eGI" = (
-/obj/item/am_containment{
-	pixel_x = 3
-	},
-/obj/structure/table/reinforced,
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/structure/window/plasma/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1
-	},
-/obj/item/am_containment,
-/obj/item/am_containment{
-	pixel_x = -3
-	},
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "eGX" = (
 /obj/structure/sink{
@@ -4729,14 +4600,14 @@
 	},
 /area/f13/followers)
 "eHh" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
+/obj/structure/rack,
+/obj/item/book/granter/crafting_recipe/blueprint/aep7,
+/obj/item/book/granter/crafting_recipe/blueprint/aer9,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "eHl" = (
@@ -4762,12 +4633,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "eJX" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/item/statuebust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "eKT" = (
 /obj/structure/sign/poster/contraband/have_a_puff{
@@ -4793,22 +4664,11 @@
 	},
 /area/f13/tunnel)
 "eLK" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/turf/open/water,
+/obj/item/lighter,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "eMA" = (
 /mob/living/simple_animal/hostile/centaur,
@@ -4817,12 +4677,8 @@
 	},
 /area/f13/tunnel)
 "eNh" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/disposalpipe/broken{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "eNq" = (
@@ -4849,16 +4705,13 @@
 	},
 /area/f13/brotherhood)
 "eOx" = (
-/obj/structure/bookcase/random,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood)
+/obj/structure/flora/junglebush/large,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "eOF" = (
-/obj/structure/closet/secure_closet/personal{
-	req_access = list(120)
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "eOW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4884,14 +4737,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ePz" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "AUX"
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "eQC" = (
 /obj/machinery/telecomms/server/presets/engineering,
@@ -4962,6 +4812,7 @@
 /area/f13/caves)
 "eUN" = (
 /obj/machinery/door/airlock/hatch{
+	name = "Dorms";
 	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4997,21 +4848,22 @@
 	},
 /area/f13/tunnel)
 "eZj" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/floor/f13/wood{
-	icon_state = "tunnelwasteland"
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "eZX" = (
 /obj/structure/bodycontainer/crematorium,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "fbp" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "fbC" = (
 /obj/structure/grille/broken,
@@ -5026,14 +4878,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "fbK" = (
-/obj/structure/sign/poster/ripped,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "fbP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
+/obj/structure/filingcabinet/employment,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "fcR" = (
 /obj/machinery/autolathe/ammo,
@@ -5042,26 +4899,20 @@
 	},
 /area/f13/followers)
 "fdp" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "fdN" = (
-/obj/structure/frame/machine,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "fee" = (
 /obj/effect/landmark/start/f13/paladin,
@@ -5121,30 +4972,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"fhk" = (
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "fhn" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "fhW" = (
-/obj/structure/disposalpipe/broken{
-	dir = 1
+/obj/machinery/button/door{
+	id = "floor1elevatordoors";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "fhZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "AUX"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "fjW" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -5159,10 +5007,9 @@
 	},
 /area/f13/tunnel)
 "fkd" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster90"
-	},
-/turf/closed/wall/r_wall,
+/obj/item/kirbyplants/photosynthetic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "fkh" = (
 /obj/machinery/light/sign{
@@ -5197,28 +5044,9 @@
 	},
 /area/f13/tunnel)
 "fli" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/turf/open/water,
+/obj/structure/bookcase/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "flj" = (
 /obj/machinery/chem_master/advanced,
@@ -5232,29 +5060,18 @@
 /area/f13/clinic)
 "flt" = (
 /obj/structure/rack,
-/obj/item/crafting/turpentine,
-/obj/item/crafting/wonderglue,
-/obj/item/crafting/wonderglue,
+/obj/item/crafting/timer,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "flC" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"flF" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "flP" = (
 /obj/effect/landmark/start/f13/prospector,
@@ -5269,7 +5086,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fmv" = (
-/turf/open/floor/plasteel/floorgrime,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "fmT" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -5293,20 +5114,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"fnD" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "A console used by the scribes of the Brotherhood of Steel.";
-	dir = 4;
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal";
-	name = "Archive Terminal"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "fnZ" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden,
@@ -5315,59 +5122,38 @@
 	},
 /area/f13/bunker)
 "fou" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/lattice{
 	layer = 3
 	},
+/obj/item/flag/bos,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
-"foM" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "fpE" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "fpU" = (
-/turf/closed/wall/mineral/wood,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "headscribedorm";
+	name = "Head Scribe's Office";
+	req_one_access = "120"
+	},
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "fqz" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "fqK" = (
 /obj/effect/decal/cleanable/generic,
@@ -5396,16 +5182,14 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "fsQ" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
 	},
-/obj/machinery/shuttle_manipulator{
-	desc = "You have no idea what this shows.";
-	name = "old hologram";
-	pixel_x = 16;
-	pixel_y = -16
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "ftU" = (
 /obj/structure/curtain{
@@ -5440,12 +5224,11 @@
 	},
 /area/f13/tunnel)
 "fwX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/closet,
+/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "fwZ" = (
@@ -5464,13 +5247,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fzR" = (
-/obj/machinery/rnd/server/bos,
+/obj/effect/landmark/start/f13/scribe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "fAf" = (
-/obj/effect/ctf/flag_reset/red,
+/obj/structure/closet,
+/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "fAs" = (
@@ -5482,15 +5268,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "fAC" = (
-/obj/machinery/smoke_machine{
-	desc = "An old world machine with a centrifuge installed into it. It produces steam with any reagents you put into the machine.";
-	name = "Steam Generator"
-	},
-/obj/structure/falsewall/wood{
-	layer = 3;
-	name = "steam generator shutter"
-	},
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/destructible/clockwork/wall_gear,
+/obj/item/projectile/magic/animate,
+/turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
 "fBi" = (
 /obj/structure/closet/crate/large,
@@ -5509,19 +5289,12 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
-"fCu" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/cans,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
 "fDh" = (
-/obj/structure/bed,
-/obj/item/bedsheet/rd{
-	desc = "A fine quilted blanket, made with purple and yellow fabric.";
-	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
-	name = "fine bedsheet"
+/obj/item/flag/bos,
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/brotherhood)
 "fDi" = (
 /obj/structure/lattice{
@@ -5535,56 +5308,22 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"fDC" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/obj/structure/barricade/wooden/planks,
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "fDJ" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8;
+	pixel_x = -6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "fDW" = (
-/obj/structure/dresser,
-/obj/structure/mirror{
-	pixel_y = 30
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
-"fDZ" = (
-/obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
-	},
-/obj/machinery/shower{
-	layer = 2.8;
-	pixel_y = 32
-	},
-/obj/structure/window/reinforced/survival_pod,
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "fEB" = (
 /obj/machinery/light{
@@ -5607,28 +5346,20 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"fFK" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "fGA" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/followers)
 "fGI" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
 	},
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/temp_visual/small_smoke,
-/turf/open/floor/plating/tunnel,
+/obj/effect/landmark/start/f13/headscribe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "fGO" = (
 /obj/structure/handrail/g_central{
@@ -5645,10 +5376,10 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "fHM" = (
-/obj/structure/punching_bag,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "fHP" = (
 /obj/structure/closet,
@@ -5658,10 +5389,8 @@
 	},
 /area/f13/clinic)
 "fIV" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/structure/table,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "fJw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5675,9 +5404,8 @@
 	},
 /area/f13/tunnel)
 "fJy" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
 /turf/open/floor/f13{
-	icon_state = "darkrusty"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "fJM" = (
@@ -5691,11 +5419,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"fKn" = (
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
-	},
-/area/f13/brotherhood)
 "fKq" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -5712,32 +5435,18 @@
 /area/f13/tunnel)
 "fLg" = (
 /obj/machinery/light/small{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Business"
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/airless,
 /area/f13/brotherhood)
 "fLF" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
 	},
-/obj/item/storage/bag/ore,
-/obj/item/t_scanner/adv_mining_scanner,
-/obj/item/clothing/glasses/meson,
-/obj/item/pickaxe/drill/diamonddrill,
-/obj/item/gps/mining,
-/obj/item/pickaxe/drill/diamonddrill,
-/obj/item/storage/bag/ore,
-/obj/item/clothing/glasses/meson,
-/obj/item/gps/mining,
-/obj/item/t_scanner/adv_mining_scanner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/airless,
 /area/f13/brotherhood)
 "fLK" = (
 /obj/effect/decal/remains{
@@ -5753,20 +5462,10 @@
 "fLU" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"fME" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "fMY" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/glass/rag/towel,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/structure/destructible/clockwork/wall_gear,
+/obj/item/projectile/magic/change,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "fNk" = (
 /obj/machinery/autolathe,
@@ -5785,19 +5484,20 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "fOD" = (
-/obj/item/trash/f13/tin,
-/turf/open/floor/wood,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "fOZ" = (
 /obj/machinery/door/airlock/abandoned,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fPg" = (
-/obj/item/flag/bos{
-	pixel_x = 16
+/obj/item/candle{
+	pixel_x = 7;
+	pixel_y = 7
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
 	},
 /area/f13/brotherhood)
 "fPj" = (
@@ -5832,12 +5532,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "fQG" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
+/obj/structure/lattice/catwalk/clockwork,
+/turf/open/floor/bronze{
+	name = "floor"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "fSe" = (
 /obj/structure/filingcabinet,
@@ -5869,10 +5567,14 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "fTD" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
+/obj/item/candle{
+	pixel_x = -6;
+	pixel_y = 7
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
+	},
 /area/f13/brotherhood)
 "fUZ" = (
 /obj/effect/decal/cleanable/blood,
@@ -5898,36 +5600,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "fXs" = (
-/obj/machinery/computer/terminal{
-	density = 0;
-	desc = "A pre-war high security terminal. There's virtually no way to hack into this thing; it holds the most secure information the Brotherhood has to offer.";
-	doc_content_1 = "The preservation of technology is our primary goal, all others are secondary. <br> <br>  Shield yourself from those not bound to you by steel, for they are the blind. Aid them when you can, but lose not sight of yourself.";
-	doc_content_2 = "Give way your suspicions to the wisdom of thine Elder. Where he shows trust, so shall you. <br> <br> Fear those who do not pledge to the Brotherhood for though their eyes may be opened through service, they are now blind. ";
-	doc_content_3 = "Through discourse, we gain the strength of our Brothers' minds. Deceit and lies of all ilk serve only to harm that strength. <br> <br> Your caste and duties mean everything, you will follow your leader and your leader will lead you. <br> <br> You may only follow the orders of another if it will save the life of a brother. ";
-	doc_content_4 = "Theft is for lesser men, the Brotherhood provides for you and you provide for the Brotherhood. <br> <br>  What lesser men see as fashionable shall be shunned. Foreign garment and practice will do nothing but shame your fellow brothers.  ";
-	doc_content_5 = "The Blind can not read, only those who have taken the Oath of Fraternity may read this text.";
-	doc_title_1 = "Doctrine pt. 1";
-	doc_title_2 = "Doctrine pt. 2";
-	doc_title_3 = "Doctrine pt. 3";
-	doc_title_4 = "Doctrine pt. 4";
-	doc_title_5 = "Doctrine pt. 5";
-	icon_screen = null;
-	icon_state = "ratvarcomputer1";
-	idle_power_usage = 1;
-	light_color = "#6e1722";
-	light_power = 2;
-	light_range = 3;
-	max_integrity = 1000;
-	name = "The Codex";
-	note = "Scribe Note of the Week:";
-	pixel_y = 16;
-	termtag = "Codex"
-	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood)
-"fYf" = (
 /obj/structure/table{
 	layer = 2.9
 	},
@@ -5946,6 +5618,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "fYC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood)
+"fYL" = (
 /obj/structure/table{
 	layer = 2.9
 	},
@@ -5955,34 +5633,23 @@
 	pixel_y = 8;
 	termtag = "Business"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood)
-"fYL" = (
-/obj/structure/weightlifter,
-/obj/machinery/light/small{
-	dir = 1;
-	layer = 2.3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
 /area/f13/brotherhood)
 "fYX" = (
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
 "fZh" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/kitchen/knife/butcher,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "fZC" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/turf/closed/mineral/random/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "fZG" = (
 /obj/machinery/telecomms/server/presets/common,
@@ -6003,29 +5670,20 @@
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "gaj" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	id_tag = null;
+	req_access_txt = "120"
 	},
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/temp_visual/small_smoke,
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "gaz" = (
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
-"gbA" = (
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "gbG" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -6066,12 +5724,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "gdm" = (
-/obj/effect/temp_visual/paper_scatter,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/bookcase/random,
 /turf/open/floor/f13{
-	icon_state = "darkrusty"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "geb" = (
@@ -6089,11 +5744,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"geG" = (
-/obj/structure/closet,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/turf/open/floor/wood,
-/area/f13/brotherhood)
 "gfz" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/rd{
@@ -6142,13 +5792,12 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood)
 "gjB" = (
+/obj/structure/table,
 /obj/machinery/light/small{
-	dir = 4;
-	light_color = "red";
-	pixel_y = 0
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
 /area/f13/brotherhood)
 "gjQ" = (
@@ -6169,22 +5818,15 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"gkL" = (
-/obj/effect/decal/remains/robot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
 "gkZ" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/brotherhood)
 "glv" = (
-/obj/machinery/light/small{
+/obj/structure/chair/stool/retro/backed{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 5
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "gmv" = (
@@ -6206,16 +5848,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "gnY" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "gov" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/shield/riot/bullet_proof,
+/obj/item/shield/riot/bullet_proof,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "goQ" = (
 /obj/structure/sign/poster/prewar/poster77,
@@ -6232,11 +5877,15 @@
 	},
 /area/f13/tunnel)
 "gqK" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red";
+	pixel_y = 0
 	},
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "gqR" = (
 /obj/structure/closet/wardrobe/pjs,
@@ -6245,51 +5894,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
-"grT" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "grX" = (
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/structure/chair/f13chair1{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "gsw" = (
 /obj/structure/chair/wood{
@@ -6311,20 +5922,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "gsT" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
 /turf/open/floor/f13{
 	icon_state = "stagestairs"
 	},
-/area/f13/brotherhood)
-"gsV" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
-	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "gta" = (
 /obj/machinery/vending/cigarette,
@@ -6333,24 +5933,20 @@
 	},
 /area/f13/tunnel)
 "gtg" = (
-/obj/structure/wreck/trash/secway,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "gtY" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gus" = (
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "guw" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -6363,20 +5959,15 @@
 	},
 /area/f13/followers)
 "gvM" = (
-/obj/structure/sign/poster/prewar/poster69{
-	icon_state = "poster66"
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"gwq" = (
-/mob/living/simple_animal/chicken,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
 "gwB" = (
 /obj/structure/mirror{
 	pixel_x = -32
@@ -6413,17 +6004,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gyq" = (
-/obj/structure/closet/crate/bin{
-	anchorable = 0;
-	storage_capacity = 30
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/machinery/light/floor,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "gyB" = (
 /obj/effect/landmark/start/f13/dendoc,
@@ -6444,14 +6026,6 @@
 /obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"gzf" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
 "gzt" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood{
@@ -6459,15 +6033,14 @@
 	},
 /area/f13/tunnel)
 "gzD" = (
-/obj/effect/turf_decal/stripes/white/line{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
 	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "gzK" = (
 /obj/structure/simple_door/room,
@@ -6515,15 +6088,20 @@
 	},
 /area/f13/tunnel)
 "gBF" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
+/obj/structure/closet/crate/bin{
+	anchorable = 0;
+	storage_capacity = 30
 	},
-/obj/effect/decal/cleanable/robot_debris/up,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1;
+	pixel_y = 6
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "gCd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6532,27 +6110,14 @@
 	},
 /area/f13/tunnel)
 "gCl" = (
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/destructible/clockwork/wall_gear,
+/obj/item/projectile/magic/animate,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "gEf" = (
-/obj/item/bedsheet/hos,
-/obj/structure/bed/pod,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
-"gEp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood)
 "gED" = (
@@ -6563,13 +6128,11 @@
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/item/statuebust,
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/robot_debris/up,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"gFk" = (
-/obj/structure/closet/crate/wicker,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "gFu" = (
 /obj/structure/sign/poster/contraband/red_rum{
@@ -6582,19 +6145,24 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "gFE" = (
-/obj/structure/chair/stool/f13stool,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood)
 "gFM" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "engine"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "gFP" = (
 /obj/structure/table/wood,
@@ -6626,26 +6194,29 @@
 	},
 /area/f13/brotherhood)
 "gHi" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+/turf/open/indestructible/ground/outside/water{
+	density = 1;
+	desc = "Deep lake water, filled with who knows what...";
+	name = "lake water"
 	},
-/area/f13/brotherhood)
+/area/f13/caves)
 "gHT" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
+/obj/machinery/door/airlock/grunge{
+	name = "Proctor's Office";
+	req_access_txt = "120"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "gIb" = (
-/obj/structure/chair/bench,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = 32
+/obj/structure/table/wood/fancy/black,
+/obj/item/pda/heads/cmo{
+	name = "Head Scribe PipBoy"
 	},
-/turf/open/floor/wood/f13/stage_r,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "gId" = (
 /obj/structure/sign/warning/securearea{
@@ -6661,10 +6232,13 @@
 	},
 /area/f13/clinic)
 "gJk" = (
-/obj/structure/sign/poster/prewar/poster89{
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/closed/indestructible/opshuttle,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood)
 "gJz" = (
 /obj/effect/landmark/start/f13/prospector,
@@ -6677,19 +6251,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"gMg" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
 "gMG" = (
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "gNj" = (
 /obj/machinery/light/small{
@@ -6727,23 +6293,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gPs" = (
-/obj/structure/lattice{
-	density = 1
+/obj/item/ship_in_a_bottle{
+	pixel_x = -5;
+	pixel_y = 5
 	},
-/obj/structure/disposalpipe/trunk{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/table/wood/fancy/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "gPF" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "AUX"
+/obj/structure/simple_door/bunker/glass{
+	name = "Proctor's Offices"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/elevatorshaft,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "gPJ" = (
 /obj/structure/simple_door/bunker,
@@ -6771,20 +6333,40 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "gSc" = (
-/mob/living/simple_animal/hostile/deathclaw{
-	name = "Rock Claw"
+/obj/structure/destructible/clockwork/wall_gear{
+	light_color = null;
+	light_power = null;
+	light_range = null;
+	pixel_y = -32
 	},
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/turf/open/floor/bronze{
+	name = "floor"
+	},
+/area/f13/brotherhood)
 "gSh" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "AUX"
+/obj/structure/table/wood,
+/obj/item/lighter{
+	color = "#3e4821";
+	desc = "That's one fancy Zippo!";
+	heat = 2500;
+	icon_state = "lighter_overlay_plain";
+	light_power = 2;
+	light_range = 1;
+	name = "Pre-War Military Lighter";
+	pixel_x = 7;
+	pixel_y = -6
 	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/storage/fancy/candle_box{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/elevatorshaft,
+/obj/item/storage/fancy/candle_box{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/open/floor/circuit/red/anim{
+	light_range = 2.5
+	},
 /area/f13/brotherhood)
 "gSD" = (
 /obj/structure/bed,
@@ -6811,17 +6393,19 @@
 	},
 /area/f13/bunker)
 "gTy" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
-"gTT" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
+/obj/structure/table/wood/fancy/black,
+/obj/item/construction/rcd/loaded,
+/obj/item/construction/rld,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
 /turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"gTT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood)
 "gUf" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -6843,9 +6427,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gVp" = (
-/obj/structure/decoration/hatch,
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood)
 "gVu" = (
 /obj/structure/simple_door/house,
@@ -6854,27 +6442,14 @@
 	},
 /area/f13/tunnel)
 "gVy" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
+/obj/structure/chair/sofa/corp{
 	dir = 8
 	},
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood)
 "gVV" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
@@ -6895,11 +6470,14 @@
 /turf/open/water,
 /area/f13/tunnel)
 "gWA" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
-/obj/effect/landmark/start/f13/elder,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood)
 "gXb" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -6946,12 +6524,14 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "hae" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/closet/crate/bin{
-	anchorable = 0;
-	storage_capacity = 30
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood)
 "han" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -6963,10 +6543,8 @@
 	},
 /area/f13/tunnel)
 "haL" = (
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hbQ" = (
@@ -6984,18 +6562,17 @@
 	},
 /area/f13/tunnel)
 "hcC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/obj/machinery/power/smes/engineering,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "hdd" = (
 /obj/structure/sink{
@@ -7034,12 +6611,20 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "hdU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/button/door{
+	id = "headscribedorm";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
-	dir = 4
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood)
 "heg" = (
@@ -7075,17 +6660,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"hfE" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/shreds,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "hgy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7132,21 +6706,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "hhZ" = (
-/obj/structure/destructible/clockwork/wall_gear{
-	light_color = null;
-	light_power = null;
-	light_range = null;
-	pixel_y = -32
+/obj/structure/simple_door/bunker/glass{
+	name = "Archives"
 	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hij" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "hil" = (
 /obj/structure/table/wood/settler,
@@ -7255,8 +6822,8 @@
 	},
 /area/f13/tunnel)
 "hqd" = (
-/obj/structure/flora/junglebush/c,
-/turf/closed/mineral/random/low_chance,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "hqg" = (
 /obj/machinery/light,
@@ -7283,10 +6850,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "hro" = (
-/obj/structure/simple_door{
-	icon_state = "brokenglass"
+/obj/machinery/computer/med_data{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "hrq" = (
 /obj/machinery/door/airlock/grunge{
@@ -7299,20 +6866,14 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood)
-"hrv" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood)
 "hsk" = (
-/obj/structure/closet/secure_closet/hydroponics{
-	desc = "A locker that smells of soil.";
-	name = "gardening locker";
-	req_access = list(120)
+/obj/structure/table/survival_pod,
+/obj/item/newspaper{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
 /area/f13/brotherhood)
 "hsv" = (
@@ -7359,32 +6920,15 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"hsX" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/integrated_electronics/debugger,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/analyzer,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
-	},
+"huv" = (
+/obj/structure/table,
 /obj/item/flashlight/lamp{
 	pixel_x = -14;
 	pixel_y = 9
 	},
-/obj/item/integrated_circuit_printer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"huv" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm5";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/obj/machinery/computer/terminal,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
 /area/f13/brotherhood)
 "huS" = (
@@ -7396,33 +6940,19 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "hvl" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hwn" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
+/obj/structure/table,
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/item/paper/crumpled,
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "hwR" = (
 /obj/structure/janitorialcart,
@@ -7432,16 +6962,6 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"hxa" = (
-/obj/item/ship_in_a_bottle{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/structure/table/wood/fancy/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
 /area/f13/brotherhood)
 "hyj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7456,9 +6976,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hyR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
+/obj/structure/bookcase/random/reference{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Archival References"
+	},
+/obj/machinery/light/small{
 	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "hzg" = (
@@ -7490,25 +7016,16 @@
 	},
 /area/f13/sewer)
 "hBf" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+/mob/living/simple_animal/hostile/deathclaw{
+	name = "Rock Claw"
 	},
-/area/f13/brotherhood)
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "hBC" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/machinery/door/airlock/maintenance{
+	name = "Power"
 	},
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster78"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hBF" = (
@@ -7544,13 +7061,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "hDE" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood)
 "hDO" = (
 /turf/open/floor/f13{
@@ -7589,12 +7102,8 @@
 	},
 /area/f13/tunnel)
 "hFC" = (
-/obj/structure/closet/secure_closet/personal{
-	req_access = list(120)
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
+/obj/structure/sign/poster/prewar/poster93,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "hGa" = (
 /obj/effect/decal/cleanable/blood/gibs{
@@ -7611,13 +7120,22 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "hGV" = (
-/obj/structure/table/reinforced,
-/obj/item/multitool,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/structure/bookcase/manuals/research_and_development{
+	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Brotherhood Historical Archives"
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood)
 "hHc" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_right"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood)
 "hHw" = (
@@ -7651,13 +7169,11 @@
 	},
 /area/f13/tunnel)
 "hHS" = (
-/obj/effect/decal/marking{
-	pixel_x = 16
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "hIl" = (
 /obj/structure/filingcabinet,
@@ -7690,28 +7206,18 @@
 	},
 /area/f13/tunnel)
 "hKx" = (
-/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/robot_debris/down,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "hKG" = (
 /obj/structure/falsewall,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"hKI" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "hKS" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
-	},
-/obj/effect/turf_decal/delivery/white,
+/obj/machinery/cell_charger,
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "vault"
 	},
@@ -7720,15 +7226,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"hLL" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "hLS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/sign{
@@ -7740,16 +7237,17 @@
 	},
 /area/f13/tunnel)
 "hMd" = (
-/obj/structure/wreck/trash/four_barrels,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
 /area/f13/brotherhood)
 "hMu" = (
-/obj/machinery/jukebox,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/bookcase/random,
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hMw" = (
 /obj/machinery/light/small,
@@ -7804,37 +7302,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
-"hND" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "hOb" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/machinery/rnd/server/bos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hOy" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
+	name = "Head Scribe's Archive Terminal"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hOz" = (
 /obj/structure/sign/poster/prewar/poster91,
@@ -7856,20 +7333,29 @@
 	},
 /area/f13/clinic)
 "hOX" = (
-/obj/machinery/rnd/destructive_analyzer,
-/turf/open/floor/plasteel/floorgrime,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "hOY" = (
 /obj/effect/decal/cleanable/shreds{
 	pixel_x = -6;
 	pixel_y = -12
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "hPn" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/animate,
-/turf/closed/wall/f13/wood,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hPF" = (
 /obj/structure/table/wood,
@@ -7879,10 +7365,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "hPN" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hQf" = (
 /obj/structure/disposalpipe/segment{
@@ -7891,14 +7375,10 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "hQt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
 /area/f13/brotherhood)
 "hQE" = (
@@ -7909,14 +7389,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "hRl" = (
-/obj/structure/fluff/broken_flooring,
-/turf/open/floor/wood,
-/area/f13/brotherhood)
-"hRu" = (
-/obj/structure/chair/left{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
+	},
+/area/f13/brotherhood)
+"hRu" = (
+/obj/machinery/button/door{
+	id = "bosshop";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hRy" = (
 /obj/structure/table/reinforced,
@@ -7929,81 +7414,32 @@
 	},
 /area/f13/bunker)
 "hRK" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
-"hRT" = (
-/obj/structure/lattice/catwalk,
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
+/turf/closed/wall/mineral/iron,
 /area/f13/brotherhood)
 "hSq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
-"hSJ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
-"hSP" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"hSQ" = (
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/structure/window/fulltile/wood/broken{
-	desc = "Feed me! FEED ME!";
-	layer = 2;
-	name = "feed trough"
-	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 4;
-	pixel_y = 16
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"hTs" = (
-/obj/item/toy/plush/nukeplushie{
-	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
-	name = "chinese operative plushie"
-	},
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"hSJ" = (
+/obj/machinery/newscaster,
+/turf/closed/wall/mineral/iron,
+/area/f13/brotherhood)
+"hSP" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"hTs" = (
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "hVk" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -8011,29 +7447,38 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "hVC" = (
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	layer = 2.9
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "hVG" = (
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
+	},
 /area/f13/brotherhood)
 "hVJ" = (
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/machinery/door/poddoor/shutters{
+	id = "bosshop";
+	name = "brotherhood shutters"
 	},
-/obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
+	},
 /area/f13/brotherhood)
 "hVK" = (
-/obj/structure/chair/middle,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hWZ" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -8042,8 +7487,7 @@
 	},
 /area/f13/bunker)
 "hXZ" = (
-/obj/machinery/processor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/turf/open/floor/carpet,
 /area/f13/brotherhood)
 "hYh" = (
 /obj/docking_port/stationary/bosaway,
@@ -8067,18 +7511,16 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "hZs" = (
-/obj/machinery/bookbinder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "hZu" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12
-	},
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
 /area/f13/brotherhood)
 "ias" = (
@@ -8134,10 +7576,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ici" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/turf/open/floor/f13{
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
@@ -8165,16 +7608,20 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood)
 "idV" = (
-/obj/effect/decal/cleanable/vomit/old,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/brotherhood)
 "ifa" = (
-/obj/structure/decoration/hatch,
-/obj/machinery/computer/shuttle/boselevator{
-	dir = 1
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/brotherhood)
 "ife" = (
 /obj/structure/closet,
@@ -8208,10 +7655,7 @@
 	},
 /area/f13/tunnel)
 "ifX" = (
-/obj/machinery/button/door{
-	id = "bosshop";
-	pixel_x = -32
-	},
+/obj/machinery/rnd/production/protolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "igC" = (
@@ -8241,15 +7685,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "igV" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
-/obj/structure/lattice{
-	layer = 3
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "ihg" = (
 /obj/structure/bed,
@@ -8266,13 +7707,13 @@
 	},
 /area/f13/clinic)
 "iiS" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/poddoor/shutters{
+	id = "bosshop";
+	name = "brotherhood shutters"
 	},
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
 /area/f13/brotherhood)
 "iiZ" = (
@@ -8283,22 +7724,16 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "ijA" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/chair/f13foldupchair{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "ijT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood)
-"ikr" = (
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
 /area/f13/brotherhood)
 "ikD" = (
 /obj/structure/table/snooker{
@@ -8337,18 +7772,34 @@
 /turf/open/floor/plating/f13,
 /area/f13/followers)
 "ill" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light/small{
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/caution/stand_clear/white{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ilw" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "imc" = (
 /obj/effect/decal/cleanable/generic,
@@ -8359,16 +7810,6 @@
 /obj/item/circular_saw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"imi" = (
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -10;
-	pixel_y = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "imj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -8388,10 +7829,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"ink" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
 "inU" = (
 /obj/structure/chair{
 	dir = 8
@@ -8399,8 +7836,31 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "ioj" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/junglebush{
+	pixel_x = -15
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "iot" = (
 /obj/machinery/light/small{
@@ -8441,12 +7901,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"ipN" = (
-/obj/structure/closet/lasertag/red,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/brotherhood)
 "iqE" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -8504,27 +7958,45 @@
 	},
 /area/f13/tunnel)
 "isU" = (
-/obj/structure/flora/junglebush/large,
-/turf/closed/mineral/random/low_chance,
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "itn" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction,
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/small{
-	brightness = 3;
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 8
 	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/brotherhood)
 "itB" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/riveted,
+/obj/structure/flora/junglebush/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/brotherhood)
 "itI" = (
 /obj/effect/decal/cleanable/ash/snappop_phoenix,
@@ -8536,12 +8008,6 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood)
-"itP" = (
-/obj/structure/rack,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
 /area/f13/brotherhood)
 "itV" = (
 /obj/machinery/vending/coffee,
@@ -8563,19 +8029,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "iuL" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"iuX" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
 /area/f13/brotherhood)
 "ivj" = (
@@ -8598,13 +8055,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iwr" = (
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -10;
-	pixel_y = -1
+/obj/structure/chair/f13chair1{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "iwu" = (
 /obj/structure/table/wood/settler,
@@ -8647,16 +8102,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"izT" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/brotherhood)
 "iAv" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice,
@@ -8684,13 +8129,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "iDk" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor6-old"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "iDt" = (
 /obj/structure/barricade/bars,
@@ -8717,7 +8166,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iFz" = (
-/turf/closed/wall/mineral/iron,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/brotherhood)
 "iFL" = (
 /obj/structure/table,
@@ -8735,13 +8187,8 @@
 	},
 /area/f13/brotherhood)
 "iGY" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "iHs" = (
 /obj/machinery/light/small{
@@ -8763,12 +8210,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
-"iIQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood)
 "iJc" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -8776,9 +8217,12 @@
 	},
 /area/f13/clinic)
 "iJp" = (
-/turf/open/floor/f13/wood{
-	icon_state = "tunnelwasteland"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 8;
+	name = "prewar lounge chair"
 	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "iJD" = (
 /obj/structure/noticeboard{
@@ -8802,19 +8246,28 @@
 	},
 /area/f13/bunker)
 "iKQ" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/animate,
-/turf/closed/wall/r_wall,
+/obj/structure/bookcase/random/reference{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Archival References"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood)
 "iLO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
 /area/f13/brotherhood)
 "iMe" = (
 /obj/structure/sign/poster/ripped,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "iMs" = (
 /obj/item/pickaxe,
@@ -8827,11 +8280,14 @@
 	},
 /area/f13/building)
 "iML" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "iNY" = (
@@ -8881,11 +8337,9 @@
 	},
 /area/f13/followers)
 "iQT" = (
-/obj/structure/barricade/bars,
-/obj/structure/decoration/rag,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/table,
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "iRc" = (
 /obj/structure/simple_door/metal/barred,
@@ -8893,16 +8347,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"iRe" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag{
-	pixel_x = -15
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "iRE" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -8987,14 +8431,8 @@
 	},
 /area/f13/bunker)
 "iVj" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/grille/broken,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "iVx" = (
 /obj/structure/curtain{
@@ -9015,10 +8453,13 @@
 	},
 /area/f13/tunnel)
 "iWr" = (
-/obj/structure/chair/right{
-	icon_state = "booth_south_west"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "iWz" = (
 /obj/effect/decal/remains/human,
@@ -9041,15 +8482,16 @@
 	},
 /area/f13/tunnel)
 "iWR" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/machinery/computer/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = -16
 	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "iXF" = (
 /obj/machinery/light/fo13colored/Red{
@@ -9078,29 +8520,19 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "iYM" = (
-/obj/structure/lattice,
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/computer/secure_data{
+	dir = 4;
+	icon_state = "computer"
 	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "iYX" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "iZB" = (
-/obj/machinery/workbench/advanced,
-/obj/item/stack/sheet/prewar/five,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/machinery/autolathe/ammo,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "iZD" = (
@@ -9110,9 +8542,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "iZQ" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/integrated_electronics/debugger,
+/obj/item/integrated_electronics/wirer,
+/obj/item/integrated_electronics/detailer,
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_circuit_printer,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
+	},
+/area/f13/brotherhood)
 "jak" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
@@ -9129,14 +8570,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jbP" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "jcf" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -9158,8 +8597,16 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood)
 "jcY" = (
-/obj/structure/mirror,
-/turf/closed/wall/f13/wood/interior,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "bosshop";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
+	},
 /area/f13/brotherhood)
 "jcZ" = (
 /obj/structure/bed/pod,
@@ -9169,12 +8616,11 @@
 	},
 /area/f13/brotherhood)
 "jdf" = (
+/obj/machinery/rnd/destructive_analyzer,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jdP" = (
 /obj/structure/chair/booth,
@@ -9196,10 +8642,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "jeq" = (
-/obj/item/flag/bos,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+/obj/machinery/rnd/destructive_analyzer,
+/obj/machinery/light/small{
+	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jeE" = (
 /obj/machinery/shower{
@@ -9221,14 +8668,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "jeW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 1
+/obj/structure/bookcase/random/religion{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Religious References"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "jfQ" = (
-/obj/machinery/vending/clothing/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/libraryscanner{
+	desc = "This device scans books and other documents for entry into the Archives.";
+	name = "archive scanner";
+	pixel_y = 7
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "jfS" = (
 /obj/item/instrument/violin,
@@ -9239,9 +8694,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "jfW" = (
-/obj/structure/simple_door/bunker/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
+	},
 /area/f13/brotherhood)
 "jga" = (
 /obj/structure/bed/mattress{
@@ -9279,22 +8735,20 @@
 	},
 /area/f13/tunnel)
 "jid" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "jig" = (
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "jiw" = (
-/obj/machinery/door/poddoor/gate{
-	id = "boscheckpoint";
-	name = "Checkpoint";
-	req_access_txt = "120";
-	req_one_access_txt = "120"
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "jiL" = (
 /obj/effect/landmark/map_load_mark/dungeons/northsewer,
@@ -9348,47 +8802,32 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "jnO" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "joo" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/structure/chair/right{
+	dir = 8
 	},
-/obj/item/newspaper{
-	pixel_x = 6;
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4;
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1;
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "jos" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"joD" = (
-/obj/structure/closet/crate/radiation,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jpg" = (
@@ -9406,17 +8845,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "jpB" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jqs" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/table/wood/bar,
+/obj/machinery/chem_dispenser/drinks{
+	pixel_y = 23
 	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "jqx" = (
 /obj/structure/table,
@@ -9426,9 +8870,10 @@
 	},
 /area/f13/tunnel)
 "jqG" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jrm" = (
 /obj/structure/barricade/wooden,
@@ -9454,35 +8899,75 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jrX" = (
-/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
+	},
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "jta" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red";
-	pixel_y = 0
+/obj/machinery/computer/terminal{
+	density = 0;
+	desc = "A pre-war high security terminal. There's virtually no way to hack into this thing; it holds the most secure information the Brotherhood has to offer.";
+	doc_content_1 = "The preservation of technology is our primary goal, all others are secondary. <br> <br>  Shield yourself from those not bound to you by steel, for they are the blind. Aid them when you can, but lose not sight of yourself.";
+	doc_content_2 = "Give way your suspicions to the wisdom of thine Elder. Where he shows trust, so shall you. <br> <br> Fear those who do not pledge to the Brotherhood for though their eyes may be opened through service, they are now blind. ";
+	doc_content_3 = "Through discourse, we gain the strength of our Brothers' minds. Deceit and lies of all ilk serve only to harm that strength. <br> <br> Your caste and duties mean everything, you will follow your leader and your leader will lead you. <br> <br> You may only follow the orders of another if it will save the life of a brother. ";
+	doc_content_4 = "Theft is for lesser men, the Brotherhood provides for you and you provide for the Brotherhood. <br> <br>  What lesser men see as fashionable shall be shunned. Foreign garment and practice will do nothing but shame your fellow brothers.  ";
+	doc_content_5 = "The Blind can not read, only those who have taken the Oath of Fraternity may read this text.";
+	doc_title_1 = "Doctrine pt. 1";
+	doc_title_2 = "Doctrine pt. 2";
+	doc_title_3 = "Doctrine pt. 3";
+	doc_title_4 = "Doctrine pt. 4";
+	doc_title_5 = "Doctrine pt. 5";
+	icon_screen = null;
+	icon_state = "ratvarcomputer1";
+	idle_power_usage = 1;
+	light_color = "#6e1722";
+	light_power = 2;
+	light_range = 3;
+	max_integrity = 1000;
+	name = "The Codex";
+	note = "Scribe Note of the Week:";
+	pixel_y = 16;
+	termtag = "Codex"
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/bronze{
+	name = "floor"
+	},
 /area/f13/brotherhood)
 "jtk" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "jtx" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jtP" = (
-/obj/structure/simple_door,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster70"
 	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "jug" = (
 /obj/structure/chair/stool/retro,
@@ -9490,9 +8975,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jum" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/side{
-	dir = 5
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "A console used by the scribes of the Brotherhood of Steel.";
+	dir = 4;
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal";
+	name = "Archive Terminal"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "juP" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -9525,12 +9019,23 @@
 /turf/open/water,
 /area/f13/brotherhood)
 "juV" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jvg" = (
 /obj/structure/bed,
@@ -9540,19 +9045,11 @@
 	},
 /area/f13/followers)
 "jvD" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/structure/wreck/trash/one_barrel,
-/obj/machinery/light/small,
+/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "darkrusty"
+	dir = 10;
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "jwm" = (
@@ -9635,17 +9132,15 @@
 	},
 /area/f13/tunnel)
 "jzs" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "jzK" = (
-/obj/structure/fence/end/wooden{
-	density = 0;
-	pixel_x = -16;
-	pixel_y = -16
-	},
-/turf/closed/wall/mineral/wood,
+/obj/structure/window/fulltile/store,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "jAZ" = (
 /obj/structure/rack,
@@ -9653,13 +9148,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jBc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "jBU" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -9667,35 +9155,45 @@
 	},
 /area/f13/tunnel)
 "jCU" = (
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "A console used by the scribes of the Brotherhood of Steel.";
+	dir = 8;
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal";
+	name = "Archive Terminal"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"jDX" = (
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster69"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood)
+"jEK" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
 	anchored = 1;
 	name = "formal attire closet"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"jDX" = (
-/obj/structure/wreck/trash/one_barrel,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_f,
 /turf/open/floor/f13{
-	icon_state = "darkrusty"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood)
-"jEK" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "jEM" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"jFd" = (
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/brotherhood)
 "jFx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9725,22 +9223,30 @@
 	},
 /area/f13/followers)
 "jGq" = (
-/obj/item/circuitboard/machine/hydroponics,
-/obj/item/circuitboard/machine/hydroponics,
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
+/obj/item/flag/bos,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "jGs" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit4"
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood)
 "jHA" = (
-/obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/closet{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
 	},
 /area/f13/brotherhood)
 "jHN" = (
@@ -9749,26 +9255,31 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jIe" = (
-/turf/open/floor/plating/tunnel,
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jJd" = (
-/obj/machinery/cell_charger,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
+/obj/structure/lattice{
+	layer = 3
 	},
+/obj/structure/window/reinforced/spawner{
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
+	},
+/obj/structure/window/reinforced/spawner{
+	color = "#777777";
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "jJo" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood)
 "jJT" = (
@@ -9806,25 +9317,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jMo" = (
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/personal{
-	req_access = list(120)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood)
 "jMp" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/door/airlock/hatch{
+	name = "Kitchen";
+	req_access_txt = "120"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "jMM" = (
 /obj/structure/window/fulltile/house{
@@ -9854,16 +9356,27 @@
 	},
 /area/f13/bunker)
 "jNr" = (
-/obj/item/toy/figure/miner{
-	desc = "A strangely dressed Knight figure, holding a pickaxe in one hand, sword in the other!";
-	name = "The Lonesome Knight";
-	toysay = "In case anyone's wondering, i'm still alive out here..."
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/brotherhood)
 "jNv" = (
-/obj/structure/mirror{
-	pixel_y = -32
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	pixel_x = -10
 	},
 /turf/open/floor/f13{
 	dir = 10;
@@ -9881,13 +9394,8 @@
 	},
 /area/f13/clinic)
 "jNC" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
 	},
 /area/f13/brotherhood)
 "jNN" = (
@@ -9907,18 +9415,18 @@
 	},
 /area/f13/tunnel)
 "jOn" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "jOq" = (
-/obj/structure/rack,
-/obj/item/twohanded/sledgehammer/supersledge,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
+/obj/structure/fence/handrail_end/non_dense{
+	dir = 1;
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jOt" = (
@@ -9928,25 +9436,28 @@
 	},
 /area/f13/tunnel)
 "jOE" = (
-/obj/item/toy/beach_ball,
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, filtered pool water.";
-	name = "pool water"
+/obj/structure/bookcase/random/religion{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Religious References"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "jPv" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "jPx" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "jPC" = (
 /obj/effect/decal/fakelattice{
@@ -9977,12 +9488,26 @@
 	},
 /area/f13/tcoms)
 "jQD" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/table/wood/fancy/black{
+	desc = "A set of thin pipes that no longer function.";
+	icon_state = "latticefull";
+	layer = 2.4;
+	name = "pipes"
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/item/statuebust,
+/obj/structure/table{
+	icon_state = "1-f"
 	},
+/obj/structure/table{
+	icon_state = "2-f"
+	},
+/obj/structure/table{
+	icon_state = "3-f"
+	},
+/obj/structure/table{
+	icon_state = "4-f"
+	},
+/obj/structure/window/reinforced/clockwork/fulltile,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "jQN" = (
@@ -10035,10 +9560,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "jSx" = (
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, filtered pool water.";
-	name = "pool water"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "jSJ" = (
 /obj/structure/table/wood,
@@ -10055,14 +9587,38 @@
 	},
 /area/f13/tunnel)
 "jUB" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/change,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
-"jUH" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/side{
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"jUH" = (
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "jUX" = (
 /obj/effect/decal/fakelattice{
@@ -10072,18 +9628,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "jVZ" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with electricity that bounces around on coils, conducting endlessly.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "fusion reactor tube"
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster90"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "jWa" = (
 /obj/structure/chair{
@@ -10152,7 +9700,10 @@
 /area/f13/followers)
 "jYZ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
+/obj/structure/simple_door/bunker{
+	name = "Head Scribe's Office"
+	},
+/turf/open/floor/carpet,
 /area/f13/brotherhood)
 "jZf" = (
 /obj/structure/rack,
@@ -10169,11 +9720,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "jZL" = (
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
+/obj/structure/simple_door/bunker{
+	name = "Head Scribe's Office"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/carpet,
 /area/f13/brotherhood)
 "jZT" = (
 /turf/open/floor/plasteel/floorgrime,
@@ -10224,20 +9774,27 @@
 	},
 /area/f13/clinic)
 "kej" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "keR" = (
-/obj/structure/glowshroom/single,
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/structure/table{
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood)
 "kfq" = (
-/obj/structure/sign/poster/prewar/poster82,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "kfQ" = (
 /obj/structure/closet/cabinet,
@@ -10262,12 +9819,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood)
-"kgF" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood)
 "kgP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -10276,14 +9827,27 @@
 	},
 /area/f13/tunnel)
 "khb" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "A console used by the scribes of the Brotherhood of Steel.";
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal";
+	name = "Archive Terminal"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "khi" = (
-/obj/effect/decal/cleanable/shreds,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1;
+	pixel_y = 6
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "khz" = (
@@ -10305,11 +9869,16 @@
 	},
 /area/f13/clinic)
 "kij" = (
-/obj/structure/sign/plaques/kiddie/library{
-	desc = "A large warning sign that states only the Head Scribe, Elders and Archivist are allowed beyond this point.";
-	name = "TECH VAULT: NO ACCESS"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "kiu" = (
 /obj/structure/chair/wood{
@@ -10324,8 +9893,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "kiX" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kja" = (
@@ -10344,37 +9912,38 @@
 	},
 /area/f13/tunnel)
 "kka" = (
-/obj/effect/decal/cleanable/shreds,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/window/reinforced/spawner/north{
+	dir = 8;
+	icon_state = "rwindow"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kkf" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
+/obj/machinery/rnd/production/circuit_imprinter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kkq" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "kkt" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	layer = 2.3
-	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "kkB" = (
 /obj/structure/chair/left{
@@ -10390,12 +9959,13 @@
 /area/f13/tunnel)
 "klK" = (
 /obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/side{
-	dir = 8
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
 	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "klZ" = (
 /obj/machinery/chem_heater,
@@ -10404,24 +9974,21 @@
 	},
 /area/f13/followers)
 "kng" = (
-/obj/effect/landmark/start/f13/offduty,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "knk" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/item/flashlight/lamp,
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
+/obj/structure/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	dir = 10;
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "kny" = (
@@ -10430,44 +9997,61 @@
 	},
 /area/f13/brotherhood)
 "knF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "stagestairs2"
 	},
 /area/f13/brotherhood)
 "kot" = (
 /obj/structure/sign/poster/prewar/poster89,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
-"koP" = (
-/obj/item/kirbyplants,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
 "kpd" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/structure/window/reinforced/spawner/north{
+	dir = 4;
+	icon_state = "rwindow"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kph" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuitoff4"
+/obj/structure/lattice{
+	layer = 3
 	},
+/obj/item/flag/bos,
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "kqM" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/structure/window/reinforced/spawner/north{
+	dir = 8;
+	icon_state = "rwindow"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kqS" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "krt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/unpowered/wooddoor{
@@ -10492,16 +10076,24 @@
 	},
 /area/f13/followers)
 "ksU" = (
-/obj/item/flag/bos,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch{
+	name = "Backup Power";
+	req_access_txt = "120"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "ktn" = (
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ktQ" = (
@@ -10551,19 +10143,9 @@
 	},
 /area/f13/tunnel)
 "kwo" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "kwy" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/books,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
@@ -10602,9 +10184,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "kzt" = (
-/obj/structure/nest/scorpion,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "kzO" = (
 /obj/machinery/vending/nukacolavend,
 /obj/machinery/light/small{
@@ -10615,17 +10200,12 @@
 	},
 /area/f13/clinic)
 "kAb" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
 	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "kAp" = (
 /obj/structure/table/wood,
@@ -10660,15 +10240,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "kBT" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
 	},
 /area/f13/brotherhood)
 "kCc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 31
+	},
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark"
@@ -10683,11 +10265,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "kCo" = (
-/obj/structure/table/wood/bar,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster82"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "kCx" = (
 /obj/structure/table/glass,
@@ -10704,45 +10285,52 @@
 	},
 /area/f13/tunnel)
 "kDi" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster77"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "kDy" = (
-/obj/structure/barricade/bars,
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster78"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kDC" = (
-/obj/structure/wreck/trash/halftire,
-/mob/living/simple_animal/mouse/gray,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "kDG" = (
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
+/obj/structure/window/reinforced/spawner/north{
+	dir = 4;
+	icon_state = "rwindow"
 	},
-/turf/open/floor/f13/wood,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kDH" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/structure/fence/handrail_end/non_dense{
+	dir = 1;
+	pixel_x = -16
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/lattice{
+	layer = 3
 	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "kDS" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -10754,11 +10342,12 @@
 	},
 /area/f13/bunker)
 "kEN" = (
-/obj/structure/closet/crate/bin{
-	anchorable = 0;
-	storage_capacity = 30
+/obj/structure/window/reinforced/spawner/north{
+	dir = 8;
+	icon_state = "rwindow"
 	},
-/turf/open/floor/wood,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kEP" = (
 /obj/item/paper/crumpled/ruins,
@@ -10781,12 +10370,18 @@
 	},
 /area/f13/sewer)
 "kFw" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/barricade/wooden,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
+/obj/structure/falsewall/reinforced{
+	layer = 3
+	},
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster74"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kFA" = (
 /obj/machinery/computer/telecomms/server{
@@ -10809,41 +10404,92 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "kHS" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "tunnelwastelandfull"
+/obj/structure/bookcase/random,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood)
 "kIo" = (
-/obj/machinery/light/small{
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
+"kIy" = (
+/obj/structure/rack,
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 13;
+	pixel_y = -8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
+"kIH" = (
+/obj/item/flag/bos,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
-"kIy" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"kIH" = (
-/obj/structure/closet/crate/large,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "kIJ" = (
-/obj/structure/ladder/unbreakable{
-	height = 3;
-	id = "AUX"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_left"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood)
 "kIS" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -10858,18 +10504,18 @@
 	},
 /area/f13/sewer)
 "kJy" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/bos,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube"
+	},
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "kKx" = (
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
-	name = "Head Scribe's Archive Terminal"
-	},
+/obj/effect/landmark/start/f13/scribe,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kKB" = (
@@ -10916,25 +10562,34 @@
 /turf/open/water,
 /area/f13/tunnel)
 "kPd" = (
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "bosengine";
+	name = "Radiation Shutters";
+	pixel_x = -32
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "kPE" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	id = "NW"
+	id = "NE"
 	},
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1;
 	icon_state = "warningline_red"
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
+	dir = 10;
 	icon_state = "warningline_red"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -10943,10 +10598,17 @@
 /obj/machinery/button/door{
 	id = "boscheckpoint";
 	name = "Research Checkpoint Button";
-	pixel_x = -7;
-	pixel_y = 23
+	pixel_x = -10;
+	pixel_y = 22
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "bosaccesscontrol";
+	normaldoorcontrol = 1;
+	pixel_x = 12;
+	pixel_y = 22;
+	specialfunctions = 4
+	},
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark"
@@ -10958,13 +10620,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kQE" = (
-/obj/structure/simple_door/bunker{
-	req_access = 120;
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "kQO" = (
 /obj/structure/simple_door/bunker/glass,
@@ -10985,13 +10645,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"kRZ" = (
-/obj/machinery/bsa/back{
-	desc = "Receives and distributes power in the Brotherhood Workshop.";
-	name = "Power Conduit"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "kSa" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11026,17 +10679,21 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "kUl" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
+/obj/machinery/power/am_control_unit{
+	anchored = 1;
+	dir = 8
 	},
-/turf/closed/wall,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "kUz" = (
-/obj/structure/wreck/car{
-	layer = 2
-	},
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "kUN" = (
 /obj/structure/window/fulltile/ruins{
@@ -11053,11 +10710,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kWj" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/chair/wood/normal{
+	dir = 1
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "tunnelwastelandfull"
+/obj/machinery/light/small,
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
 	},
 /area/f13/brotherhood)
 "kWl" = (
@@ -11082,19 +10740,32 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kYh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/brotherhood)
 "kZq" = (
 /obj/structure/sign/poster/prewar/poster69,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "kZB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/junglebush{
+	pixel_x = -15
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/brotherhood)
 "kZR" = (
 /obj/structure/table/wood,
@@ -11106,15 +10777,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "lbi" = (
-/obj/structure/closet,
-/obj/item/stack/sheet/mineral/sandbags,
-/obj/item/stack/sheet/mineral/sandbags,
-/obj/item/stack/sheet/mineral/sandbags,
-/obj/item/stack/sheet/mineral/sandbags,
-/obj/item/stack/sheet/mineral/sandbags,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
 	},
 /area/f13/brotherhood)
 "lbk" = (
@@ -11128,8 +10795,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "lcp" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "lcE" = (
 /obj/structure/handrail/g_central{
@@ -11141,8 +10809,10 @@
 	},
 /area/f13/tunnel)
 "lcZ" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
-/turf/open/floor/wood,
+/obj/item/flag/bos,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "ldi" = (
 /obj/structure/table{
@@ -11152,28 +10822,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ldA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_left"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/power/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "ldK" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ldP" = (
-/obj/machinery/suit_storage_unit/mining,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "ldY" = (
 /obj/machinery/light/small{
@@ -11214,15 +10878,6 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"leG" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "lfw" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11257,11 +10912,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "liM" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/machinery/camera/autoname{
+	dir = 5;
+	icon_state = "camera"
 	},
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "liS" = (
 /obj/machinery/telecomms/server/presets/security,
@@ -11287,13 +10942,9 @@
 	},
 /area/f13/followers)
 "ljC" = (
-/obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet00"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "ljD" = (
 /obj/machinery/light/small{
@@ -11311,8 +10962,15 @@
 /turf/open/water,
 /area/f13/tunnel)
 "lkk" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "lkt" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -11381,16 +11039,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lnF" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "bosshop";
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "lnL" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -11398,7 +11048,11 @@
 	},
 /area/f13/tunnel)
 "lnZ" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/decal/cleanable/oil/streak,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "loc" = (
 /obj/structure/dresser,
@@ -11437,23 +11091,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "lqB" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
+/obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	layer = 3
 	},
+/obj/item/flag/bos,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "lqT" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "lre" = (
 /obj/structure/rack,
@@ -11461,27 +11115,9 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"lrs" = (
-/obj/effect/decal/remains/human,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
 "lrP" = (
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"lsz" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
 /area/f13/brotherhood)
 "lsW" = (
 /obj/effect/decal/cleanable/oil,
@@ -11501,7 +11137,9 @@
 	},
 /area/f13/tunnel)
 "ltR" = (
-/obj/structure/simple_door/metal/barred,
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -11523,10 +11161,17 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood)
 "lvv" = (
-/obj/structure/weightlifter,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
 	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/item/flag/bos,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "lvT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11545,39 +11190,34 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/followers)
-"lwl" = (
-/obj/machinery/smartfridge/bottlerack/gardentool,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
 "lwz" = (
 /obj/structure/filingcabinet/employment,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood)
 "lwY" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "lxk" = (
-/obj/structure/chair/bench,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/wood/f13/stage_t,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "lxD" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/wood,
+/obj/effect/decal/cleanable/robot_debris/limb,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "lyh" = (
 /obj/structure/reagent_dispensers/barrel/four,
@@ -11596,39 +11236,32 @@
 	},
 /area/f13/tunnel)
 "lyG" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with electricity that bounces around on coils, conducting endlessly.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "fusion reactor tube"
+/obj/structure/decoration/vent{
+	layer = 2
 	},
-/obj/item/flag/bos{
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
-"lzc" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 1;
-	icon_state = "twindow"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"lzS" = (
-/obj/structure/disposalpipe/junction,
-/obj/structure/lattice/clockwork,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/lattice{
-	density = 1
+	layer = 3
 	},
 /turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
+"lzc" = (
+/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/space_cube{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/f13/brotherhood)
+"lzS" = (
+/obj/machinery/ore_silo,
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster70";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
+	},
 /area/f13/brotherhood)
 "lzW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11666,14 +11299,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lBg" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
+	},
 /area/f13/brotherhood)
 "lBi" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	icon_state = "conveyor_map"
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
 /area/f13/brotherhood)
 "lBm" = (
@@ -11694,20 +11331,14 @@
 	icon_state = "purplefull"
 	},
 /area/f13/brotherhood)
-"lCa" = (
-/obj/structure/fence/end/wooden{
-	density = 0;
-	pixel_x = -16;
-	pixel_y = -16
+"lDo" = (
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	icon_state = "conveyor_map"
 	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"lDo" = (
-/obj/machinery/ore_silo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "engine"
 	},
@@ -11736,18 +11367,26 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "lFo" = (
-/obj/structure/debris/v4,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	icon_state = "conveyor_map"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
+	},
+/area/f13/brotherhood)
 "lGo" = (
 /obj/structure/sign/poster/prewar/poster88,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "lHV" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/conveyor/auto{
+	dir = 6;
+	icon_state = "conveyor_map"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
+	},
 /area/f13/brotherhood)
 "lIx" = (
 /obj/structure/simple_door/bunker,
@@ -11762,35 +11401,19 @@
 	},
 /area/f13/tunnel)
 "lIH" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"lJI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/radiation{
+	anchored = 1
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "lKa" = (
-/obj/structure/closet/secure_closet/personal{
-	req_access = list(120)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
+/obj/item/multitool,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "lKk" = (
 /obj/item/flashlight/flare,
@@ -11799,9 +11422,13 @@
 	},
 /area/f13/bunker)
 "lKs" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bookcase/manuals/engineering,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
 "lKT" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -11814,42 +11441,34 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lLe" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood)
+"lLy" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
-/obj/structure/simple_door/bunker/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
+/obj/item/stack/sheet/prewar/five,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
-"lLy" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood)
 "lLG" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	layer = 2.3
-	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "lLI" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 9
+	},
 /area/f13/brotherhood)
 "lLP" = (
 /obj/structure/closet/fridge,
@@ -11893,21 +11512,21 @@
 /area/f13/clinic)
 "lMT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "stagestairs2"
 	},
 /area/f13/brotherhood)
 "lNO" = (
-/obj/structure/window/reinforced/spawner/north{
+/obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4;
-	icon_state = "rwindow"
+	pixel_x = 6
 	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/turf_decal/trimline/yellow/line{
+	pixel_y = -6
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "lOt" = (
 /obj/structure/flora/grass/wasteland{
@@ -11942,12 +11561,11 @@
 	},
 /area/f13/tunnel)
 "lPf" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance{
+	name = "Power"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "lPs" = (
 /obj/structure/sign/poster/contraband/pinup_funk{
@@ -11988,31 +11606,21 @@
 	},
 /area/f13/tunnel)
 "lQB" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "lQI" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"lRn" = (
-/obj/structure/chair/office/dark{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pool/ladder{
 	dir = 8
 	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/shreds,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, filtered pool water.";
+	name = "pool water"
 	},
 /area/f13/brotherhood)
 "lRu" = (
@@ -12023,21 +11631,18 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "lRC" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
 "lSE" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/item/toy/poolnoodle/yellow,
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, filtered pool water.";
+	name = "pool water"
 	},
 /area/f13/brotherhood)
 "lSQ" = (
@@ -12053,10 +11658,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "lTT" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster89"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/oil/streak,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "lUq" = (
 /obj/structure/table/wood,
@@ -12102,36 +11710,57 @@
 	},
 /area/f13/followers)
 "lWC" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "lWZ" = (
-/obj/structure/table,
-/obj/item/pda/heads/cmo{
-	name = "Head Scribe PipBoy"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/machinery/light/small{
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "lXw" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "SE"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9;
-	icon_state = "warningline_red"
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/turf/open/water,
 /area/f13/brotherhood)
 "lYx" = (
 /obj/machinery/light/small{
@@ -12162,14 +11791,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "lZs" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/robot_debris/up,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"maX" = (
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "mba" = (
 /obj/structure/rack,
@@ -12180,22 +11805,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mbx" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "mbN" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 1
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "mbT" = (
 /obj/item/trash/f13/porknbeans,
@@ -12207,16 +11831,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "mcC" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
-	},
-/area/f13/brotherhood)
-"mdm" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
 /area/f13/brotherhood)
 "mdD" = (
@@ -12226,13 +11843,11 @@
 	},
 /area/f13/sewer)
 "men" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	layer = 3
+/obj/machinery/conveyor/auto,
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
-/obj/item/flag/bos,
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "mfC" = (
 /obj/machinery/light{
@@ -12241,11 +11856,11 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "mfM" = (
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/radiation{
+	anchored = 1
 	},
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "mgx" = (
 /obj/structure/table/reinforced,
@@ -12256,13 +11871,14 @@
 	},
 /area/f13/bunker)
 "mgX" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	layer = 2.7;
-	name = "prewar lounge chair"
+/obj/item/bedsheet/hos,
+/obj/structure/bed/pod,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/landmark/start/f13/headscribe,
-/turf/open/floor/carpet/black,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "miv" = (
 /obj/structure/noticeboard{
@@ -12291,11 +11907,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "miG" = (
-/obj/machinery/light/small,
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "miI" = (
 /turf/open/floor/f13{
@@ -12366,13 +11978,19 @@
 	},
 /area/f13/tunnel)
 "mmF" = (
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = -4
 	},
-/obj/structure/disposalpipe/broken{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_x = -8;
+	pixel_y = 8
 	},
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "mmL" = (
 /obj/machinery/light{
@@ -12401,31 +12019,28 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"mow" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/wall/mineral/wood{
-	icon_state = "girder"
-	},
-/area/f13/brotherhood)
 "moY" = (
-/obj/item/trash/f13/electronic/toaster{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
-"mpn" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/obj/machinery/light/small{
-	brightness = 3;
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
+"mpn" = (
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "mpE" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -12441,15 +12056,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "mpL" = (
-/obj/structure/closet/radiation{
-	anchored = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 6
+/turf/open/floor/plasteel/f13/vault_floor/floor{
+	icon_state = "floordirty"
 	},
 /area/f13/brotherhood)
 "mpX" = (
@@ -12500,34 +12109,31 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "mrx" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/destructible/clockwork/wall_gear,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "mrV" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+/obj/item/toy/figure/miner{
+	desc = "A strangely dressed Knight figure, holding a pickaxe in one hand, sword in the other!";
+	name = "The Lonesome Knight";
+	toysay = "In case anyone's wondering, i'm still alive out here..."
 	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "msd" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "msw" = (
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "msK" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -12536,14 +12142,19 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "muj" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/fence/handrail_corner{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = 16;
+	pixel_y = 16
 	},
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "muA" = (
 /obj/structure/table,
@@ -12554,21 +12165,14 @@
 	},
 /area/f13/tunnel)
 "muD" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "NE"
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10;
-	icon_state = "warningline_red"
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -16
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
 "mvH" = (
@@ -12577,15 +12181,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mxa" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/lattice{
 	layer = 3
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
@@ -12597,6 +12197,7 @@
 /area/f13/clinic)
 "mxQ" = (
 /mob/living/simple_animal/mouse/gray,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "mzn" = (
@@ -12668,21 +12269,27 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/tunnel)
 "mCP" = (
-/obj/structure/mirror{
-	pixel_y = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "greenmark"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
 "mDq" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "mDr" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
+/obj/structure/lattice{
+	layer = 3
 	},
+/obj/structure/window/reinforced/spawner{
+	color = "#777777";
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "mDK" = (
 /obj/machinery/light{
@@ -12693,10 +12300,14 @@
 	},
 /area/f13/followers)
 "mDO" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "mDR" = (
 /obj/structure/simple_door/bunker,
@@ -12705,19 +12316,8 @@
 	},
 /area/f13/clinic)
 "mEm" = (
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = 16;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/bookcase/random,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/brotherhood)
 "mEQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -12730,12 +12330,9 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "mEW" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood)
 "mFz" = (
@@ -12767,11 +12364,11 @@
 	},
 /area/f13/tunnel)
 "mGw" = (
-/obj/structure/table/wood/bar,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "mGH" = (
 /obj/structure/dresser,
@@ -12804,13 +12401,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "mIY" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "mJG" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -12855,19 +12447,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mMv" = (
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Power"
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "mMw" = (
-/obj/structure/sign/poster/prewar/poster70,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "mMC" = (
 /obj/structure/barricade/wooden,
@@ -12924,10 +12511,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "mRj" = (
-/obj/structure/chair/stool/f13stool,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
 "mRH" = (
@@ -12935,37 +12522,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"mRM" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "mRT" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"mSk" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood)
 "mSs" = (
 /obj/structure/table,
 /obj/item/roller,
@@ -12985,38 +12545,16 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/tunnel)
 "mTt" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/structure/glowshroom/single,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"mTv" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/water,
-/area/f13/brotherhood)
-"mTF" = (
+/obj/machinery/suit_storage_unit/mining,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
+/area/f13/brotherhood)
+"mTv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "mUb" = (
 /turf/open/floor/f13{
@@ -13024,12 +12562,17 @@
 	},
 /area/f13/tunnel)
 "mUo" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/machinery/button/door{
+	id = "bosengineaccess";
+	name = "Engineering Lockdown";
+	pixel_x = 34;
+	pixel_y = -4
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "mUv" = (
 /obj/structure/chair/middle,
@@ -13038,18 +12581,20 @@
 	},
 /area/f13/tunnel)
 "mUS" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "mVX" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit3"
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/bos{
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 8
 	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "mXi" = (
 /obj/structure/flora/ausbushes/stalkybush,
@@ -13127,9 +12672,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "nby" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nbz" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -13137,11 +12685,9 @@
 	},
 /area/f13/tunnel)
 "nbS" = (
-/obj/structure/closet/radiation{
-	anchored = 1
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
 /area/f13/brotherhood)
 "ncx" = (
 /obj/structure/chair/stool/retro,
@@ -13165,39 +12711,43 @@
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
 "neb" = (
-/obj/item/kirbyplants,
-/turf/open/floor/f13{
-	icon_state = "bluedirtysolid"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "neq" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster70"
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "net" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"neu" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/lattice{
+	layer = 3
 	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "neP" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/effect/decal/cleanable/insectguts,
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/obj/structure/rack,
-/obj/item/book/granter/crafting_recipe/blueprint/aep7,
-/obj/item/book/granter/crafting_recipe/blueprint/aer9,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	layer = 3
 	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "nfz" = (
 /obj/machinery/light/small{
@@ -13226,20 +12776,6 @@
 	dir = 8
 	},
 /area/f13/tcoms)
-"ngA" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/shreds,
-/obj/structure/window/reinforced/tinted{
-	dir = 1;
-	icon_state = "twindow"
-	},
-/mob/living/simple_animal/mouse/white,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "nha" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/box/white,
@@ -13261,17 +12797,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"nhO" = (
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/effect/decal/remains/xeno/larva,
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "nhY" = (
 /obj/effect/landmark/start/f13/followersvolunteer,
 /turf/open/floor/f13{
@@ -13295,10 +12820,10 @@
 	},
 /area/f13/bunker)
 "niW" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "njZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13315,13 +12840,15 @@
 	},
 /area/f13/followers)
 "nkL" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/shuttle/boselevator{
+	dir = 1
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "nlw" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -13344,13 +12871,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"nnH" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "noe" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -13358,17 +12878,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "non" = (
-/obj/item/kirbyplants,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "noH" = (
-/obj/structure/closet/crate/bin{
-	anchorable = 0;
-	storage_capacity = 30
-	},
-/turf/open/floor/f13{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
@@ -13395,36 +12922,19 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"npl" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "npK" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_3";
-	name = "Level 3: Archives; Recreation; Elders";
-	width = 5
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel/elevatorshaft,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "npR" = (
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "nqk" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "nqA" = (
 /obj/structure/barricade/bars,
@@ -13434,16 +12944,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"nqF" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "nqO" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
@@ -13473,18 +12973,15 @@
 	},
 /area/f13/clinic)
 "nsN" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/obj/item/stack/sheet/prewar/five,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	layer = 3
 	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "nue" = (
 /obj/structure/simple_door/metal/barred,
@@ -13544,45 +13041,28 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood)
 "nwH" = (
-/obj/structure/window/fulltile/wood,
-/turf/open/floor/wood/f13/stage_b,
+/obj/effect/decal/cleanable/insectguts,
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "nxH" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"nxX" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
 "nyn" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/ausbushes,
-/turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "nyK" = (
 /obj/structure/chair/comfy/shuttle{
@@ -13594,16 +13074,23 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood)
 "nzb" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/airless,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood)
 "nzl" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
+	},
 /area/f13/brotherhood)
 "nzm" = (
 /obj/structure/closet,
@@ -13645,13 +13132,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nBh" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood)
 "nBk" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
@@ -13660,21 +13140,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nCg" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood)
 "nCD" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -13682,9 +13147,12 @@
 	},
 /area/f13/followers)
 "nDK" = (
-/obj/structure/chair/stool/f13stool,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/machinery/mineral/equipment_vendor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
 /area/f13/brotherhood)
 "nEe" = (
@@ -13698,8 +13166,38 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "nEt" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/item/am_containment{
+	pixel_x = 3
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1
+	},
+/obj/item/am_containment,
+/obj/item/am_containment{
+	pixel_x = -3
+	},
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/corner,
 /area/f13/brotherhood)
 "nEz" = (
 /obj/structure/campfire/barrel,
@@ -13725,32 +13223,27 @@
 	},
 /area/f13/tunnel)
 "nFR" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_x = 3;
+	pixel_y = 12
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "nGb" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster74"
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "nGh" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "nGN" = (
 /obj/machinery/light/small{
@@ -13761,9 +13254,7 @@
 	},
 /area/f13/clinic)
 "nHu" = (
-/obj/structure/decoration/vent{
-	layer = 2
-	},
+/obj/structure/sign/poster/contraband/hacking_guide,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "nHH" = (
@@ -13794,9 +13285,11 @@
 	},
 /area/f13/brotherhood)
 "nIl" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 4
+	},
+/area/f13/brotherhood)
 "nIL" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -13813,12 +13306,12 @@
 	},
 /area/f13/bunker)
 "nIY" = (
-/obj/machinery/computer/shuttle/boselevator{
-	dir = 1
+/obj/machinery/button/door{
+	id = "floor2elevatordoors";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "nJB" = (
 /obj/machinery/light/fo13colored/Pink{
@@ -13833,8 +13326,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "nKH" = (
-/turf/closed/wall/mineral/wood{
-	icon_state = "girder"
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "nKZ" = (
@@ -13842,14 +13337,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "nLH" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bosengineaccess";
+	name = "Engine Access Shutters"
 	},
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 8
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "nLK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13882,21 +13377,26 @@
 	},
 /area/f13/tunnel)
 "nMG" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bosengineaccess";
+	name = "Engine Access Shutters"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 4
 	},
 /area/f13/brotherhood)
 "nMN" = (
 /obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
+	pixel_x = -16;
+	pixel_y = 8
 	},
-/obj/structure/lattice{
-	layer = 3
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "nMQ" = (
 /obj/structure/toilet{
@@ -13912,9 +13412,12 @@
 	},
 /area/f13/tunnel)
 "nNj" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/books,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "nNx" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
@@ -13931,10 +13434,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nOZ" = (
-/obj/machinery/door/airlock/wood,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "nPp" = (
 /obj/structure/window/reinforced{
@@ -13949,12 +13452,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "nPC" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "nQe" = (
 /obj/structure/table,
@@ -13963,14 +13469,11 @@
 	},
 /area/f13/clinic)
 "nQl" = (
-/obj/structure/grille,
-/obj/structure/grille,
 /obj/structure/table/reinforced,
 /obj/structure/window/fulltile/store,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "nQI" = (
@@ -13978,11 +13481,22 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "nQS" = (
-/obj/structure/noticeboard{
-	desc = "\[FLOOR 1 - MILITARY PERSONNEL] \[FLOOR 2 - WORKSHOPS & LIBRARIES] \[FLOOR 3 - COUNCIL CHAMBERS & MESS HALL]";
-	name = "FLOOR INDEX"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/closed/wall/r_wall,
+/obj/item/storage/bag/ore,
+/obj/item/t_scanner/adv_mining_scanner,
+/obj/item/clothing/glasses/meson,
+/obj/item/pickaxe/drill/diamonddrill,
+/obj/item/gps/mining,
+/obj/item/pickaxe/drill/diamonddrill,
+/obj/item/storage/bag/ore,
+/obj/item/clothing/glasses/meson,
+/obj/item/gps/mining,
+/obj/item/t_scanner/adv_mining_scanner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood)
 "nRP" = (
 /obj/structure/sink{
@@ -14008,16 +13522,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "nSP" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/mug/coco{
-	pixel_x = 21;
-	pixel_y = 8
+/obj/structure/ore_box,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/item/flashlight/lamp{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "nTr" = (
 /obj/structure/sign/poster/prewar/poster61,
@@ -14037,51 +13546,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"nTN" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "nUD" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/brotherhood)
-"nUF" = (
-/obj/structure/bookcase/manuals/engineering,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood)
 "nVP" = (
 /obj/structure/rack,
 /obj/item/mining_scanner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"nVZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
 "nWb" = (
 /obj/effect/decal/remains/robot,
 /obj/effect/decal/cleanable/dirt,
@@ -14097,28 +13577,35 @@
 	},
 /area/f13/clinic)
 "nWG" = (
-/obj/item/flag/bos,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
 "nWV" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
+/obj/structure/frame/machine,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "nXe" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	dir = 4;
-	name = "Recreational Halls"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "nXj" = (
 /turf/open/floor/f13{
@@ -14162,9 +13649,15 @@
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/brotherhood)
 "nYh" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_left"
+/obj/effect/decal/cleanable/robot_debris,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "nYR" = (
 /obj/structure/bed,
@@ -14178,10 +13671,10 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood)
 "nZo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/dresser,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "nZI" = (
 /obj/structure/girder,
@@ -14190,10 +13683,20 @@
 	},
 /area/f13/tunnel)
 "oar" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/frame/machine,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "obS" = (
 /obj/machinery/light/small{
@@ -14236,17 +13739,13 @@
 /turf/closed/wall,
 /area/f13/tunnel)
 "oei" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 9
-	},
-/area/f13/brotherhood)
-"oeF" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "AUX"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "ofm" = (
@@ -14254,13 +13753,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ogh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/airlock/hatch{
+	name = "Power Stores";
+	req_access_txt = "120"
 	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "ohv" = (
 /obj/item/gun/ballistic/automatic/marksman/sniper/gold,
@@ -14271,48 +13772,37 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ohD" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "ohN" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/light/small,
-/turf/open/water,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "ohO" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
-"oim" = (
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "ois" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/bos{
-	dir = 8;
-	pixel_x = 7;
-	pixel_y = 8
+/obj/machinery/door/airlock/hatch{
+	name = "Power Stores";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "oiy" = (
 /obj/item/storage/trash_stack,
@@ -14324,16 +13814,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"oiI" = (
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 4;
-	pixel_y = 16
-	},
-/mob/living/simple_animal/cow/brahmin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
 "ojR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -14342,12 +13822,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ojS" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/turf/open/floor/plasteel/f13/vault_floor/floor{
+	icon_state = "floordirty"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced/clockwork/fulltile,
-/turf/open/water,
 /area/f13/brotherhood)
 "okO" = (
 /obj/structure/table,
@@ -14368,20 +13845,19 @@
 	},
 /area/f13/followers)
 "olI" = (
-/obj/item/reagent_containers/food/snacks/f13/yumyum,
-/obj/structure/table/wood,
-/turf/open/floor/f13{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "olK" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "olU" = (
 /obj/structure/ladder/unbreakable{
@@ -14398,10 +13874,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "omE" = (
-/obj/structure/window/fulltile/wood,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/brotherhood)
 "omL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14410,9 +13883,7 @@
 	},
 /area/f13/tunnel)
 "onB" = (
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
+/turf/closed/mineral/random/low_chance,
 /area/f13/brotherhood)
 "onL" = (
 /obj/machinery/light,
@@ -14421,12 +13892,10 @@
 /area/f13/brotherhood)
 "onR" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
-	},
+/obj/structure/cable,
+/obj/machinery/power/terminal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
@@ -14456,10 +13925,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "oqU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "orc" = (
@@ -14499,21 +13971,17 @@
 	},
 /area/f13/tunnel)
 "ost" = (
-/obj/structure/lattice{
-	density = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 4
+	},
 /area/f13/brotherhood)
 "otf" = (
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
-	},
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "otF" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -14540,18 +14008,19 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "ovz" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/right{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ovQ" = (
-/obj/structure/decoration/vent{
-	layer = 2
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "owa" = (
 /turf/open/floor/carpet/black,
@@ -14568,14 +14037,10 @@
 	},
 /area/f13/tunnel)
 "owX" = (
-/obj/machinery/door/airlock/clockwork{
-	desc = "A massive gear set into two heavy slabs of brass.";
-	name = "brotherhood airlock";
-	req_access = null;
-	req_access_txt = "120";
-	req_one_access_txt = null
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster81"
 	},
-/turf/open/floor/wood,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "oyr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14613,47 +14078,48 @@
 /turf/open/water,
 /area/f13/tunnel)
 "ozX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "oAt" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"oBm" = (
-/obj/item/trash/f13/tin,
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "oCp" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	layer = 3.3;
-	name = "Bathrooms"
-	},
-/turf/closed/wall/r_wall,
+/obj/structure/closet/radiation,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "oCy" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "oCU" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "oDd" = (
-/turf/closed/wall,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "oDf" = (
 /obj/structure/closet/crate,
@@ -14743,9 +14209,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "oIK" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/floorgrime,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "oJc" = (
 /obj/machinery/light/small{
@@ -14765,12 +14238,19 @@
 	},
 /area/f13/tunnel)
 "oMK" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/glowshroom/single,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/caves)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/power/smes/engineering,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "oNj" = (
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = -30
@@ -14779,20 +14259,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "oNu" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 10
+	},
+/area/f13/brotherhood)
 "oOk" = (
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 6
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "oOw" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
@@ -14861,31 +14337,28 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "oRl" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "oRq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oRt" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = null;
-	req_access_txt = "120"
+/obj/machinery/door/airlock/clockwork{
+	desc = "A massive gear set into two heavy slabs of brass.";
+	name = "brotherhood airlock";
+	req_access = null;
+	req_access_txt = "120";
+	req_one_access_txt = null
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "oSc" = (
 /obj/effect/spawner/lootdrop/f13/cash_legion_med,
@@ -14906,24 +14379,12 @@
 	},
 /area/f13/tunnel)
 "oUi" = (
-/obj/machinery/button/door{
-	id = "bosengine";
-	name = "Radiation Shutters";
-	pixel_x = -32
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
-/area/f13/brotherhood)
-"oUK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "oUO" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -14956,9 +14417,9 @@
 	},
 /area/f13/tunnel)
 "oVz" = (
-/obj/structure/fireaxecabinet,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
+/obj/structure/flora/junglebush/b,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "oVE" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -14987,25 +14448,15 @@
 	},
 /area/f13/tcoms)
 "oWr" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oWE" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/brotherhood)
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/junglebush/b,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "oXs" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -15021,13 +14472,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
-"oXx" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
 "oXD" = (
 /obj/structure/falsewall/reinforced,
 /obj/structure/sign/poster/prewar/poster78,
@@ -15083,9 +14527,6 @@
 /obj/item/stack/sheet/prewar,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"paF" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood)
 "pbr" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/dirt,
@@ -15095,37 +14536,36 @@
 /area/f13/tunnel)
 "pbt" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 8;
-	icon_state = "rwindow"
+	light_color = "#d8b1b1"
 	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/item/paper/crumpled,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "pcA" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/brotherhood)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "pdh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/workbench/forge,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "pdB" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "pdH" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -15134,13 +14574,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"peb" = (
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "pez" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15171,19 +14604,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "pgH" = (
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/chicken/rabbit{
-	desc = "The hippiest hoppin' Proctor.";
-	dir = 8;
-	name = "Proctor Vree"
+/obj/structure/rack,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "pgS" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/flora/junglebush/c,
+/obj/structure/debris/v4,
+/turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "phh" = (
 /obj/structure/dresser,
@@ -15210,9 +14639,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pis" = (
-/obj/item/am_shielding_container,
-/turf/open/floor/plating,
-/area/f13/brotherhood)
+/obj/structure/flora/junglebush/large,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pjj" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -15221,19 +14650,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "pkl" = (
-/obj/structure/closet,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/flora/junglebush/large,
+/turf/open/indestructible/ground/outside/water{
+	density = 1;
+	desc = "Deep lake water, filled with who knows what...";
+	name = "lake water"
 	},
-/area/f13/brotherhood)
-"pkC" = (
-/obj/structure/wreck/trash/engine,
-/mob/living/simple_animal/mouse/gray,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
+/area/f13/caves)
 "pkL" = (
 /obj/effect/decal/cleanable/blood/old,
 /mob/living/simple_animal/hostile/raider/ranged,
@@ -15253,15 +14676,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "pmk" = (
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/glowshroom/single,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
+/area/f13/caves)
 "pmU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/pinup_shower{
@@ -15277,15 +14697,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "pnk" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/obj/machinery/button/door{
-	id = "bosdorm1";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
+/obj/structure/simple_door/house{
+	icon_state = "room"
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood)
 "pnL" = (
 /obj/structure/curtain{
@@ -15308,17 +14726,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pph" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/structure/decoration/vent{
-	pixel_x = 16;
-	pixel_y = 16
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4;
+	pixel_x = 6
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "ppv" = (
@@ -15330,14 +14744,8 @@
 	},
 /area/f13/followers)
 "ppw" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
+/obj/machinery/rnd/destructive_analyzer,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "pqw" = (
 /obj/structure/chair{
@@ -15367,25 +14775,19 @@
 	},
 /area/f13/brotherhood)
 "psj" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "psu" = (
-/obj/structure/table/wood,
-/obj/item/crafting/coffee_pot{
-	pixel_x = -5;
-	pixel_y = 5
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/obj/item/storage/box/drinkingglasses{
-	pixel_x = 10;
-	pixel_y = 2
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
+/area/f13/caves)
 "psv" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -15409,8 +14811,17 @@
 	},
 /area/f13/tunnel)
 "ptx" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/fluff/railing{
+	dir = 4;
+	pixel_x = 6
+	},
+/obj/structure/chair/f13chair1,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "ptQ" = (
 /obj/structure/kitchenspike,
@@ -15422,21 +14833,13 @@
 	},
 /area/f13/bunker)
 "pud" = (
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "puJ" = (
 /turf/closed/wall/r_wall/rust,
@@ -15473,12 +14876,14 @@
 	},
 /area/f13/followers)
 "pvX" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
+/obj/structure/flora/grass/wasteland,
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/brotherhood)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "pwa" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -15493,37 +14898,31 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pwP" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/obj/item/integrated_electronics/debugger,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_circuit_printer,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood)
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "pwR" = (
-/obj/item/kirbyplants,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/brotherhood)
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pwY" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pwZ" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
+/obj/effect/temp_visual/steam_release,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "pxe" = (
-/turf/open/floor/f13/wood{
-	icon_state = "tunnelwastelandfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
 /area/f13/brotherhood)
 "pxy" = (
 /obj/structure/table{
@@ -15604,10 +15003,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pAJ" = (
-/obj/effect/temp_visual/paper_scatter,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8;
+	pixel_x = -6
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 4;
+	name = "light fixture"
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "pAK" = (
@@ -15647,43 +15053,36 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"pDM" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "pEF" = (
 /obj/item/instrument/piano_synth,
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "pEO" = (
-/obj/structure/rack,
-/obj/item/flashlight/seclite,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/obj/structure/flora/junglebush,
+/turf/open/indestructible/ground/outside/water{
+	density = 1;
+	desc = "Deep lake water, filled with who knows what...";
+	name = "lake water"
+	},
+/area/f13/caves)
 "pFn" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "pGd" = (
-/turf/open/floor/wood/airless,
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "pGw" = (
 /obj/machinery/door/airlock/medical{
@@ -15697,11 +15096,10 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "pHE" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/obj/structure/glowshroom/single,
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "pHQ" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -15716,11 +15114,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "pIJ" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/structure/flora/junglebush,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pIX" = (
 /obj/structure/table{
 	layer = 2.9
@@ -15742,19 +15138,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "pKM" = (
-/obj/structure/statue_fal{
-	color = "#cfcfcf";
-	desc = "Nathanael Greene August 7, 1742 - June 19, 1786. General of the Continental Army in the American Revolutionary War. Emerged from the war with a reputation as General George Washington's most gifted and dependable officer. Successfully commanded the southern theater of the war, leading to victory over the British.";
-	light_power = 5;
-	light_range = 5;
-	name = "Statue of Nathanael Greene";
-	pixel_y = 5
-	},
-/obj/structure/fluff/broken_flooring{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood)
+/obj/structure/debris/v1,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "pLC" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -15772,33 +15158,15 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"pNF" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/integrated_electronics/debugger,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_circuit_printer,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "pNK" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pNT" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
-	},
-/area/f13/brotherhood)
+/obj/structure/flora/junglebush,
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "pOc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -15811,11 +15179,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pQe" = (
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
+/obj/structure/debris/v2,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "pQq" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15849,12 +15215,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pRz" = (
-/obj/structure/wreck/trash/two_tire,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/wreck/car{
+	layer = 2
 	},
-/area/f13/brotherhood)
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pRM" = (
 /obj/machinery/telecomms/message_server,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -15886,10 +15254,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pTj" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "pUF" = (
 /obj/machinery/camera/autoname{
@@ -15901,25 +15268,15 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
-"pVA" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "pVQ" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pVV" = (
 /obj/machinery/door/airlock/hatch{
+	name = "Brig";
 	req_access_txt = "120"
 	},
 /turf/open/floor/f13{
@@ -15927,10 +15284,8 @@
 	},
 /area/f13/brotherhood)
 "pWc" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster81"
-	},
-/turf/closed/wall/r_wall,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "pWi" = (
 /obj/machinery/rnd/server/followers{
@@ -15941,13 +15296,9 @@
 	},
 /area/f13/followers)
 "pWw" = (
-/obj/structure/rack,
-/obj/item/bot_assembly/cleanbot,
-/obj/item/bot_assembly/cleanbot,
-/obj/item/bot_assembly/cleanbot,
-/obj/item/bodypart/r_arm/robot,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pWX" = (
 /obj/structure/chair/wood/modern{
 	icon_state = "wooden_chair_settler"
@@ -16012,12 +15363,10 @@
 /turf/open/water,
 /area/f13/tunnel)
 "qba" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "qbK" = (
 /obj/structure/table{
 	layer = 2.9
@@ -16074,14 +15423,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qdM" = (
-/obj/machinery/bsa/back{
-	desc = "Receives and distributes power in the Brotherhood Workshop.";
-	name = "Power Conduit"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "qdZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16178,15 +15521,15 @@
 	},
 /area/f13/followers)
 "qhK" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/debris/v3{
+	layer = 2
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/turf/open/indestructible/ground/outside/water{
+	density = 1;
+	desc = "Deep lake water, filled with who knows what...";
+	name = "lake water"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/caves)
 "qhW" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -16230,30 +15573,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"qkz" = (
-/obj/effect/ctf/flag_reset/blue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"qlH" = (
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 4;
-	pixel_y = 16
-	},
-/obj/structure/fence/end/wooden{
-	density = 0;
-	pixel_x = -16;
-	pixel_y = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"qmh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
 "qmV" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -16283,16 +15602,13 @@
 /obj/structure/sign/poster/prewar/poster73,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
-"qpe" = (
-/obj/machinery/vending/robotics,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood)
 "qpE" = (
-/turf/open/floor/f13/wood{
-	icon_state = "tunnelwastelandfullvar"
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Secret"
 	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "qpG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16324,27 +15640,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"qqF" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
-"qrk" = (
-/obj/effect/decal/marking{
-	pixel_x = 16
-	},
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
-"qrl" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/mineral/iron,
-/area/f13/brotherhood)
 "qrJ" = (
 /obj/structure/simple_door/bunker{
 	name = "Head Paladin's Office";
@@ -16368,15 +15663,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"qsP" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	dir = 8;
-	layer = 3.3;
-	name = "Living Quarters"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
 "qtb" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -16400,36 +15686,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"qtD" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
-"qtL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
-"qvg" = (
-/obj/structure/sign/poster/official/safety_eye_protection,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
-"qvs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/caution{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "qvI" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -16512,20 +15768,6 @@
 /obj/structure/chair/stool/retro,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"qCi" = (
-/obj/effect/decal/marking{
-	pixel_x = -16
-	},
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 4;
-	light_color = "#800080";
-	name = "light fixture"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
 "qCu" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -16541,19 +15783,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"qEb" = (
-/obj/structure/closet/firecloset/full,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood)
-"qEd" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "qEf" = (
 /obj/machinery/light{
 	dir = 1;
@@ -16567,15 +15796,6 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"qEh" = (
-/obj/structure/chair/comfy/black{
-	dir = 8;
-	icon_state = "comfychair"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
 "qEm" = (
 /obj/structure/bookcase/manuals,
 /turf/open/floor/f13/wood,
@@ -16589,22 +15809,17 @@
 	},
 /area/f13/tunnel)
 "qFc" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/item/integrated_electronics/debugger,
+/obj/item/integrated_electronics/wirer,
+/obj/item/integrated_electronics/detailer,
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_circuit_printer,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
-"qFe" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "qFn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16628,20 +15843,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"qFU" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
-"qGe" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
-	},
-/area/f13/caves)
 "qGf" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/electropack/shockcollar{
@@ -16651,9 +15852,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qGz" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "qHc" = (
 /obj/structure/flora/wasteplant/wild_fungus,
@@ -16677,37 +15880,13 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/tunnel)
-"qIh" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 4
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 4
-	},
-/obj/item/kirbyplants,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
 "qJi" = (
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
+/obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/area/f13/brotherhood)
-"qJI" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/vending/sustenance{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "qJM" = (
 /obj/machinery/door/unpowered/wooddoor{
@@ -16733,40 +15912,9 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"qLw" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "qLD" = (
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"qMj" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"qMn" = (
-/obj/machinery/camera/autoname{
-	dir = 5;
-	icon_state = "camera"
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "qMO" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -16810,13 +15958,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/followers)
-"qOe" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "qOG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -16826,19 +15967,6 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/tunnel)
-"qOJ" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood)
-"qPb" = (
-/obj/structure/chair/bench,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood)
 "qPh" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
@@ -16862,38 +15990,21 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"qRv" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "qRZ" = (
-/obj/structure/grille,
-/obj/structure/grille,
 /obj/structure/table/reinforced,
 /obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
 /obj/structure/window/fulltile/house{
 	dir = 2;
 	icon_state = "storewindowtop"
 	},
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "qSL" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/f13/wood{
-	icon_state = "tunnelwastelandfull"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
 	},
 /area/f13/brotherhood)
 "qTb" = (
@@ -16901,9 +16012,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qTn" = (
-/obj/structure/filingcabinet/filingcabinet,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "qUw" = (
@@ -16917,14 +16030,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"qUL" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
-	},
-/area/f13/caves)
 "qUO" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters{
@@ -16948,23 +16053,10 @@
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"qVC" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/machinery/light/floor,
-/obj/effect/temp_visual/impact_effect/blue_laser,
-/obj/effect/decal/cleanable/glitter/blue,
-/turf/closed/wall/mineral/iron,
-/area/f13/brotherhood)
 "qVG" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"qVR" = (
-/obj/structure/chair/bronze,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
 "qWm" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -16977,17 +16069,32 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/autolathe,
+/obj/structure/closet/crate/large,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "qWx" = (
-/obj/structure/table,
+/obj/structure/window/reinforced/spawner/north{
+	dir = 4;
+	icon_state = "rwindow"
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen/fourcolor,
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "qWW" = (
-/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/closet/radiation,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood)
 "qXo" = (
 /obj/machinery/sleeper{
@@ -17024,21 +16131,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"qZA" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"qZY" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_2";
-	name = "Level 2: Engineering";
-	width = 5
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood)
 "raA" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -17063,25 +16155,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"rbu" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "rbE" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"rbI" = (
-/obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet00"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "rca" = (
 /turf/open/floor/wood,
 /area/f13/tunnel)
@@ -17130,45 +16207,9 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
-"rev" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "rex" = (
 /turf/closed/indestructible/rock,
 /area/f13/bunker)
-"rfs" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/water,
-/area/f13/brotherhood)
-"rfD" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "rfH" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cloth/ten,
@@ -17183,12 +16224,23 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "rgN" = (
-/obj/structure/closet/crate/large{
-	storage_capacity = 20
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "tunnelwastelandfullvar"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
 	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/brotherhood)
 "rgX" = (
 /obj/structure/ladder/unbreakable{
@@ -17199,14 +16251,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"rgY" = (
-/obj/structure/chair/bench,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = 32
-	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood)
 "rhP" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
@@ -17237,10 +16281,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"riR" = (
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "riT" = (
 /obj/structure/mirror{
 	pixel_x = 32
@@ -17250,12 +16290,8 @@
 	},
 /area/f13/tunnel)
 "riY" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "rjq" = (
 /obj/structure/toilet{
@@ -17273,25 +16309,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rjQ" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	icon_state = "conveyor_map"
-	},
 /obj/machinery/light/small{
-	dir = 1
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood)
-"rkD" = (
-/obj/item/bedsheet/hos,
-/obj/structure/bed/pod,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
 "rkH" = (
@@ -17316,10 +16339,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "rmv" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
+/obj/effect/spawner/lootdrop/trash,
+/obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -17334,47 +16355,16 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"rnU" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
 "roc" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"rom" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "roz" = (
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 4;
-	pixel_y = 16
-	},
-/obj/structure/fence/end/wooden{
-	density = 0;
-	pixel_x = -16;
-	pixel_y = -16
-	},
-/mob/living/simple_animal/chicken,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"rpA" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/table/wood,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "rpI" = (
@@ -17427,14 +16417,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"rsA" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "rsB" = (
 /obj/machinery/light{
 	dir = 1
@@ -17447,23 +16429,6 @@
 /obj/effect/landmark/start/f13/Knight,
 /obj/effect/landmark/start/f13/initiate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"rsM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood)
-"rtf" = (
-/obj/item/flag/bos,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
 /area/f13/brotherhood)
 "rtk" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -17511,15 +16476,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"rvb" = (
-/obj/machinery/conveyor/auto{
-	dir = 6;
-	icon_state = "conveyor_map"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood)
 "rvf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -17541,27 +16497,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"rwk" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "rwA" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"rwK" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/construction/rld,
-/obj/item/construction/rcd/loaded,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood)
 "rwQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
@@ -17570,14 +16510,6 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"rxi" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
 "rxG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17593,10 +16525,6 @@
 /area/f13/tunnel)
 "ryy" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"ryL" = (
-/obj/structure/sign/poster/contraband/hacking_guide,
-/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "ryV" = (
 /obj/structure/closet/crate/bin,
@@ -17640,45 +16568,17 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"rAs" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "rAx" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"rBh" = (
-/obj/structure/table,
-/obj/structure/showcase/machinery/microwave{
-	pixel_y = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
-"rBs" = (
-/mob/living/simple_animal/cow/brahmin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
 "rBS" = (
 /obj/structure/sign/warning,
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
-"rBT" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit2"
-	},
-/area/f13/brotherhood)
 "rCv" = (
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17689,12 +16589,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rDm" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood)
 "rDu" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -17704,42 +16598,15 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood)
-"rDv" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/item/paper/crumpled,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "rDS" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"rEj" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "rEl" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster89"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"rFc" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "rFz" = (
 /obj/machinery/power/port_gen/pacman/super,
@@ -17760,39 +16627,20 @@
 	},
 /area/f13/followers)
 "rHJ" = (
-/obj/structure/simple_door/bunker{
-	name = "Head Scribe's Office"
-	},
-/turf/open/floor/wood/airless,
-/area/f13/brotherhood)
-"rHN" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/airless,
 /area/f13/brotherhood)
 "rIS" = (
 /obj/structure/sign/poster/prewar/poster89,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
-"rIV" = (
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/window/reinforced/tinted{
-	dir = 1;
-	icon_state = "twindow"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "rJn" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/structure/dresser,
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "rJA" = (
@@ -17825,11 +16673,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"rKE" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "rKW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -17859,20 +16702,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"rNl" = (
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
-"rOh" = (
-/obj/item/reagent_containers/food/snacks/f13/specialapples{
-	pixel_y = 8
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
 "rOj" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/brotherhood)
@@ -17882,30 +16711,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"rOy" = (
-/obj/machinery/camera/autoname{
-	dir = 9;
-	icon_state = "camera"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "rOM" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"rPe" = (
-/obj/structure/simple_door/bunker{
-	req_access = 120;
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampupbottom"
-	},
-/area/f13/brotherhood)
 "rPi" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -17943,41 +16753,14 @@
 /obj/structure/sign/poster/prewar/poster91,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
-"rSw" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/wood,
-/area/f13/brotherhood)
 "rSC" = (
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/structure/window/fulltile/wood/broken{
-	desc = "Feed me! FEED ME!";
-	layer = 2;
-	name = "feed trough"
-	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 4;
-	pixel_y = 16
-	},
-/obj/structure/fence/end/wooden{
-	density = 0;
-	pixel_x = -16;
-	pixel_y = -16
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"rSF" = (
-/obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table/wood,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "rSM" = (
@@ -18015,29 +16798,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood)
-"rWE" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "rWY" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -18064,12 +16824,6 @@
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"rXR" = (
-/obj/structure/lattice/catwalk/clockwork,
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood)
 "rXS" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -18081,26 +16835,6 @@
 /obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"rYn" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"rZw" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"rZE" = (
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/window/reinforced/tinted,
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "rZF" = (
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18108,6 +16842,7 @@
 "rZW" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/broken_bottle,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "rZZ" = (
@@ -18122,11 +16857,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"sak" = (
-/turf/open/floor/f13{
-	icon_state = "bluedirtysolid"
-	},
-/area/f13/brotherhood)
 "saC" = (
 /obj/structure/sink{
 	dir = 4;
@@ -18136,19 +16866,9 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
-"sbW" = (
-/obj/structure/closet/crate/secure/hydroponics{
-	name = "gardening toolbox"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
 "scG" = (
-/obj/machinery/conveyor/auto,
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "sdI" = (
 /obj/structure/table/wood,
@@ -18163,8 +16883,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "seJ" = (
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "seL" = (
 /obj/machinery/computer/operating{
@@ -18172,16 +16895,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood)
-"sfi" = (
-/obj/item/candle{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
 	},
 /area/f13/brotherhood)
 "sfj" = (
@@ -18237,13 +16950,12 @@
 	},
 /area/f13/bunker)
 "sgm" = (
-/obj/item/candle{
-	pixel_x = -6;
-	pixel_y = 7
+/obj/structure/bookcase/manuals/medical{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Brotherhood Historical Archives
 	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "sgn" = (
@@ -18257,12 +16969,6 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"sgE" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
 "shl" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -18327,11 +17033,6 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"sjk" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "ska" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -18356,15 +17057,14 @@
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"sll" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood)
 "slT" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
+	icon_state = "generator_on";
+	name = "superheating forge"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood)
 "smm" = (
@@ -18377,37 +17077,29 @@
 	},
 /area/f13/tunnel)
 "smv" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/line{
+	pixel_y = -6
 	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/shreds,
-/obj/structure/decoration/rag,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8;
+	pixel_x = -6
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/brotherhood)
+"snJ" = (
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"snY" = (
+/obj/structure/table/wood/fancy,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood)
-"snJ" = (
-/obj/structure/closet/radiation,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"snL" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/effect/decal/cleanable/robot_debris/down,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"snY" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "sor" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -18429,8 +17121,20 @@
 	},
 /area/f13/tunnel)
 "sqa" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/structure/rack,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "sqr" = (
@@ -18446,26 +17150,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"srH" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
-/area/f13/brotherhood)
 "srZ" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ssx" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "ssQ" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal"
@@ -18486,52 +17176,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"stR" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
-"stU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
-	},
-/area/f13/brotherhood)
-"sul" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood)
-"suF" = (
-/obj/structure/flora/junglebush,
-/obj/structure/bus_door,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
-"svu" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood)
-"swO" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	dir = 8;
-	name = "Mess Hall"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
-"swW" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
-	},
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
-/area/f13/brotherhood)
 "swY" = (
 /obj/docking_port/stationary{
 	area_type = /area/f13;
@@ -18563,11 +17207,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"syR" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuitoff3"
-	},
-/area/f13/brotherhood)
 "sAa" = (
 /obj/structure/campfire,
 /obj/structure/spider/stickyweb,
@@ -18588,32 +17227,18 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"sBJ" = (
-/obj/structure/closet/crate/bin{
-	anchorable = 0;
-	storage_capacity = 30
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
 "sBO" = (
-/obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"sCv" = (
-/obj/structure/chair/brass{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 8;
-	light_color = "#800080";
-	name = "light fixture"
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
+/obj/machinery/power/terminal,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "sCB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18646,36 +17271,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "sFc" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/vending/nukacolavendfull,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"sGm" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "sGs" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
 	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
+/obj/structure/decoration/hatch{
+	dir = 1
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "sGx" = (
 /obj/structure/simple_door/room{
@@ -18690,18 +17302,45 @@
 	},
 /area/f13/tunnel)
 "sGK" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
 	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "sHo" = (
@@ -18723,49 +17362,25 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"sIK" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "sIN" = (
 /obj/effect/decal/cleanable/cobweb,
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sJl" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/brotherhood)
 "sJm" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	id = "SW"
+	id = "SE"
 	},
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 5;
+	dir = 9;
 	icon_state = "warningline_red"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood)
-"sJV" = (
-/obj/structure/closet/crate/large,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "sKg" = (
 /obj/structure/curtain,
@@ -18792,20 +17407,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"sLL" = (
-/obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
-	},
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "neutralsolid"
-	},
-/area/f13/brotherhood)
 "sMc" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -18821,29 +17422,15 @@
 	},
 /area/f13/bunker)
 "sME" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bossecgear";
+	name = "Internal Security Gear";
+	req_access_txt = "120"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"sMJ" = (
-/obj/structure/closet/cardboard/metal,
-/obj/item/stack/sheet/mineral/wood/five,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "sMQ" = (
 /obj/structure/simple_door/bunker,
@@ -18869,12 +17456,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/followers)
-"sNx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/brotherhood)
 "sNF" = (
 /obj/structure/closet/fridge,
 /obj/item/storage/fancy/egg_box,
@@ -18885,32 +17466,15 @@
 	},
 /area/f13/tunnel)
 "sNO" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
+/obj/structure/window/fulltile/wood,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "sNX" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sOf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "sOq" = (
 /obj/structure/sink{
 	dir = 8;
@@ -18931,17 +17495,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"sOX" = (
-/obj/structure/closet/crate/miningcar,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
-"sPl" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "sPC" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -18949,6 +17502,7 @@
 	layer = 3.1;
 	pixel_x = -16
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
@@ -18980,6 +17534,7 @@
 /obj/item/pda/engineering{
 	name = "Knight-Engineer Pip-Boy 3000"
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "sSS" = (
@@ -18995,11 +17550,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"sUn" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "sWb" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosdorm7";
@@ -19018,11 +17568,13 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood)
 "sWr" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "sWB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19030,36 +17582,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"sWR" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/brotherhood)
 "sWX" = (
 /obj/structure/sign/poster/prewar/poster75,
 /turf/closed/wall/r_wall,
-/area/f13/brotherhood)
-"sWZ" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
-"sXi" = (
-/obj/structure/frame/machine,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "sXC" = (
 /obj/structure/table/wood,
@@ -19069,36 +17594,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"sXP" = (
-/obj/structure/glowshroom/single,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "sXV" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
-"sZa" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/rack,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/brotherhood)
 "sZJ" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"tau" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Business"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "taI" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -19106,15 +17610,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"tbg" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	icon_state = "conveyor_map"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood)
 "tbD" = (
 /obj/structure/filingcabinet/employment,
 /obj/item/toy/figure/borg{
@@ -19141,15 +17636,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"tcW" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/disposalpipe/broken{
-	dir = 2
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "tda" = (
 /obj/structure/toilet{
 	dir = 8
@@ -19161,9 +17647,10 @@
 	},
 /area/f13/tunnel)
 "tdl" = (
-/obj/structure/closet/crate/internals,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
+/obj/structure/chair/bench{
+	icon_state = "dropshipright"
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "tev" = (
 /obj/structure/showcase/horrific_experiment{
@@ -19187,17 +17674,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"tfd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "tfw" = (
 /obj/effect/decal/cleanable/blood/innards,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -19232,10 +17708,6 @@
 /obj/structure/table/reinforced{
 	req_access_txt = "120"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
 /obj/structure/barricade/bars{
 	layer = 5
 	},
@@ -19253,12 +17725,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "thO" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/structure/sign/poster/official/safety_eye_protection,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "tiS" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -19273,15 +17741,6 @@
 "tjd" = (
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"tjo" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "tjt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -19309,14 +17768,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
-"tkU" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
-	},
-/area/f13/caves)
 "tlc" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/reedbush,
@@ -19327,19 +17778,6 @@
 	},
 /turf/open/water,
 /area/f13/brotherhood)
-"tlm" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "tlS" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small{
@@ -19348,11 +17786,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "tmh" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/water{
+	density = 1;
+	desc = "Deep lake water, filled with who knows what...";
+	name = "lake water"
 	},
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tmM" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -19375,11 +17814,6 @@
 /obj/item/bedsheet/brown,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"tnl" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_right"
-	},
-/area/f13/brotherhood)
 "tnp" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
@@ -19398,15 +17832,8 @@
 	color = "#3e3d42"
 	},
 /obj/structure/flora/ausbushes/reedbush,
+/obj/effect/light_emitter,
 /turf/open/water,
-/area/f13/brotherhood)
-"tor" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	layer = 3.3;
-	name = "RESTRICTED - Council Chambers"
-	},
-/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "toA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19441,32 +17868,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"trr" = (
-/obj/structure/table/abductor{
-	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
-	name = "advanced table"
-	},
-/obj/structure/fluff/paper/stack,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
-"trC" = (
-/obj/structure/wreck/trash/engine,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
-"tsb" = (
-/obj/structure/disposalpipe/junction,
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "tse" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -19476,10 +17877,11 @@
 	},
 /area/f13/tunnel)
 "tsq" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster77"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "tsy" = (
 /obj/structure/simple_door/bunker{
@@ -19516,13 +17918,14 @@
 	},
 /area/f13/tunnel)
 "ttW" = (
-/obj/structure/simple_door/blast{
-	max_integrity = 10000;
-	name = "bunker entry";
-	req_access_txt = "120"
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood)
 "tur" = (
@@ -19533,19 +17936,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "tva" = (
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/shower{
-	layer = 2.8;
-	pixel_y = 32
-	},
-/obj/structure/window/reinforced/survival_pod,
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/decoration/vent,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "tvc" = (
@@ -19563,10 +17957,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/sewer)
-"tvo" = (
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
 "tvw" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -19574,28 +17964,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "tvx" = (
-/obj/structure/table/wood,
-/obj/item/lighter{
-	color = "#3e4821";
-	desc = "That's one fancy Zippo!";
-	heat = 2500;
-	icon_state = "lighter_overlay_plain";
-	light_power = 2;
-	light_range = 1;
-	name = "Pre-War Military Lighter";
-	pixel_x = 7;
-	pixel_y = -6
-	},
-/obj/item/storage/fancy/candle_box{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/candle_box{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
 	},
 /area/f13/brotherhood)
 "tvN" = (
@@ -19613,13 +17987,6 @@
 	dir = 8
 	},
 /turf/open/water,
-/area/f13/brotherhood)
-"tvP" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/matches,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
 /area/f13/brotherhood)
 "tvZ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -19650,10 +18017,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "txh" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/f13/wood{
-	icon_state = "tunnelwastelandfull"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_right"
 	},
 /area/f13/brotherhood)
 "tyR" = (
@@ -19664,9 +18029,6 @@
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
-/area/f13/brotherhood)
-"tzl" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "tzH" = (
 /obj/structure/table/reinforced,
@@ -19687,38 +18049,11 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/tunnel)
-"tAi" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
 "tAP" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser/bluetag,
-/obj/item/gun/energy/laser/bluetag,
-/obj/item/gun/energy/laser/redtag,
-/obj/item/gun/energy/laser/redtag,
-/obj/item/clothing/suit/redtag,
-/obj/item/clothing/suit/redtag,
-/obj/item/clothing/suit/redtag,
-/obj/item/clothing/suit/bluetag,
-/obj/item/clothing/suit/bluetag,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/brotherhood)
-"tAT" = (
-/obj/structure/table,
-/turf/open/floor/carpet/black,
+/obj/machinery/vending/dinnerware,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "tBw" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -19730,13 +18065,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"tCe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood)
 "tCt" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -19841,19 +18169,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"tIE" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 4
-	},
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "tII" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -19861,13 +18176,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"tIT" = (
-/obj/machinery/rnd/production/protolathe,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
 "tJD" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -19889,12 +18197,6 @@
 	color = "#845f58"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"tJL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
 /area/f13/brotherhood)
 "tJM" = (
 /obj/machinery/light/small,
@@ -19947,13 +18249,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"tJV" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood)
 "tKy" = (
 /obj/structure/table{
 	layer = 2.9
@@ -19964,15 +18259,13 @@
 	},
 /area/f13/brotherhood)
 "tKF" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
+/obj/structure/chair/comfy/black{
 	dir = 8;
-	icon_state = "rwindow"
+	icon_state = "comfychair"
 	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/item/trash/cheesie,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "tKU" = (
@@ -19980,12 +18273,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"tLb" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/bomb_suit/security,
-/obj/item/clothing/head/bomb_hood/security,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "tLd" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -19995,14 +18282,12 @@
 	},
 /area/f13/tunnel)
 "tLn" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/structure/decoration/vent{
-	pixel_x = 16;
-	pixel_y = 16
+/obj/machinery/processor,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "tMw" = (
 /obj/structure/table/glass,
@@ -20013,10 +18298,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "tMB" = (
-/obj/structure/rack,
-/obj/item/bot_assembly/secbot,
-/obj/item/bodypart/r_arm/robot,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "tMD" = (
 /obj/structure/wreck/trash/machinepile,
@@ -20073,37 +18359,25 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"tPF" = (
-/obj/structure/rack,
-/obj/item/kitchen/knife,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "tPY" = (
 /obj/structure/curtain,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "tQe" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "A console used by the scribes of the Brotherhood of Steel.";
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal";
-	name = "Archive Terminal"
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/junglebush{
+	pixel_x = -15
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/water,
 /area/f13/brotherhood)
 "tQi" = (
-/obj/structure/closet/lasertag/blue,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "tQw" = (
 /obj/structure/table,
@@ -20124,17 +18398,12 @@
 	},
 /area/f13/clinic)
 "tSl" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
+/obj/effect/turf_decal/trimline/blue/line{
+	pixel_y = -6
 	},
-/obj/structure/filingcabinet/chestdrawer,
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "tSr" = (
@@ -20148,6 +18417,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "tSK" = (
@@ -20169,29 +18440,9 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"tTx" = (
-/obj/structure/chair/brass{
-	dir = 8
-	},
-/obj/machinery/light/fo13colored/Aqua{
-	bulb_colour = "#800080";
-	dir = 4;
-	light_color = "#800080";
-	name = "light fixture"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
 "tTM" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/airless,
 /area/f13/brotherhood)
 "tUk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20224,22 +18475,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood)
-"tWO" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood)
-"tXd" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -20248,18 +18483,6 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tXw" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "tYd" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -20274,16 +18497,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"tYH" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/temp_visual/small_smoke/halfsecond,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "tZf" = (
 /obj/structure/sink{
 	pixel_y = 19
@@ -20320,16 +18533,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"uay" = (
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
-"uaI" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/grimy,
-/area/f13/brotherhood)
 "uaL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
@@ -20337,21 +18540,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"uaT" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
-"uaY" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "ubN" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -20360,42 +18548,10 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ucn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
-"ucp" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood)
 "ucS" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"uef" = (
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "uej" = (
 /obj/structure/table/wood/fancy/black{
 	desc = "A set of thin pipes that no longer function.";
@@ -20429,19 +18585,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ufO" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/broken,
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/disposalpipe/broken{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "ufQ" = (
 /obj/structure/decoration/warning,
 /turf/closed/wall/rust,
@@ -20461,12 +18604,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"ugE" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "uhE" = (
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
@@ -20488,14 +18625,13 @@
 	},
 /area/f13/caves)
 "uiT" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/structure/chair/stool/f13stool{
-	pixel_x = -8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
 "uiV" = (
@@ -20529,13 +18665,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"ukZ" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/f13/elder,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "uls" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/pa_wear,
@@ -20553,10 +18682,6 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/tunnel)
-"ulx" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13,
-/area/f13/brotherhood)
 "ulE" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13{
@@ -20571,14 +18696,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
-"umC" = (
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "umG" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -20587,24 +18704,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "unw" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/machinery/computer/terminal{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/blue/line{
 	dir = 4;
-	termtag = "Business"
+	pixel_x = 6
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1;
-	icon_state = "twindow"
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "unV" = (
@@ -20627,27 +18737,8 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood,
 /area/f13/brotherhood)
-"uoK" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "uoO" = (
 /turf/closed/mineral/random/low_chance,
-/area/f13/caves)
-"upu" = (
-/obj/structure/wreck/car{
-	layer = 2
-	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "upC" = (
 /obj/structure/table/wood,
@@ -20655,12 +18746,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "upI" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
 /area/f13/brotherhood)
 "uqk" = (
 /obj/item/flashlight,
@@ -20679,13 +18773,6 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood)
-"uqP" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/f13/wood,
 /area/f13/brotherhood)
 "uri" = (
 /obj/structure/fireaxecabinet{
@@ -20712,15 +18799,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "usy" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	name = "light fixture"
 	},
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "utr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20769,24 +18854,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "uvD" = (
-/obj/structure/rack,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/book/granter/trait/pa_wear,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"uwd" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
 "uwt" = (
@@ -20801,10 +18871,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"uwN" = (
-/obj/structure/wreck/bus/rusted,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "uwT" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/floor/f13{
@@ -20812,9 +18878,11 @@
 	},
 /area/f13/bunker)
 "uwV" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "uxq" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/decal/cleanable/cobweb,
@@ -20823,17 +18891,12 @@
 	},
 /area/f13/tunnel)
 "uxw" = (
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/tato,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato/sweet,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood)
 "uyl" = (
 /obj/machinery/sleeper/clockwork{
@@ -20860,29 +18923,15 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"uzA" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood)
 "uzO" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "uzQ" = (
-/obj/structure/barricade/bars,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "uAb" = (
 /obj/effect/decal/fakelattice{
@@ -20904,29 +18953,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"uDE" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/turf/open/water,
-/area/f13/brotherhood)
 "uEb" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -20951,11 +18977,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "uFg" = (
-/mob/living/simple_animal/mouse/white,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "uFj" = (
 /obj/machinery/autolathe,
@@ -20979,17 +19003,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"uFF" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood)
-"uFO" = (
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "uFQ" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -20997,14 +19010,12 @@
 	},
 /area/f13/tunnel)
 "uGI" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -3;
-	pixel_y = 5
+/obj/machinery/shower{
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/decoration/vent,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "uGR" = (
 /obj/structure/table,
@@ -21031,8 +19042,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uHP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 1;
+	height = 4;
+	id = "bos_level_2";
+	name = "Level 2: Engineering";
+	width = 5
+	},
+/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood)
 "uHU" = (
 /obj/item/storage/trash_stack,
@@ -21060,43 +19078,19 @@
 "uJD" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/tunnel)
-"uJS" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood)
 "uJY" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"uKh" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/side{
-	dir = 6
-	},
-/area/f13/brotherhood)
 "uKn" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/atmos,
+/obj/item/twohanded/fireaxe,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "uKB" = (
 /obj/structure/barricade/wooden,
@@ -21125,23 +19119,12 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"uKV" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
-/obj/structure/lattice/clockwork,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "uLl" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "uLn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21218,14 +19201,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"uMH" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/effect/turf_decal/stripes/red/line,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
 "uMO" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -21243,11 +19218,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"uOo" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/table,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood)
 "uOE" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
@@ -21270,19 +19240,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "uPS" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = -2
 	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
+/obj/structure/decoration/vent,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "uPY" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "uQO" = (
 /obj/machinery/light/fo13colored/Aqua{
@@ -21291,15 +19260,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uRE" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "uRG" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -21319,12 +19279,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uSG" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood)
 "uSI" = (
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -21332,25 +19286,12 @@
 	},
 /area/f13/tunnel)
 "uTN" = (
-/obj/structure/dresser,
-/obj/structure/mirror{
-	pixel_y = 30
+/obj/structure/destructible/clockwork/wall_gear,
+/obj/item/projectile/magic/animate{
+	layer = 2.5;
+	name = "weird light"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
-"uTP" = (
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
-	},
+/turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
 "uUk" = (
 /obj/structure/table{
@@ -21358,22 +19299,6 @@
 	},
 /obj/item/trash/cheesie,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"uUA" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
-"uUZ" = (
-/obj/structure/closet/secure_closet/personal{
-	req_access = list(120)
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
 /area/f13/brotherhood)
 "uVp" = (
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
@@ -21390,21 +19315,14 @@
 	},
 /area/f13/followers)
 "uVt" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/robot_debris/up,
+/obj/effect/turf_decal/trimline/yellow/line{
+	pixel_y = -6
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"uVC" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "uVN" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -21432,13 +19350,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
-"uWA" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "uWC" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/hos,
@@ -21451,28 +19362,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uXE" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
-"uXQ" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/brotherhood)
 "uXT" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/ce,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"uXY" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "uZa" = (
 /obj/machinery/vending/wallmed{
@@ -21522,15 +19415,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"vch" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "vcL" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -21562,21 +19446,6 @@
 /obj/item/pickaxe/drill,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"veL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood)
-"veN" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
-/area/f13/brotherhood)
 "veO" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -21640,23 +19509,14 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "vgd" = (
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/black{
+	dir = 8;
+	icon_state = "comfychair"
 	},
-/obj/structure/window/fulltile/wood/broken{
-	desc = "Feed me! FEED ME!";
-	layer = 2;
-	name = "feed trough"
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 4;
-	pixel_y = 16
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "vgo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21676,35 +19536,14 @@
 	},
 /area/f13/tunnel)
 "vid" = (
-/obj/effect/landmark/start/f13/scribe,
+/obj/structure/fence/handrail_end/non_dense{
+	dir = 1;
+	pixel_x = -16
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"viJ" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/f13{
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood)
-"vjk" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"vju" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "vkc" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -21739,29 +19578,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"vla" = (
-/obj/structure/bookcase/manuals,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
 "vmm" = (
 /turf/closed/wall{
 	icon_state = "fwall_opening"
 	},
 /area/f13/tunnel)
-"vmx" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/closet/radiation,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/grimy,
-/area/f13/brotherhood)
-"vna" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
 "vnJ" = (
 /obj/item/instrument/guitar,
 /obj/structure/rack,
@@ -21845,18 +19666,6 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"vqm" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "vqo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21873,27 +19682,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vrm" = (
-/obj/machinery/camera/autoname,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/lattice{
+	layer = 3
 	},
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "vrv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood)
-"vrC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "vrH" = (
 /obj/structure/bed,
@@ -21905,8 +19702,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "vrY" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/airless,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "vsC" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -21915,10 +19716,10 @@
 	},
 /area/f13/tunnel)
 "vsI" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster82"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "vsJ" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -21927,22 +19728,13 @@
 	},
 /area/f13/clinic)
 "vsT" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
 	id = "bosdoors";
 	name = "brotherhood shutters"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood)
-"vsW" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood)
 "vtz" = (
@@ -22012,9 +19804,9 @@
 	},
 /area/f13/tunnel)
 "vxo" = (
-/obj/structure/flora/junglebush/large,
-/obj/structure/flora/junglebush/b,
-/turf/closed/mineral/random/low_chance,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "vxs" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -22027,27 +19819,21 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "vyg" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/obj/item/integrated_electronics/debugger,
+/obj/item/integrated_electronics/wirer,
+/obj/item/integrated_electronics/detailer,
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_circuit_printer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "vyN" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"vyS" = (
-/obj/structure/chair/wood,
-/turf/open/floor/wood,
-/area/f13/brotherhood)
-"vyU" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "vzL" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -22072,35 +19858,20 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"vBj" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "vBx" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/blast{
+	max_integrity = 10000;
+	name = "bunker entry";
+	req_access_txt = "120"
+	},
 /turf/open/floor/f13{
-	icon_state = "rampdowntop"
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
 "vBA" = (
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"vBG" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/oil/streak,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "vBO" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22116,16 +19887,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"vCh" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm1";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood)
 "vCi" = (
 /obj/effect/spawner/lootdrop/f13/cash_ncr_med,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22149,38 +19910,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"vCS" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/disposalpipe/broken{
-	dir = 2
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
-"vDj" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood)
 "vDl" = (
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vDn" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
 "vDC" = (
 /obj/structure/lattice{
 	layer = 3
@@ -22206,12 +19940,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"vEJ" = (
-/obj/structure/punching_bag,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood)
 "vEV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -22222,14 +19950,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"vFh" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
 "vFl" = (
 /obj/machinery/light{
 	dir = 1
@@ -22268,20 +19988,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"vHQ" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "vIa" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood)
 "vIp" = (
 /obj/structure/showcase/horrific_experiment{
@@ -22298,46 +20008,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "vIL" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood)
-"vJc" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuitoff2"
+	icon_state = "casino"
 	},
 /area/f13/brotherhood)
 "vJu" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"vJL" = (
-/obj/structure/chair/bench{
-	icon_state = "dropshipleft"
-	},
-/obj/structure/chair/bench{
-	icon_state = "dropshipleft"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
-"vJX" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "vKh" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -22353,20 +20031,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
-"vKT" = (
-/obj/machinery/jukebox,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
-"vLa" = (
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "vLg" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/landmark/start/f13/followersadministrator,
@@ -22374,16 +20038,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"vLB" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
 "vLO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -22393,14 +20047,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"vMM" = (
-/obj/machinery/camera/autoname{
-	dir = 8;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
 "vMO" = (
 /obj/machinery/light{
 	dir = 8
@@ -22416,18 +20062,11 @@
 	},
 /area/f13/sewer)
 "vNy" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/structure/wreck/trash/one_tire,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "vOf" = (
 /obj/structure/table{
@@ -22440,37 +20079,9 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood)
-"vOk" = (
-/obj/effect/decal/remains/xeno,
-/obj/item/paper/crumpled/ruins,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "vOo" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood)
-"vOD" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
-	},
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 1
-	},
+/obj/item/am_shielding_container,
+/turf/open/floor/plating,
 /area/f13/brotherhood)
 "vPw" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -22497,58 +20108,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"vQq" = (
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 4;
-	pixel_y = 16
-	},
-/mob/living/simple_animal/chicken,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"vQE" = (
-/obj/structure/chair/stool/f13stool,
-/obj/machinery/light/fo13colored/Aqua{
-	name = "light fixture"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
 "vQU" = (
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "vRu" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/turf/open/floor/circuit/red/anim{
+	light_range = 2.5
 	},
 /area/f13/brotherhood)
 "vSd" = (
 /obj/effect/landmark/start/f13/settler,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vSw" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/brotherhood)
-"vSF" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
 "vTa" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -22556,22 +20128,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/followers)
-"vTd" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood)
-"vTr" = (
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/structure/rack,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
 "vTH" = (
 /obj/structure/barricade/wooden{
 	layer = 2.5
@@ -22608,11 +20164,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vWb" = (
-/obj/item/toy/cattoy,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "vWg" = (
 /obj/structure/handrail/g_central{
@@ -22640,18 +20193,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
-"vWw" = (
-/obj/structure/closet/fridge/standard,
-/obj/machinery/light/small,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
-"vWE" = (
-/obj/structure/cargocrate,
-/turf/closed/wall,
-/area/f13/brotherhood)
 "vWN" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22702,10 +20243,9 @@
 	},
 /area/f13/clinic)
 "vXX" = (
-/obj/effect/decal/cleanable/robot_debris/up,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "vYw" = (
 /obj/structure/closet/crate/bin,
@@ -22718,21 +20258,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "vYG" = (
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/chair/f13chair1,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "vYZ" = (
 /obj/machinery/light/small{
@@ -22741,19 +20270,6 @@
 /obj/effect/landmark/start/f13/ncrranger,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"vZr" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "vZI" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/trash,
@@ -22783,22 +20299,17 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "wad" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/filingcabinet/filingcabinet,
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/no_erp{
+	pixel_y = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood)
 "wbe" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "wbh" = (
 /obj/item/reagent_containers/pill/patch/turbo,
@@ -22836,10 +20347,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"wdG" = (
-/obj/structure/cargocrate,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "wdL" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
@@ -22913,16 +20420,9 @@
 	},
 /area/f13/bunker)
 "wiP" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/carpet,
 /area/f13/brotherhood)
 "wjW" = (
 /obj/structure/billboard/cola/pristine,
@@ -22933,6 +20433,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/item/flag/bos,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "wkx" = (
@@ -22949,23 +20450,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"wmt" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
-"wmN" = (
-/obj/structure/weightlifter,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "wmT" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -22975,11 +20459,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"wne" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
-/area/f13/brotherhood)
 "wom" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -23048,10 +20527,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"wup" = (
-/obj/structure/sign/poster/prewar/poster81,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
 "wus" = (
 /obj/structure/curtain,
 /turf/open/floor/f13{
@@ -23064,10 +20539,6 @@
 /obj/item/flashlight,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"wuE" = (
-/obj/structure/filingcabinet/filingcabinet,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
 "wuM" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -23082,27 +20553,21 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"wvP" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "wwU" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"wxb" = (
-/obj/structure/flora/junglebush/large,
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "wxE" = (
-/obj/machinery/button/door{
-	id = "bosdorm5";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/turf/open/floor/carpet/black,
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower"
+	},
+/obj/structure/decoration/vent,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "wyl" = (
 /obj/structure/table,
@@ -23111,63 +20576,20 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"wyD" = (
-/obj/item/trash/f13/blamco_large,
-/turf/open/floor/wood,
-/area/f13/brotherhood)
 "wAe" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	icon_state = "neutralrusty"
 	},
 /area/f13/tunnel)
-"wAi" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red";
-	pixel_y = 0
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustyfull"
-	},
-/area/f13/brotherhood)
 "wAq" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /obj/structure/wreck/trash/engine,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"wAv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
-"wAB" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuitoff1"
-	},
-/area/f13/brotherhood)
 "wCi" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
-"wCV" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
@@ -23192,26 +20614,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"wDV" = (
-/obj/machinery/light/fo13colored/Aqua{
-	name = "light fixture"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtysolid"
-	},
-/area/f13/brotherhood)
 "wEw" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/destructible/clockwork/wall_gear,
+/obj/machinery/light/floor,
+/obj/effect/temp_visual/impact_effect/blue_laser,
+/obj/effect/decal/cleanable/glitter/blue,
+/turf/closed/wall/mineral/iron,
 /area/f13/brotherhood)
 "wEL" = (
 /obj/structure/chair/wood{
@@ -23224,10 +20632,8 @@
 	},
 /area/f13/tunnel)
 "wEX" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/mineral/random/low_chance,
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wFu" = (
 /obj/effect/landmark/start/f13/Knight,
@@ -23271,14 +20677,14 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "wKm" = (
-/obj/structure/lattice{
-	layer = 3
-	},
 /obj/structure/fence/handrail{
 	density = 0;
 	dir = 4;
 	layer = 3.1;
 	pixel_x = -16
+	},
+/obj/structure/lattice{
+	layer = 3
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
@@ -23293,33 +20699,6 @@
 "wKH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wKL" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"wKM" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	layer = 3.3;
-	name = "RESTRICTED - Archives & Tech Vault"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
-"wKZ" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "wLM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -23348,17 +20727,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wNs" = (
-/obj/effect/decal/cleanable/robot_debris,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "wOg" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -23379,15 +20747,6 @@
 	},
 /turf/open/water,
 /area/f13/brotherhood)
-"wPh" = (
-/obj/structure/chair/office/dark,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/effect/landmark/start/f13/elder,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
 "wPV" = (
 /obj/structure/noticeboard{
 	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Head Paladin on duty.";
@@ -23402,52 +20761,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wQz" = (
-/obj/structure/rack,
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 11
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -6;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -2;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = 2;
-	pixel_y = -10
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 13;
-	pixel_y = -8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "wQB" = (
 /obj/structure/chair{
@@ -23466,27 +20782,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wQJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
-"wSn" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood)
 "wTm" = (
 /obj/structure/sign/poster/ncr/keep_to_myself{
 	pixel_x = -32
@@ -23497,16 +20792,6 @@
 /obj/effect/turf_decal/arrows/white,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"wTI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 "wUi" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -23515,12 +20800,6 @@
 /obj/item/mining_scanner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wUo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
-	dir = 4
-	},
-/area/f13/brotherhood)
 "wUv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23534,49 +20813,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wUT" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "wVl" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
-"wVt" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/item/flashlight/lamp,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "wVD" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"wVN" = (
-/obj/effect/decal/cleanable/flour,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
 "wWc" = (
 /obj/machinery/button/crematorium{
 	pixel_y = 19
@@ -23586,16 +20833,9 @@
 	},
 /area/f13/followers)
 "wWf" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/structure/window/reinforced/tinted,
-/obj/item/paper/crumpled/bloody,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, filtered pool water.";
+	name = "pool water"
 	},
 /area/f13/brotherhood)
 "wWF" = (
@@ -23605,11 +20845,10 @@
 	},
 /area/f13/tunnel)
 "wWM" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "wXG" = (
@@ -23635,23 +20874,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/tunnel)
-"wYx" = (
-/obj/structure/simple_door/blast{
-	color = "#3e3d42";
-	max_integrity = 10000;
-	name = "tech vault door";
-	req_access_txt = "150"
+"wZH" = (
+/obj/structure/bookcase/manuals/research_and_development{
+	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Brotherhood Historical Archives"
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
-"wZH" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "wZZ" = (
@@ -23707,18 +20937,9 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"xdu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
-	dir = 8
-	},
-/area/f13/brotherhood)
 "xdB" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/mineral/random/low_chance,
+/obj/structure/flora/junglebush,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "xdS" = (
 /obj/machinery/light/small{
@@ -23794,20 +21015,13 @@
 	},
 /area/f13/tunnel)
 "xhA" = (
-/obj/structure/sign/poster/prewar/poster66,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "xhF" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"xia" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood)
 "xie" = (
 /obj/machinery/cell_charger{
 	pixel_y = 6
@@ -23818,6 +21032,9 @@
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = -9
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xig" = (
@@ -23825,14 +21042,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"xiI" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
 "xjk" = (
 /obj/structure/chair/bench,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -23843,21 +21052,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xju" = (
-/obj/structure/filingcabinet/filingcabinet,
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/glass/rag/towel,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"xjU" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
 "xkd" = (
@@ -23879,13 +21081,6 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"xks" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
 "xkx" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
@@ -23897,15 +21092,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xmH" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
-	},
-/obj/structure/simple_door/bunker/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
-/area/f13/brotherhood)
 "xmX" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -23915,13 +21101,9 @@
 	},
 /area/f13/tunnel)
 "xnb" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	icon_state = "conveyor_map"
-	},
-/obj/structure/plasticflaps,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
 "xnk" = (
@@ -23938,56 +21120,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"xnV" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/atmos,
-/obj/item/twohanded/fireaxe,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "xoo" = (
 /obj/structure/table{
 	layer = 2.9
 	},
 /obj/machinery/computer/security/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"xoU" = (
-/obj/structure/table/wood/fancy/black{
-	desc = "A set of thin pipes that no longer function.";
-	icon_state = "latticefull";
-	layer = 2.4;
-	name = "pipes"
-	},
-/obj/item/statuebust,
-/obj/structure/table{
-	icon_state = "1-f"
-	},
-/obj/structure/table{
-	icon_state = "2-f"
-	},
-/obj/structure/table{
-	icon_state = "3-f"
-	},
-/obj/structure/table{
-	icon_state = "4-f"
-	},
-/obj/structure/window/reinforced/clockwork/fulltile,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"xpo" = (
-/obj/machinery/autolathe/ammo,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"xps" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xqa" = (
@@ -24009,11 +21146,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "xsD" = (
-/obj/effect/turf_decal/stripes/red/line{
+/obj/machinery/computer/shuttle/boselevator{
 	dir = 1;
-	icon_state = "warningline_red"
+	pixel_y = -2
 	},
-/obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xsL" = (
@@ -24022,21 +21158,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"xtE" = (
-/obj/structure/table/wood,
-/obj/item/storage/lockbox/medal,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
-"xtH" = (
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood)
 "xvg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -24046,15 +21167,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"xvO" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
 "xvS" = (
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire,
@@ -24068,19 +21180,9 @@
 	},
 /area/f13/followers)
 "xvW" = (
-/obj/item/trash/f13/tin,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
-"xwX" = (
-/obj/effect/decal/marking{
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "xxJ" = (
 /obj/structure/timeddoor,
@@ -24101,7 +21203,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xyH" = (
-/obj/structure/destructible/clockwork/wall_gear,
 /obj/item/projectile/magic/animate{
 	layer = 2.5;
 	name = "weird light"
@@ -24129,15 +21230,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"xzr" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "xzX" = (
 /obj/item/storage/trash_stack,
 /obj/structure/handrail/g_central{
@@ -24163,13 +21255,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"xBu" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "xCd" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -24182,13 +21267,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xCP" = (
-/obj/structure/decoration/vent,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "xDr" = (
 /obj/machinery/light{
@@ -24217,12 +21298,6 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"xEZ" = (
-/obj/structure/chair/right{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood)
 "xFN" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -24236,25 +21311,22 @@
 	},
 /area/f13/tunnel)
 "xGl" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood)
 "xGn" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden/planks,
-/obj/structure/decoration/rag,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/wood,
 /area/f13/brotherhood)
 "xGV" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xHc" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
 "xHs" = (
 /obj/item/circuitboard/machine/gibber,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
@@ -24282,10 +21354,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"xIN" = (
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "xJE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -24294,11 +21362,10 @@
 	},
 /area/f13/tunnel)
 "xKk" = (
-/obj/machinery/vending/hydroseeds,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/chair/bench{
+	icon_state = "dropshipleft"
 	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "xLd" = (
 /obj/structure/table/snooker{
@@ -24314,20 +21381,11 @@
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"xLE" = (
-/obj/structure/window/fulltile/wood,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood)
 "xMa" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/decoration/vent{
+	layer = 2
 	},
-/obj/item/flag/bos,
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/turf/open/floor/plating/tunnel,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "xMb" = (
 /obj/structure/barricade/bars,
@@ -24340,26 +21398,17 @@
 /area/f13/caves)
 "xMO" = (
 /obj/structure/rack,
-/obj/item/crafting/timer,
-/obj/item/crafting/duct_tape,
-/obj/item/book/granter/crafting_recipe/blueprint/aep7,
-/obj/item/book/granter/crafting_recipe/blueprint/aer9,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "xNg" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/cans,
-/obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
-"xNs" = (
-/obj/item/projectile/magic/animate{
-	layer = 2.5;
-	name = "weird light"
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
 "xNu" = (
 /obj/machinery/light/small,
@@ -24403,15 +21452,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xPR" = (
-/obj/structure/closet/crate/rcd,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood)
 "xSb" = (
 /obj/structure/bookcase/manuals,
 /turf/open/floor/f13{
@@ -24430,30 +21470,16 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"xUd" = (
+"xVf" = (
 /obj/structure/lattice{
 	layer = 3
 	},
-/obj/structure/spacevine{
-	name = "vines"
+/obj/item/flag/bos,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood)
-"xVf" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "xVt" = (
 /obj/structure/bed,
@@ -24473,24 +21499,9 @@
 	},
 /area/f13/clinic)
 "xWz" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
-"xWQ" = (
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood)
-"xXs" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "mine"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
 "xXU" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/female/flapper,
@@ -24519,31 +21530,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"xYM" = (
-/obj/structure/chair/stool/retro/backed,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
-"xYS" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood)
 "xYV" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"xYY" = (
-/obj/structure/chair/bench{
-	icon_state = "dropshipright"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
 "xZd" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -24556,27 +21547,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xZY" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
-"yav" = (
-/obj/structure/chair/comfy/black{
-	dir = 8;
-	icon_state = "comfychair"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood)
-"yay" = (
-/obj/machinery/microwave/stove,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "ybf" = (
 /obj/effect/decal/remains/human,
@@ -24584,14 +21558,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "ybF" = (
-/obj/structure/chair/office/dark{
-	dir = 1;
-	icon_state = "officechair_dark"
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "ycc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -24609,25 +21577,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ycS" = (
-/obj/structure/disposalpipe/broken{
-	dir = 1
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
-"ydE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "ydV" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -24654,12 +21603,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"yfL" = (
-/obj/structure/debris/v3{
-	layer = 2
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "ygg" = (
 /obj/item/flashlight,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -24686,44 +21629,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"ygS" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
-"yhd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood)
-"ylf" = (
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"ymd" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood)
 
 (1,1,1) = {"
 eLE
@@ -53779,7 +50684,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -54292,9 +51197,9 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
-hQE
 uoO
 uoO
 uoO
@@ -54545,18 +51450,18 @@ uoO
 uoO
 uoO
 uoO
-hQE
-lnr
-lnr
-lnr
-hQE
-uoO
-lnr
-lnr
-lnr
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -54802,18 +51707,18 @@ uoO
 uoO
 uoO
 uoO
-lnr
-lnr
-lnr
-lnr
-lnr
-lnr
-lnr
-lKs
-lnr
-hQE
+uoO
 uoO
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -55056,21 +51961,21 @@ eLE
 uoO
 uoO
 uoO
-uoO
-uoO
-lnr
-lnr
-cwq
-lnr
-lnr
-lnr
-voG
-sOX
-lnr
-lnr
+aoj
+aoj
+aoj
 uoO
 uoO
 aoj
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -55313,21 +52218,21 @@ eLE
 uoO
 uoO
 uoO
-uoO
-uoO
-lnr
-lnr
-sUn
-lnr
-lnr
-lnr
-lnr
-lnr
-lnr
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -55572,15 +52477,15 @@ uoO
 uoO
 uoO
 uoO
-lnr
-lnr
-lnr
-fLU
-fLU
-fLU
-lnr
-lnr
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -55829,15 +52734,15 @@ uoO
 uoO
 uoO
 uoO
-hQE
-lnr
-lnr
-fLU
-xXs
-eIg
-lnr
-lnr
-hQE
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -56087,13 +52992,13 @@ uoO
 uoO
 uoO
 uoO
-lnr
-lnr
-fLU
-fLU
-fLU
-lnr
-lnr
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -56341,17 +53246,17 @@ eLE
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
-lnr
-sOX
-lnr
-lnr
-lnr
-lnr
-lnr
-lnr
+uoO
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -56600,16 +53505,16 @@ uoO
 uoO
 uoO
 uoO
-lnr
-lnr
-lnr
-voG
-lnr
-lnr
-sUn
-cwq
-lnr
-lnr
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -56855,19 +53760,19 @@ eLE
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
 uoO
 uoO
-lnr
-lnr
-lnr
 uoO
 uoO
 uoO
-lnr
-lnr
-lnr
-lnr
-hQE
+aoj
+uoO
+aoj
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -57113,15 +54018,15 @@ uoO
 uoO
 uoO
 uoO
-uoO
-lnr
-lnr
-hQE
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
-jmN
-lnr
+uoO
+aoj
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -57370,9 +54275,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -57627,9 +54532,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -57888,9 +54793,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -58403,7 +55308,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 aoj
@@ -61773,7 +58678,7 @@ uoO
 uoO
 uoO
 aoj
-gSc
+aoj
 aoj
 uoO
 uoO
@@ -62510,6 +59415,9 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -62518,9 +59426,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -62767,17 +59672,17 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 aoj
 aoj
 uoO
 uoO
 uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -63024,17 +59929,17 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 aoj
 aoj
 uoO
 uoO
 uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -63287,12 +60192,12 @@ aoj
 aoj
 aoj
 uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -63539,6 +60444,9 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -63546,10 +60454,7 @@ uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -63799,29 +60704,6 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -63830,6 +60712,29 @@ uoO
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -64054,28 +60959,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -64084,7 +60969,27 @@ uoO
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -64311,41 +61216,41 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-aoj
 aoj
 aoj
 aoj
 uoO
 uoO
+uoO
+uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -64568,35 +61473,35 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+aoj
 uoO
 uoO
 uoO
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -64824,36 +61729,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
 aoj
-aoj
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -64867,10 +61745,37 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -65085,30 +61990,37 @@ uoO
 uoO
 uoO
 uoO
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -65124,13 +62036,6 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -65342,35 +62247,35 @@ uoO
 uoO
 uoO
 uoO
-eLE
-eLE
-eLE
-jZH
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -65598,31 +62503,6 @@ uoO
 uoO
 uoO
 uoO
-eLE
-eLE
-eLE
-eLE
-jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
 uoO
@@ -65630,12 +62510,13 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -65645,6 +62526,30 @@ aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 aoj
@@ -65855,36 +62760,20 @@ uoO
 uoO
 uoO
 uoO
-eLE
-eLE
-eLE
-eLE
-jZH
-rOj
-jZH
-cXG
-owa
-xks
-owa
-owa
-xks
-owa
-owa
-slT
-dZz
-bki
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+aoj
+uoO
+aoj
 uoO
 uoO
+aoj
 uoO
+aoj
 uoO
+aoj
 uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -65899,8 +62788,24 @@ uoO
 uoO
 uoO
 aoj
+aoj
+aoj
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -66104,60 +63009,60 @@ eLE
 "}
 (162,1,1) = {"
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-jZH
-rOj
-jZH
-owa
-cTh
-cTh
-vJL
-cTh
-cTh
-cTh
-owa
-rtf
-qys
-iML
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
 aoj
 uoO
 uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -66361,60 +63266,60 @@ eLE
 "}
 (163,1,1) = {"
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-jZH
-rOj
-jZH
-owa
-xYY
-xYY
-xYY
-xYY
-xYY
-xYY
-owa
-dZz
-bVY
-tnl
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -66618,54 +63523,54 @@ eLE
 "}
 (164,1,1) = {"
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-jZH
-rOj
-jZH
-hij
-owa
-owa
-owa
-owa
-owa
-owa
-owa
-qys
-srH
-ksU
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -66875,54 +63780,54 @@ eLE
 "}
 (165,1,1) = {"
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-jZH
-rOj
-jZH
-owa
-cTh
-cTh
-cTh
-cTh
-cTh
-cTh
-owa
-hHc
-bVY
-nYh
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -67132,54 +64037,54 @@ eLE
 "}
 (166,1,1) = {"
 eLE
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-rOj
-jZH
-owa
-xYY
-xYY
-xYY
-xYY
-xYY
-xYY
-owa
-nWG
-qys
-iML
-jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -67389,54 +64294,54 @@ eLE
 "}
 (167,1,1) = {"
 eLE
-jZH
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-jZH
-cXG
-ohD
-owa
-owa
-ohD
-owa
-owa
-owa
-slT
-hHc
-bki
-jZH
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -67646,54 +64551,54 @@ eLE
 "}
 (168,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-adR
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-qqF
-qqF
-qqF
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-nNF
-nNF
-nNF
-nNF
-nNF
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -67903,54 +64808,11 @@ eLE
 "}
 (169,1,1) = {"
 eLE
-jZH
-rOj
-efw
-fQG
-col
-vDn
-amV
-rwk
-ost
-rwk
-ost
-rwk
-ost
-rwk
-ost
-fhk
-pmk
-jZH
-abN
-abN
-fhk
-iLO
-iLO
-abN
-abN
-jZH
-kqM
-eqw
-uwd
-eey
-qys
-qys
-uOo
-nNF
-lQB
-hHS
-qrk
-hHS
-hHS
-nMG
-lPf
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -67959,6 +64821,49 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 aoj
 aoj
@@ -68160,54 +65065,11 @@ eLE
 "}
 (170,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-owa
-owa
-owa
-fhk
-pwZ
-uTP
-pNT
-uTP
-uTP
-pNT
-uTP
-pwZ
-fhk
-pmk
-adR
-wKZ
-abN
-iLO
-iLO
-iLO
-abN
-blk
-jZH
-jZH
-jZH
-uwd
-omE
-rgY
-qys
-lxk
-xLE
-pwZ
-jSx
-jSx
-jSx
-jOE
-pwZ
-fMY
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -68216,6 +65078,49 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 aoj
 aoj
@@ -68417,54 +65322,6 @@ eLE
 "}
 (171,1,1) = {"
 eLE
-jZH
-rOj
-gvM
-bIz
-fLg
-eyt
-fhk
-pwZ
-xtH
-aSI
-xtH
-xtH
-aSI
-xtH
-pwZ
-fhk
-ugE
-rev
-ioj
-ioj
-iLO
-iLO
-iLO
-ioj
-ioj
-aPa
-hPN
-jZH
-uwd
-omE
-gIb
-qys
-lxk
-nwH
-pwZ
-jSx
-jSx
-jSx
-jSx
-pwZ
-qEh
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
 uoO
@@ -68473,6 +65330,54 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 aoj
 aoj
@@ -68674,59 +65579,59 @@ eLE
 "}
 (172,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-jZH
-kij
-fhk
-pwZ
-pNT
-pNT
-pNT
-pNT
-pNT
-pNT
-pwZ
-fhk
-pmk
-wKM
-abN
-abN
-iLO
-iLO
-iLO
-abN
-abN
-adR
-vTd
-jZH
-uFF
-nNF
-nNF
-veL
-qPb
-nNF
-pwZ
-jSx
-jSx
-jSx
-jSx
-nMG
-vQE
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -68931,59 +65836,59 @@ eLE
 "}
 (173,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cko
-kny
-wYx
-fhk
-pwZ
-xtH
-aSI
-xtH
-xtH
-aSI
-xtH
-pwZ
-fhk
-pmk
-jZH
-wKZ
-abN
-iLO
-iLO
-iLO
-abN
-blk
-jZH
-onB
-jZH
-onB
-jZH
-nNF
-qys
-qPb
-nNF
-pwZ
-jSx
-jSx
-jSx
-jSx
-nMG
-nDK
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
+uoO
 aoj
+uoO
+uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -69188,62 +66093,62 @@ eLE
 "}
 (174,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cko
-kny
-wYx
-fhk
-pwZ
-uTP
-pNT
-uTP
-uTP
-pNT
-uTP
-pwZ
-fhk
-pmk
-jZH
-cIQ
-abN
-fhk
-iLO
-iLO
-abN
-gPs
-jZH
-mUo
-jZH
-eey
-jZH
-nNF
-qys
-qPb
-nNF
-pwZ
-jSx
-jSx
-jSx
-jSx
-nMG
-vKT
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
 aoj
-aoj
-aoj
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -69445,60 +66350,60 @@ eLE
 "}
 (175,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-qMj
-fhW
-mIY
-rwk
-mIY
-rwk
-mIY
-rwk
-mIY
-noH
-pmk
-jZH
-abN
-abN
-iLO
-iLO
-iLO
-abN
-abN
-jZH
-uwd
-eqw
-onB
-jZH
-nNF
-fAC
-nNF
-nNF
-nDK
-xwX
-qCi
-cbU
-cbU
-pwZ
-sBJ
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
 uoO
 uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -69702,54 +66607,54 @@ eLE
 "}
 (176,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-adR
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-wKZ
-abN
-iLO
-iLO
-fhk
-abN
-blk
-jZH
-gFE
-uwd
-uwd
-uzA
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-nOZ
-jZH
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -69959,59 +66864,59 @@ eLE
 "}
 (177,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-jcY
-cWR
-cWR
-cWR
-jZH
-jZH
-cIQ
-abN
-fhk
-iLO
-iLO
-abN
-gPs
-jZH
-lvv
-uwd
-uwd
-uzA
-jZH
-rAs
-rwk
-ost
-rwk
-rwk
-jZH
-lqB
-dnH
-fhk
-uzA
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -70216,59 +67121,59 @@ eLE
 "}
 (178,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cWR
-fDh
-uqP
-lkk
-cWR
-fDh
-wPh
-rsA
-cWR
-dcF
-klK
-sLL
-cWR
-jZH
-jZH
-abN
-abN
-iLO
-iLO
-iLO
-abN
-abN
-jZH
-fYL
-uwd
-uwd
-uUZ
-jZH
-eNh
-mRj
-iLO
-iLO
-sLI
-kDH
-cEF
-dsy
-iLO
-uzA
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -70473,59 +67378,59 @@ eLE
 "}
 (179,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cWR
-ukZ
-xWQ
-kDG
-cWR
-xWQ
-xWQ
-kDG
-cWR
-jUH
-lnZ
-dIf
-cWR
-jZH
-jZH
-wKZ
-abN
-iLO
-iLO
-iLO
-abN
-blk
-jZH
-lvv
-uwd
-uwd
-hFC
-jZH
-rwk
-mRj
-iLO
-bQD
-rwk
-jZH
-dTN
-bQD
-bQD
-eOF
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -70730,59 +67635,59 @@ eLE
 "}
 (180,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cWR
-tau
-xWQ
-kDG
-cWR
-xWQ
-xWQ
-lkk
-cWR
-jum
-ekv
-uKh
-cWR
-jZH
-jZH
-cIQ
-abN
-iLO
-iLO
-iLO
-abN
-gPs
-jZH
-jZH
-vEJ
-uwd
-onB
-kDH
-sLI
-iLO
-iLO
-iLO
-kPd
-jZH
-fHM
-iLO
-bQD
-eOF
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -70987,61 +67892,61 @@ eLE
 "}
 (181,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-jZH
-rxi
-jZH
-jZH
-jZH
-rxi
-jZH
-jZH
-jZH
-hOy
-jZH
-jZH
-jZH
-jZH
-abN
-abN
-fhk
-fhk
-iLO
-abN
-abN
-abN
-jZH
-jZH
-jMo
-lKa
-jZH
-rwk
-iLO
-xjU
-vBj
-rwk
-jZH
-wmN
-iLO
-kIo
-gCl
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
+uoO
+aoj
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -71244,61 +68149,61 @@ eLE
 "}
 (182,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-pwR
-pwZ
-kkf
-uDE
-wne
-pwZ
-kkf
-wne
-jeq
-sak
-kkf
-jZH
-jZH
-jZH
-wKZ
-abN
-hOJ
-sLI
-sLI
-abN
-iYM
-abN
-aUc
-jZH
-jZH
-jZH
-jZH
-jZH
-nXe
-kQE
-kQE
-adR
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -71501,59 +68406,59 @@ eLE
 "}
 (183,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-wne
-pwZ
-wne
-wne
-sak
-cZI
-sak
-wne
-wne
-sak
-wne
-jZH
-bUR
-abN
-abN
-abN
-iLO
-iLO
-fhk
-abN
-abN
-tcW
-eBz
-eBz
-eBz
-eBz
-eBz
-eBz
-eBz
-ioj
-ioj
-eBz
-eBz
-eBz
-eBz
-eBz
-eBz
-jZH
-jZH
-jZH
-jZH
-jZH
-rOj
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -71758,68 +68663,63 @@ eLE
 "}
 (184,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-wne
-pwZ
-sak
-sak
-wDV
-jZH
-dze
-sak
-sak
-sak
-wne
-jZH
-jZH
-cIQ
-abN
-jVZ
-fhk
-fhk
-iLO
-jVZ
-abN
-abN
-abN
-abN
-blk
-hVC
-wKZ
-abN
-abN
-ioj
-ioj
-abN
-abN
-blk
-jZH
-wKZ
-abN
-pIJ
-dpR
-dpR
-gPF
-jZH
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -71864,6 +68764,11 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -72015,59 +68920,6 @@ eLE
 "}
 (185,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-wne
-jeq
-pwZ
-qIh
-dHm
-sCv
-sak
-sak
-wne
-wne
-uVC
-jZH
-tor
-wKZ
-abN
-fPg
-rBT
-rBT
-rBT
-fhk
-abN
-abN
-abN
-abN
-abN
-aSZ
-abN
-abN
-uaY
-ioj
-ioj
-uaY
-abN
-abN
-aSZ
-abN
-abN
-bUR
-dpR
-dpR
-dpR
-dpR
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
 uoO
@@ -72110,6 +68962,59 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -72272,59 +69177,59 @@ eLE
 "}
 (186,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-wne
-wne
-neb
-hvl
-hvl
-hvl
-sak
-cRy
-sak
-sak
-sak
-ojS
-eRI
-bVY
-aSI
-jGs
-vJc
-vJc
-syR
-pNT
-fhk
-iLO
-geb
-iLO
-geb
-fhk
-geb
-iLO
-eRI
-iLO
-geb
-fhk
-geb
-iLO
-geb
-iLO
-dYf
-adR
-dpR
-dpR
-dpR
-dpR
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -72358,24 +69263,24 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -72529,59 +69434,59 @@ eLE
 "}
 (187,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-msd
-wne
-sak
-qVR
-trr
-hvl
-sak
-cRy
-cRy
-cRy
-cRy
-ulx
-eRI
-bVY
-aSI
-jGs
-kph
-cxQ
-vJc
-pNT
-iLO
-iLO
-fhk
-eRI
-fhk
-cHA
-iLO
-eRI
-iLO
-geb
-bQD
-eRI
-iLO
-geb
-iLO
-geb
-iLO
-lLe
-dpR
-dpR
-dpR
-dpR
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -72615,27 +69520,27 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-jZH
-due
-due
-due
-due
-due
-due
-due
-due
-due
-due
-due
-due
-jZH
-ryy
-jZH
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -72786,59 +69691,59 @@ eLE
 "}
 (188,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-wne
-wne
-neb
-hvl
-hvl
-hvl
-sak
-cRy
-sak
-sak
-sak
-ojS
-eRI
-bVY
-aSI
-jGs
-wAB
-kph
-wAB
-pNT
-fhk
-iLO
-geb
-iLO
-geb
-bQD
-geb
-iLO
-eRI
-fhk
-eRI
-iLO
-geb
-iLO
-geb
-iLO
-geb
-adR
-npK
-dpR
-dpR
-dpR
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -72874,22 +69779,22 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-itB
-itB
-itB
-itB
-itB
-itB
-itB
-itB
-itB
-itB
-due
-jZH
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -73043,59 +69948,6 @@ eLE
 "}
 (189,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-wne
-jeq
-pwZ
-neb
-djn
-tTx
-sak
-sak
-wne
-wne
-uVC
-jZH
-tor
-wKZ
-abN
-lyG
-mVX
-mVX
-mVX
-jVZ
-abN
-abN
-abN
-abN
-abN
-pVQ
-abN
-abN
-uaY
-sLI
-sLI
-uaY
-abN
-abN
-pVQ
-abN
-abN
-bUR
-dpR
-dpR
-dpR
-dpR
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
 uoO
@@ -73103,13 +69955,8 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
 aoj
 uoO
 uoO
@@ -73128,25 +69975,83 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
-jZH
-due
-itB
-kYh
-wAv
-oqU
-oqU
-oqU
-oqU
-wAv
-kYh
-itB
-due
-jZH
-ryy
-jZH
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+hBf
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -73300,59 +70205,59 @@ eLE
 "}
 (190,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-wne
-sak
-pwZ
-sak
-wDV
-jZH
-dze
-sak
-sak
-sak
-wne
-jZH
-jZH
-cIQ
-abN
-fhk
-fhk
-iLO
-fhk
-fhk
-abN
-abN
-mmF
-abN
-blk
-hVC
-wKZ
-abN
-abN
-sLI
-sLI
-abN
-abN
-blk
-jZH
-wKZ
-abN
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -73388,22 +70293,22 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-itB
-sjk
-pis
-pis
-pis
-pis
-pis
-pis
-bUw
-itB
-due
-jZH
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -73557,59 +70462,59 @@ eLE
 "}
 (191,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-wne
-sak
-wne
-wne
-sak
-cEK
-sak
-wne
-wne
-sak
-wne
-jZH
-bUR
-abN
-abN
-abN
-iLO
-iLO
-iLO
-abN
-abN
-abN
-ssx
-epW
-epW
-epW
-epW
-epW
-epW
-sLI
-sLI
-epW
-epW
-epW
-epW
-epW
-epW
-jZH
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -73645,22 +70550,22 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-itB
-sjk
-pis
-pis
-pis
-pis
-pis
-pis
-bUw
-itB
-due
-jZH
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -73814,59 +70719,44 @@ eLE
 "}
 (192,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-pwR
-pwZ
-wAi
-gVy
-wne
-pwZ
-wAi
-wne
-jeq
-sak
-wAi
-jZH
-jZH
-jZH
-wKZ
-abN
-sLI
-sLI
-sLI
-abN
-vCS
-epW
-qOe
-jZH
-jZH
-jZH
-jZH
-jZH
-swO
-kQE
-kQE
-adR
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -73902,22 +70792,37 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-itB
-sjk
-pis
-pis
-pis
-pis
-pis
-pis
-bUw
-itB
-due
-jZH
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -74071,59 +70976,59 @@ eLE
 "}
 (193,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-jZH
-rxi
-jZH
-jZH
-jZH
-rxi
-jZH
-jZH
-jZH
-rxi
-jZH
-jZH
-jZH
-jZH
-cIQ
-abN
-iLO
-iLO
-fhk
-abN
-ufO
-kDi
-jZH
-jZH
-itn
-lzS
-lzS
-tsb
-gaj
-cDx
-cDx
-gyq
-jZH
-hae
-nWV
-uXE
-rNl
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -74154,27 +71059,27 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-jZH
-due
-itB
-kej
-qvs
-qvs
-qba
-dGU
-qvs
-qvs
-kej
-itB
-due
-jZH
-ryy
-jZH
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -74328,59 +71233,59 @@ eLE
 "}
 (194,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cWR
-ukZ
-xWQ
-kDG
-cWR
-vLa
-xWQ
-kDG
-cWR
-uaT
-xWQ
-xtE
-cWR
-jZH
-jZH
-abN
-abN
-fhk
-iLO
-fhk
-abN
-gaz
-jZH
-jZH
-jZH
-uoK
-vyS
-wyD
-aqB
-cKI
-aqB
-aqB
-hMu
-jZH
-uUA
-uHP
-tzl
-vTr
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -74411,27 +71316,27 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-jZH
-due
-jZH
-jZH
-fhZ
-oRq
-qmh
-kZB
-oRq
-fhZ
-jZH
-jZH
-due
-jZH
-ryy
-jZH
 uoO
 uoO
 uoO
@@ -74585,59 +71490,59 @@ eLE
 "}
 (195,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cWR
-ejY
-xWQ
-lkk
-cWR
-xWQ
-xWQ
-ukZ
-cWR
-gWA
-xWQ
-lkk
-cWR
-jZH
-jZH
-wKZ
-abN
-fhk
-fhk
-fhk
-abN
-qhK
-jZH
-jZH
-jZH
-lLG
-aqB
-svu
-svu
-aqB
-dMm
-dMm
-fhk
-mfM
-tzl
-uHP
-tzl
-rNl
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -74668,30 +71573,30 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
 uoO
 uoO
-jZH
-due
-fbP
-umC
-qmh
-qmh
-qmh
-kZB
-vMM
-qmh
-jZL
-fbP
-due
-jZH
-ryy
-jZH
 uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
 aoj
 aoj
 aoj
@@ -74842,59 +71747,59 @@ eLE
 "}
 (196,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cWR
-fDh
-hSJ
-aNH
-cWR
-fDh
-wmt
-bHC
-cWR
-kDG
-hSJ
-fDh
-cWR
-jZH
-jZH
-cIQ
-abN
-iLO
-iLO
-iLO
-abN
-gaz
-jZH
-nLH
-mMv
-fGI
-aqB
-aqB
-aqB
-lxD
-lxD
-dMm
-pcA
-jZH
-lHV
-uHP
-moY
-trC
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -74925,31 +71830,31 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
 uoO
 uoO
-jZH
-due
-fbP
-jZH
-jZH
-ymd
-ymd
-rWE
-kwo
-jZH
-jZH
-fbP
-due
-jZH
-ryy
-jZH
 uoO
+aoj
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -75099,55 +72004,9 @@ eLE
 "}
 (197,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-cWR
-jZH
-jZH
-abN
-abN
-iLO
-iLO
-iLO
-abN
-gaz
-jZH
-nLH
-aqB
-cKI
-aqB
-fOD
-lxD
-uoI
-uoI
-dMm
-pcA
-jZH
-cGO
-uHP
-uHP
-tvo
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
+uoO
+aoj
 aoj
 aoj
 uoO
@@ -75158,6 +72017,34 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 aoj
 aoj
 uoO
@@ -75176,6 +72063,8 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -75185,28 +72074,44 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-jZH
-due
-fbP
-jzs
-lwY
-hyR
-dSr
-dNh
-xdu
-oUi
-tJL
-fbP
-due
-jZH
-ryy
-jZH
 uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
 aoj
 aoj
 aoj
@@ -75356,58 +72261,14 @@ eLE
 "}
 (198,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-mIV
-mIV
-jZH
-jZH
-jZH
-jZH
-wKZ
-abN
-iLO
-fhk
-iLO
-abN
-qhK
-jZH
-kkt
-svu
-aqB
-hRl
-pKM
-lxD
-rSw
-dBy
-dMm
-fhk
-jZH
-rOh
-wVN
-uHP
-jid
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -75416,6 +72277,7 @@ uoO
 uoO
 uoO
 aoj
+uoO
 aoj
 uoO
 uoO
@@ -75444,26 +72306,69 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-wUo
-fbP
-dSr
-fbP
-dSr
-dNh
-dSr
-fbP
-fbP
-eGI
-due
-jZH
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
 aoj
 aoj
 aoj
@@ -75613,58 +72518,13 @@ eLE
 "}
 (199,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-ylf
-ryy
-ryy
-vWE
-net
-ryy
-boI
-boI
-jZH
-ePz
-hZu
-ijA
-vSw
-hOb
-jZH
-cIQ
-abN
-iLO
-iLO
-fhk
-abN
-gaz
-jZH
-nLH
-bpv
-aqB
-ekY
-rDm
-aqB
-lxD
-lxD
-dMm
-yav
-jZH
-fZh
-tzl
-uHP
-vWw
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -75673,8 +72533,31 @@ uoO
 uoO
 uoO
 aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -75701,22 +72584,44 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-jeW
-nqk
-ozX
-ozX
-ozX
-veN
-fbP
-dSr
-fbP
-nbS
-due
-jZH
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -75870,56 +72775,6 @@ eLE
 "}
 (200,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-ryy
-vWE
-ryy
-oDd
-ryy
-vWE
-bRE
-fpE
-bUR
-jDX
-sNx
-sNx
-cTM
-jvD
-jZH
-abN
-abN
-fhk
-iLO
-fhk
-abN
-gaz
-jZH
-nLH
-aqB
-dMm
-dMm
-dMm
-dMm
-aqB
-aqB
-aqB
-rbu
-jZH
-fbp
-tzl
-uHP
-lLI
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -75931,7 +72786,37 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -75952,28 +72837,48 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
-jZH
-due
-glv
-hdU
-blo
-mcC
-stU
-wUo
-blo
-stU
-stU
-mpL
-due
-jZH
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -76127,55 +73032,6 @@ eLE
 "}
 (201,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-ryy
-oDd
-cfA
-ryy
-ryy
-wdG
-ryy
-vWE
-jZH
-uXQ
-ikr
-sNx
-oWE
-nUD
-jZH
-wKZ
-abN
-fhk
-iLO
-iLO
-abN
-qhK
-jZH
-kkt
-dMm
-kEN
-hRu
-xEZ
-lxD
-lxD
-lxD
-lxD
-fhk
-jZH
-yay
-uHP
-uHP
-aoq
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-aoj
 uoO
 uoO
 uoO
@@ -76188,7 +73044,36 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -76209,28 +73094,48 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-jZH
-due
-jZH
-wTI
-qLw
-jZH
-jZH
-vOD
-swW
-due
-due
-due
-due
-jZH
-ryy
-jZH
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -76384,64 +73289,64 @@ eLE
 "}
 (202,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-cfA
-cfA
-cfA
-cfA
-ryy
-ryy
-ryy
-kUl
-jZH
-jZH
-cqm
-jZH
-jZH
-jZH
-jZH
-cIQ
-abN
-iLO
-iLO
-iLO
-abN
-gaz
-jZH
-uoK
-dMm
-iWr
-hRK
-hRK
-olI
-hRK
-tvP
-psu
-fhk
-uMH
-tzl
-uHP
-sgE
-hVG
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -76472,26 +73377,26 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-sXi
-vch
-uRE
-hSq
-jZH
-qFe
-eDB
-due
-jZH
-jZH
-jZH
-jZH
-ryy
-jZH
-uoO
+aoj
+aoj
 uoO
 uoO
 aoj
+aoj
+aoj
+aoj
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -76641,116 +73546,83 @@ eLE
 "}
 (203,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-niW
-cfA
-xzr
-cfA
-cfA
-cfA
-cfA
-bpg
-jZH
-gMG
-sNx
-dDj
-sNx
-hMd
-oCp
-abN
-abN
-fhk
-iLO
-iLO
-abN
-gaz
-adR
-mbx
-aqB
-hVK
-cZu
-tzl
-uHP
-uHP
-uHP
-tzl
-oCU
-hVJ
-tzl
-uHP
-xHc
-xHc
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-jZH
-due
-wQJ
-vJX
-qRv
-tfd
-jZH
-jeW
-eDB
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
 uoO
 uoO
 uoO
 aoj
+uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -76769,6 +73641,39 @@ uoO
 uoO
 aoj
 aoj
+aoj
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
@@ -76898,64 +73803,20 @@ eLE
 "}
 (204,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-iDk
-cfA
-ryy
-ryy
-vWE
-ryy
-vWE
-ryy
-rPe
-sNx
-sNx
-sNx
-sNx
-fJy
-emn
-ioj
-ioj
-fhk
-fhk
-fhk
-ioj
-ioj
-emn
-ioj
-lcZ
-atn
-agy
-tzl
-uHP
-tzl
-uHP
-dwd
-uHP
-jZH
-uHP
-uHP
-tzl
-idV
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -76986,22 +73847,25 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-wNs
-vch
-uRE
-vrC
-jZH
-oCy
-jYZ
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -77026,6 +73890,47 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
@@ -77155,86 +74060,6 @@ eLE
 "}
 (205,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-pHE
-ryy
-vyU
-ryy
-oDd
-ryy
-oDd
-ryy
-jZH
-eJX
-cmj
-sJl
-sZa
-gdm
-jZH
-abN
-hVC
-kng
-pQe
-kng
-hVC
-tYH
-adR
-uKV
-tIE
-ycS
-hji
-kka
-dSs
-kCo
-mGw
-oVz
-tzl
-mfM
-tzl
-hXZ
-xHc
-xHc
-jZH
-rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
 uoO
@@ -77243,22 +74068,63 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-fdN
-eaR
-ldA
-hcC
-jZH
-eDT
-eDB
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -77283,6 +74149,45 @@ uoO
 uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 aoj
@@ -77412,86 +74317,6 @@ eLE
 "}
 (206,1,1) = {"
 eLE
-jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-fdp
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-qsP
-gkZ
-qsP
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
 uoO
@@ -77500,28 +74325,101 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-jZH
-wTI
-onR
-jZH
-jZH
-vOD
-xmH
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
 uoO
 uoO
-vHQ
+psj
 uoO
 uoO
 uoO
@@ -77536,6 +74434,13 @@ aoj
 aoj
 aoj
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -77669,7 +74574,6 @@ eLE
 "}
 (207,1,1) = {"
 eLE
-jZH
 rOj
 rOj
 rOj
@@ -77722,33 +74626,7 @@ rOj
 rOj
 rOj
 rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+rOj
 uoO
 uoO
 uoO
@@ -77757,22 +74635,42 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-rnU
-xvO
-aRj
-hGV
-stR
-jeW
-eDB
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 aoj
@@ -77793,6 +74691,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -77979,33 +74884,6 @@ jZH
 jZH
 jZH
 rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
 uoO
 uoO
 uoO
@@ -78014,22 +74892,42 @@ uoO
 uoO
 uoO
 uoO
-jZH
-due
-aXh
-qmh
-qmh
-jEK
-stR
-jeW
-jYZ
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 aoj
@@ -78050,6 +74948,13 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -78185,18 +75090,18 @@ eLE
 eLE
 rOj
 jZH
-ryy
-ryy
-ryy
+aam
+adR
+cfA
 rZW
-ryy
+cfA
 ryy
 oDP
 ryy
-ryy
-ryy
-ryy
-ryy
+cfA
+cfA
+cfA
+cfA
 vnZ
 ryy
 hJk
@@ -78204,14 +75109,14 @@ ryy
 ryy
 ryy
 oDP
-vnZ
-ryy
-ryy
+dyR
+cfA
+cfA
 mxQ
-ryy
-ryy
-ryy
-ryy
+cfA
+ekv
+eBz
+eDT
 hVk
 jZH
 ujt
@@ -78236,57 +75141,50 @@ nHR
 vDC
 jZH
 rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-due
-aXh
-qmh
-qmh
-nSP
-stR
-jeW
-eDB
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -78308,6 +75206,13 @@ uoO
 aoj
 aoj
 uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -78445,9 +75350,9 @@ jZH
 tuO
 jZH
 jZH
-mIV
-mIV
 jZH
+jZH
+oDP
 jZH
 jZH
 jZH
@@ -78456,7 +75361,6 @@ jZH
 qhw
 jZH
 jZH
-jZH
 qhw
 jZH
 jZH
@@ -78464,6 +75368,7 @@ jZH
 jZH
 jZH
 jZH
+oDP
 jZH
 jZH
 jZH
@@ -78493,57 +75398,50 @@ pOc
 vDC
 jZH
 rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-jZH
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-due
-kZB
-uay
-ajd
-eod
-stR
-jeW
-jYZ
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -78568,6 +75466,13 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -78701,29 +75606,29 @@ rOj
 jZH
 tva
 uGI
-jZH
-izT
-izT
-jZH
-uGI
+agy
+jHA
+aOr
+geb
+aXh
 dQy
-jZH
-grT
-wVt
+bbd
+xZY
+xZY
 non
 pph
 unw
-wVt
-non
 pph
-grT
-pbt
-non
-tLn
-sGs
-cCE
-hND
+cBm
 jZH
+cWS
+pbt
+dze
+tLn
+vWb
+jZH
+pTj
+ejF
 pdB
 ijA
 nGh
@@ -78750,58 +75655,51 @@ pOc
 vDC
 jZH
 rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-jZH
-rOj
-jZH
-nTr
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-aam
-aam
-aam
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-due
-ucn
-qmh
-ois
-fIV
-stR
-oCy
-jYZ
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 aoj
 uoO
@@ -78821,6 +75719,13 @@ uoO
 uoO
 aoj
 aoj
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -78957,32 +75862,32 @@ eLE
 rOj
 jZH
 uPS
-aSW
-boe
-eRI
-eRI
-boe
-aSW
-jNv
 jZH
-hfE
-rDv
+boe
+jHA
+aPa
+geb
+geb
+geb
+bbd
+xZY
+tSl
 aQN
-aQN
-ngA
-peb
-geb
-pRz
-hfE
-vIa
-geb
-geb
-lRn
-vXX
-eRI
+wWf
+wWf
+wWf
+cCE
+jZH
+cXG
+vWb
 uPY
-ikr
-ikr
+vWb
+vWb
+eey
+vWb
+uPY
+vWb
+vWb
 tQi
 jZH
 mkC
@@ -79007,57 +75912,50 @@ hrq
 jZH
 jZH
 rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-jZH
-rOj
-jZH
-euI
-xYM
-mDO
-mbN
-jZH
-rFJ
-jtP
-jdf
-mCP
-jZH
-kLC
-vDC
-vDC
-vDC
-vDC
-vDC
-vDC
-vDC
-vDC
-vDC
-vDC
-vDC
-vDC
-jZH
-paF
-paF
-paF
-jZH
-due
-beL
-jZH
-vna
-vna
-jZH
-qFe
-jYZ
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -79078,6 +75976,13 @@ uoO
 uoO
 aoj
 aoj
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -79213,33 +76118,33 @@ eLE
 eLE
 rOj
 jZH
-jZH
-jZH
+tva
+aeM
 kfq
-kNb
-eRI
-wup
+ash
+atn
+geb
 jZH
 jZH
 jZH
 cZT
-tjo
-vOk
-geb
-nhO
-aIX
-geb
-geb
-qJi
-lsz
-geb
-geb
-lZs
-tjo
-vNy
+tSl
+wWf
+wWf
+wWf
+wWf
+cCE
 jZH
+qJi
+vWb
+dBy
+dSs
+lZs
+jZH
+vNy
+ekY
 ejF
-ikr
+vWb
 tAP
 jZH
 xLA
@@ -79264,57 +76169,50 @@ kLC
 jcZ
 mIV
 rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 rOj
-jZH
-cQU
-ygS
-iLO
-fhk
-jZH
-aVe
-jZH
-ljC
-aOr
-viJ
-kLC
-kLC
-kLC
-kLC
-kLC
-kLC
-kLC
-kLC
-kLC
-kLC
-bVY
-kLC
-kLC
-jZH
-paF
-paF
-jZH
-jZH
-due
-kZB
-jZH
-oei
-jzs
-lwY
-hyR
-eDB
-due
-jZH
-ryy
-ryy
-ryy
-ryy
-jZH
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+rOj
+rOj
 uoO
 uoO
 aoj
@@ -79335,6 +76233,13 @@ uoO
 uoO
 aoj
 aoj
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -79470,34 +76375,34 @@ eLE
 eLE
 rOj
 jZH
-uPS
-bxo
-boe
+tva
+uGI
+kfq
+atn
+atn
 geb
-geb
-boe
-bxo
+pnk
 jNv
 jZH
 xju
-geb
-imi
-geb
-geb
-geb
+tSl
+wWf
+wWf
+wWf
+wWf
 khi
-geb
-geb
-geb
-geb
-geb
-geb
-geb
-oBm
-sWR
-ikr
-ikr
-ipN
+jZH
+cZu
+vWb
+dDj
+dTN
+uPY
+eey
+vWb
+vWb
+uPY
+eGI
+tQi
 jZH
 iIs
 rFJ
@@ -79521,20 +76426,28 @@ ftU
 qfK
 jZH
 rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 rOj
 jZH
 jZH
-rBh
-iLO
-iLO
-wbe
-aVe
 jZH
 jZH
 jZH
@@ -79551,33 +76464,18 @@ jZH
 jZH
 jZH
 jZH
-kLC
-jZH
-paF
-paF
-jZH
-jnO
-bNO
-vLB
-jZH
-jeW
-dSr
-dSr
-dSr
-jYZ
 jZH
 jZH
 jZH
 jZH
 jZH
-jZH
-jZH
+rOj
 uoO
 uoO
 aoj
 xVz
 xVz
-qZA
+iGY
 uoO
 uoO
 uoO
@@ -79592,6 +76490,13 @@ aoj
 aoj
 aoj
 aoj
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -79727,31 +76632,31 @@ eLE
 eLE
 rOj
 jZH
-fDZ
-rbI
+uPS
 jZH
-geb
+boe
+jHA
+aPa
 geb
 jZH
-rbI
-aOr
+jZH
 jZH
 tKF
-cHK
-geb
-geb
-lJI
+tSl
 wWf
-geb
-gus
-sGs
-wVt
-geb
-sGm
-tXd
-fAf
-pTj
+wWf
+wWf
+wWf
+cCE
 jZH
+sGs
+vWb
+vWb
+uPY
+vWb
+jZH
+pTj
+emn
 kDC
 xCP
 gtg
@@ -79778,61 +76683,54 @@ kLC
 jcZ
 mIV
 rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-jZH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 rOj
 jZH
-jZH
-qFU
-iLO
-mDO
-jZH
-oZd
-aVe
-jZH
-jZH
-vDC
-vDC
-jZH
-jZH
-kRZ
 qdM
-kRZ
-jZH
-jZH
-jZH
+qdM
+kkt
+ksU
+kzt
+kzt
 ebN
-ebN
+kPd
 lqT
-kLC
-jZH
-paF
-paF
-jZH
+kzt
+lkk
 wWM
-cmM
-nxX
-jZH
+wWM
+mDO
+wWM
+wWM
+wWM
+mDO
 oCy
-dSr
-dSr
-dSr
-dSr
-psj
-ryy
-ryy
-ryy
-ryy
-ryy
+qdM
+qdM
 jZH
 uoO
 uoO
 uoO
-qZA
+uoO
+iGY
 xVz
 xVz
 uoO
@@ -79845,6 +76743,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -79984,26 +76889,26 @@ eLE
 eLE
 rOj
 jZH
-jZH
-jZH
-jZH
+tva
+kfq
+agy
 jHA
-jHA
-jZH
-jZH
-jZH
+aQg
+geb
+pnk
+jNv
 jZH
 dcI
-peb
-geb
-geb
+tSl
+wWf
+bCf
 lSE
-rZE
-geb
-geb
-hfE
-tXd
-geb
+wWf
+khi
+jZH
+cZI
+vWb
+dFd
 qhw
 jZH
 jZH
@@ -80035,57 +76940,50 @@ hrq
 jZH
 jZH
 rOj
-jZH
-eLE
-eLE
-eLE
-eLE
-jZH
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
 rOj
 jZH
-jZH
-ici
-gjB
-tPF
-jZH
-iIs
-aVe
-jZH
-jZH
-vDC
-jZH
-jZH
-cWS
 bik
 cVH
 tMB
-pWw
+jZH
 lcp
-jZH
-ebN
-ebN
-jZH
-jZH
-jZH
-paF
-paF
-jZH
-jZH
-jZH
-jZH
-uWn
+xhA
+xhA
+kQE
+xhA
+xhA
+kAb
+qdM
+qdM
+qdM
+qdM
+qdM
+qdM
+qdM
 jOn
-jOn
-cRN
-uWn
+qdM
+qdM
 jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-ryy
-jZH
+uoO
 uoO
 uoO
 uoO
@@ -80106,6 +77004,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -80240,26 +77145,26 @@ eLE
 (217,1,1) = {"
 eLE
 rOj
-xhA
-hPF
-tnk
 jZH
-kNb
+kfq
+kfq
+jZH
+jZH
+jZH
 geb
-vCh
-sCB
-phh
+jZH
+jZH
 jZH
 eet
 tSl
-geb
-geb
-rIV
+wWf
+wWf
+wWf
 lQI
-geb
-geb
-oim
-fDC
+cCE
+jZH
+dcF
+vWb
 vWb
 lia
 qaR
@@ -80293,56 +77198,49 @@ vDC
 jZH
 rOj
 jZH
-eLE
-eLE
-eLE
-eLE
-jZH
-rOj
 jZH
 jZH
 jZH
 jZH
 jZH
 jZH
-iIs
-aVe
-jZH
-jZH
-jZH
-jZH
-djs
-djs
-djs
-djs
-djs
-djs
-djs
-gFM
-ebN
-ebN
-ebN
-paF
 fZC
-paF
-paF
-paF
-paF
-paF
 jZH
 jZH
-rFJ
-aVe
-rFJ
-uWn
 jZH
-paF
-paF
-paF
-paF
 jZH
-ryy
 jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jPx
+kej
+klK
+jZH
+kAb
+gFM
+gFM
+kUl
+gFM
+ldP
+fZC
+lIH
+mfM
+qdM
+mTv
+nEt
+jZH
+jZH
+ogh
+ois
+jZH
+jZH
+uoO
 uoO
 uoO
 uoO
@@ -80365,8 +77263,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80498,26 +77403,26 @@ eLE
 eLE
 rOj
 jZH
-phh
 wxE
-huv
+wxE
+jZH
+dQy
 geb
 geb
-vyb
 pnk
-oVE
+jNv
 jZH
 qTn
-pkC
-geb
+xZY
+fDJ
 pAJ
 fDJ
-xWz
-imi
-geb
-eRI
-eRI
-geb
+fDJ
+xZY
+jZH
+ddJ
+vWb
+uPY
 jZH
 sDK
 eRI
@@ -80550,56 +77455,49 @@ vDC
 jZH
 rOj
 jZH
-eLE
-eLE
-eLE
-eLE
 jZH
-rOj
-jZH
-jZH
-xiI
-tAT
-fhk
-wbe
+fpE
+fIV
+fJy
+gHT
 aVe
 aVe
 jZH
 jZH
 jZH
-djs
-djs
-pvX
-mDr
-uSG
-xia
-pwP
-qpe
+kBT
+kBT
+hQt
+hMd
+hZu
+iuL
+iZQ
+jfW
 jZH
 jZH
 jZH
-paF
-paF
-jZH
-paF
-paF
-paF
-paF
-paF
 jZH
 jZH
-rFJ
-aVe
-aVe
+jZH
+xhA
+xhA
+vOo
+vOo
+vOo
+liM
 jZH
 jZH
-paF
-paF
-paF
-paF
 jZH
-ryy
+mGw
 jZH
+jZH
+jZH
+nWV
+ohD
+onR
+oCU
+jZH
+uoO
 uoO
 uoO
 aoj
@@ -80619,6 +77517,13 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80759,20 +77664,20 @@ jZH
 jZH
 jZH
 cCr
-eRI
+aRj
 jZH
-uZa
+jZH
 jZH
 jZH
 sNO
-wVt
-geb
-geb
-jos
-wVt
-geb
-geb
+blo
 sNO
+nNF
+jZH
+jZH
+cDx
+jZH
+diM
 hwn
 jMp
 jZH
@@ -80807,56 +77712,49 @@ vDC
 jZH
 rOj
 jZH
-eLE
-eLE
-eLE
-eLE
 jZH
-rOj
-jZH
-jZH
-liM
+fqz
 owa
-jBc
+gaz
 jZH
 aVe
 rFJ
 jZH
 jZH
-ddJ
-djs
+hsk
+kBT
+hKS
+fDi
+fDi
+fDi
+seJ
+fDi
+iWr
 jJd
-fDi
-fDi
-fDi
-fFK
-fDi
-fou
-pDM
+jGs
+jZH
+jZH
+jZH
+jZH
+qGz
+xhA
 vOo
+vOo
+vOo
+ljC
 jZH
+lKa
+qdM
+qdM
+qdM
+mIY
 jZH
-paF
+nXe
+ohN
+oqU
+oDd
 jZH
-paF
-paF
-paF
-paF
-paF
-jZH
-jZH
-aVe
-aVe
-rFJ
-jZH
-jZH
-paF
-paF
-paF
-paF
-jZH
-ryy
-jZH
+uoO
 uoO
 uoO
 aoj
@@ -80879,6 +77777,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -81021,17 +77926,17 @@ aHn
 owa
 phh
 jZH
-dcI
+bfh
 vIa
-geb
-geb
-dcI
+bfh
+nNF
+xWz
 gBF
-geb
-pAJ
+cEF
+cQU
 smv
-peb
-khi
+aVe
+aVe
 jZH
 kgs
 aIS
@@ -81065,55 +77970,48 @@ jZH
 rOj
 jZH
 jZH
-jZH
-jZH
-jZH
-jZH
-rOj
-jZH
-jZH
 eOh
+fYC
+gdm
+jZH
+aVe
+aVe
+jZH
+jZH
 iLO
 kBT
-jZH
-aVe
-aVe
-jZH
-jZH
-eHh
-djs
-mDr
+hMd
 fDi
-qGz
-byA
-vZr
-neP
-bKF
-wUT
-neu
+wbe
+ici
+iDk
+eHh
+jid
+mDr
+jJo
 jZH
 jZH
 jZH
 jZH
-paF
-paF
-paF
-paF
-paF
+xhA
+xhA
+vOo
+vOo
+vOo
+xhA
 jZH
+lKs
+miG
+qdM
+mUo
+nFR
 jZH
-bTG
-aVe
-otJ
+nYh
+ohD
+onR
+oIK
 jZH
-jZH
-paF
-paF
-paF
-paF
-jZH
-ryy
-jZH
+aoj
 uoO
 uoO
 uoO
@@ -81136,6 +78034,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -81279,16 +78184,16 @@ mkc
 oVE
 jZH
 wad
-uef
-geb
-khi
-oim
-tSl
-geb
-geb
+vIa
+hDE
+nNF
+xWz
+cmj
+uFg
+cGO
 uVt
-hSP
-geb
+aVe
+dGU
 bUR
 rVE
 aTP
@@ -81320,57 +78225,50 @@ sLI
 sLI
 jZH
 rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
 jZH
 jZH
-pkl
-fhk
-itP
+fwX
+fJy
+pgH
 jZH
-bTG
+gMG
 aVe
 jZH
 jZH
+kBT
+kBT
+kBT
+jNC
+wbe
+idV
+iFz
 djs
-djs
-djs
-slT
-qGz
-bdP
-efS
-xYS
-qGz
+wbe
 sLI
-anf
+slT
 jZH
 jZH
 jZH
 jZH
-paF
-paF
-paF
-paF
-paF
+qGz
+xhA
+vOo
+vOo
+vOo
+ljC
 jZH
-fDi
+lLe
+mmF
+mIY
+mVX
+nGb
+jZH
+oar
 pFn
 sBO
-rFJ
-sIK
+oMK
 jZH
-paF
-paF
-paF
-paF
-jZH
-ryy
-jZH
+aoj
 uoO
 uoO
 uoO
@@ -81393,6 +78291,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
 uoO
 uoO
 aoj
@@ -81536,16 +78441,16 @@ jZH
 jZH
 jZH
 hDE
-cHx
-geb
-geb
+vrv
+hDE
+nNF
 xWz
 jqs
 xvW
-geb
-geb
-geb
-geb
+cGO
+uVt
+aVe
+aVe
 goQ
 pxS
 aTP
@@ -81579,55 +78484,48 @@ jZH
 rOj
 jZH
 jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-rkD
-iLO
-iuX
+mgX
+fYC
+glv
 jZH
 iIs
 aVe
 jZH
 jZH
-djs
-djs
-djs
-slT
-qGz
-thO
-efS
-jPx
-qGz
+kBT
+kBT
+kBT
+jNC
+wbe
+ifa
+iFz
+jbP
+wbe
 sLI
-hrv
+jMo
 jZH
-qvg
+thO
 qpc
 jZH
+xhA
+xhA
+vOo
+vOo
+vOo
+xhA
+jZH
+lLG
+lLG
+lLG
+lLG
+lLG
 jZH
 jZH
+ois
+ois
 jZH
 jZH
-jZH
-jZH
-fDi
-pFn
-aVe
-aVe
-rFc
-jZH
-paF
-paF
-paF
-paF
-jZH
-ryy
-jZH
+uoO
 uoO
 uoO
 uoO
@@ -81648,7 +78546,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -81792,17 +78697,17 @@ psg
 sCB
 phh
 jZH
-qkz
-eRI
-geb
-geb
-iRe
-eRI
+nNF
+bnT
+nNF
+nNF
+xWz
+cmZ
 uFg
-geb
-geb
-geb
-jMp
+cGO
+uVt
+aVe
+aVe
 jZH
 pxS
 aTP
@@ -81835,56 +78740,49 @@ qQP
 jZH
 rOj
 jZH
-cIQ
+jZH
 nZo
 abN
 snY
-btq
-jZH
-jZH
-jZH
-jrX
-gjB
-hKI
 jZH
 iIs
 aVe
 jZH
 jZH
-lLy
-djs
-djs
+gjB
+kBT
+kBT
 fDi
-qGz
+wbe
+igV
+iML
+lLy
+jiw
+mDr
+jNr
+jZH
 vyg
 gzD
-nsN
-rEj
-wUT
-bFa
-jZH
-ink
-ekN
-hOX
 jZH
 jZH
+xhA
+vOo
+vOo
+vOo
+xhA
 jZH
-jZH
-jZH
-jZH
+lLI
+moY
+moY
+moY
+moY
+nLH
 bio
-pFn
-aVe
-aVe
-igV
+ojS
+ojS
+oNu
 jZH
-paF
-paF
-paF
-paF
-jZH
-ryy
-jZH
+uoO
 uoO
 uoO
 uoO
@@ -81905,7 +78803,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82049,17 +78954,17 @@ kZq
 twR
 oVE
 jZH
-mRM
-knk
-lzc
-geb
-sNO
-cHK
-geb
-geb
-mRM
-bTW
-geb
+jZH
+jZH
+jZH
+jZH
+xWz
+col
+cEK
+cGO
+uVt
+aVe
+dHm
 jZH
 tkO
 kvO
@@ -82080,7 +78985,7 @@ cbs
 sRA
 rFJ
 rFJ
-otJ
+rFJ
 jZH
 aVe
 jZH
@@ -82092,13 +78997,6 @@ rFJ
 jZH
 rOj
 jZH
-abN
-bbd
-ryy
-ryy
-ryy
-jZH
-jZH
 jZH
 jZH
 jZH
@@ -82108,40 +79006,40 @@ iIs
 aVe
 jZH
 jZH
-iWR
-djs
-djs
+huv
+kBT
+kBT
 fDi
+hVC
+fDi
+fDi
+fDi
+fDi
+jJd
+jMo
 ekD
-fDi
-fDi
-fDi
-fDi
-pDM
-hrv
+keR
+kng
+kwo
+kCo
 xhA
 fmv
+xhA
 fmv
-fmv
+xhA
+jZH
 vsI
+mpL
+mpL
+nbS
+nIl
+nMG
+nIl
+nIl
+ost
+oOk
 jZH
-jZH
-jZH
-jZH
-jZH
-fDi
-pFn
-aVe
-aVe
-rFc
-jZH
-paF
-paF
-paF
-paF
-jZH
-ryy
-jZH
+uoO
 uoO
 uoO
 uoO
@@ -82162,8 +79060,15 @@ aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 aoj
@@ -82306,17 +79211,17 @@ jZH
 uZa
 jZH
 jZH
-aeR
+idU
 vXX
 lzc
-geb
+dMm
 usy
-gBF
-geb
-geb
+cqm
+cGO
+cGO
 aeR
-vXX
-geb
+aVe
+jrn
 jZH
 tgY
 eRI
@@ -82337,7 +79242,7 @@ vQU
 tEG
 cuJ
 aVe
-ujt
+fbP
 jZH
 oZd
 vQU
@@ -82349,56 +79254,49 @@ rFJ
 jZH
 rOj
 jZH
-oOk
-nZo
-abN
-abN
-ryy
 jZH
-jZH
-jZH
-xiI
-tAT
-iLO
-wbe
+fpE
+fIV
+fYC
+gHT
 aVe
 aVe
 jZH
 jZH
 jZH
 jZH
-djs
-rsM
-riY
-riY
+kBT
+hRl
+hVG
+hVG
+hVG
+jcY
+jnO
+jZH
+jZH
+jZH
 riY
 lnF
-sll
+lnF
+jZH
+kDy
 jZH
 jZH
 jZH
-wuE
-nVZ
-nVZ
 jZH
+uWn
+lPf
 hBC
+mMv
+uWn
 jZH
 jZH
 jZH
 jZH
-fDi
-pFn
-rFJ
-aVe
-rFc
 jZH
-paF
-paF
-paF
-paF
 jZH
-ryy
 jZH
+uoO
 uoO
 uoO
 aoj
@@ -82421,6 +79319,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 aoj
@@ -82564,16 +79469,16 @@ owa
 phh
 jZH
 dUm
-tjo
-geb
-imi
-flC
+bpg
+uoI
+vXX
+idU
 joo
-geb
-geb
+cHx
+cRy
 lNO
-jJo
-geb
+aVe
+aVe
 lia
 hoh
 eRI
@@ -82607,16 +79512,9 @@ jZH
 rOj
 jZH
 jZH
-jZH
-jZH
-jZH
-ryy
-jZH
-jZH
-jZH
-liM
+fqz
 owa
-rbu
+gvM
 jZH
 aVe
 aVe
@@ -82626,36 +79524,36 @@ jZH
 jZH
 jZH
 jZH
-hKS
+hVJ
+iiS
+iiS
+jZH
+jZH
+jtP
+jZH
+jZH
 ppw
-ppw
-jZH
-jZH
-neq
-jZH
-jZH
-hZs
-rFJ
+aVe
 rFJ
 iIs
-vDj
-vRu
+neq
+bOf
 jZH
 jZH
 jZH
+hOX
+lQB
+aVe
+aVe
+neb
+jZH
+nNj
 mUS
-pFn
-aVe
-aVe
-igV
+olI
+xGl
 jZH
-paF
-paF
-paF
-paF
 jZH
-ryy
-jZH
+uoO
 uoO
 uoO
 aoj
@@ -82674,6 +79572,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -82820,17 +79725,17 @@ ggq
 lDH
 oVE
 jZH
-axQ
+vXX
 gus
-geb
-geb
-geb
-geb
-geb
-geb
-geb
-geb
-jMp
+bri
+vXX
+idU
+bHC
+cIQ
+iwr
+idU
+aVe
+dGU
 jZH
 hNy
 eDA
@@ -82851,7 +79756,7 @@ vQU
 epa
 gXH
 aVe
-ujt
+fbP
 jZH
 rFJ
 mZX
@@ -82864,16 +79769,9 @@ jZH
 rOj
 jZH
 jZH
-jZH
-jZH
-jZH
-azX
-jZH
-jZH
-jZH
-cOm
-iLO
-kBT
+fAf
+fYC
+gdm
 jZH
 aVe
 aVe
@@ -82882,37 +79780,37 @@ jZH
 aVe
 qii
 qii
+hRu
+hVK
+ill
+hVK
+jdf
+jos
+jum
 ifX
 rEl
-hLL
-rEl
-ill
-rZw
-fnD
-bOf
-lTT
-xps
-rFJ
+ifX
+aVe
 rFJ
 iIs
-rJn
-vRu
+vIL
+bOf
 jZH
 jZH
 jZH
-uXY
-pFn
+lnZ
+lQB
 aVe
-uFO
-rFc
+mMw
+net
 jZH
-paF
-paF
-paF
-paF
+mUS
+xGl
+xGl
+mUS
 jZH
-ryy
 jZH
+uoO
 uoO
 uoO
 aoj
@@ -82925,6 +79823,13 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -83077,17 +79982,17 @@ jZH
 jZH
 bUR
 jZH
-vjk
-eRI
-eRI
+dMm
 vXX
-eRI
-eRI
-geb
+vXX
+dMm
+idU
+bHC
+cIQ
 iwr
-eRI
-msw
-nyn
+dMm
+aVe
+aVe
 jZH
 jZH
 jZH
@@ -83108,9 +80013,9 @@ cbs
 aVe
 gcD
 aVe
-otJ
+jZH
 qpc
-aVe
+jZH
 jZH
 jZH
 gOH
@@ -83120,17 +80025,10 @@ rFJ
 jZH
 rOj
 jZH
-vRu
-wSn
-fYf
-pgH
-iIQ
-ohN
-jZH
 jZH
 eOh
-iLO
-itP
+fYC
+pgH
 jZH
 oZd
 aVe
@@ -83145,31 +80043,31 @@ aVe
 aVe
 aVe
 aVe
-vIL
+jvD
 rFJ
 iDS
-dEk
+jos
 aVe
 aVe
 iIs
-rJn
-tJV
+vIL
+kHS
 jZH
-qOJ
-xGl
+dEk
+ybF
 fDi
+tsq
+aVe
+aVe
+neP
+jZH
+xGl
+xGl
 jtk
-aVe
-aVe
-tXw
+ovQ
 jZH
-paF
-paF
-paF
-paF
 jZH
-ryy
-jZH
+uoO
 uoO
 uoO
 aoj
@@ -83178,6 +80076,13 @@ uoO
 aoj
 xVz
 xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -83335,16 +80240,16 @@ gZx
 gHh
 jZH
 xGn
-lBi
-kDy
-lBi
-lBi
-ltR
-lBi
+idU
+idU
+idU
+idU
+idU
+idU
 uzQ
-lBi
-iQT
-lBi
+idU
+aVe
+aVe
 jZH
 dgH
 bqU
@@ -83365,10 +80270,10 @@ jZH
 jZH
 jZH
 jZH
-jZH
-jZH
+fdp
 wbe
-jZH
+wbe
+fhZ
 jZH
 jZH
 jZH
@@ -83377,25 +80282,18 @@ rFJ
 jZH
 rOj
 jZH
-vRu
+jZH
 mgX
 fYC
 sWr
-iIQ
-fli
-jZH
-jZH
-rkD
-iLO
-fqz
 jZH
 iIs
 aVe
 jZH
 jZH
-jfW
+hvl
 jZH
-sPl
+hMu
 aVe
 aVe
 aVe
@@ -83404,29 +80302,29 @@ rFJ
 rFJ
 aVe
 otJ
-xoU
-tQe
-ybF
+jQD
+khb
+knk
 rFJ
 rFJ
 rFJ
 iIs
 jZH
+tQe
+ybF
+fDi
+lQB
+aVe
+aVe
+rFJ
 bmF
 xGl
-fDi
-pFn
-aVe
-aVe
-wvP
-jZH
-paF
+oei
 jZH
 jZH
 jZH
 jZH
-ryy
-jZH
+uoO
 uoO
 uoO
 uoO
@@ -83435,6 +80333,13 @@ aoj
 aoj
 xVz
 xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -83592,16 +80497,16 @@ eRI
 eRI
 ber
 ptx
-ryy
-ryy
-ryy
-ryy
-ryy
+pud
+grX
+bHC
+pud
+iwr
 vYG
 pud
 grX
-jCU
-eNq
+aVe
+dIf
 gFv
 psv
 rFJ
@@ -83622,11 +80527,11 @@ jZH
 jZH
 jZH
 jZH
+wbe
 jZH
 jZH
-dpR
-dpR
-kIJ
+jZH
+jZH
 jZH
 jZH
 jZH
@@ -83634,17 +80539,10 @@ vDC
 jZH
 rOj
 jZH
-vRu
+jZH
 rJn
 gqK
-sCB
-tCe
-vRu
-jZH
-jZH
-fDW
-dFd
-hKI
+snY
 jZH
 iIs
 rFJ
@@ -83653,37 +80551,37 @@ jZH
 aVe
 jZH
 iIs
-iFz
+hRK
 aVe
-qWx
-qWx
-qWx
-qWx
+kiX
+iQT
+kiX
+kiX
 aVe
 aVe
-iFz
-hsX
+hRK
+qWx
+kpd
+aVe
+aVe
+kDG
+hRK
+jZH
+xMa
 wEw
-rFJ
-rFJ
-iuL
-iFz
-jZH
-nHu
-qVC
 fDi
-vBG
+lTT
 rFJ
 aVe
-psv
-ryL
+rFJ
+nHu
 jZH
 jZH
-gSh
-dpR
-psj
-ryy
 jZH
+jZH
+jZH
+jZH
+uoO
 uoO
 uoO
 uoO
@@ -83700,6 +80598,13 @@ uoO
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -83855,10 +80760,10 @@ aVe
 aVe
 aVe
 aVe
-aVe
-aVe
 rFJ
 aVe
+aVe
+dKo
 btW
 aVe
 aVe
@@ -83872,15 +80777,15 @@ aVe
 cgy
 cfA
 eAO
-cfA
+eJX
 gFj
 cnf
-cfA
-cmZ
-kCg
-fqU
+eNh
+ryy
+eZj
 jZH
-jZH
+aVe
+fdN
 dpR
 dpR
 dpR
@@ -83891,56 +80796,49 @@ vDC
 jZH
 rOj
 jZH
-iIQ
-tCe
-rJn
-rJn
-iIQ
-tJV
 jZH
 jZH
 jZH
 jZH
 jZH
 jZH
-jZH
-cPq
+gPF
 jZH
 jZH
 oZd
-dDE
-fzR
+hFC
+hOb
 iqN
 aVe
-qWx
+kiX
+iWr
+seJ
+pWc
+fzR
+rFJ
+jSx
+fDi
 fou
-fFK
+wbe
 gnY
 seJ
-rFJ
+iWr
 mxa
 fDi
-npl
-qGz
-oUK
-fFK
-fou
-leG
-fDi
-nHu
-men
-rfs
-oUK
-oUK
-mTv
-lBg
+xMa
+lqB
+lWZ
+xGl
+xGl
+wbe
+wCi
 dpR
 dpR
 dpR
 dpR
 jZH
-ryy
 jZH
+aoj
 uoO
 uoO
 uoO
@@ -83955,8 +80853,15 @@ uoO
 uoO
 uoO
 xVz
-kzt
+uiV
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -84106,16 +81011,16 @@ geb
 geb
 hji
 toq
-rFJ
-aVe
-aVe
-aVe
-aVe
-aVe
-aVe
-aVe
-aVe
-jrn
+bpv
+btq
+bIz
+bUw
+cqo
+cIS
+bpv
+djn
+bIz
+dLO
 btW
 aVe
 aVe
@@ -84130,14 +81035,14 @@ rFJ
 aVe
 aVe
 aVe
-aVe
-qEd
+due
+rFJ
 aVe
 rFJ
 aVe
-ifa
-nQS
-jZH
+aVe
+rFJ
+fhW
 dpR
 dpR
 dpR
@@ -84148,56 +81053,49 @@ vDC
 jZH
 rOj
 jZH
-iIQ
-rJn
-rJn
-rJn
-iIQ
-iIQ
-rJn
+jZH
+tTM
+fLg
+tTM
+tTM
+fLg
+tTM
 rHJ
-vrY
-rHN
-vrY
-vrY
-rHN
-vrY
-pGd
 ojR
 aVe
 jZH
 rFJ
 aVe
 aVe
+pGd
+iWR
+fDi
+jpB
+kKx
+jOq
+upI
 upI
 fsQ
-fDi
-awF
+wbe
+xGl
 vid
-dyO
+sPC
 sPC
 sPC
 dlT
-qGz
-oUK
+sPC
+sPC
 dGD
-bvC
-bvC
-bvC
-jiw
-bvC
-bvC
-vqm
-qGz
+wbe
+niW
 nIY
-jZH
 dpR
 dpR
 dpR
 dpR
 jZH
-ryy
 jZH
+aoj
 uoO
 uoO
 uoO
@@ -84210,9 +81108,9 @@ aoj
 aoj
 uoO
 uoO
-gbA
+isU
 xVz
-upu
+pRz
 aoj
 uoO
 uoO
@@ -84220,7 +81118,14 @@ uoO
 uoO
 uoO
 uoO
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -84361,8 +81266,8 @@ ulS
 mpX
 iBR
 geb
-eUN
-qii
+bdP
+bki
 aVe
 aVe
 hFb
@@ -84370,8 +81275,8 @@ aVe
 aVe
 rFJ
 aVe
-uJY
-rFJ
+hFb
+aVe
 aVe
 qii
 aVe
@@ -84390,9 +81295,9 @@ aVe
 aVe
 aVe
 aVe
-rFJ
+ePz
 aVe
-rFJ
+aVe
 xsD
 vJu
 dpR
@@ -84405,16 +81310,9 @@ vDC
 jZH
 rOj
 jZH
-rwK
+jZH
 tTM
-hxa
-rJn
-iIQ
-iIQ
-iIQ
-jZH
-vrY
-vrY
+tTM
 jrn
 aVe
 aVe
@@ -84423,38 +81321,38 @@ jrn
 aVe
 aVe
 jZH
-kKx
-wCV
+hOy
+hSq
 aVe
 rFJ
 fDi
 fDi
-gnY
-vid
+pWc
+kKx
 aVe
 qii
 qii
-euS
-qGz
-oUK
-oUK
+gnY
+wbe
+xGl
+xGl
 qii
 qii
 qii
-uHP
+vWb
 qii
 qii
-euS
-euS
-sOf
-iiS
+gnY
+gnY
+nkL
+nKH
 dpR
 dpR
 dpR
 dpR
 jZH
-ryy
 jZH
+aoj
 uoO
 uoO
 uoO
@@ -84469,15 +81367,22 @@ uoO
 uoO
 xVz
 xVz
-pgS
-sXP
+pVQ
+pWw
 aoj
 aoj
 aoj
 aoj
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -84649,8 +81554,8 @@ rFJ
 aVe
 aVe
 aVe
-gVp
-nQS
+rFJ
+aVe
 jZH
 swY
 dpR
@@ -84663,55 +81568,48 @@ jZH
 rOj
 jZH
 jZH
-jZH
-jZH
-jZH
-iIQ
-rJn
-rJn
+tTM
+fLF
+tTM
+tTM
+fLF
+rHJ
 rHJ
 vrY
-nzb
-vrY
-vrY
-nzb
-pGd
-pGd
-nFR
 jrn
 jZH
-gsV
+hPn
 aVe
 aVe
-qWx
+kiX
 fDi
 fDi
-dGu
-vid
+jqG
+kKx
 aVe
 qii
 qii
-oUK
-oUK
-oUK
-qGz
+xGl
+xGl
+xGl
+wbe
 qii
 qii
 qii
+vWb
+qii
+qii
+msd
+gnY
+noH
+jZH
 uHP
-qii
-qii
-sOf
-euS
-ydE
-jZH
-qZY
 dpR
 dpR
 dpR
 jZH
-ryy
 jZH
+aoj
 uoO
 uoO
 uoO
@@ -84735,6 +81633,13 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -84900,15 +81805,15 @@ aVe
 uUk
 cfA
 iav
-cfA
-gFj
+eJX
+eLK
 eDv
 cfA
 cfA
 wke
-fqU
 jZH
-jZH
+uJY
+fdN
 dpR
 dpR
 dpR
@@ -84919,55 +81824,47 @@ vDC
 jZH
 rOj
 jZH
-cqo
-lWZ
-dMm
+jZH
+jZH
+fMY
 oRt
-iIQ
-tJV
+fMY
+jZH
 jZH
 jZH
 jZH
 jUB
 owX
-jUB
-jZH
-jZH
-jZH
-jZH
-fME
-pWc
-bmK
+hPN
 rFJ
 aVe
-qWx
-ekD
-fFK
-gnY
-vid
-dyO
+kiX
+hVC
+seJ
+pWc
+kKx
+jOq
+jUH
+kij
+kph
+xGl
+wbe
+kDH
+kIo
 baZ
 wKm
 xMa
-oUK
-qGz
+lvv
+lXw
 nMN
-nTN
-bor
+wbe
+wbe
 wCi
-nHu
-kAb
-dKo
-vsW
-qGz
-mTv
-lBg
 dpR
 dpR
 dpR
 dpR
-psj
-ryy
+jZH
 jZH
 uoO
 uoO
@@ -84976,22 +81873,30 @@ uoO
 uoO
 uoO
 uoO
+uoO
+xVz
+uoO
+uoO
+uoO
+uoO
+xVz
 xVz
 uoO
 uoO
 uoO
 uoO
-xVz
-xVz
-uoO
-uoO
-uoO
-uoO
 uoO
 aoj
 aoj
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -85125,23 +82030,23 @@ eLE
 rOj
 jZH
 jZH
-maX
-maX
-maX
 jZH
 jZH
 jZH
 jZH
-maX
-maX
-maX
-maX
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
 iMe
-maX
-maX
-rOj
-maX
-maX
+jZH
+jZH
+jZH
+jZH
+jZH
 jZH
 jZH
 jZH
@@ -85176,56 +82081,49 @@ tuO
 jZH
 rOj
 jZH
-flF
+vRu
+vRu
+fOD
 aqB
-dMm
-jZH
-iIQ
+fOD
+vRu
 vRu
 jZH
-fKn
-fKn
-jIe
-aqB
-jIe
-fKn
-fKn
 jZH
-jZH
-kiX
+jIe
 jZH
 iIs
-qrl
+hSJ
 rFJ
-qWx
-qWx
-qWx
-upI
+kiX
+iQT
+kiX
+pGd
 aVe
 aVe
-iFz
-pNF
-tlm
+hRK
+kka
+kqM
 aVe
 rFJ
-oWr
-iFz
+kEN
+hRK
 jZH
-nHu
-qVC
-uWA
-bxX
+xMa
+wEw
+lwY
+mbx
 aVe
 aVe
-ash
+npK
 jZH
 jZH
 jZH
 jZH
 jZH
 jZH
-ryy
 jZH
+uoO
 uoO
 uoO
 uoO
@@ -85246,6 +82144,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85388,25 +82293,25 @@ dok
 wJQ
 dEm
 kwy
-jZH
-jZH
-maX
-sMJ
-dLO
+qpX
+xNC
+blk
+vrm
+vDC
 xVf
-muj
-maX
-rOj
+vDC
+vrm
+cKI
 jZH
 geb
-lRC
+eRI
 qii
 qii
 vqo
 pUF
 ojR
 eFS
-vsT
+qii
 vsT
 aVe
 aVe
@@ -85433,25 +82338,18 @@ mKE
 jZH
 rOj
 jZH
-geG
-idU
-dMm
-jZH
-iIQ
-eLK
-jZH
-fKn
+vRu
 nNF
 nNF
 aqB
 nNF
 nNF
-fKn
+vRu
 jZH
 jZH
-jfW
+hvl
 jZH
-sPl
+hMu
 rFJ
 aVe
 aVe
@@ -85460,29 +82358,29 @@ aVe
 aVe
 jrn
 otJ
-xoU
-tQe
-ybF
-rFJ
+jQD
+khb
+knk
+aVe
 aVe
 rFJ
 iIs
 jZH
-nkL
-xGl
+kYh
+ybF
 fDi
-pFn
+lQB
 aVe
 aVe
-eAw
+nqk
 jZH
-cIS
+scG
 ryy
 ryy
-nEt
+ozX
 jZH
-pEO
 jZH
+uoO
 uoO
 uoO
 uoO
@@ -85505,6 +82403,13 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -85641,29 +82546,29 @@ jZH
 dok
 eiN
 geb
-nLM
-rSF
-cHA
-nNj
+azX
+geb
+aSW
+qpX
 hac
-jZH
-maX
-ogh
-diM
+vBx
+vqo
+btW
+btW
 uiT
-diM
-dQB
-rOj
-jZH
+btW
+vqo
+btL
+cTh
 geb
 lRC
 btW
-tWO
+qii
 qii
 qii
 aVe
 eFS
-vsT
+qii
 vsT
 jrn
 aVe
@@ -85690,18 +82595,11 @@ tJM
 jZH
 rOj
 jZH
-gTT
-sCB
-sWZ
-jZH
-rJn
-btL
-jZH
 nNF
-hPn
-fKn
+fAC
+vRu
 aqB
-fKn
+vRu
 nNF
 nNF
 nNF
@@ -85711,35 +82609,35 @@ jZH
 iIs
 aVe
 aVe
-iIs
+rFJ
 aVe
 rFJ
 rFJ
-nBh
+jzs
 rFJ
 iDS
-dEk
+kkf
 aVe
 aVe
 iIs
-rJn
-tJV
+vIL
+kHS
 jZH
-uJS
-xGl
+kZB
+ybF
 fDi
-pFn
+lQB
 aVe
 aVe
-sIK
+nsN
 jZH
-cIS
-jZH
-jZH
+scG
 jZH
 jZH
 jZH
 jZH
+jZH
+uoO
 uoO
 uoO
 uoO
@@ -85760,6 +82658,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85898,21 +82803,21 @@ jZH
 nLM
 geb
 geb
-geb
+aNH
 cHA
-cHA
+aSZ
 voZ
 cHA
 vBx
-kFw
-bnT
-pxV
-pxV
-hBf
-maX
-gJk
-jZH
-axQ
+vqo
+btW
+btL
+qii
+btW
+vqo
+btW
+cTM
+eRI
 jZH
 jZH
 jZH
@@ -85947,20 +82852,13 @@ coe
 jZH
 rOj
 jZH
-gEf
-sCB
-sWZ
-jZH
-xPR
-jZH
-jZH
 nNF
-bCf
-sfi
+fDh
+fPg
 aqB
 aqB
-sfi
-sgm
+fPg
+fTD
 nNF
 jZH
 aVe
@@ -85970,35 +82868,35 @@ aVe
 rFJ
 iIs
 rFJ
-ilw
-rZw
-dUG
+jeq
+jos
+jCU
+ifX
+jVZ
+ifX
+aVe
+aVe
+iIs
+vIL
 bOf
-fkd
-xps
-rFJ
-rFJ
-iIs
-rJn
-vRu
 jZH
 jZH
 jZH
 fDi
-pFn
+lQB
 aVe
 rFJ
-rFc
+net
 jZH
 ryy
 jZH
-dyR
-dyR
+olK
+olK
 jZH
 jZH
-riR
+oRq
 uoO
-wEX
+uwV
 uoO
 uoO
 uoO
@@ -86015,6 +82913,13 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -86163,13 +83068,13 @@ skL
 jZH
 fbK
 vrm
-pxV
-pxV
-bTN
-jZH
-rOj
-jZH
-geb
+vDC
+bLY
+vDC
+vrm
+cOm
+cUF
+eRI
 jZH
 rOj
 qXN
@@ -86206,56 +83111,49 @@ rOj
 jZH
 uTN
 jta
-sWZ
-jZH
-jZH
-jZH
-jZH
-xyH
-fXs
-rXR
-khb
+fQG
+gyq
 aqB
-rXR
+fQG
+gSc
+xyH
+jZH
+jZH
+jZH
+jZH
+jZH
 hhZ
-xNs
+jZH
+hhZ
 jZH
 jZH
+jDX
 jZH
 jZH
-jZH
-cPq
-jZH
-cPq
-jZH
-jZH
-dtm
-jZH
-jZH
-hZs
+ppw
 aVe
-rFJ
+aVe
 iIs
-rJn
-vRu
+vIL
+bOf
 jZH
 jZH
 jZH
-iVj
-pFn
+lxk
+lQB
 rFJ
 aVe
-igV
+neb
 jZH
 ryy
+iVj
+ryy
+ryy
+jZH
+jZH
+xVz
+uoO
 uwV
-ryy
-ryy
-jZH
-jZH
-xVz
-uoO
-wEX
 xVz
 xVz
 xVz
@@ -86272,6 +83170,13 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -86408,26 +83313,26 @@ eLE
 (241,1,1) = {"
 eLE
 rOj
-maX
-rYn
+jZH
+jZH
 qWW
-geb
+ajd
 rmv
-cHA
+aSI
 hKx
 qpX
-lWm
 jZH
 jZH
-sul
-kJy
-qEb
-lbi
-fbK
-rOj
 jZH
-geb
-maX
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
 rOj
 qhw
 xoo
@@ -86461,58 +83366,51 @@ jZH
 jZH
 rOj
 jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
 nNF
-bCf
-sgm
+fDh
+fTD
 aqB
 aqB
-sgm
-sfi
+fTD
+fPg
 nNF
 jZH
-ewy
-mEW
-ewy
-ucp
-hRT
-hRT
-hRT
-ucp
-mEW
+sgm
+hGV
+wZH
+wZH
+tvx
+ilw
+nzl
 ewy
 ewy
+hGV
+wZH
 jZH
-wuE
-nVZ
-fmv
+riY
+lnF
+kwo
 jZH
-nGb
+kFw
 jZH
 jZH
 jZH
 jZH
 fDi
-uKn
+mbN
 aVe
 aVe
-rFc
+net
 jZH
 ryy
 jZH
-xnV
-dyR
+uKn
+olK
 jZH
 jZH
 xVz
 uoO
-wEX
+uwV
 xVz
 xVz
 xVz
@@ -86526,7 +83424,7 @@ uoO
 uoO
 uoO
 xVz
-riR
+oRq
 uoO
 aoj
 uoO
@@ -86538,6 +83436,13 @@ xVz
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86665,15 +83570,6 @@ eLE
 (242,1,1) = {"
 eLE
 rOj
-ovz
-jqG
-qWW
-geb
-muD
-geb
-lXw
-geb
-lWm
 jZH
 jZH
 jZH
@@ -86683,13 +83579,22 @@ jZH
 jZH
 jZH
 jZH
-geb
-maX
+jZH
+jZH
+hji
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
 rOj
 jZH
 iZB
 pxV
-xpo
+oZm
 bTN
 miX
 dtH
@@ -86717,59 +83622,52 @@ qXo
 shO
 jZH
 rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
 jZH
 nNF
-hPn
-fKn
+fAC
+vRu
 aqB
-fKn
+vRu
 nNF
 nNF
 nNF
 jZH
-ewy
-koP
-mTF
-sLI
-qJI
+sgm
+mEW
+tvx
+mEW
+tvx
+ioj
+nzl
+mEW
+tvx
+mEW
+wZH
+auO
 uLl
 sFc
-sLI
-kny
-mTF
-ewy
-auO
-fmv
-fmv
-fmv
+kwo
+kDi
+jZH
+jZH
+jZH
+jZH
+jZH
+lxD
 tsq
-jZH
-jZH
-jZH
-jZH
-jZH
-dmp
-jtk
 aVe
 aVe
-rFc
+net
 jZH
 ryy
 jZH
 jZH
-kpd
+nOZ
 jZH
 jZH
 xVz
 uoO
-wEX
+uwV
 xVz
 xVz
 xVz
@@ -86795,6 +83693,13 @@ xVz
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -86922,27 +83827,27 @@ eLE
 (243,1,1) = {"
 eLE
 rOj
-maX
-lrs
-geb
-geb
-geb
-geb
-geb
-geb
-rom
-xNC
-qMn
-nnH
-vDC
+jZH
+xNg
+xNg
+amV
+xNg
+xNg
+aUc
+xNg
+xNg
+beL
+bTN
+uvD
+bxX
 mpn
-vDC
-nnH
-jbP
+jZH
+cwq
+aVe
 ctL
-rom
+dkT
 ovz
-rOj
+dNh
 bDG
 qWo
 kCc
@@ -86975,58 +83880,51 @@ oVJ
 dHn
 rOj
 jZH
-uoO
-uoO
-uoO
-uoO
-uoO
-rOj
-jZH
-fKn
+vRu
 nNF
 nNF
 aqB
 nNF
 nNF
-tvx
+gSh
 jZH
+hij
+sgm
+sgm
+ewy
+ewy
+tvx
+jPv
 nzl
-mSk
-oXx
-mTF
+sgm
+sgm
+sgm
 wZH
-mTF
+jZH
 qFc
 lWC
-hsk
-mTF
-mTF
-jNC
 jZH
-oIK
-tIT
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
 hOX
-jZH
-jPv
-ewy
-ewy
-ewy
-jZH
-mUS
-uKn
+mbN
 rFJ
 aVe
-igV
+neb
 jZH
 ryy
 jZH
-jFd
-paF
+omE
+onB
 jZH
 jZH
 xVz
 uoO
-wEX
+uwV
 xVz
 xVz
 xVz
@@ -87046,6 +83944,13 @@ qxo
 qxo
 qxo
 qxo
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -87179,33 +84084,33 @@ eLE
 (244,1,1) = {"
 eLE
 rOj
-maX
-uaI
-qpX
-imi
-geb
-geb
-geb
-geb
-bTN
-ttW
-vqo
-btW
-btW
-gEp
-btW
-vqo
-yhd
-vsT
-geb
-maX
-rOj
 jZH
-cUF
-kCc
-xBu
+xNg
+xNg
+xNg
+anO
+xNg
+xNg
+xNg
+xNg
+ttW
 bTN
-miG
+uvD
+uvD
+uvD
+bVN
+cxQ
+aVe
+aVe
+dmp
+dsy
+aVe
+jZH
+jZH
+jZH
+jZH
+eod
+jZH
 bPW
 tSD
 rFJ
@@ -87232,57 +84137,57 @@ oVJ
 lGo
 rOj
 jZH
-uoO
-uoO
-uoO
-uoO
-uoO
-rOj
-jZH
-fKn
-fKn
-jIe
+vRu
+vRu
+fOD
 aqB
-jIe
-fKn
-fKn
+fOD
+vRu
+vRu
 jZH
 jZH
+hyR
+hHc
+tvx
 mEW
-mTF
-mTF
-mTF
-mTF
-mTF
-mTF
-mTF
-mTF
-mTF
+tvx
+jPv
+nzl
 mEW
+tvx
+hHc
+jOE
 jZH
-qvg
+thO
 vfU
 jZH
 jZH
-ewy
-ewy
-ewy
-ewy
 jZH
-uWA
-pFn
+jZH
+jZH
+jZH
+jZH
+lwY
+lQB
 aVe
 aVe
-rFc
+net
 jZH
-cIS
+scG
 jZH
-paF
-paF
+onB
+onB
 jZH
 jZH
 xVz
 uoO
+uwV
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 wEX
 xVz
 xVz
@@ -87290,19 +84195,19 @@ xVz
 xVz
 xVz
 xVz
-iZQ
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
 xVz
 uoO
 qxo
 qxo
 qxo
 qxo
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -87436,35 +84341,35 @@ eLE
 (245,1,1) = {"
 eLE
 rOj
-maX
-biy
+jZH
+xNg
 anO
-vla
-geb
-aic
-geb
-fCu
-gkL
-jZH
-wKL
-nnH
-vDC
-nqF
-vDC
-nnH
-jQD
-ctL
-rOy
-maX
-rOj
-jZH
-rFJ
-kCc
-pxV
+xNg
+xNg
+xNg
+xNg
+xNg
+xNg
+ttW
 bTN
+uvD
+wQz
+uvD
+bVN
+wug
+aVe
+aVe
+aVe
+aVe
+aVe
+aVe
+aVe
+sWB
+jrn
+aVe
 kny
 gsT
-vju
+aVe
 rFJ
 aVe
 ryy
@@ -87489,65 +84394,58 @@ pwa
 hYT
 rOj
 jZH
-uoO
-uoO
-uoO
-uoO
-uoO
-rOj
+jZH
+jZH
+jZH
+gCl
 jZH
 jZH
 jZH
 jZH
+hij
 iKQ
+iKQ
+iKQ
+iKQ
+hXZ
+itn
+pxe
+jeW
+jeW
+jeW
+jeW
 jZH
 jZH
 jZH
 jZH
-nzl
-mEW
-mTF
-mTF
-mTF
-mTF
-oar
-rpA
-aeM
-mTF
-mTF
-mEW
 jZH
 jZH
 jZH
 jZH
-ewy
-ewy
-ewy
-ewy
-ewy
 jZH
-ovQ
-jtk
+jZH
+lyG
+tsq
 aVe
 aVe
-rfD
+nwH
 jZH
-cIS
+scG
 jZH
-paF
-paF
+onB
+onB
 jZH
 jZH
 xVz
 uoO
-wEX
+uwV
 xVz
-bfh
-lIH
+pcA
+pis
 xVz
-lFo
-gbA
-dWT
+xVz
+isU
+ahx
 xVz
 xVz
 xVz
@@ -87557,6 +84455,13 @@ xVz
 uoO
 uoO
 qxo
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -87694,32 +84599,32 @@ eLE
 eLE
 rOj
 jZH
-jZH
-vmx
-nUF
-pVA
-vFh
-snL
+anO
 xNg
-jZH
-maX
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-rOj
-jZH
-hTs
+xNg
+xNg
+xNg
+xNg
+xNg
+xNg
+ttW
+bTN
+uvD
+uvD
+bNO
+bVN
+oZd
+aVe
+aVe
+aVe
+aVe
+aVe
+aVe
+aVe
 aVe
 sWB
-aVe
-jfQ
+dGU
+jZH
 iJD
 dWN
 vIu
@@ -87746,74 +84651,74 @@ oVJ
 qhw
 rOj
 jZH
-uoO
-uoO
-uoO
-uoO
-uoO
-rOj
+fkd
+fDW
+sCB
+gEf
+gIb
+gPs
+gTy
 jZH
 jZH
-dUu
-dUu
-fpU
-fpU
-dUu
-dUu
-jZH
-jZH
+jPv
+hHS
+hHS
+xZY
+pxe
+itB
+hXZ
 sGK
-oXx
-mTF
-oXx
-mTF
-mTF
-mTF
-mTF
-mTF
-mTF
+jrX
+jEK
+pxe
+jYZ
+owa
+kqS
+owa
+kqS
+owa
 jNC
+kIJ
+kWj
 jZH
 jZH
 jZH
-ewy
-ewy
-ewy
-ewy
-ewy
-ewy
-jZH
-jZH
-jZH
-bFi
+msw
 jZH
 jZH
 qpc
-kpd
+nOZ
 jZH
-jFd
-jFd
+omE
+omE
 jZH
 jZH
-gbA
+isU
 uoO
-wEX
+uwV
 xVz
-wEX
-qUL
-qUL
-qGe
-tkU
-kqS
-nIl
-qZA
-xVz
-xVz
+uwV
+pkl
+pkl
+tmh
+pEO
+pIJ
+otf
+iGY
 xVz
 xVz
-uwN
+xVz
+xVz
+xVz
 uoO
 qxo
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -87951,30 +84856,30 @@ eLE
 eLE
 rOj
 jZH
-maX
-maX
-maX
-jZH
-jZH
-maX
-jZH
-maX
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-jZH
-hji
-jZH
-mMw
+xNg
+xNg
+aoq
+xNg
+xNg
+aoq
+xNg
+xNg
+aoq
+uvD
+uvD
+byA
+wQz
+cbU
+aVe
+jrn
+cVj
+jrn
+due
+dQB
+dWT
+aVe
+aVe
+aVe
 aVe
 jZH
 jZH
@@ -87989,7 +84894,7 @@ bCh
 qhw
 jZH
 jZH
-jZH
+fbp
 jZH
 jZH
 jZH
@@ -88003,74 +84908,74 @@ tuO
 jZH
 rOj
 jZH
-uoO
-uoO
-uoO
-uoO
-uoO
-rOj
-jZH
-jZH
-dUu
-vQq
+fli
+sCB
+fXs
+gEf
+vIL
+gEf
+gTT
+gWA
+jzK
+xZY
 vgd
-oiI
-hSQ
-dUu
+vgd
+xZY
+hXZ
 rgN
-jPv
-ewy
-koP
-mTF
-mTF
-mTF
-mTF
-vSF
-xKk
-ele
-jpB
-mEW
-jPv
+rFJ
+rFJ
+rFJ
+rFJ
+hXZ
 jZH
-sGK
-mEW
-ewy
-ewy
-ewy
-ewy
-ewy
-neq
-lDo
+jGq
+xKk
+xKk
+xKk
+owa
+kIH
+qys
+lbi
+jZH
+lzS
+lBg
+muj
+gsT
+nyn
+mRj
+nQS
+jZH
 mrV
 mEm
-bVY
-qtL
-knF
-fLF
 jZH
-jNr
+jZH
+xVz
+xVz
+oUi
+xVz
 eOx
-jZH
-jZH
-xVz
-xVz
-xdB
-xVz
-isU
-oMK
-iGY
-otf
+pmk
+psu
+gHi
 qxo
-oNu
-suF
-gbA
+xdB
+pNT
+isU
 uiV
-qZA
+iGY
 xVz
 xVz
 xVz
 uoO
 qxo
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -88207,17 +85112,6 @@ eLE
 (248,1,1) = {"
 eLE
 rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
 jZH
 jZH
 jZH
@@ -88227,12 +85121,23 @@ jZH
 jZH
 jZH
 jZH
-rOj
-rOj
-rOj
-rOj
 jZH
-bFi
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+efw
+efS
+epW
 jZH
 rOj
 rOj
@@ -88246,7 +85151,7 @@ rOj
 rOj
 rOj
 rOj
-rOj
+aVe
 rOj
 rOj
 rOj
@@ -88260,80 +85165,80 @@ oDP
 jZH
 rOj
 jZH
-uoO
-uoO
-uoO
-uoO
-uoO
-rOj
-jZH
-jZH
+fli
+fGI
+fYL
+gFE
+vIL
+gEf
+vIL
+hae
 jzK
-lCa
-dZj
-dZj
-qpX
-mow
+xZY
+xZY
 pxe
-mdm
-hRT
-hRT
-hRT
-wiP
-mEW
-hRT
-ewy
-nCg
-mEW
-mEW
-ewy
+pxe
+pxe
+pxe
+pxe
 jPv
+jPv
+xZY
+wiP
+jZH
+owa
+tdl
+tdl
+tdl
+owa
+kIJ
+gsT
 txh
-mEW
-mEW
-mEW
-mEW
-ewy
-ewy
-ewy
 jZH
-mrV
-mrV
-tAi
-tAi
+lBg
+lBg
+muD
+muD
+nzb
+xnb
+nSP
+jZH
+jZH
+jZH
+jZH
 mrx
-mTF
-qtD
-jZH
-jZH
-jZH
-jZH
-jZH
+xVz
+xVz
+xVz
+xVz
+pgS
+oUi
+pvX
 nby
-xVz
-xVz
-xVz
+qxo
+qxo
+pQe
 hqd
-xdB
-dur
+hqd
+xVz
+tmh
 tmh
 qxo
-qxo
-qxo
-gTy
-gTy
-xVz
-qGe
-qGe
-qxo
-otf
+gHi
 qxo
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -88473,23 +85378,23 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
 jZH
-jZH
-rFJ
-rFJ
-rFJ
-jZH
+bQD
+cko
 flt
-cVj
+jZH
 xMO
-rFJ
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-aVe
+dny
+dur
+bFi
+dYf
+dZz
+oZm
+uvD
+eqw
 jZH
 jZH
 jZH
@@ -88503,7 +85408,7 @@ jZH
 jZH
 jZH
 jZH
-jZH
+fbp
 jZH
 jZH
 jZH
@@ -88517,73 +85422,66 @@ ryy
 jZH
 rOj
 jZH
-uoO
-uoO
-uoO
-uoO
-uoO
-rOj
-jZH
-jZH
+fli
+fHM
+fZh
+gEf
+vIL
+gEf
+gEf
+gEf
 fpU
-gFk
-cEm
-gwq
-qpX
+pxe
+pxe
+pxe
+hSP
 hro
 qpE
-jZH
-jZH
+iYM
+hSP
 jPv
 xZY
-jPv
-jZH
-fTD
-jPv
-jZH
-nzl
-jPv
-jPv
-qSL
 pxe
-mEW
-mEW
-mEW
-ewy
-ewy
-ewy
-ewy
+jYZ
+owa
+owa
+owa
+owa
+owa
+qys
+qSL
+lcZ
 jZH
+lBi
+jZH
+mCP
+mRj
+mCP
+mRj
+nUD
 xnb
-jZH
+lMT
 lMT
 knF
-lMT
-knF
-hQt
-mTF
-gHi
-gHi
-cZm
-slT
-slT
+jNC
+xVz
 xVz
 xVz
 uoO
-yfL
-otf
+qxo
+gHi
+xVz
+pwZ
+qxo
+qxo
+qxo
+qxo
+qxo
 kUz
-bri
 qxo
 qxo
 qxo
-qxo
-qxo
-xIN
-qxo
-qxo
-qxo
-otf
+qhK
 aoj
 uoO
 aoj
@@ -88591,6 +85489,13 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -88730,107 +85635,100 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
 jZH
-sJV
-bLY
-rFJ
-rFJ
-jZH
-bTG
+bRE
 aVe
 aVe
-aVe
-jZH
+cPq
 uvD
-oeF
-kgF
-etu
-joD
-jrn
-aVe
-gHT
+wQz
+uvD
+uvD
+uvD
+uvD
+uvD
+uvD
+euI
+hji
+jZH
 jZH
 jZH
 jZH
 ryy
 vnZ
+cfA
+cfA
+cfA
 ryy
+eOF
+cfA
 ryy
-ryy
-ryy
-ryy
-ryy
-oDP
 hOY
-ryy
-ryy
+cfA
+oDP
 vUF
 ryy
-ryy
-vnZ
-ryy
-ryy
-ryy
+cfA
+dyR
+eOF
+cfA
+cfA
 jZH
 rOj
 jZH
-uoO
-uoO
-uoO
-uoO
-uoO
-rOj
 jZH
 jZH
-dUu
+jZH
+gEf
+gEf
+gEf
+vIL
+hae
+jzK
 cVA
-qpX
-rBs
-qpX
-nKH
+cVA
+xZY
+hTs
+owa
 iJp
-eZj
+owa
+hSP
+jPv
+xZY
+wiP
 jZH
-jZH
-sbW
-nVZ
-nVZ
-nVZ
-nVZ
-nVZ
-nVZ
-kHS
+owa
+xKk
+xKk
+xKk
+owa
 bVY
-pxe
-pxe
-mEW
-mEW
-mEW
-ewy
-ewy
-ewy
-ewy
+gsT
+ldA
 jZH
+lDo
+mcC
+xnb
+mRj
+mRj
+mCP
+nWG
 rjQ
-bJh
-mTF
-knF
-knF
+jNC
 lMT
-aQg
-fwX
-slT
+knF
+jNC
+xVz
+xVz
+xVz
+uoO
 gHi
-cZm
-slT
-slT
+gHi
 xVz
-xVz
-uoO
-otf
-otf
-xVz
-bri
+pwZ
 qxo
 qxo
 qxo
@@ -88839,7 +85737,7 @@ qxo
 qxo
 qxo
 qxo
-rKE
+qba
 uoO
 aoj
 uoO
@@ -88848,6 +85746,13 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -88987,25 +85892,25 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
 jZH
-kIH
-oZm
-oZm
-oZm
-jZH
+bTW
+haL
 eAw
-oZm
-bTN
-aVe
 jZH
+cWR
+wQz
+dwd
 wQz
 sqa
 juV
-bTN
-bTN
-bTN
-bTN
-jOq
+wQz
+ejY
+jZH
+jZH
+jZH
 tuO
 oDP
 ryy
@@ -89031,72 +85936,65 @@ jZH
 jZH
 rOj
 jZH
-uoO
-uoO
-uoO
-uoO
-uoO
-rOj
-jZH
-jZH
+phh
+fDW
+gaj
+gEf
+gEf
+gEf
+gVp
+hcC
 jzK
 roz
 rSC
-qlH
-hSQ
-fpU
-pxe
-qpE
-jZH
-jZH
+xZY
+owa
+hZs
+sCB
+fHM
+jfQ
+jPv
 uxw
-gzf
+pxe
+jZH
 jGq
-jGq
-gMg
-lwl
 tdl
-kHS
-bVY
-pxe
-pxe
-mEW
-mEW
-mEW
-ewy
-ewy
-ewy
-ewy
+tdl
+tdl
+owa
+kJy
+qys
+lbi
 jZH
-tbg
+lFo
 jZH
-mTF
-ldP
-mTF
+xnb
+mTt
+xnb
 jZH
-kpd
+nOZ
 jZH
 jZH
 jZH
 jZH
-jZH
-nby
+mrx
+xVz
 xVz
 xVz
 uoO
+gHi
+gHi
+xVz
+qxo
+qxo
+qxo
+qxo
 otf
 otf
 xVz
-qxo
-cBm
-qxo
-qxo
-nIl
-nIl
+otf
 xVz
-nIl
-xVz
-nIl
+otf
 uoO
 eLE
 uoO
@@ -89105,6 +86003,13 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -89244,24 +86149,24 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
 jZH
-sJV
-rFJ
-rFJ
-rFJ
-jZH
+bTW
+aVe
 haL
-aVe
-aVe
-aVe
-jZH
-jZH
-hji
-jZH
-bTN
-bTN
-bTN
-bTN
+cPq
+uvD
+wQz
+uvD
+uvD
+wQz
+uvD
+uvD
+uvD
+eyt
+eDB
 gov
 jZH
 jZH
@@ -89288,21 +86193,14 @@ rOj
 rOj
 rOj
 jZH
-uoO
-uoO
-uoO
-uoO
-uoO
-rOj
+flC
+uWC
 jZH
-jZH
-fpU
-fpU
-fpU
-dUu
-dUu
-fpU
-jZH
+vIL
+gJk
+gEf
+gVy
+hdU
 jZH
 jZH
 jZH
@@ -89315,40 +86213,40 @@ jZH
 jZH
 jZH
 pxe
-pxe
+jZL
+owa
+fHM
+owa
+fHM
+owa
+jNC
+bVY
 kWj
-xUd
-ewy
-ewy
-ewy
-ewy
-ewy
-ewy
 jZH
-rvb
+lHV
+men
+lBg
+kCo
+nDK
+jZH
 scG
-mrV
-vsI
-olK
+scG
+scG
+oCp
 jZH
-cIS
-cIS
-cIS
+jZH
+xVz
+xVz
+xVz
+xVz
 snJ
-jZH
-jZH
+gHi
 xVz
-xVz
-xVz
-xVz
+qxo
+pHE
+qxo
+xdB
 ahx
-otf
-xVz
-qxo
-keR
-qxo
-oNu
-dWT
 xVz
 xVz
 xVz
@@ -89356,6 +86254,13 @@ xVz
 xVz
 uoO
 eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -89501,55 +86406,32 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
 jZH
-rFJ
-rFJ
-rFJ
-rFJ
-jZH
-tLb
-dny
-dyL
+haL
 aVe
+aVe
+jZH
+dyL
+dnH
 bFi
 oRl
 nPC
-aVe
-hFb
-foM
+eaR
+uvD
+uvD
 sME
-eiZ
+wQz
 kIy
 jZH
 ryy
+cfA
+cfA
 ryy
 ryy
-ryy
-ryy
 jZH
-rOj
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-uoO
-uoO
-uoO
-uoO
-uoO
 rOj
 jZH
 jZH
@@ -89594,25 +86476,48 @@ jZH
 jZH
 jZH
 jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
 xVz
-wEX
+uwV
 xVz
-wxb
+oWr
 xVz
+oUi
+pwP
+nby
+qxo
+pKM
 xdB
-bVN
-tmh
-qxo
-qxo
-oNu
-kqS
-qZA
+pIJ
+iGY
 xVz
 xVz
 xVz
-sXP
+pWw
 uoO
 eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -89758,13 +86663,13 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
 jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
+aVe
+haL
+bTW
 jZH
 jZH
 jZH
@@ -89801,68 +86706,61 @@ uoO
 uoO
 uoO
 uoO
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+uwV
 uoO
+oVz
+oWE
+eOx
 uoO
-uoO
-uoO
-uoO
-uoO
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-wEX
-uoO
-cmy
-vxo
-isU
-uoO
-mTt
+pwR
 xVz
-nIl
-gbA
-dkT
-kqS
+otf
+isU
+vxo
+pIJ
 uoO
 uoO
 uoO
@@ -89870,6 +86768,13 @@ uoO
 uoO
 uoO
 eLE
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -16961,7 +16961,7 @@
 "sgm" = (
 /obj/structure/bookcase/manuals/medical{
 	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives
+	name = "Brotherhood Historical Archives"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -13534,13 +13534,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
-"nRt" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/lattice/catwalk,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
 "nRP" = (
 /obj/structure/sink{
 	pixel_y = 19
@@ -17944,10 +17937,6 @@
 	pixel_y = 16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"tsw" = (
-/obj/structure/falsewall/reinforced,
-/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "tsy" = (
 /obj/structure/simple_door/bunker{
@@ -77276,7 +77265,7 @@ jZH
 jZH
 jZH
 jZH
-fZC
+jZH
 jZH
 jZH
 jZH
@@ -82146,8 +82135,8 @@ jZH
 jZH
 jZH
 jZH
-tsw
-tuO
+jZH
+jZH
 jZH
 oDP
 jZH
@@ -83977,8 +83966,8 @@ qFc
 lWC
 jZH
 jZH
-nRt
-nRt
+jZH
+jZH
 fOD
 fOD
 jZH

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2007,6 +2007,30 @@
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 3
+	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "cmZ" = (

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1671,6 +1671,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
+"bOd" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "bOf" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -3115,6 +3120,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"drY" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "dsy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -3455,6 +3467,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"dGf" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/obj/structure/mirror{
+	pixel_x = -27
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "dGD" = (
 /obj/structure/fence/handrail_end/non_dense{
 	pixel_x = -16;
@@ -3734,6 +3757,10 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"dQH" = (
+/obj/machinery/door/unpowered/wooddoor,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "dRM" = (
 /turf/open/floor/f13{
@@ -9138,6 +9165,16 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
+"jzz" = (
+/obj/structure/toilet{
+	pixel_y = 10
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = -10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "jzK" = (
 /obj/structure/window/fulltile/store,
 /turf/open/floor/wood,
@@ -11214,9 +11251,8 @@
 /area/f13/brotherhood)
 "lxD" = (
 /obj/effect/decal/cleanable/robot_debris/limb,
-/obj/structure/lattice{
-	layer = 3
-	},
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "lyh" = (
@@ -13498,6 +13534,13 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"nRt" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/lattice/catwalk,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood)
 "nRP" = (
 /obj/structure/sink{
 	pixel_y = 19
@@ -15167,6 +15210,12 @@
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"pNY" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "pOc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -16977,6 +17026,19 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"shN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/structure/mirror{
+	pixel_x = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "shO" = (
 /obj/structure/closet,
 /obj/item/storage/box/gloves,
@@ -17883,6 +17945,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"tsw" = (
+/obj/structure/falsewall/reinforced,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood)
 "tsy" = (
 /obj/structure/simple_door/bunker{
 	name = "Star Paladin Office";
@@ -18559,7 +18625,6 @@
 	layer = 2.4;
 	name = "pipes"
 	},
-/obj/structure/simple_door/metal/ventilation,
 /obj/structure/lattice{
 	layer = 3
 	},
@@ -19107,9 +19172,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uKR" = (
-/obj/structure/falsewall/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror{
+	pixel_x = 27
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
 /turf/open/floor/f13{
-	icon_state = "darkrusty"
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
 "uKU" = (
@@ -75347,7 +75419,7 @@ eLE
 eLE
 rOj
 jZH
-tuO
+jZH
 jZH
 jZH
 jZH
@@ -75373,7 +75445,7 @@ jZH
 jZH
 jZH
 jZH
-uKR
+jZH
 jZH
 jZH
 ujt
@@ -75867,9 +75939,9 @@ boe
 jHA
 aPa
 geb
-geb
-geb
-bbd
+uKR
+shN
+jZH
 xZY
 tSl
 aQN
@@ -80535,7 +80607,7 @@ jZH
 jZH
 jZH
 jZH
-vDC
+drY
 jZH
 rOj
 jZH
@@ -82074,10 +82146,10 @@ jZH
 jZH
 jZH
 jZH
-jZH
+tsw
 tuO
 jZH
-tuO
+oDP
 jZH
 rOj
 jZH
@@ -83393,11 +83465,11 @@ kwo
 jZH
 kFw
 jZH
-jZH
-jZH
-jZH
-fDi
-mbN
+dGf
+dGf
+bOd
+pNY
+jrn
 aVe
 aVe
 net
@@ -83648,13 +83720,13 @@ uLl
 sFc
 kwo
 kDi
-jZH
-jZH
-jZH
-jZH
-jZH
+jzz
+dQH
+fOD
+bOd
+bOd
 lxD
-tsq
+rFJ
 aVe
 aVe
 net
@@ -83905,10 +83977,10 @@ qFc
 lWC
 jZH
 jZH
-jZH
-jZH
-jZH
-jZH
+nRt
+nRt
+fOD
+fOD
 jZH
 hOX
 mbN
@@ -84162,10 +84234,10 @@ thO
 vfU
 jZH
 jZH
-jZH
-jZH
-jZH
-jZH
+jzz
+dQH
+fOD
+fOD
 jZH
 lwY
 lQB
@@ -85911,7 +85983,7 @@ ejY
 jZH
 jZH
 jZH
-tuO
+jZH
 oDP
 ryy
 pRW
@@ -86169,7 +86241,7 @@ eyt
 eDB
 gov
 jZH
-jZH
+oDP
 jZH
 jZH
 jZH

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2352,8 +2352,7 @@
 "cDx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
-	color = "#5c131b";
-	open = 0
+	color = "#5c131b"
 	},
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13{
@@ -3003,11 +3002,11 @@
 /area/f13/bunker)
 "dlT" = (
 /obj/machinery/door/poddoor/gate{
+	icon_state = "open";
 	id = "boscheckpoint";
 	name = "Checkpoint";
 	req_access_txt = "120";
-	req_one_access_txt = "120";
-	state_open = 1
+	req_one_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -9702,7 +9701,7 @@
 "jYZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker{
-	name = "Head Scribe's Office"
+	name = "Ceremony Room"
 	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
@@ -9722,7 +9721,7 @@
 /area/f13/brotherhood)
 "jZL" = (
 /obj/structure/simple_door/bunker{
-	name = "Head Scribe's Office"
+	name = "Ceremony Room"
 	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
@@ -16498,6 +16497,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"rwn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "rwA" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
@@ -81260,7 +81268,7 @@ eLE
 rOj
 gkZ
 feM
-geb
+rwn
 geb
 eRI
 ulS

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -16958,15 +16958,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"sgm" = (
-/obj/structure/bookcase/manuals/medical{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood)
 "sgn" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -83384,7 +83375,7 @@ fTD
 fPg
 nNF
 jZH
-sgm
+wZH
 hGV
 wZH
 wZH
@@ -83641,7 +83632,7 @@ nNF
 nNF
 nNF
 jZH
-sgm
+wZH
 mEW
 tvx
 mEW
@@ -83898,16 +83889,16 @@ nNF
 gSh
 jZH
 hij
-sgm
-sgm
+wZH
+wZH
 ewy
 ewy
 tvx
 jPv
 nzl
-sgm
-sgm
-sgm
+wZH
+wZH
+wZH
 wZH
 jZH
 qFc

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -4737,11 +4737,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ePz" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "AUX"
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "eQC" = (
 /obj/machinery/telecomms/server/presets/engineering,
@@ -4902,6 +4901,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -4990,6 +4990,7 @@
 	id = "AUX"
 	},
 /obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -80271,8 +80272,8 @@ jZH
 jZH
 jZH
 fdp
-wbe
-wbe
+xGl
+xGl
 fhZ
 jZH
 jZH
@@ -80527,7 +80528,7 @@ jZH
 jZH
 jZH
 jZH
-wbe
+ePz
 jZH
 jZH
 jZH
@@ -81295,7 +81296,7 @@ aVe
 aVe
 aVe
 aVe
-ePz
+rFJ
 aVe
 aVe
 xsD

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -4341,7 +4341,7 @@
 /obj/machinery/button/door{
 	id = "bosarmoryacc";
 	normaldoorcontrol = 1;
-	pixel_y = -22;
+	pixel_x = -23;
 	specialfunctions = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4390,6 +4390,7 @@
 "euI" = (
 /obj/machinery/light/small,
 /obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -12580,6 +12581,15 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"mRU" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "mSs" = (
 /obj/structure/table,
 /obj/item/roller,
@@ -21005,6 +21015,17 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
+"xcc" = (
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
+	icon_state = "generator_on";
+	name = "superheating forge"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "xcm" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -85488,9 +85509,9 @@ dYf
 dZz
 oZm
 uvD
+uvD
 eqw
-jZH
-jZH
+xcc
 jZH
 rOj
 jZH
@@ -85746,8 +85767,8 @@ uvD
 uvD
 uvD
 euI
-hji
-jZH
+mRU
+uvD
 jZH
 jZH
 jZH

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -957,10 +957,6 @@
 /area/f13/brotherhood)
 "beL" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
 /obj/machinery/light/fo13colored/Aqua{
 	dir = 8;
 	name = "light fixture"
@@ -5092,13 +5088,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "flC" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/machinery/shower{
+	pixel_y = 27
 	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/turf/open/floor/carpet/black,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "flP" = (
 /obj/effect/landmark/start/f13/prospector,
@@ -5702,7 +5699,7 @@
 	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "gaz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6259,13 +6256,10 @@
 	},
 /area/f13/clinic)
 "gJk" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "gJz" = (
 /obj/effect/landmark/start/f13/prospector,
@@ -17872,6 +17866,15 @@
 "tnp" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
+"tnE" = (
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "toq" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/grass/jungle/b,
@@ -17974,10 +17977,6 @@
 /area/f13/tunnel)
 "ttW" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -18719,6 +18718,16 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"ulj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	id_tag = null;
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood)
 "uls" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/pa_wear,
@@ -85743,9 +85752,9 @@ jZH
 jZH
 jZH
 jZH
-gEf
-gEf
-gEf
+jZH
+ulj
+jZH
 vIL
 hae
 jzK
@@ -85997,12 +86006,12 @@ jZH
 jZH
 rOj
 jZH
-phh
-fDW
+jzz
+ryy
 gaj
-gEf
-gEf
-gEf
+gJk
+sCB
+jZH
 gVp
 hcC
 jzK
@@ -86255,11 +86264,11 @@ rOj
 rOj
 jZH
 flC
+ryy
+jZH
+tnE
 uWC
 jZH
-vIL
-gJk
-gEf
 gVy
 hdU
 jZH

--- a/code/modules/shuttle/f13.dm
+++ b/code/modules/shuttle/f13.dm
@@ -30,7 +30,7 @@
 	light_color = LIGHT_COLOR_CYAN
 	circuit = /obj/item/circuitboard/computer/bos_control
 	shuttleId = "bos_elevator"
-	possible_destinations = "bos_level_1;bos_level_2;bos_level_3"
+	possible_destinations = "bos_level_1;bos_level_2;"
 	flags_1 = NODECONSTRUCT_1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 


### PR DESCRIPTION
**Blah blah blah bitch bitch bitch**
### First Floor
**Living area**
- Pool, sauna, kitchen, bar, and eating area moved from level three to old office space
- Slightly expanded pool, added more flavor
- Cannibalized two dorm rooms for shower/bathroom area
- QOL changes to kitchen organization
- Singular corner of bunker for recreation/living instead of multiple floors
- Modern open floor plan
![wearearaer](https://user-images.githubusercontent.com/60239538/112554564-f03ee380-8d9c-11eb-902e-05f941777472.JPG)

**Armory & Access Area**
- With bigger focus on surface building/interaction, slimmed down entryway
- Separated access control and armory to ease confusion
- Added firing range
- Made access control and armory lockable from the inside
![New Amory And Entrance](https://user-images.githubusercontent.com/60239538/112554612-03ea4a00-8d9d-11eb-9a0a-659280acb1a4.JPG)

**Elevator**
- Centered elevator console so there is no way on a snowy day in hell you can miss it
- Made elevator doors around corners, with a window to look into the elevator, so you have nobody to blame but yourself
- Moved emergency ladders to separate auxiliary
- Added button to lock elevator doors from the inside and out. Use them for safety, fools.
![efaefadvcxz](https://user-images.githubusercontent.com/60239538/112555015-bb7f5c00-8d9d-11eb-83af-9e67e75b43e3.JPG)
 areas

### Second Floor
**Power**
- Rotated department to slim down bunker as a whole, discovered it fits nicely nuzzled up against the shop
- Cut some of hallway in order to trim unused space, and to make it more visible from elevator
- Due to the rotation, the bunker is now more raidable from this direction. Huzzah
![Reactor](https://user-images.githubusercontent.com/60239538/112555283-495b4700-8d9e-11eb-81f2-3c647886a2a1.JPG)
**Scribe Area**
- RnD machinery moved closer to checkpoint RnD stations to prevent unlinking
- Checkpoint gate will now spawn in the open position
- Archives moved to east side of floor
- Head Scribe office moved to north of Archives
- Ceremony room attached to Archives
- Field Scribe outfits added in various areas
- Shop condensed slightly
![Scribe Level](https://user-images.githubusercontent.com/60239538/112555732-22e9db80-8d9f-11eb-9fea-e37d2e84a130.JPG)

**Elevator**
- Centers elevator console
- Added button to lock elevator doors from the inside and out. Use them for safety, fools
- Created janitor's closet to hide ladder in

![Full Size](https://user-images.githubusercontent.com/60239538/112556439-98a27700-8da0-11eb-9e6a-abfe1247aaec.JPG)
### Level three is gone
### Removes old Locust underground mine (leftover, oversight)
### Scorpion spawn in mines changes to radroach so initiates don't get murdered for no reason
### RockClaw moved slightly closer to mine entrance
### Surface By Leudo
**Surface**
- Hydroponics moved to greenhouse on surface
- Farm moved to surface area
- Locust bunker re-added
- Exterior buildings/tents/area shifted about to facilitate coming BoS faction changes
![surface](https://user-images.githubusercontent.com/60239538/112558736-d1911a80-8da5-11eb-8259-c375905843f5.JPG)
