### PR TITLE
Adds more dense rock to the BoS surface camp.

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -62757,16 +62757,16 @@ gcK
 gbL
 gcK
 gcK
-gcK
 ktB
 ktB
 ktB
 ktB
+ktB
 gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -64053,7 +64053,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -65082,7 +65082,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -66110,7 +66110,7 @@ qPL
 hlM
 iFI
 gcK
-gcK
+ktB
 gbL
 gcK
 gbL
@@ -66367,7 +66367,7 @@ qPL
 khn
 iFI
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -78940,11 +78940,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
 ktB
 ktB
-gcK
-gcK
+ktB
+ktB
+ktB
 ktB
 gcK
 gcK
@@ -79203,7 +79203,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -79474,8 +79474,8 @@ ktB
 ktB
 ktB
 ktB
-gcK
-gcK
+ktB
+ktB
 ktB
 ktB
 gcK
@@ -79707,7 +79707,7 @@ ktB
 "}
 (180,1,1) = {"
 ktB
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -79726,8 +79726,7 @@ ktB
 ktB
 ktB
 ktB
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -79737,7 +79736,8 @@ gcK
 gcK
 gcK
 ktB
-gbL
+ktB
+ktB
 gbL
 gcK
 gcK
@@ -79998,7 +79998,7 @@ gbL
 ktB
 ktB
 ktB
-gcK
+ktB
 ktB
 ktB
 ktB


### PR DESCRIPTION
### Changes
- Added more dense rock around the Brotherhood area, leaving 5 points of entry.

### Reasoning
- Old outlaw cave got moved to where the Khans used to be, made it way too easy to just mine straight into the camp.

### Pictures
https://gyazo.com/dcdaea3e5aac44c86cc4eb8e67339f44