### PR TITLE
Black Market Hotfix 2

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -4578,7 +4578,7 @@
 	},
 /area/f13/building)
 "dtJ" = (
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "badboys";
 	name = "Outlaw City"
 	},
@@ -32312,7 +32312,7 @@
 /area/f13/city)
 "xqk" = (
 /obj/structure/barricade/wooden,
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "badboys";
 	name = "Outlaw City"
 	},
@@ -32437,7 +32437,7 @@
 	icon_state = "gib6-old";
 	pixel_y = 11
 	},
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "badboys";
 	name = "Outlaw City"
 	},
@@ -33614,6 +33614,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/random,
 /obj/item/restraints/handcuffs/fake/kinky,
+/obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ykq" = (
@@ -82631,7 +82632,7 @@ ugm
 uTq
 csO
 rpu
-qkP
+qsB
 sYX
 sKH
 sYX


### PR DESCRIPTION
Makes it so the outlaw city shutters start open, as to let outlaws that spawn outside of the city have a chance to enter

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See above
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So outlaws can actually use the place, regardless if they spawn inside the city or not
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a couple more outlaw spawn points in the outlaw city
tweak: Outlaw city shutters start open now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
