### PR TITLE
Emergency Hotfix

### DIFF
--- a/_maps/map_files/templates/dungeons/north_sewer_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_sewer_2.dmm
@@ -1682,11 +1682,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"II" = (
-/mob/living/simple_animal/hostile/raider/ranged,
-/obj/item/clothing/suit/armor/f13/power_armor/t45d,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "IL" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/abomhorror{
@@ -2377,7 +2372,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "XH" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "XJ" = (
@@ -3950,7 +3945,7 @@ BH
 QU
 QU
 nQ
-II
+QO
 he
 Ko
 fV


### PR DESCRIPTION
Removes something which shouldn't exist at all in the North Sewer Bunker #2 - namely, an accidentally placed T-45d body nowhere near where it's meant to be.

Changes:
- Removes accidental T-45d placement, now it's only where intended