### PR TITLE
North Sewer 2: Electric Boogaloo

### DIFF
--- a/_maps/map_files/templates/dungeons/north_sewer_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_sewer_2.dmm
@@ -1,19 +1,549 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"cA" = (
-/mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
+"ag" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"aC" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"aD" = (
+/obj/machinery/door/airlock/grunge,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor/shutters{
+	id = "pain";
+	name = "door shutters"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"aI" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy{
+	faction = list("raider")
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"aJ" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"aK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"aM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/tunnel)
+"aN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"aU" = (
+/mob/living/simple_animal/hostile/handy/protectron{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"aX" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/sentrybot{
+	faction = list("raider")
+	},
+/obj/structure/chair/f13chair2,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"bl" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"bt" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
+"by" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"bE" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"bG" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"cb" = (
+/obj/effect/decal/fakelattice,
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"ck" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"cs" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"cA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"cI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "cQ" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"cR" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"cT" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"cW" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"cY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"cZ" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"db" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"dc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"df" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"dk" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"dp" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"dr" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"dx" = (
+/mob/living/simple_animal/hostile/handy/protectron{
+	faction = list("raider")
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"dL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"dP" = (
+/obj/structure/wreck/trash/five_tires,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"dT" = (
+/obj/machinery/autolathe/ammo,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ee" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"en" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder/reinforced,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"eu" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"ew" = (
+/obj/machinery/chem_master/advanced,
+/obj/machinery/chem_master/advanced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"eF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"eU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"eY" = (
+/mob/living/simple_animal/hostile/handy/protectron{
+	faction = list("raider")
+	},
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"fg" = (
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/splats,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"fk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"fs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"fu" = (
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"fD" = (
+/obj/item/storage/trash_stack,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"fG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"fI" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"fV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ga" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"gB" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gI" = (
+/mob/living/simple_animal/hostile/raider/ranged/legendary{
+	desc = "A notorious cannibal raider, with a strong revolver. Oh no.";
+	name = "Bob";
+	retreat_distance = 0;
+	speed = 1.5
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"gM" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	name = "Repaired Turret"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gS" = (
+/obj/structure/table,
+/obj/item/healthanalyzer/advanced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"hc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"he" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/tunnel)
+"hy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"if" = (
+/obj/structure/barricade/bars,
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ik" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "pain";
+	name = "door shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"in" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"iw" = (
+/turf/closed/indestructible/fakedoor{
+	desc = "An indestructible door. Hm.";
+	name = "Strong Door"
+	},
+/area/f13/bunker)
+"iK" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"iT" = (
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"jc" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"je" = (
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/water,
+/area/f13/caves)
+"jj" = (
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"jl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/caves)
+"jq" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"jr" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"jv" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"jB" = (
+/obj/structure/girder/reinforced,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "jG" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"jM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"jX" = (
+/obj/item/storage/trash_stack,
+/obj/structure/wreck/trash/two_tire,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
+"jZ" = (
+/obj/machinery/light/broken,
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ka" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ki" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"kj" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"km" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "kE" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"kO" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"ld" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	name = "Repaired Turret"
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"lh" = (
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"ln" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"lo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stacklifter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"lw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/splats,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "lz" = (
 /mob/living/simple_animal/hostile/stalker,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -22,20 +552,797 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"mZ" = (
-/obj/structure/barricade/sandbags,
+"lP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/caves)
+"lZ" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"mt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"mx" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/indestructible/fakedoor{
+	desc = "An indestructible door. Hm.";
+	name = "Strong Door"
+	},
+/area/f13/bunker)
+"mC" = (
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/item/clothing/suit/armor/f13/power_armor/t45d{
+	color = "#C1C1C1";
+	desc = "(IX) Originally developed and manufactured for the United States Army by American defense contractor West Tek, the T-45d power armor was the first version of power armor to be successfully deployed in battle. This set looks somewhat bashed up and worn";
+	item_color = "#C1C1C1"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"mP" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/water,
+/area/f13/tunnel)
+"mQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/mob_spawn/human/corpse/raider/tribal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"nc" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"nd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"np" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"nq" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"ns" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"ny" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/mob/living/simple_animal/hostile/handy/gutsy{
+	faction = list("raider")
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"nC" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"nQ" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
+"oo" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"op" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"oq" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"ov" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"oF" = (
+/obj/machinery/defibrillator_mount,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"oJ" = (
+/obj/item/storage/trash_stack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"oO" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "pain";
+	name = "door shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"oV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"pe" = (
+/mob/living/simple_animal/hostile/handy/playable{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"po" = (
+/obj/effect/decal/fakelattice,
+/obj/item/storage/toolbox/emergency/old,
+/obj/item/storage/toolbox/emergency/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"pv" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	name = "Repaired Turret"
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"pC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"pE" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
+"pJ" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/securitron{
+	faction = list("raider")
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"qt" = (
+/obj/item/trash/f13/yumyum,
+/obj/effect/mob_spawn/human/corpse/raider,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qz" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"qF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"qG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/item/reagent_containers/food/snacks/f13/deathclawomelette,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"qH" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	name = "Repaired Turret"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"qL" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"qN" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qQ" = (
-/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/closed/indestructible/fakedoor{
+	desc = "An indestructible door. Hm.";
+	name = "Strong Door"
+	},
+/area/f13/radiation)
+"qZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shovel/spade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"rb" = (
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"rg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"rj" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"ru" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"rM" = (
+/obj/structure/fluff/paper/stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"st" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/item/wallframe/camera,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"sF" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/playable{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sH" = (
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"sI" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sK" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sR" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"sT" = (
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ta" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/baseball,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ts" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"tt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/human/corpse/raider,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"tx" = (
+/obj/structure/closet/crate/freezer/blood/anchored,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"tG" = (
+/obj/item/trash/f13/yumyum,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"tI" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"tN" = (
+/obj/machinery/door/airlock/grunge,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"tU" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
+"uv" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"uw" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"uz" = (
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"uJ" = (
+/mob/living/simple_animal/hostile/deathclaw/legendary,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"uL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"uO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"uX" = (
+/obj/effect/decal/remains/robot,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"vb" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"vc" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"ve" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/securitron{
+	faction = list("raider")
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"vf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"vh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"vi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"vj" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"vk" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"vm" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/wreck/trash/engine,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"vu" = (
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/item/gun/ballistic/revolver/m29/alt,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"vv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"vw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"vB" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"vI" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"vN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"vQ" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
+"vR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"vS" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wm" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"wv" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw,
+/obj/effect/decal/cleanable/blood,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"wy" = (
+/obj/machinery/light/broken,
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"wC" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/robobrain{
+	desc = "A next-gen cybor developed by General Atomic International. This one seems particularly fond of Paper and Paper related products";
+	faction = list("raider");
+	health = 300;
+	name = "Fishbrain"
+	},
+/obj/item/paper,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wD" = (
+/obj/item/storage/trash_stack,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"wG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/f13/yumyum,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wI" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel)
+"xg" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/radiation)
+"xl" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"xv" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/legendary{
+	desc = "A notorious cannibal raider, with a BIG knife. Oh no.";
+	health = 600;
+	name = "Jim";
+	speed = 1.5
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"xw" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"xJ" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"yd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"yg" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"yh" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"yk" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"yl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
+"yp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"yq" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"yu" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"yI" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"yL" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy/gutsy{
+	faction = list("raider")
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"yP" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"yR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
+"yW" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"yY" = (
+/obj/item/storage/trash_stack,
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"zi" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"zo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"zz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wallframe/camera,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"zD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"zF" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/door/poddoor/shutters{
+	id = "pain";
+	name = "door shutters"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"zH" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"zX" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"Af" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"Ai" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"AB" = (
+/obj/structure/simple_door/fakeglass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"AC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"Ba" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "Bu" = (
 /obj/machinery/light/small,
 /obj/structure/table/wood/settler,
@@ -45,20 +1352,417 @@
 "BH" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"BI" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"BL" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"BW" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Cc" = (
+/obj/machinery/door/airlock/grunge,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Ce" = (
+/mob/living/simple_animal/hostile/handy/securitron{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Ch" = (
+/mob/living/simple_animal/hostile/handy/protectron{
+	faction = list("raider")
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"Cp" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"Cr" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"Cx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/blackbox_recorder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"CF" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wrench/power,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"CN" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Df" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "pain";
+	name = "Door Control"
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"Dg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"Dh" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"Dj" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"Dn" = (
+/obj/structure/girder/reinforced,
+/turf/open/water,
+/area/f13/caves)
+"Dq" = (
+/obj/structure/stacklifter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"DA" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/wall/f13/ruins,
+/area/f13/tunnel)
+"DB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"DD" = (
+/turf/open/water,
+/area/f13/caves)
+"DI" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"DQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/mob_spawn/human/corpse/raidermelee,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"DV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"DZ" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"Ed" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"Ee" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy{
+	faction = list("raider")
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"Em" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "Er" = (
 /obj/machinery/workbench/advanced,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"Et" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"EM" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"EO" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/water,
+/area/f13/bunker)
+"EQ" = (
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ER" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Fj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"Fo" = (
+/obj/item/paper/crumpled,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Fw" = (
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/structure/table,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"FP" = (
+/obj/item/wrench/crude,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"FT" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"FV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "Ga" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"Gi" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"Gp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"Gs" = (
+/obj/machinery/door/airlock/grunge,
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Gw" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"Gx" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"GA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"GT" = (
+/obj/item/ammo_casing/shotgun/improvised,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "GY" = (
 /mob/living/simple_animal/hostile/stalkeryoung,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"He" = (
+/mob/living/simple_animal/hostile/handy/gutsy{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Hr" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"Hw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Hz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/baseball,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"HE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/item/paper/crumpled/bloody/ruins,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"HM" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/water,
+/area/f13/caves)
+"HX" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"If" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"Ik" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper/crumpled,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Ix" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"IG" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"II" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/obj/item/clothing/suit/armor/f13/power_armor/t45d,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"IL" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/abomhorror{
+	faction = list("raider")
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
+"IR" = (
+/mob/living/simple_animal/hostile/handy/sentrybot{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"IW" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"Jc" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"Jf" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/securitron{
+	faction = list("raider")
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"Jj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/chainsaw,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"Jq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"Jx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Jz" = (
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"JA" = (
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"JI" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"JO" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	name = "Repaired Turret"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "JS" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
@@ -66,28 +1770,409 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"Ko" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"KA" = (
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"KD" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"KI" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/storage/box/strange_seeds_10pack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"KK" = (
+/obj/item/storage/trash_stack,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	name = "Repaired Turret"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"KL" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"KM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"KO" = (
+/mob/living/simple_animal/hostile/abomhorror{
+	desc = "A terrible fusion of man and something else entirely. It looks to be in great pain.";
+	faction = list("raider");
+	health = 900;
+	icon_living = "abomination";
+	icon_state = "abomination";
+	name = "Abomination";
+	speed = -1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"KP" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/water,
+/area/f13/caves)
+"KQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"KW" = (
+/obj/effect/decal/fakelattice,
+/mob/living/simple_animal/hostile/handy/gutsy{
+	faction = list("raider")
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"Lg" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/mineral/random/low_chance,
+/area/f13/tunnel)
+"Ls" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"Lx" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/radiation)
+"LB" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"LE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/item/gun/ballistic/automatic/pistol/pistol127/compact,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"LG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"LH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"LP" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"LR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"LZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Mc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/corner,
+/obj/item/paper_bin/bundlenatural,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"MC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	name = "Repaired Turret"
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"MR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/weightlifter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"MX" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/water,
+/area/f13/caves)
+"MZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"Ni" = (
+/obj/machinery/light/broken,
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "Ns" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
+"Nu" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/protectron{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"NN" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "NS" = (
-/obj/structure/timeddoor,
+/mob/living/simple_animal/hostile/raider/thief,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "OT" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"OX" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"Pp" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw/legendary,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"Pr" = (
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Ps" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"Pv" = (
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"PE" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"PF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"PI" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Qh" = (
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"Qj" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Qk" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/ash/large,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"PQ" = (
-/mob/living/simple_animal/hostile/supermutant/legendary,
-/turf/open/indestructible/ground/inside/subway,
+"QB" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"QG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/item/autosurgeon,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/item/clothing/head/helmet/f13/power_armor/t45d{
+	color = "#C1C1C1";
+	desc = "(IX) It's an old pre-War power armor helmet. It's pretty hot inside of it. Nice.";
+	item_color = "#C1C1C1"
+	},
+/obj/item/defibrillator/compact/combat/loaded,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"QK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paperplane/origami,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"QN" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"PS" = (
-/obj/structure/timeddoor,
-/turf/closed/wall/r_wall/f13/vault,
+"QO" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"QP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/item/gun/energy/laser/aer14,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "QU" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
+"QX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Re" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/tunnel)
+"Rq" = (
+/obj/machinery/gibber,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"Rx" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/machinery/pdapainter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Ry" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"RH" = (
+/obj/item/paper,
+/obj/item/paper/crumpled,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"RK" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"RR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"RU" = (
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"RZ" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"Sx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"Sy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Sz" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"SD" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"SK" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "SR" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -95,23 +2180,259 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"SW" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+"SS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"Tm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/item/toy/plush/mr_buckety,
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "Tq" = (
-/mob/living/simple_animal/hostile/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"Tt" = (
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"TO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"TY" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"TZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"Up" = (
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Uv" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/ash,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"Uz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
+/obj/item/pizzabox/meat,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"UD" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/door/poddoor/shutters{
+	id = "pain";
+	name = "door shutters"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"UM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"UO" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/one_barrel,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
+"UR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/one_barrel,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "UX" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"Yn" = (
-/mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
+"Va" = (
+/turf/open/water,
+/area/f13/tunnel)
+"Vd" = (
+/obj/item/fishingrod,
+/turf/open/water,
+/area/f13/tunnel)
+"Vp" = (
+/mob/living/simple_animal/hostile/handy/playable{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"Vw" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
+"Vx" = (
+/mob/living/simple_animal/hostile/raider/biker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"VE" = (
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/item/gun/ballistic/automatic/m1garand/oldglory,
+/obj/item/clothing/suit/armor/f13/battlecoat,
+/obj/item/ammo_box/a762box,
+/obj/item/ammo_box/a762box,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"VN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"VS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"WG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"WY" = (
+/obj/structure/nest/deathclaw{
+	desc = "A nest... full of deathclaws. Genuine pain."
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"Xa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Xf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/tunnel)
+"Xi" = (
+/mob/living/simple_animal/hostile/raider/biker,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"Xr" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"Xs" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"Xy" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"XE" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"XH" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"XJ" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"XO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"Yg" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/centaur,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"Yk" = (
+/obj/item/gun/ballistic/automatic/tribalbow{
+	desc = "A simple wooden bow with small pieces of turquiose. This one looks particularly blood-covered. Who the fuck brings a /BOW/ to a /BUNKER/"
+	},
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"Yn" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"Ys" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"YA" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"YE" = (
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
+"YG" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "YH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -119,10 +2440,67 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"ZN" = (
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
+"YP" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"YU" = (
+/obj/item/cultivator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"Za" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"Zo" = (
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ZB" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/sentrybot{
+	faction = list("raider")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ZF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"ZK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"ZN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"ZP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper_bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ZR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/radiation)
+"ZZ" = (
+/mob/living/simple_animal/hostile/handy/assaultron{
+	faction = list("raider")
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 
 (1,1,1) = {"
 QU
@@ -164,11 +2542,11 @@ BH
 "}
 (2,1,1) = {"
 QU
-kE
-kE
-kE
-kE
-BH
+Yn
+Yn
+Yn
+Yn
+Yn
 QU
 BH
 BH
@@ -202,11 +2580,11 @@ BH
 "}
 (3,1,1) = {"
 QU
-kE
-kE
-kE
-kE
-BH
+Yn
+df
+ZN
+jM
+Yn
 QU
 BH
 BH
@@ -240,11 +2618,11 @@ QU
 "}
 (4,1,1) = {"
 QU
-kE
-kE
-kE
-kE
-BH
+Yn
+wm
+ZR
+KI
+Yn
 QU
 BH
 BH
@@ -278,11 +2656,11 @@ BH
 "}
 (5,1,1) = {"
 QU
-kE
-kE
-kE
-kE
-BH
+Yn
+wm
+ZN
+Df
+Yn
 QU
 BH
 BH
@@ -316,11 +2694,11 @@ BH
 "}
 (6,1,1) = {"
 QU
-kE
-kE
+Yn
+wm
 ZN
-kE
-BH
+wm
+Yn
 QU
 BH
 BH
@@ -354,14 +2732,14 @@ BH
 "}
 (7,1,1) = {"
 QU
-kE
-kE
-kE
-kE
-BH
+Yn
+dr
+KO
+DB
+Yn
 QU
-BH
-BH
+QU
+QU
 QU
 QU
 QU
@@ -392,22 +2770,22 @@ qz
 "}
 (8,1,1) = {"
 QU
-kE
-kE
-kE
-kE
-BH
-QU
-BH
-BH
-QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+Yn
+QG
+ZN
+oq
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
 QU
 BH
 BH
@@ -430,22 +2808,22 @@ qz
 "}
 (9,1,1) = {"
 QU
-kE
-kE
-kE
-kE
-BH
-QU
-QU
-QU
-QU
-BH
-kE
-kE
-kE
-kE
-BH
-BH
+Yn
+cs
+ln
+ZN
+Yn
+jX
+yl
+yR
+bt
+pE
+Lx
+OT
+tI
+tI
+fk
+Yn
 QU
 BH
 BH
@@ -468,22 +2846,22 @@ BH
 "}
 (10,1,1) = {"
 QU
-kE
-kE
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-kE
+Yn
+nC
+ZN
+ru
+tU
+UO
+IL
+UR
+vQ
+Yn
+dL
+iK
+Ba
 OT
-BH
-BH
+ew
+Yn
 QU
 BH
 BH
@@ -506,22 +2884,22 @@ QU
 "}
 (11,1,1) = {"
 QU
-kE
-kE
-kE
+Yn
+Yn
+Yn
 qQ
-mZ
-kE
-kE
-kE
-kE
-mZ
-qQ
-kE
-kE
-kE
-BH
-BH
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+QB
+Vp
+OT
+qF
+wy
+Yn
 QU
 BH
 BH
@@ -544,22 +2922,22 @@ BH
 "}
 (12,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-mZ
-BH
-BH
-kE
-kE
-kE
-kE
-BH
-BH
+QU
+Yn
+hc
+xg
+PI
+PI
+uv
+Nu
+pC
+oF
+km
+OT
+yh
+yh
+MZ
+Yn
 QU
 BH
 BH
@@ -581,23 +2959,23 @@ BH
 BH
 "}
 (13,1,1) = {"
+BH
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-BH
-kE
-kE
-kE
-kE
-BH
-BH
+Yn
+ER
+aU
+pC
+pC
+rg
+pC
+PI
+iw
+NN
+OT
+yh
+KM
+fu
+Yn
 QU
 BH
 BH
@@ -619,23 +2997,23 @@ BH
 BH
 "}
 (14,1,1) = {"
+BH
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+Tq
+Ai
+vv
+pC
+ER
+YG
+yg
+Yn
+OT
+JI
+VS
+gS
+tx
+Yn
 QU
 BH
 BH
@@ -657,23 +3035,23 @@ BH
 BH
 "}
 (15,1,1) = {"
-QU
-QU
-QU
-QU
-QU
-QU
-QU
 BH
+QU
+nQ
+BL
 kE
-BH
-QU
-QU
-QU
-QU
-QU
-QU
-QU
+Cp
+Yn
+Yn
+Yn
+aJ
+Yn
+op
+Yn
+Yn
+aN
+aJ
+Yn
 QU
 BH
 BH
@@ -695,23 +3073,23 @@ BH
 BH
 "}
 (16,1,1) = {"
+BH
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+Ls
+he
+SK
+aJ
+vf
+yY
+vB
+DV
+Xs
+yI
+yL
+vf
+xl
+Yn
 QU
 BH
 BH
@@ -733,23 +3111,23 @@ BH
 BH
 "}
 (17,1,1) = {"
+BH
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+he
+he
+Xf
+Yn
+Yn
+Yn
+aJ
+Yn
+ve
+Yn
+Yn
+Yn
+Yn
+Yn
 QU
 BH
 BH
@@ -771,23 +3149,23 @@ BH
 BH
 "}
 (18,1,1) = {"
+BH
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+ZK
+Xf
+Va
+Yn
+fI
+HE
+RH
+Yn
+by
+Yn
+eY
+Tm
+LP
+Yn
 QU
 BH
 BH
@@ -809,23 +3187,23 @@ BH
 BH
 "}
 (19,1,1) = {"
+BH
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+Dg
+he
+Va
+Yn
+wC
+rM
+PI
+Yn
+vf
+Yn
+QX
+YU
+nd
+Yn
 QU
 BH
 BH
@@ -847,23 +3225,23 @@ BH
 BH
 "}
 (20,1,1) = {"
+BH
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+XO
+aM
 kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+Yn
+Sy
+XH
+Mc
+Yn
+dp
+Yn
+KL
+qZ
+LP
+Yn
 QU
 BH
 BH
@@ -885,23 +3263,23 @@ BH
 BH
 "}
 (21,1,1) = {"
+BH
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+mP
+Va
+Qk
+Yn
+Rx
+Fo
+pC
+Yn
+Xy
+aJ
+pC
+yg
+Hw
+Yn
 QU
 BH
 BH
@@ -923,23 +3301,23 @@ BH
 BH
 "}
 (22,1,1) = {"
+BH
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+Va
 kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+Tq
+Yn
+sh
+PI
+QK
+Yn
+jq
+Yn
+KD
+pC
+LP
+Yn
 QU
 BH
 BH
@@ -961,23 +3339,23 @@ BH
 BH
 "}
 (23,1,1) = {"
+BH
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-qQ
-qQ
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+jc
+he
+Uv
+Yn
+Jz
+ZP
+Ik
+Yn
+vI
+Yn
+gP
+PI
+yu
+Yn
 QU
 BH
 BH
@@ -999,34 +3377,34 @@ BH
 BH
 "}
 (24,1,1) = {"
-QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-mZ
-mZ
-BH
-BH
-BH
-BH
-BH
-PS
-PS
+oo
+oo
+nQ
 wI
+uL
+Cr
+Yn
+Yn
+Cc
+Yn
+Yn
+op
+Yn
+Yn
+mx
+Yn
+Yn
+DA
+Re
+Re
 wI
-wI
-wI
-wI
-wI
-wI
-wI
-wI
-wI
-wI
+Re
+Re
+Ns
+Ns
+Ns
+Ns
+Ns
 Ns
 Ns
 Ns
@@ -1037,27 +3415,27 @@ Ns
 Ns
 "}
 (25,1,1) = {"
-QU
+oo
+BH
 BH
 kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
+wI
+Cr
+FV
+vj
 Tq
+Sx
+yP
+Tq
+Tq
+Xi
+kE
+wI
+wI
+Lg
 kE
 kE
 kE
-mZ
-NS
-kE
-kE
-kE
-SR
 kE
 kE
 kE
@@ -1075,28 +3453,28 @@ kE
 SR
 "}
 (26,1,1) = {"
-QU
+oo
 BH
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-PQ
+BH
+wI
+Cr
+Em
+Ps
+UM
 Tq
+Tq
+Tq
+Gx
+vv
+UM
+wI
+cR
 kE
-kE
-kE
-kE
-kE
-NS
-kE
-kE
-kE
-kE
-kE
+Ys
+zX
+wI
+wI
+wI
 kE
 Kb
 kE
@@ -1113,30 +3491,30 @@ kE
 kE
 "}
 (27,1,1) = {"
-QU
+oo
 BH
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
+BH
+MC
+Vx
 Tq
-kE
-kE
-mZ
+Sx
+Sx
+Sx
+ns
+Jc
+YE
+Tq
+PE
+bG
+rj
 NS
+Lg
 kE
 kE
-kE
-kE
-kE
-kE
-kE
+wI
+wI
+wI
+wI
 kE
 kE
 kE
@@ -1153,32 +3531,32 @@ Kb
 (28,1,1) = {"
 QU
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-mZ
-mZ
-kE
-BH
-BH
-BH
-BH
-PS
-PS
+nQ
+Fw
+UM
+Sx
+Yn
+Yn
+Yn
+uz
+Yn
+Yn
+Yn
+st
+Yn
+Yn
+Pv
+Lg
 wI
+Re
 wI
+Re
+Re
 wI
-wI
-wI
-wI
-wI
-wI
-wI
-wI
-wI
+Re
+Re
+Re
+Ns
 Ns
 Ns
 Ns
@@ -1191,21 +3569,21 @@ Ns
 (29,1,1) = {"
 QU
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-qQ
-qQ
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+FP
+Sx
+Tq
+Yn
+xJ
+MR
+pC
+MR
+sI
+Yn
+fs
+TO
+vf
+Yn
 QU
 BH
 BH
@@ -1229,21 +3607,21 @@ BH
 (30,1,1) = {"
 QU
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+vb
+Sx
+Tq
+Yn
+hc
+XE
+vS
+xJ
+sT
+Yn
+Yn
+Yn
+fD
+Yn
 QU
 BH
 BH
@@ -1266,22 +3644,22 @@ BH
 "}
 (31,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+nQ
+Tq
+If
+RZ
+Yn
+ee
+pC
+CN
+aK
+ee
+Yn
+dP
+Ix
+cb
+Yn
 QU
 BH
 BH
@@ -1304,22 +3682,22 @@ BH
 "}
 (32,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+ld
+Sx
+Fj
+Tq
+Yn
+yq
+Dq
+PI
+lo
+PI
+Yn
+po
+Yn
+LR
+Yn
 QU
 BH
 BH
@@ -1342,22 +3720,22 @@ BH
 "}
 (33,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+db
+Sx
+cW
+Tq
+Yn
+Yn
+Yn
+Yn
+Yn
+aJ
+Yn
+vm
+Gw
+vf
+Yn
 QU
 QU
 QU
@@ -1380,228 +3758,228 @@ BH
 "}
 (34,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+Ps
+Sx
+vv
+Ry
+Yn
+TY
+ta
+PI
+aJ
+dp
+Yn
+Yn
+Yn
+RR
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
 QU
 BH
 BH
 "}
 (35,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+pv
 kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+mP
+kE
+uz
+PI
+bE
+Cx
+Yn
+vB
+DV
+XJ
+ts
+kO
+bl
+uw
+aJ
+vc
+ki
+Za
+ki
+ki
+Rq
+Yn
+by
+Yn
+pe
+LB
+qt
+IG
+Yn
 QU
 BH
 BH
 "}
 (36,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+QU
+nQ
+Va
+UM
 kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-mZ
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+vk
+Yn
+Yn
+Yn
+mt
+GT
+lw
+jj
+iT
+SS
+op
+Af
+op
+pC
+mQ
+aX
+qN
+Yn
 QU
 BH
 BH
 "}
 (37,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-kE
-mZ
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-BH
 QU
+Vd
+Va
+kE
+Tq
+pC
+EQ
+PI
+LZ
+pC
+DI
+PI
+Yn
+zz
+ee
+Et
+gM
+Yn
+wD
+yd
+sH
+xv
+Jj
+eU
+Yn
+dp
+Yn
+aU
+pC
+vh
+nc
+Yn
 QU
 BH
 BH
 "}
 (38,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-kE
-BH
-BH
+QU
+QU
+he
+he
+vv
+PI
+pC
+BW
+Et
+ee
+lZ
+Xa
+Gs
+PI
+pC
+kj
+kj
+tN
+Jq
+AC
+BI
+gI
+TZ
+Yg
+Yn
+ZZ
+Yn
+Qj
+aK
+LH
+qN
+Yn
 QU
 BH
 BH
 "}
 (39,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
 QU
-QU
-QU
-QU
-QU
-QU
-QU
-QU
-QU
-QU
-QU
-QU
-QU
-BH
-BH
-kE
-BH
-QU
-BH
-kE
-mZ
-kE
-kE
+nQ
+II
+he
+Ko
+fV
+PI
+pC
+PI
+PI
+pC
+jZ
+Yn
+Qj
+yu
+pC
+qL
+Yn
+sH
+ki
+DQ
+vR
+fg
+FT
+Yn
+yI
+Yn
+tG
+IG
+RU
+Ni
+Yn
 QU
 BH
 BH
@@ -1609,37 +3987,37 @@ BH
 (40,1,1) = {"
 QU
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-QU
-BH
-BH
-kE
-BH
-QU
-BH
-kE
-kE
-mZ
-kE
+nQ
+nq
+Sx
+Tq
+JA
+if
+Up
+Zo
+AB
+Zo
+Yn
+Yn
+Yn
+zH
+dp
+Yn
+Yn
+JO
+sH
+Dj
+ki
+eF
+Uz
+Yn
+pJ
+Yn
+gB
+Ce
+RU
+wG
+Yn
 QU
 BH
 BH
@@ -1647,37 +4025,37 @@ BH
 (41,1,1) = {"
 QU
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-kE
-kE
-kE
-kE
-mZ
+nQ
+oJ
+Fj
+Sx
+Tt
+KK
+sK
+PI
+zz
+dT
+zH
+qH
+VN
+Xy
+vf
+CF
 Yn
-SW
-kE
-BH
-QU
-BH
-BH
-kE
-BH
-QU
-BH
-kE
-kE
-kE
-kE
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+cI
+Yn
+rb
+He
+qG
+Gi
+Yn
 QU
 BH
 BH
@@ -1685,37 +4063,37 @@ BH
 (42,1,1) = {"
 QU
 BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
 kE
-kE
-kE
-kE
-mZ
-kE
-kE
-kE
-kE
-mZ
-kE
-kE
-kE
-BH
-QU
-BH
-BH
-kE
-BH
-QU
-BH
-kE
-cA
-kE
-kE
+vv
+QN
+Tt
+xJ
+pC
+EM
+PI
+pC
+dp
+vB
+Hz
+zo
+jr
+RK
+Sz
+cT
+vf
+cY
+hy
+KW
+aC
+DZ
+np
+aJ
+tt
+YG
+Gi
+GA
+Yn
 QU
 BH
 BH
@@ -1723,37 +4101,37 @@ BH
 (43,1,1) = {"
 QU
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+nQ
+wI
 kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-BH
-QU
-BH
-BH
-kE
-BH
-QU
-BH
-kE
-kE
-kE
-kE
+Sx
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+zF
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+UD
+Yn
+Yn
+Yn
+aD
+Yn
+Yn
 QU
 BH
 BH
@@ -1762,36 +4140,36 @@ BH
 QU
 BH
 BH
+wI
+cZ
+vv
+QO
+Tq
+Tq
+uX
+Sx
+Ko
+ik
+PI
+zD
+LZ
+dc
+YP
+Pr
+PI
+He
+sF
+LZ
+uO
+pC
+ka
+YP
+Qh
 BH
 BH
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-kE
-kE
-kE
-kE
-mZ
-Yn
-BH
+in
 QU
-BH
-BH
-kE
-BH
-QU
-BH
-BH
-BH
-BH
-BH
 QU
 BH
 BH
@@ -1800,36 +4178,36 @@ BH
 QU
 BH
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+wI
+wI
+zX
 kE
-kE
-kE
-kE
-kE
-kE
-kE
-mZ
+Tq
+cW
+Gp
+Gx
+Tq
+oO
+yg
+pC
+pC
+ZB
+pC
+ck
+dc
+Pr
+PI
+IR
+PI
+PI
+KA
+EO
+vN
 BH
-QU
 BH
 BH
-kE
-BH
-QU
-QU
-QU
-QU
-QU
-QU
+HM
+lP
 QU
 BH
 BH
@@ -1838,36 +4216,36 @@ BH
 QU
 BH
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-BH
+wI
+yk
+fG
+ld
+Sx
+QN
+Sx
+Tq
+If
+ik
+YP
+LG
+Jx
+pC
+ny
+dk
+Vw
+pC
+ka
+YG
+PI
+Ch
+ck
+Ee
+Pv
 QU
 BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+jl
+DD
+QU
 QU
 BH
 BH
@@ -1876,36 +4254,36 @@ BH
 QU
 BH
 BH
+Yn
+Dh
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+jB
+xw
+ag
+ck
+ag
+jv
+jB
+Yn
+Yn
+Yn
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-BH
+Yn
+Yn
 QU
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+Dn
+MX
+DD
+nQ
 QU
 BH
 BH
@@ -1914,36 +4292,36 @@ BH
 QU
 BH
 BH
+Pv
+Qh
+ck
+HX
+eu
+dx
 BH
 BH
 BH
 BH
+WG
+Ed
+ck
+Jf
+yW
+WG
+ck
+en
+Ee
+vw
+KQ
 BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
 BH
 QU
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+QU
+QU
+OX
+DD
+DD
+nQ
 QU
 BH
 BH
@@ -1951,6 +4329,13 @@ BH
 (49,1,1) = {"
 QU
 BH
+Vw
+Jf
+vw
+dx
+Jf
+vw
+vw
 BH
 BH
 BH
@@ -1958,30 +4343,23 @@ BH
 BH
 BH
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-mZ
-BH
-BH
-BH
-BH
+SD
+aI
+ck
+en
+WG
+ck
+Vw
 BH
 BH
 QU
+QU
 BH
 BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+sR
+DD
+lP
+nQ
 QU
 BH
 BH
@@ -1989,37 +4367,37 @@ BH
 (50,1,1) = {"
 QU
 BH
+ck
+Ch
+ck
+ck
+ck
+vu
 BH
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-QU
-QU
 QU
 QU
 QU
 QU
 BH
 BH
-kE
 BH
 BH
 BH
 BH
 BH
 BH
+LE
 BH
+BH
+QU
+BH
+BH
+BH
+BH
+DD
+zi
+QU
 QU
 BH
 BH
@@ -2029,35 +4407,35 @@ QU
 BH
 BH
 BH
+ck
+ck
+BH
+BH
+BH
+QU
 BH
 BH
 BH
 BH
+QU
+QU
+BH
+BH
+QU
+QU
+QU
 BH
 BH
 BH
+QU
+QU
+QU
+sR
 BH
 BH
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+lP
+sR
+QU
 QU
 BH
 BH
@@ -2065,35 +4443,35 @@ BH
 (52,1,1) = {"
 QU
 BH
+QU
+BH
+BH
+IW
+BH
+BH
+QU
+BH
+BH
+Xr
+sR
 BH
 BH
 BH
+QU
+QU
 BH
 BH
 BH
+QU
+QU
+QU
+QU
 BH
 BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-kE
-BH
-BH
-BH
-BH
-BH
+cA
+DD
+DD
+DD
 BH
 BH
 QU
@@ -2102,6 +4480,20 @@ BH
 "}
 (53,1,1) = {"
 QU
+QU
+BH
+QU
+BH
+BH
+BH
+BH
+QU
+BH
+sR
+cA
+lP
+DD
+sR
 BH
 BH
 BH
@@ -2113,26 +4505,12 @@ BH
 BH
 BH
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
+sR
+cA
+KP
+lP
+DD
+sR
 BH
 QU
 BH
@@ -2143,35 +4521,35 @@ QU
 BH
 BH
 BH
+QU
+BH
+BH
+QU
+BH
+BH
+cA
+lP
+DD
+DD
+lP
+Hr
+DD
+lP
+cA
+cA
+sR
 BH
 BH
 BH
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-kE
-kE
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+sR
+sR
+DD
+DD
+cA
+yp
+cA
+sR
 QU
 BH
 BH
@@ -2179,36 +4557,36 @@ BH
 (55,1,1) = {"
 QU
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+mC
 BH
 BH
 QU
-BH
-BH
-kE
-BH
-QU
-QU
-QU
 QU
 BH
+BH
+cA
+sR
+sR
+sR
+sR
+lP
+DD
+DD
+DD
+DD
+DD
+sR
+sR
+sR
+BH
+sR
+lP
+lP
+DD
+cA
+YA
+lh
+ZF
 BH
 QU
 BH
@@ -2217,36 +4595,36 @@ BH
 (56,1,1) = {"
 QU
 BH
+QP
+ga
 BH
 BH
 BH
 BH
+sR
+cA
 BH
 BH
 BH
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-QU
-BH
-BH
-mZ
-BH
-BH
-BH
-BH
-QU
-BH
+cA
+sR
+DD
+lP
+lP
+DD
+DD
+DD
+cA
+sR
+lP
+je
+sR
+sR
+yp
+oV
+wv
+vi
 BH
 QU
 BH
@@ -2256,35 +4634,35 @@ BH
 QU
 BH
 BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-QU
-BH
-kE
+ov
+Pp
 cA
-kE
-kE
-kE
+cA
+cA
+uJ
+BH
 BH
 QU
+QU
 BH
+BH
+sR
+WY
+cA
+cA
+sR
+DD
+DD
+lP
+DD
+DD
+cA
+cA
+BH
+cA
+ZF
+cA
+sR
 BH
 QU
 BH
@@ -2292,58 +4670,46 @@ BH
 "}
 (58,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-QU
-BH
-kE
-ZN
-kE
-kE
-kE
-BH
 QU
 BH
 BH
+Hr
+sR
+Yk
+PF
+BH
+BH
+QU
+QU
+Hr
+cA
+cA
+sR
+BH
+BH
+BH
+sR
+sR
+DD
+cA
+sR
+sR
+sR
+BH
+BH
+sR
+BH
+sR
+QU
+QU
 QU
 BH
 BH
 "}
 (59,1,1) = {"
 QU
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
-BH
+QU
+QU
 BH
 BH
 BH
@@ -2352,14 +4718,26 @@ BH
 BH
 BH
 QU
+QU
 BH
-kE
-kE
-kE
-kE
-kE
+VE
+BH
 BH
 QU
+BH
+BH
+BH
+sR
+sR
+cA
+BH
+BH
+BH
+QU
+QU
+BH
+BH
+BH
 BH
 BH
 QU


### PR DESCRIPTION
### **NSB 2: ELECTRIC BOOGALOO**

Reworks the second version of the North Sewer Bunker's RNG options from the random mutie cave to a new raider/robot bunker (with complimentary super painful clawcave at the end). Made in a VC with others, so it should be all cool and good.

### More Exact Changes:
- Adds a ton of robots, raiders and claws alongside a claw nest for very nice loot such as a suit of T-45d (with the Helmet somewhere else in the bunker ;))
- Adds the three unique weapons for the bunker's loot alongside a battlecoat, combat defib, autosurgeon and other spawns.
- Adds decoration and depth to the bunker, albeit basic, to make it not el-generico cave.
![image](https://user-images.githubusercontent.com/76075239/112768921-51bdb700-9016-11eb-917e-d6c78f658253.png)