### PR TITLE
Hotfix: BoS ORM, Locked Gate, Etc

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -337,18 +337,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/legion)
-"alw" = (
-/obj/structure/simple_door{
-	icon_state = "brokenglass"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/brotherhood)
 "alE" = (
 /obj/structure/chair/comfy,
 /obj/structure/decoration/rag{
@@ -453,15 +441,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"aqc" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "aqv" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -597,16 +576,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"avd" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/brotherhood)
 "avh" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -796,10 +765,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"aCY" = (
-/obj/structure/simple_door/interior,
-/turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
 "aDb" = (
 /obj/effect/landmark/start/f13/slave,
 /turf/open/floor/f13/wood{
@@ -1291,9 +1256,6 @@
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "aWg" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/table,
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /obj/item/storage/pill_bottle/chem_tin/radx,
@@ -1388,9 +1350,6 @@
 	},
 /area/f13/village)
 "aYV" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/wreck/car/bike{
 	pixel_x = -12;
 	pixel_y = 1
@@ -1761,9 +1720,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bmW" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -2603,15 +2559,6 @@
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/city)
-"bSa" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "bSR" = (
 /obj/machinery/autolathe,
 /turf/open/floor/f13{
@@ -2988,18 +2935,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"ckO" = (
-/obj/item/folder/yellow,
-/obj/item/folder/yellow,
-/obj/item/folder/yellow,
-/obj/structure/table/wood,
-/obj/structure/table/wood,
-/obj/machinery/light/small/broken,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "ckV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -3208,29 +3143,11 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"ctf" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/under/f13/combat,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "cts" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
-"ctz" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "ctE" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -3416,15 +3333,6 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
-"cAD" = (
-/obj/structure/closet,
-/obj/item/clothing/under/f13/combat,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "cAI" = (
 /obj/machinery/light{
 	dir = 1;
@@ -3985,16 +3893,6 @@
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
-"cYb" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/table,
-/turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
 "cYz" = (
 /obj/item/target,
@@ -4843,10 +4741,6 @@
 	},
 /area/f13/village)
 "dAo" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/closet{
 	pixel_x = -9;
 	pixel_y = 13
@@ -5159,13 +5053,6 @@
 /obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dQw" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/reagent_dispensers/barrel/three,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "dRd" = (
 /obj/item/seeds/pumpkin,
 /obj/item/seeds/wheat,
@@ -5794,15 +5681,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"evy" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/rack,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "evV" = (
 /obj/structure/fence/corner/wooden{
 	dir = 8
@@ -6018,13 +5896,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
-"eFV" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "eFW" = (
 /obj/structure/sign/poster/official/fruit_bowl{
 	pixel_x = -32
@@ -6046,17 +5917,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"eGR" = (
-/obj/structure/closet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "eGX" = (
 /obj/item/trash/f13/steak,
 /turf/open/floor/f13/wood,
@@ -6141,15 +6001,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/f13,
 /area/f13/building)
-"eJZ" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib1-old"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "eKs" = (
 /obj/structure/decoration/rag{
 	pixel_x = -14
@@ -6241,15 +6092,6 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
-"eMV" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "eNs" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -7244,15 +7086,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"fvh" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "fvi" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Followers Clinic"
@@ -7261,15 +7094,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"fvj" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
 "fvm" = (
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -7323,16 +7147,6 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
-"fxG" = (
-/obj/structure/bookcase,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/brotherhood)
 "fxK" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/f13/police,
@@ -9046,15 +8860,6 @@
 /obj/item/clothing/shoes/combat,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gIN" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "gJe" = (
 /obj/structure/chair/f13foldupchair,
 /turf/open/floor/f13{
@@ -9145,15 +8950,6 @@
 	desc = "Deep, poorly filtered gardening water.";
 	name = "stagnant water"
 	},
-/area/f13/brotherhood)
-"gNj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "gNA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9551,17 +9347,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"gZy" = (
-/obj/structure/bookcase,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/curtain,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/brotherhood)
 "gZD" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9582,24 +9367,6 @@
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"haV" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/item/storage/belt/military/assault,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/window/fulltile,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
 "hbm" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/brotherhood)
@@ -9836,16 +9603,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"hiK" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/chair/wood,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "hiS" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -9926,16 +9683,6 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"hlB" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/item/storage/belt/military/assault,
-/obj/item/clothing/under/f13/combat,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
 "hlI" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9977,18 +9724,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"hmr" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "hmy" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -10425,14 +10160,6 @@
 /area/f13/legion)
 "hzt" = (
 /obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj/item/storage/belt/military/assault,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -10578,13 +10305,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"hES" = (
-/obj/item/flag/bos,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "hET" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/dirt,
@@ -10759,19 +10479,6 @@
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"hJu" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood)
 "hJv" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -11377,15 +11084,6 @@
 /obj/effect/landmark/start/f13/shopkeeper,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"iie" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "iik" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11425,9 +11123,6 @@
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/village)
 "ijj" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/sign/warning/securearea{
 	pixel_y = -33
 	},
@@ -11438,21 +11133,6 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
-"ijn" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"iju" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "ijO" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -11722,9 +11402,6 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
 "itj" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
 	},
@@ -11823,15 +11500,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/village)
-"iwo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "iwp" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -11854,20 +11522,6 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
-"ixn" = (
-/obj/structure/chair/wood/worn{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/brotherhood)
 "ixG" = (
 /obj/effect/landmark/start/f13/pusher,
 /turf/open/indestructible/ground/outside/wood,
@@ -12023,13 +11677,6 @@
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"iDw" = (
-/obj/structure/closet/crate/bin,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "iEg" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -12039,15 +11686,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"iET" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "iFb" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -12356,11 +11994,6 @@
 	},
 /area/f13/ncr)
 "iNp" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/pill/patch/turbo,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
@@ -13209,20 +12842,6 @@
 /obj/structure/chair/wood/fancy,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"jto" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibtorso"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood)
 "jts" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -13382,16 +13001,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
-"jzB" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "jzN" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -14658,13 +14267,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
-"kvU" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "kvZ" = (
 /obj/item/bedsheet/random,
 /obj/structure/bed,
@@ -15124,13 +14726,6 @@
 	icon_state = "verticalleftborderright2top"
 	},
 /area/f13/ncr)
-"kOU" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "kPX" = (
 /obj/structure/fence/corner/wooden{
 	dir = 8
@@ -15265,16 +14860,6 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
-"kVP" = (
-/obj/effect/turf_decal/caution/stand_clear/red,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_2"
-	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
 "kVS" = (
 /obj/structure/rack,
@@ -15516,14 +15101,6 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"lhq" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "lhz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15665,16 +15242,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"lnx" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "lnX" = (
 /obj/item/clothing/under/jabroni,
 /obj/structure/displaycase,
@@ -15920,15 +15487,6 @@
 	},
 /area/f13/followers)
 "luc" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -16042,27 +15600,6 @@
 /obj/item/chair/stool/retro,
 /turf/open/floor/carpet,
 /area/f13/city)
-"lwQ" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10;
-	icon_state = "warningline_red"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "NE"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/chair/stool{
-	icon_state = "bench"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "lxe" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16435,16 +15972,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"lMc" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosgarage";
-	name = "shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "lMn" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -16587,14 +16114,6 @@
 	},
 /area/f13/wasteland)
 "lRV" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/indestructible/ground/outside/wood,
@@ -17629,21 +17148,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
-"mKj" = (
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5;
-	icon_state = "warningline_red"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "SW"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/tunnel,
-/area/f13/brotherhood)
 "mKm" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/desert,
@@ -18490,9 +17994,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "nvH" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/closet/crate/freezer/blood{
 	pixel_y = 20
 	},
@@ -18877,21 +18378,6 @@
 /obj/item/clothing/mask/bandana/gold,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nLx" = (
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9;
-	icon_state = "warningline_red"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "SE"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
 "nMk" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -18983,15 +18469,6 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
-"nPn" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "nPq" = (
 /obj/machinery/light{
 	dir = 1
@@ -19714,9 +19191,6 @@
 	},
 /area/f13/clinic)
 "oqp" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/chair/stool{
 	dir = 4;
 	icon_state = "bench"
@@ -19806,15 +19280,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"ovb" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "ovr" = (
 /obj/structure/table,
 /obj/item/kitchen/fork,
@@ -20637,17 +20102,6 @@
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
-"oYB" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
-	},
-/obj/effect/decal/remains/human,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "oYI" = (
 /obj/effect/decal/waste{
 	pixel_x = 20;
@@ -20751,12 +20205,8 @@
 	},
 /area/f13/followers)
 "pcV" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
-/obj/effect/spawner/lootdrop/clothing_middle,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -21644,19 +21094,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"pLK" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/item/clothing/shoes/f13/military,
-/obj/item/clothing/under/f13/combat,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
 "pMf" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -21755,16 +21192,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/ncr)
-"pON" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
 "pPe" = (
 /obj/structure/fence{
 	dir = 4
@@ -22463,13 +21890,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"qqg" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "qqK" = (
 /obj/structure/chair/stool/f13stool{
 	pixel_x = -8
@@ -22711,24 +22131,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
-"qzO" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
-	icon_state = "warningline_red"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "NW"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "qAc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -22766,12 +22168,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "qCb" = (
-/obj/structure/chair/wood/fancy{
-	icon_state = "officechair_dark"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/blood/radaway,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -22976,15 +22372,6 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
-"qJs" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "qJB" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -23215,16 +22602,6 @@
 /obj/structure/simple_door/interior{
 	req_access_txt = "120"
 	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
-"qQI" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
 "qQQ" = (
@@ -23462,19 +22839,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
-"rbT" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood)
 "rco" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -23889,13 +23253,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/ncr)
-"rtW" = (
-/obj/item/flag/bos,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "ruD" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
@@ -25190,20 +24547,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"stv" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj/item/clothing/shoes/f13/military,
-/obj/item/clothing/under/f13/combat,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "stG" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubble"
@@ -25355,19 +24698,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"syC" = (
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Security"
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "syG" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/f13{
@@ -25827,9 +25157,6 @@
 /obj/structure/sign/poster/prewar/poster69{
 	pixel_x = -32
 	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
 "sQX" = (
@@ -26218,13 +25545,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"tdG" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "tdU" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -26397,16 +25717,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"tln" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "tlr" = (
 /obj/structure/sink{
 	pixel_y = 28
@@ -26835,17 +26145,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"tAb" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red";
-	pixel_y = 0
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "tAg" = (
 /obj/structure/fence{
 	dir = 4
@@ -27059,17 +26358,6 @@
 "tHU" = (
 /obj/effect/mine/stun,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"tIe" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "tIr" = (
 /obj/machinery/light/small{
@@ -27750,9 +27038,6 @@
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/bar)
 "uhh" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/small{
 	dir = 8
@@ -28123,14 +27408,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"utY" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "uug" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -28287,15 +27564,6 @@
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"uzf" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "uzn" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/floorgrime,
@@ -28558,15 +27826,6 @@
 /obj/item/clothing/under/f13/bluedress,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"uHx" = (
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/structure/rack,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/table,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "uHA" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13{
@@ -28692,18 +27951,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"uMg" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood)
 "uMZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -28799,14 +28046,6 @@
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"uPX" = (
-/obj/effect/turf_decal/stripes/red/line,
-/obj/machinery/light/small,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
 "uQe" = (
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -29447,15 +28686,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"vnn" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibdown1"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "vno" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/f13/wood,
@@ -29635,18 +28865,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"vvE" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/obj/structure/sign/poster/prewar/poster69{
-	pixel_x = -32
-	},
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "vvU" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -29983,15 +29201,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"vHW" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "vIb" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -30286,12 +29495,6 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
 "vUX" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib2-old"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/machinery/deepfryer,
 /obj/machinery/light/small{
 	dir = 1
@@ -30453,13 +29656,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"wcY" = (
-/obj/structure/barricade/sandbags,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "wdl" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -30542,12 +29738,6 @@
 	},
 /area/f13/wasteland)
 "whm" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/sink/kitchen{
 	dir = 8;
 	pixel_x = 12
@@ -30558,13 +29748,6 @@
 /obj/item/reagent_containers/food/condiment/soymilk,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"whE" = (
-/obj/effect/turf_decal/caution/stand_clear/red,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
 "whO" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs"
@@ -30737,16 +29920,6 @@
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wqb" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "wqe" = (
 /obj/structure/table/wood,
 /obj/structure/wreck/trash/one_tire{
@@ -30781,16 +29954,6 @@
 "wqS" = (
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/building)
-"wrd" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/item/clothing/under/f13/combat,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
 "wrg" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/desert,
@@ -30822,15 +29985,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "wsA" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/obj/item/clothing/under/f13/combat,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/lattice/catwalk,
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -30846,16 +30000,6 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wsM" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/item/clothing/shoes/f13/military,
-/obj/item/clothing/under/f13/combat,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
@@ -31622,13 +30766,6 @@
 	icon_state = "verticaloutermain2top"
 	},
 /area/f13/wasteland)
-"wVx" = (
-/obj/item/flag/bos,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "wVI" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
@@ -32135,16 +31272,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
-"xke" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "xkj" = (
 /obj/machinery/mineral/wasteland_vendor/advcomponents,
 /turf/open/floor/f13{
@@ -32439,18 +31566,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"xtZ" = (
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/structure/table/wood,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
 "xuv" = (
 /obj/structure/barricade/wooden,
 /obj/structure/urinal,
@@ -32519,16 +31634,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"xww" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/brown,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/under/f13/combat,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
 "xwN" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/wood,
@@ -33312,13 +32417,6 @@
 /obj/machinery/vending/hydronutrients,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
-"xYt" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "xYN" = (
 /obj/structure/chair{
 	dir = 4
@@ -33528,9 +32626,6 @@
 	},
 /area/f13/wasteland)
 "yev" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/chair/stool{
 	dir = 8;
 	icon_state = "bench"
@@ -66641,11 +65736,11 @@ gcK
 gcK
 gcK
 iFI
-lnx
 iFI
-iwo
 iFI
-xtZ
+iFI
+iFI
+iFI
 uFB
 los
 los
@@ -66900,14 +65995,14 @@ gcK
 iFI
 qCb
 bXl
-ixn
-avd
-ckO
+bXl
+bXl
+iFI
 los
 los
 los
 iFI
-gIN
+jXh
 qPL
 qPL
 iFI
@@ -67159,7 +66254,7 @@ aWg
 bXl
 bXl
 bXl
-eFV
+iFI
 los
 los
 los
@@ -67416,7 +66511,7 @@ iFI
 nvH
 bXl
 bXl
-syC
+iFI
 los
 los
 los
@@ -67669,9 +66764,9 @@ gcK
 iFI
 dAo
 bXl
-gZy
+xwk
 bXl
-fxG
+bXl
 bXl
 moA
 los
@@ -67927,7 +67022,7 @@ iFI
 xeo
 bXl
 xwk
-alw
+bXl
 gEn
 txO
 iFI
@@ -68181,7 +67276,7 @@ gcK
 gcK
 gcK
 gcK
-lhq
+iFI
 iFI
 iFI
 iFI
@@ -68438,7 +67533,7 @@ gcK
 gcK
 gcK
 gcK
-tIe
+gcK
 iFI
 iku
 qPL
@@ -68695,10 +67790,10 @@ gcK
 gcK
 gcK
 gcK
-ctz
+gcK
 iFI
 qPL
-vHW
+qPL
 xtG
 qPL
 yev
@@ -68952,10 +68047,10 @@ gcK
 gcK
 gcK
 gcK
-cAD
+gcK
 iFI
 xZQ
-xYt
+oAB
 oAB
 qPL
 qPL
@@ -68963,7 +68058,7 @@ iFI
 anP
 qPL
 qPL
-iie
+daH
 qPL
 qPL
 qPL
@@ -69209,7 +68304,7 @@ gcK
 gcK
 gcK
 gcK
-eGR
+gcK
 iFI
 qPL
 qPL
@@ -69220,7 +68315,7 @@ goO
 qPL
 qPL
 qPL
-iie
+daH
 qPL
 qPL
 qPL
@@ -69475,7 +68570,7 @@ qPL
 lKO
 iFI
 qPL
-wcY
+qPL
 pcb
 iFI
 mEh
@@ -69729,7 +68824,7 @@ iFI
 iFI
 iFI
 qPL
-ijn
+lKO
 iFI
 qPL
 qPL
@@ -69986,10 +69081,10 @@ gcK
 iFI
 iFI
 goO
-nPn
+iFI
 iFI
 daH
-iie
+daH
 iFI
 iFI
 qPL
@@ -70240,10 +69335,10 @@ gcK
 gcK
 gcK
 gcK
-fvh
-utY
+iFI
 qPL
-utY
+qPL
+hlM
 iFI
 wLO
 ijj
@@ -70494,7 +69589,7 @@ gBd
 mwt
 gND
 tka
-wVx
+gcK
 gcK
 gcK
 iFI
@@ -70752,12 +69847,12 @@ mwt
 gND
 tka
 tka
-kVP
-aqc
-iwo
-evy
+dxJ
+gcK
 iFI
-hES
+qPL
+iFI
+iFI
 jem
 mwt
 mwt
@@ -71008,13 +70103,13 @@ laZ
 mwt
 gND
 tka
-gNj
-dQw
+tka
+xVC
 gcK
 iFI
-qzO
 iFI
-mKj
+iFI
+jem
 jem
 mwt
 mwt
@@ -71022,7 +70117,7 @@ gND
 dxJ
 iFI
 wpd
-lMc
+wpd
 wpd
 iFI
 gcK
@@ -71266,12 +70361,12 @@ mwt
 sNB
 hbm
 hbm
-whE
-fvj
 hbm
-pON
 hbm
-uPX
+hbm
+hbm
+hbm
+hbm
 hsj
 mwt
 mwt
@@ -71521,14 +70616,14 @@ prR
 yeL
 mwt
 mwt
-aCY
-rtW
+hDf
+cSU
 cSU
 hab
-tAb
-lwQ
-jzB
-nLx
+cSU
+eWH
+vNv
+hbm
 xCo
 mwt
 mwt
@@ -71536,7 +70631,7 @@ gND
 tka
 aYV
 mwt
-wqb
+cPZ
 mwt
 eUz
 gcK
@@ -72307,8 +71402,8 @@ mwt
 mwt
 mwt
 hvp
-qJs
-vnn
+mwt
+mwt
 sQO
 mwt
 vnR
@@ -72551,9 +71646,9 @@ mwt
 gND
 hbm
 lRV
-vvE
-uHx
-iDw
+cSU
+xHg
+cSU
 eWH
 paM
 hbm
@@ -72566,7 +71661,7 @@ mwt
 mwt
 mwt
 mwt
-qqg
+mwt
 mwt
 mwt
 mwt
@@ -72807,15 +71902,14 @@ hsj
 mwt
 gND
 hbm
-qQI
-eJZ
-cYb
-iET
+aqv
+cSU
+xHg
+cSU
 xHg
 xHg
 hbm
 hsj
-iju
 mwt
 mwt
 mwt
@@ -72823,7 +71917,8 @@ mwt
 mwt
 mwt
 mwt
-oYB
+mwt
+mwt
 mwt
 iyy
 mwt
@@ -73067,7 +72162,7 @@ hbm
 vUX
 whm
 luc
-hmr
+cSU
 eWH
 vNv
 hbm
@@ -73321,10 +72416,10 @@ gin
 mwt
 hft
 hbm
-xww
-wrd
 hbm
-hlB
+hbm
+hbm
+hbm
 hbm
 hbm
 hbm
@@ -73578,9 +72673,9 @@ mwt
 mwt
 mwt
 mwt
-bSa
 mwt
-uzf
+mwt
+sQv
 mwt
 mwt
 mwt
@@ -73588,7 +72683,7 @@ mUo
 mwt
 mwt
 mwt
-tln
+sNB
 hbm
 fkP
 cSU
@@ -73835,10 +72930,10 @@ qRg
 qRg
 iFI
 fOf
-ctf
-pLK
 iFI
-haV
+fOf
+iFI
+qRg
 qRg
 iFI
 iFI
@@ -73849,8 +72944,8 @@ mwt
 qQD
 cSU
 cSU
-kvU
-ovb
+cSU
+cSU
 cSU
 hbm
 gcK
@@ -74092,13 +73187,13 @@ tAN
 seE
 rOo
 sgw
-rbT
-jto
-hJu
-uMg
+sgw
+sgw
+rOo
+tAN
 seE
 seE
-tdG
+vCw
 hsj
 mwt
 mwt
@@ -74106,8 +73201,8 @@ mwt
 qQD
 cSU
 cSU
-kOU
-hiK
+cSU
+iNp
 dhj
 hbm
 gcK
@@ -74351,7 +73446,7 @@ gyd
 rmY
 hzt
 wsA
-stv
+gyd
 wsM
 nUm
 seE
@@ -74359,11 +73454,11 @@ qRg
 hsj
 hhC
 mwt
-xke
+vSH
 hbm
 xwN
 cSU
-eMV
+luc
 iNp
 jgY
 hbm

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -512,7 +512,9 @@
 /area/f13/brotherhood)
 "aDN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "aEq" = (
@@ -833,6 +835,17 @@
 	pixel_x = -16
 	},
 /turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
+"bbq" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 1;
+	height = 4;
+	id = "bos_level_2";
+	name = "Level 2: Engineering";
+	width = 5
+	},
+/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood)
 "bbs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1286,7 +1299,9 @@
 /area/space)
 "btW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
@@ -1686,7 +1701,9 @@
 	pixel_y = -6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "bMq" = (
@@ -1931,6 +1948,10 @@
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"cej" = (
+/obj/machinery/ore_silo,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "cek" = (
 /obj/item/organ/liver,
 /obj/effect/decal/cleanable/dirt,
@@ -2178,16 +2199,12 @@
 	},
 /area/f13/bunker)
 "ctL" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "rampdowntop"
+	dir = 10;
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "cuj" = (
@@ -2338,6 +2355,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
+"cFj" = (
+/obj/machinery/button/door{
+	id = "floor2elevatordoors";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood)
 "cFE" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/human,
@@ -2370,7 +2395,9 @@
 /area/f13/sewer)
 "cHA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -3011,7 +3038,9 @@
 	light_color = "#d8b1b1"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -3021,7 +3050,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "dEy" = (
@@ -3223,7 +3254,6 @@
 	icon_state = "generator_on";
 	name = "superheating forge"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -3342,6 +3372,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"dRm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood)
 "dRM" = (
 /turf/open/floor/f13{
 	icon_state = "dark"
@@ -3352,7 +3389,9 @@
 	pixel_x = 16
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dSd" = (
@@ -3799,7 +3838,9 @@
 /area/f13/followers)
 "ene" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "eom" = (
@@ -3908,7 +3949,9 @@
 /area/f13/caves)
 "euS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -4491,8 +4534,14 @@
 	},
 /area/f13/brotherhood)
 "fcn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/computer/shuttle/boselevator{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -4870,6 +4919,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -4891,7 +4943,9 @@
 	pixel_x = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/machinery/light/fo13colored/Aqua{
 	dir = 8;
 	name = "light fixture"
@@ -5135,7 +5189,9 @@
 /area/f13/tunnel)
 "fNB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
@@ -5185,14 +5241,18 @@
 /area/f13/tunnel)
 "fQF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood)
 "fRN" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -5755,7 +5815,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
@@ -6407,7 +6469,9 @@
 /area/f13/tunnel)
 "hpM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
@@ -6594,7 +6658,9 @@
 "hBz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/wood,
 /area/f13/brotherhood)
 "hBC" = (
@@ -6903,7 +6969,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -7078,6 +7146,12 @@
 	pixel_y = 12
 	},
 /obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_y = -32;
+	req_one_access_txt = "120"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "idi" = (
@@ -7094,7 +7168,9 @@
 /area/f13/tunnel)
 "idU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/wood,
 /area/f13/brotherhood)
 "ife" = (
@@ -7869,7 +7945,9 @@
 /area/f13/brotherhood)
 "iUq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/machinery/light/fo13colored/Aqua{
 	dir = 8;
 	name = "light fixture"
@@ -8276,7 +8354,9 @@
 /area/f13/caves)
 "jrn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jro" = (
@@ -8332,7 +8412,9 @@
 	pixel_y = -6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "juP" = (
@@ -8861,14 +8943,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "jVx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/shuttle/boselevator{
-	dir = 1
+/obj/structure/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_x = -32;
+	pixel_y = 64
+	},
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "jWa" = (
@@ -9003,7 +9090,9 @@
 /area/f13/brotherhood)
 "kcF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
@@ -9100,7 +9189,9 @@
 "kiV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 31
 	},
@@ -9166,13 +9257,6 @@
 "kny" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood)
-"knF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
 "kot" = (
@@ -9432,11 +9516,10 @@
 	},
 /area/f13/brotherhood)
 "kFc" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	req_access_txt = "120"
+/obj/structure/window/spawner/north,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "kFg" = (
 /obj/effect/decal/waste,
@@ -9770,8 +9853,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ldP" = (
-/obj/machinery/suit_storage_unit/mining,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -10311,7 +10396,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "lLP" = (
@@ -10362,7 +10449,9 @@
 "lMT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -10445,7 +10534,6 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "lSl" = (
-/obj/machinery/ore_silo,
 /obj/structure/sign/poster/prewar/poster94{
 	icon_state = "poster70";
 	pixel_y = 32
@@ -10506,7 +10594,9 @@
 /area/f13/clinic)
 "lWm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "lWy" = (
@@ -10537,14 +10627,13 @@
 	},
 /area/f13/brotherhood)
 "lYu" = (
-/obj/machinery/door/poddoor/gate{
-	icon_state = "open";
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/gate/preopen{
 	id = "boscheckpoint";
 	name = "Checkpoint";
-	req_access_txt = "120";
+	req_one_access = "120";
 	req_one_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "lYx" = (
@@ -10885,7 +10974,9 @@
 	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -10970,9 +11061,9 @@
 	},
 /area/f13/tunnel)
 "mzu" = (
-/obj/machinery/light/small,
+/obj/machinery/suit_storage_unit/mining,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "engine"
 	},
 /area/f13/brotherhood)
 "mzP" = (
@@ -11415,12 +11506,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "mWp" = (
-/obj/machinery/button/door{
-	id = "floor2elevatordoors";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "mWM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11653,7 +11742,9 @@
 /area/f13/followers)
 "nkx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -12560,6 +12651,9 @@
 "omk" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
 	},
@@ -12753,7 +12847,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/wood,
 /area/f13/brotherhood)
 "oyr" = (
@@ -13542,7 +13638,9 @@
 /area/f13/brotherhood)
 "pxV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark"
@@ -14886,15 +14984,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qZY" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_2";
-	name = "Level 2: Engineering";
-	width = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood)
 "raA" = (
 /obj/structure/table,
@@ -14980,7 +15074,9 @@
 /area/f13/tunnel)
 "rcX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "rex" = (
@@ -15404,7 +15500,9 @@
 	pixel_x = -6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/machinery/light/small{
 	dir = 8;
 	light_color = "#d8b1b1"
@@ -16149,7 +16247,9 @@
 	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/machinery/light/small,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -16361,7 +16461,9 @@
 "szW" = (
 /obj/structure/chair/f13chair1,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/wood,
 /area/f13/brotherhood)
 "sAa" = (
@@ -16423,7 +16525,9 @@
 	pixel_x = -6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "sFl" = (
@@ -16630,7 +16734,9 @@
 "sOf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -16747,7 +16853,9 @@
 "sWB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "sWX" = (
@@ -17150,7 +17258,9 @@
 /area/f13/tunnel)
 "tsm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -17376,7 +17486,9 @@
 /area/f13/tunnel)
 "tCe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
@@ -17686,7 +17798,9 @@
 	},
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "tLS" = (
@@ -18068,7 +18182,9 @@
 	color = "#5c131b"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "uhE" = (
@@ -18601,7 +18717,9 @@
 	pixel_y = 16
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "uKB" = (
@@ -19231,7 +19349,9 @@
 "voZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -19252,7 +19372,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -19260,7 +19382,9 @@
 "vqo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
@@ -19270,7 +19394,9 @@
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "vqH" = (
@@ -19278,7 +19404,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
@@ -20181,7 +20309,9 @@
 	pixel_x = -8;
 	pixel_y = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood)
 "wgg" = (
@@ -20511,7 +20641,9 @@
 "wJQ" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "wKm" = (
@@ -20847,7 +20979,9 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "xcH" = (
@@ -21264,7 +21398,9 @@
 /area/f13/building)
 "xCf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "xCv" = (
@@ -21488,8 +21624,13 @@
 /area/f13/followers)
 "xSi" = (
 /obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_x = 11;
+	pixel_y = 22
+	},
 /obj/structure/window/reinforced{
-	color = "#3e3d42";
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -21591,6 +21732,12 @@
 	dir = 1;
 	icon_state = "officechair_dark"
 	},
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_x = 32;
+	pixel_y = 64
+	},
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark"
@@ -21613,11 +21760,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ydE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	req_access_txt = "120"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ydV" = (
 /obj/structure/closet/cabinet,
@@ -21726,7 +21873,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
@@ -80958,13 +81107,13 @@ men
 rfs
 oUK
 oUK
-qGz
+oUK
 kFc
+ydE
 dpR
 dpR
 dpR
 dpR
-jZH
 jZH
 aoj
 uoO
@@ -81215,13 +81364,13 @@ bvC
 bvC
 vqm
 qGz
-mzu
+oUK
 mWp
+cFj
 dpR
 dpR
 dpR
 dpR
-jZH
 jZH
 aoj
 uoO
@@ -81472,13 +81621,13 @@ qii
 qii
 euS
 euS
-jVx
+oUK
 fcn
+dRm
 dpR
 dpR
 dpR
 dpR
-jZH
 jZH
 aoj
 uoO
@@ -81729,13 +81878,13 @@ qii
 qii
 sOf
 euS
-ydE
-jZH
+oUK
 qZY
-dpR
-dpR
-dpR
 jZH
+bbq
+dpR
+dpR
+dpR
 jZH
 aoj
 uoO
@@ -81986,13 +82135,13 @@ kAb
 dKo
 vsW
 qGz
-qGz
+oUK
 kFc
+ydE
 dpR
 dpR
 dpR
 dpR
-jZH
 jZH
 uoO
 uoO
@@ -82488,7 +82637,7 @@ jrn
 otJ
 xoU
 tQe
-ybF
+jVx
 aVe
 aVe
 rFJ
@@ -82687,7 +82836,7 @@ gEp
 btW
 vqo
 yhd
-ctL
+vsT
 geb
 aSW
 btW
@@ -83718,7 +83867,7 @@ jZH
 jZH
 jZH
 jZH
-rOj
+jZH
 jZH
 xpo
 pxV
@@ -85071,7 +85220,7 @@ mrV
 mEm
 bVY
 qtL
-knF
+ldP
 fLF
 jZH
 jNr
@@ -85520,7 +85669,7 @@ ucQ
 mDt
 sxs
 bvP
-oZm
+ctL
 gJD
 gJD
 qpd
@@ -85583,9 +85732,9 @@ jZH
 xnb
 jZH
 lMT
-knF
+ldP
 lMT
-knF
+ldP
 hQt
 mTF
 gHi
@@ -85781,7 +85930,7 @@ gJD
 gJD
 ejQ
 tZQ
-gJD
+qLb
 jZH
 jZH
 jZH
@@ -85840,8 +85989,8 @@ jZH
 rjQ
 bJh
 mTF
-knF
-knF
+ldP
+ldP
 lMT
 aQg
 fwX
@@ -86096,10 +86245,10 @@ iML
 jZH
 tbg
 jZH
-mTF
+ldP
 ldP
 mTF
-jZH
+mrV
 kpd
 jZH
 jZH
@@ -86354,10 +86503,10 @@ jZH
 rvb
 scG
 mrV
-vsI
+mzu
 olK
-jZH
-cIS
+mrV
+cej
 cIS
 cIS
 snJ
@@ -86611,7 +86760,7 @@ jZH
 jZH
 jZH
 jZH
-jZH
+vsI
 jZH
 jZH
 jZH

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2309,13 +2309,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/f13/brotherhood)
-"cAO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
 "cBH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6971,7 +6964,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -8367,6 +8359,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"jrA" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "jrV" = (
 /obj/machinery/light{
 	dir = 4
@@ -10032,6 +10030,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
+"llp" = (
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "llv" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -10449,9 +10464,6 @@
 "lMT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -11509,6 +11521,9 @@
 /area/f13/brotherhood)
 "mWp" = (
 /obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -19372,9 +19387,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -80851,7 +80863,7 @@ nHu
 qVC
 fDi
 vBG
-rFJ
+jrA
 aVe
 rFJ
 ryL
@@ -81110,7 +81122,7 @@ men
 rfs
 oUK
 oUK
-oUK
+euS
 kFc
 ydE
 dpR
@@ -82394,7 +82406,7 @@ qVC
 uWA
 bxX
 aVe
-aVe
+jrn
 sHk
 jZH
 jZH
@@ -83677,7 +83689,7 @@ cZP
 cZP
 emg
 hxe
-jrn
+aVe
 aVe
 aVe
 rFc
@@ -85477,7 +85489,7 @@ tnl
 jZH
 mrV
 mrV
-tAi
+llp
 tAi
 mrx
 mTF
@@ -85734,7 +85746,7 @@ ksU
 jZH
 xnb
 jZH
-cAO
+mTF
 ldP
 lMT
 ldP
@@ -85992,9 +86004,9 @@ jZH
 rjQ
 bJh
 mTF
+mTF
 ldP
-ldP
-cAO
+lMT
 aQg
 fwX
 slT
@@ -86249,7 +86261,7 @@ jZH
 tbg
 jZH
 ldP
-ldP
+mTF
 mTF
 mrV
 kpd

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -10733,8 +10733,10 @@
 	},
 /area/f13/bunker)
 "mhc" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
+/obj/machinery/computer/shuttle/boselevator{
+	dir = 1;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "miv" = (
@@ -16413,17 +16415,9 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "swY" = (
-/obj/docking_port/stationary{
-	area_type = /area/f13;
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_1";
-	name = "Level 1: Operations";
-	roundstart_template = /datum/map_template/shuttle/bos/elevator;
-	width = 5
-	},
-/turf/open/floor/plasteel/elevatorshaft,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "sxs" = (
 /obj/structure/rack,
@@ -18418,11 +18412,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "usN" = (
-/obj/machinery/computer/shuttle/boselevator{
-	dir = 1;
-	pixel_y = -2
+/obj/docking_port/stationary{
+	area_type = /area/f13;
+	dir = 2;
+	dwidth = 1;
+	height = 4;
+	id = "bos_level_1";
+	name = "Level 1: Operations";
+	roundstart_template = /datum/map_template/shuttle/bos/elevator;
+	width = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood)
 "utr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21271,6 +21271,9 @@
 "xrz" = (
 /obj/machinery/smartfridge/food,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood)
+"xss" = (
+/turf/closed/mineral/random/high_chance,
 /area/f13/brotherhood)
 "xsL" = (
 /mob/living/simple_animal/hostile/radroach,
@@ -76479,15 +76482,15 @@ rOj
 rOj
 rOj
 rOj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
 rOj
 rOj
 uoO
@@ -77003,7 +77006,7 @@ psA
 qmh
 qmh
 jZH
-uoO
+jZH
 uoO
 uoO
 uoO
@@ -77260,7 +77263,7 @@ nld
 qmh
 qmh
 jZH
-uoO
+jZH
 uoO
 uoO
 uoO
@@ -77517,7 +77520,7 @@ hXf
 oAp
 jZH
 jZH
-uoO
+jZH
 uoO
 uoO
 uoO
@@ -78031,7 +78034,7 @@ vJX
 qRv
 tfd
 jZH
-uoO
+jZH
 uoO
 uoO
 aoj
@@ -78288,7 +78291,7 @@ vch
 uRE
 vrC
 jZH
-aoj
+jZH
 uoO
 uoO
 uoO
@@ -78545,7 +78548,7 @@ eaR
 ldA
 hcC
 jZH
-aoj
+xss
 uoO
 uoO
 uoO
@@ -78802,7 +78805,7 @@ oAp
 oAp
 jZH
 jZH
-uoO
+jZH
 uoO
 uoO
 uoO
@@ -79059,7 +79062,7 @@ dSr
 dSr
 spS
 jZH
-uoO
+jZH
 uoO
 uoO
 uoO
@@ -79316,7 +79319,7 @@ stU
 gim
 qUR
 jZH
-uoO
+jZH
 uoO
 uoO
 uoO
@@ -79573,7 +79576,7 @@ jZH
 jZH
 jZH
 jZH
-uoO
+jZH
 uoO
 uoO
 aoj
@@ -80858,7 +80861,7 @@ jZH
 jZH
 jZH
 jZH
-uoO
+rOj
 uoO
 uoO
 uoO
@@ -81061,13 +81064,13 @@ crH
 ryy
 qPC
 jZH
+rFJ
 aVe
 jsD
 dpR
 dpR
 dpR
 dpR
-jZH
 jZH
 vDC
 jZH
@@ -81115,7 +81118,7 @@ dpR
 dpR
 dpR
 jZH
-aoj
+rOj
 uoO
 uoO
 uoO
@@ -81318,13 +81321,13 @@ aVe
 rFJ
 aVe
 aVe
+aVe
 rFJ
 qqN
 dpR
 dpR
 dpR
 dpR
-jZH
 jZH
 vDC
 jZH
@@ -81372,7 +81375,7 @@ dpR
 dpR
 dpR
 jZH
-aoj
+jZH
 uoO
 uoO
 uoO
@@ -81575,13 +81578,13 @@ aVe
 rFJ
 aVe
 aVe
-usN
+aVe
 mhc
+swY
 dpR
 dpR
 dpR
 dpR
-jZH
 jZH
 vDC
 jZH
@@ -81629,7 +81632,7 @@ dpR
 dpR
 dpR
 jZH
-aoj
+jZH
 uoO
 uoO
 uoO
@@ -81833,12 +81836,12 @@ aVe
 aVe
 rFJ
 aVe
+aVe
 jZH
-swY
+usN
 dpR
 dpR
 dpR
-jZH
 jZH
 beN
 jZH
@@ -81886,7 +81889,7 @@ dpR
 dpR
 dpR
 jZH
-aoj
+jZH
 uoO
 uoO
 uoO
@@ -82089,13 +82092,13 @@ cfA
 cfA
 tgU
 jZH
+rFJ
 uJY
 jsD
 dpR
 dpR
 dpR
 dpR
-jZH
 jZH
 vDC
 jZH
@@ -82143,7 +82146,7 @@ dpR
 dpR
 dpR
 jZH
-uoO
+rOj
 uoO
 uoO
 uoO
@@ -82400,7 +82403,7 @@ jZH
 jZH
 jZH
 jZH
-uoO
+rOj
 uoO
 uoO
 uoO

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2309,6 +2309,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/f13/brotherhood)
+"cAO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "cBH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4919,9 +4926,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -6968,10 +6972,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -85734,7 +85734,7 @@ ksU
 jZH
 xnb
 jZH
-lMT
+cAO
 ldP
 lMT
 ldP
@@ -85994,7 +85994,7 @@ bJh
 mTF
 ldP
 ldP
-lMT
+cAO
 aQg
 fwX
 slT


### PR DESCRIPTION
Ore Silo is in a position that blocks access to the ORM, and due to the design of the mining room, it requires a huge pain the ass to bypass. Not intended, this moves the ore silo to the opposite corner of the room.

The lockdown gate that leads into the RnD floor also spawns closed, and as security features, the only buttons from the outside are on another floor.

This makes sure the gate spawns open, and it also adds a access-locked button into the security checkpoint for the reactor, and two more buttons closer to the gate within RnD.

Also fixes a wall-in-door on the surface

Also fixes a couple decals that shouldn't be there in the bunker.
