### PR TITLE
R&D Fixes + Others

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -8948,6 +8948,10 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gLx" = (
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "gLH" = (
 /obj/structure/table,
 /obj/item/roller,
@@ -14083,6 +14087,7 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "barshutters"
 	},
+/obj/structure/table/wood/settler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
 "kmv" = (
@@ -25965,6 +25970,7 @@
 "tit" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "tiu" = (
@@ -29739,12 +29745,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "vNH" = (
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/obj/effect/decal/cleanable/generic,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "vOq" = (
 /obj/structure/fence/corner{
 	dir = 4
@@ -30151,12 +30155,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wgO" = (
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "whm" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -31371,12 +31373,6 @@
 "xaG" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"xaI" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerturn"
-	},
-/area/f13/wasteland)
 "xbv" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -35127,7 +35123,7 @@ wVT
 wVT
 wVT
 wVT
-wVT
+wWI
 xEc
 xEc
 xEc
@@ -35381,15 +35377,15 @@ wVT
 wVT
 fju
 wWI
-gTR
-gTR
-gTR
-eEM
+wVT
+wVT
+wVT
+wVT
 wVT
 siE
-vNH
+siS
 siE
-nGs
+wVT
 siE
 xEc
 unI
@@ -35895,10 +35891,10 @@ wVT
 wVT
 fju
 uru
-wVT
-wVT
-wVT
-wVT
+gTR
+gTR
+gTR
+eEM
 wVT
 wVT
 wVT
@@ -36409,15 +36405,15 @@ wVT
 wVT
 fju
 siE
-nGs
+wVT
 tXt
-nGs
+wVT
 siE
-wWI
+wVT
 siE
-wgO
+fIF
 siE
-nGs
+wVT
 siE
 xEc
 unI
@@ -39260,9 +39256,9 @@ sTa
 etV
 ybI
 ybI
-dkP
-hQr
-erY
+cpK
+unI
+hbW
 wGJ
 apk
 wwM
@@ -39517,9 +39513,9 @@ aJb
 tUb
 idu
 hOl
-wGJ
-wGJ
-erY
+cpK
+unI
+hbW
 erY
 ubg
 koD
@@ -39774,9 +39770,9 @@ sgz
 sgz
 kjQ
 ehN
-wGJ
-wGJ
-wGJ
+cpK
+unI
+hbW
 wGJ
 snB
 koD
@@ -40031,9 +40027,9 @@ dmL
 fvz
 kaM
 kaM
-wGJ
-wGJ
-wGJ
+cpK
+unI
+hbW
 wGJ
 snB
 koD
@@ -40288,9 +40284,9 @@ gQv
 jgx
 fsm
 fsm
-fsm
-xaI
-erY
+cpK
+unI
+hbW
 cdc
 snB
 sBk
@@ -44540,7 +44536,7 @@ hZo
 cGw
 tit
 eUp
-cGw
+wgO
 hHz
 bKE
 sfB
@@ -45822,13 +45818,13 @@ brH
 brH
 sfB
 pGa
-ruN
+vNH
+wgO
 cGw
 cGw
 cGw
-cGw
-cGw
-hHz
+wgO
+gLx
 vYE
 cpK
 nyZ
@@ -46199,7 +46195,7 @@ fyf
 fyf
 fyf
 kGc
-uCW
+cpK
 unI
 hbW
 mmK
@@ -46456,7 +46452,7 @@ fyf
 fyf
 fyf
 kGc
-uCW
+cpK
 pBv
 box
 erY
@@ -46713,7 +46709,7 @@ fyf
 fyf
 fyf
 kGc
-uCW
+cpK
 ajD
 lSD
 erY
@@ -46970,8 +46966,8 @@ fyf
 fyf
 fyf
 kGc
-cpK
-pBv
+sJw
+onk
 hbW
 erY
 erY
@@ -47227,9 +47223,9 @@ fyf
 fyf
 fyf
 kGc
-cpK
-ajD
-hbW
+idu
+idu
+ehN
 dFQ
 gmX
 geM
@@ -47484,9 +47480,9 @@ fyf
 fyf
 fyf
 kGc
-cpK
-ofX
-hbW
+hOl
+ehN
+ehN
 cdc
 dFQ
 koD
@@ -47741,9 +47737,9 @@ fyf
 fyf
 fyf
 kGc
-cpK
-ajD
-hbW
+kaM
+kaM
+ehN
 cdc
 snB
 koD
@@ -47998,8 +47994,8 @@ fyf
 fyf
 fyf
 kGc
-uCW
-unI
+fsm
+muk
 dXy
 cdc
 vnc
@@ -52876,7 +52872,7 @@ gcK
 usx
 aSo
 grf
-iOg
+gsj
 dbz
 usx
 uCW
@@ -53133,7 +53129,7 @@ ktB
 usx
 iOg
 eHk
-iOg
+gsj
 tpM
 usx
 uCW
@@ -55189,7 +55185,7 @@ dhC
 ljG
 iOg
 grf
-iOg
+gsj
 dbz
 usx
 uaf
@@ -55446,7 +55442,7 @@ usx
 usx
 iOg
 iau
-iOg
+gsj
 wGc
 usx
 uaf
@@ -55703,7 +55699,7 @@ fyf
 usx
 aSo
 eHk
-iOg
+gsj
 tpM
 usx
 uaf

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -842,10 +842,6 @@
 	pixel_y = 8;
 	termtag = "Business"
 	},
-/obj/item/pen{
-	pixel_x = -16;
-	pixel_y = 6
-	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood)
 "aWx" = (
@@ -862,16 +858,6 @@
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"aWM" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "aXW" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
@@ -1505,7 +1491,22 @@
 	},
 /area/f13/brotherhood)
 "bvP" = (
-/obj/structure/filingcabinet/employment,
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -1689,58 +1690,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"bED" = (
-/obj/structure/rack,
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 11
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -6;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -2;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = 2;
-	pixel_y = -10
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 13;
-	pixel_y = -8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "bFa" = (
 /obj/machinery/light/sign{
 	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
@@ -1884,7 +1833,7 @@
 	pixel_y = -12
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/stairs,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "bKX" = (
 /obj/structure/curtain{
@@ -2030,8 +1979,14 @@
 /turf/open/water,
 /area/f13/tunnel)
 "bUn" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "bUR" = (
 /obj/structure/decoration/vent,
@@ -2304,9 +2259,6 @@
 	},
 /obj/item/paper_bin{
 	pixel_y = 6
-	},
-/obj/item/pen{
-	pixel_y = 7
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
@@ -2730,8 +2682,8 @@
 /area/f13/brotherhood)
 "cLp" = (
 /obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
+	input_dir = 8;
+	output_dir = 4
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -3632,23 +3584,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLF" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
+	icon_state = "generator_on";
+	name = "superheating forge"
 	},
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_red,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -3934,13 +3874,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dUW" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/crafting/wonderglue,
-/obj/item/crafting/wonderglue,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "dVs" = (
@@ -4225,11 +4163,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "ejQ" = (
+/obj/machinery/light/small,
+/obj/machinery/autolathe,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -4306,7 +4242,6 @@
 "eoA" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/crafting/timer,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "eoC" = (
@@ -4388,10 +4323,10 @@
 	},
 /area/f13/tunnel)
 "erF" = (
-/obj/item/toy/plush/nukeplushie{
-	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
-	name = "Knight-Captain Aryom";
-	pixel_x = 9
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bossecgear";
+	name = "Internal Security Gear";
+	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -4912,13 +4847,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood)
-"eRO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "eSC" = (
 /obj/structure/window/fulltile/store,
 /turf/open/floor/wood,
@@ -5036,11 +4964,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
-"fah" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
 "faR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/radiation{
@@ -5082,11 +5005,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood)
-"fcJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "fdN" = (
 /obj/structure/frame/machine,
@@ -5342,8 +5260,6 @@
 /obj/structure/janitorialcart,
 /obj/item/mop,
 /obj/structure/sink/kitchen{
-	desc = "Strictly for filling up mop buckets.";
-	name = "Mop Sink";
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -6010,10 +5926,6 @@
 	pixel_y = 5
 	},
 /obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/item/pen/fountain{
-	pixel_x = 15;
-	pixel_y = 5
-	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "fYq" = (
@@ -6259,19 +6171,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
-"gmk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "gmv" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -6400,11 +6299,15 @@
 	},
 /area/f13/followers)
 "gvt" = (
-/obj/structure/closet/crate/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/crafting/lunchbox,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
@@ -6450,16 +6353,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood)
-"gxP" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
-	},
-/obj/item/pen/fountain/captain{
-	name = "elder's fountain pen"
-	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "gyf" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -6632,31 +6525,6 @@
 	},
 /turf/closed/wall,
 /area/f13/tcoms)
-"gIK" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "gJa" = (
 /obj/effect/mine/stun,
 /turf/open/floor/f13{
@@ -6785,13 +6653,6 @@
 /obj/structure/mirror,
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
-"gRE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "gRQ" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/inside/subway,
@@ -7272,9 +7133,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "hpT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/machinery/light/small{
+/obj/item/crafting/transistor,
+/obj/item/crafting/abraxo,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -7765,12 +7628,7 @@
 	},
 /area/f13/clinic)
 "hPn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/figure/warden{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Knight Action Figure";
-	toysay = "Steel be with you."
-	},
+/obj/structure/falsewall/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "hPD" = (
@@ -7898,8 +7756,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "hXn" = (
+/obj/structure/wreck/trash/secway,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hYh" = (
@@ -8402,16 +8260,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"itY" = (
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "iue" = (
 /obj/machinery/light/fo13colored/Red,
 /turf/open/floor/plating/tunnel,
@@ -8456,13 +8304,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"iwr" = (
-/obj/machinery/workbench/advanced,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "iwu" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -8578,6 +8419,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"iBF" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/grille,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "iBR" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/washing_machine,
@@ -9039,16 +8889,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "iZB" = (
+/obj/machinery/workbench/advanced,
 /obj/machinery/camera/autoname{
-	dir = 8;
+	dir = 1;
 	name = "Armory Camera";
 	network = list("BoS");
 	pixel_x = -1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -10037,9 +9884,7 @@
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
 /obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/pda/heads/hos{
-	name = "Head Knight's PDA"
-	},
+/obj/item/pda/heads/hos,
 /obj/item/storage/briefcase,
 /obj/item/clothing/suit/armor/vest/capcarapace/syndicate{
 	desc = "A sinister looking vest of advanced armor worn over a black and red fireproof jacket. The gold collar and shoulders denote that this belongs to a high ranking officer of some lost prewar army.";
@@ -10971,9 +10816,14 @@
 /turf/open/water,
 /area/f13/brotherhood)
 "kXI" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "kYh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11054,11 +10904,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"ldo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood)
 "ldA" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -11237,27 +11082,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"ljP" = (
-/obj/structure/rack,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/book/granter/trait/pa_wear,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9;
-	icon_state = "warningline_red"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "ljY" = (
 /obj/structure/handrail/g_end{
 	pixel_x = 12;
@@ -12497,9 +12321,7 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "mDt" = (
-/obj/machinery/autolathe/ammo,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/effect/turf_decal/stripes/box,
+/obj/structure/rack,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -12823,15 +12645,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood)
-"mTL" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "mUb" = (
@@ -13305,18 +13118,7 @@
 	},
 /obj/item/clothing/accessory/bos/elder,
 /obj/item/clothing/suit/f13/elder,
-/obj/item/pda/heads/hop{
-	name = "Elder's PDA"
-	},
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood)
-"ntz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
-	icon_state = "warningline_red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "nue" = (
 /obj/structure/simple_door/metal/barred,
@@ -13937,6 +13739,12 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
+"ocY" = (
+/obj/structure/rack,
+/obj/item/crafting/timer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "odj" = (
 /obj/structure/ore_box,
 /turf/open/floor/f13/wood,
@@ -14009,20 +13817,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ofY" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "ogl" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -14143,11 +13937,6 @@
 /obj/item/book/manual/wiki/circuitry,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"omB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood)
 "omE" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13{
@@ -14672,9 +14461,12 @@
 	},
 /area/f13/tunnel)
 "oTZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/secway,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "oUK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14849,9 +14641,7 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /obj/structure/sink/kitchen{
-	desc = "Strictly For filling Up mop buckets.";
 	dir = 8;
-	name = "Mop Sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -14991,11 +14781,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"pkR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "pkW" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -15278,11 +15063,31 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "pyn" = (
-/obj/structure/rack,
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/crafting/abraxo,
-/obj/item/crafting/transistor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "pzu" = (
 /turf/open/floor/f13{
@@ -15415,6 +15220,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "pGd" = (
+/obj/item/candle/infinite{
+	lit = 1;
+	pixel_x = 7;
+	pixel_y = 10
+	},
 /obj/item/card/id/dogtag{
 	desc = "Never thirsty is the grave of the fallen Brother, for their kin floods the ground with the blood of the blind.";
 	name = "The Fallen Brother's Holotags";
@@ -15425,10 +15235,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/fancy/blackred,
-/obj/item/candle{
-	pixel_x = 7;
-	pixel_y = 13
-	},
 /turf/open/floor/clockwork/reebe{
 	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
 	name = "cool metal floor"
@@ -15538,10 +15344,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "pQz" = (
-/obj/structure/closet/crate/large,
-/obj/item/crafting/turpentine,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/rack,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "pQF" = (
 /obj/machinery/light/small{
@@ -15575,6 +15392,11 @@
 /obj/effect/decal/cleanable/shreds{
 	pixel_x = -6;
 	pixel_y = -12
+	},
+/obj/item/toy/figure/warden{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	name = "Knight Action Figure";
+	toysay = "Steel be with you."
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
@@ -15920,20 +15742,8 @@
 /area/f13/brotherhood)
 "qmL" = (
 /obj/structure/rack,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
-	icon_state = "warningline_red"
-	},
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -16695,6 +16505,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qWq" = (
+/obj/item/candle/infinite{
+	lit = 1;
+	pixel_x = -7;
+	pixel_y = 10
+	},
 /obj/item/reagent_containers/food/snacks/grown/poppy{
 	pixel_x = 4;
 	pixel_y = 2
@@ -16707,10 +16522,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/fancy/blackred,
-/obj/item/candle{
-	pixel_x = -6;
-	pixel_y = 13
-	},
 /turf/open/floor/clockwork/reebe{
 	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
 	name = "cool metal floor"
@@ -16916,15 +16727,6 @@
 	density = 1
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
-"rfG" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
 /area/f13/brotherhood)
 "rfH" = (
 /obj/structure/rack,
@@ -17816,10 +17618,6 @@
 /obj/item/clothing/mask/gas/explorer{
 	pixel_y = 11
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -18296,17 +18094,9 @@
 	},
 /area/f13/brotherhood)
 "sql" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/bomb_suit/security,
-/obj/item/clothing/head/bomb_hood/security,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10;
-	icon_state = "warningline_red"
-	},
+/obj/structure/wreck/trash/machinepile,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "sqr" = (
 /obj/effect/decal/cleanable/blood/innards,
@@ -18382,11 +18172,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "sxs" = (
+/obj/structure/rack,
+/obj/item/twohanded/sledgehammer/supersledge,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -18482,12 +18277,11 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "sFl" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bossecgear";
-	name = "Internal Security Gear";
-	req_access_txt = "120"
+/obj/item/toy/plush/nukeplushie{
+	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
+	name = "Knight-Captain Aryom";
+	pixel_x = 9
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -18634,9 +18428,23 @@
 	},
 /area/f13/bunker)
 "sME" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -20145,6 +19953,9 @@
 /area/f13/brotherhood)
 "tZc" = (
 /obj/structure/rack,
+/obj/item/crafting/turpentine,
+/obj/item/crafting/wonderglue,
+/obj/item/crafting/wonderglue,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
@@ -20176,11 +19987,8 @@
 	},
 /area/f13/tunnel)
 "tZQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -20228,7 +20036,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/bucket,
-/obj/item/storage/bag/trash,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -20517,17 +20324,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
-"uoC" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "uoI" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood,
@@ -20632,9 +20428,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "utP" = (
+/obj/structure/closet/crate/large,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "uub" = (
@@ -20648,31 +20443,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
-"uuj" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "uuo" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/ammo,
@@ -21111,13 +20881,9 @@
 	},
 /area/f13/tunnel)
 "uMR" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
+/obj/structure/rack,
+/obj/item/shield/riot/bullet_proof,
+/obj/item/shield/riot/bullet_proof,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -21324,13 +21090,10 @@
 /area/f13/tunnel)
 "uZG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/structure/simple_door/bunker{
+	name = "Locker Room"
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "uZS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21478,16 +21241,6 @@
 "vfU" = (
 /obj/structure/sign/poster/prewar/poster71,
 /turf/closed/wall/r_wall,
-/area/f13/brotherhood)
-"vgn" = (
-/obj/structure/rack,
-/obj/item/pda/warden{
-	desc = "The RobCo PipBoy. This one is only issued to the acting Armory Warden.";
-	name = "Armory Warden PDA"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
 /area/f13/brotherhood)
 "vgo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22205,9 +21958,6 @@
 /obj/item/paper_bin{
 	pixel_y = 6
 	},
-/obj/item/pen{
-	pixel_y = 7
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -22558,6 +22308,7 @@
 /obj/structure/closet/secure_closet/contraband/armory{
 	req_access_txt = "120"
 	},
+/obj/item/pda/warden,
 /obj/item/clothing/head/helmet/f13/power_armor/t45d,
 /obj/item/clothing/suit/armor/f13/power_armor/t45d/knightcaptain,
 /turf/open/floor/wood/f13/stage_t,
@@ -22637,23 +22388,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"wio" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/twohanded/sledgehammer/supersledge,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "wiz" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/heat,
@@ -22731,15 +22465,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"wni" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "wnM" = (
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
@@ -23172,20 +22897,6 @@
 	},
 /turf/open/water,
 /area/f13/brotherhood)
-"wOD" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood)
 "wPP" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -23203,15 +22914,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wQy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "wQB" = (
 /obj/structure/chair{
 	dir = 4
@@ -23740,7 +23442,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "xpo" = (
-/obj/structure/closet/crate/large,
+/obj/machinery/autolathe/ammo,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xqa" = (
@@ -23784,14 +23487,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"xug" = (
-/obj/structure/rack,
-/obj/item/shield/riot/bullet_proof,
-/obj/item/shield/riot/bullet_proof,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
 "xvg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -23822,13 +23517,16 @@
 /area/f13/followers)
 "xxn" = (
 /obj/structure/rack,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -24153,16 +23851,15 @@
 	pixel_x = 9;
 	pixel_y = 3
 	},
-/obj/item/export/bottle/whiskey{
-	pixel_x = -8;
-	pixel_y = 9
-	},
-/obj/item/export/bottle/tequila{
-	pixel_x = -12;
-	pixel_y = 3
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/tequila{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = -8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
@@ -24459,8 +24156,52 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ygM" = (
+/obj/structure/rack,
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 13;
+	pixel_y = -8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 11;
+	pixel_y = 8
+	},
 /obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -79599,7 +79340,7 @@ qta
 eaz
 psA
 qmh
-omB
+qmh
 jZH
 jZH
 uoO
@@ -79856,7 +79597,7 @@ qmh
 qmh
 nld
 qmh
-fah
+qmh
 jZH
 jZH
 uoO
@@ -80837,7 +80578,7 @@ jZH
 jZH
 ioQ
 pOc
-wOD
+vOf
 pOc
 hYS
 vDC
@@ -82393,7 +82134,7 @@ rbu
 rFJ
 aVe
 aVe
-eAw
+iIs
 jZH
 jZH
 jZH
@@ -86211,7 +85952,7 @@ jZH
 rOj
 qhw
 xoo
-mTL
+oZm
 bTN
 bTN
 rFJ
@@ -86502,7 +86243,7 @@ cfA
 jZH
 fqM
 owa
-gxP
+cLV
 aqB
 aqB
 aqB
@@ -87752,16 +87493,16 @@ jrn
 jFC
 llQ
 vqD
-ntz
-eRO
-eRO
-eRO
+aVe
+aVe
+aVe
+aVe
 jZH
 jZH
 jZH
 jZH
 jZH
-oDP
+jZH
 jZH
 acJ
 rRQ
@@ -87779,7 +87520,7 @@ jZH
 jZH
 rIS
 jZH
-jZH
+hPn
 iKQ
 cfA
 jZH
@@ -88014,20 +87755,20 @@ xSi
 tkD
 hUV
 jZH
-jZH
-jZH
-bUn
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
+rOj
 cfA
-cfA
-jZH
 rOj
-rOj
-rOj
-rOj
-rOj
-jZH
-cfA
-jZH
 rOj
 rOj
 rOj
@@ -88259,23 +88000,23 @@ uoO
 jZH
 tZc
 hpT
-tZc
+ocY
 jZH
-gJD
+qmL
 qQF
 mDt
-iwr
+mDt
 sxs
 bvP
 ctL
 gJD
-ejQ
+gJD
 qpd
 dLF
 jZH
-hPn
+rOj
 jZH
-ryy
+jZH
 jZH
 jZH
 jZH
@@ -88514,10 +88255,10 @@ uoO
 uoO
 uoO
 jZH
+sql
 aVe
 aVe
-aVe
-bqZ
+uZG
 gJD
 qLb
 gJD
@@ -88527,29 +88268,29 @@ gJD
 gJD
 gJD
 ejQ
-gJD
-gIK
+tZQ
+qLb
 jZH
 jZH
 jZH
+ryy
 vnZ
-jZH
 cfA
 cfA
 cfA
-bUn
+ryy
 ukN
-fcJ
+cfA
 ryy
 bKT
-pkR
+cfA
 oDP
 vUF
-qOT
-ldo
+ryy
+cfA
 hcx
 ukN
-fXs
+cfA
 cfA
 jZH
 rOj
@@ -88772,28 +88513,28 @@ uoO
 uoO
 jZH
 utP
-aVe
+eoA
 hXn
 jZH
-gJD
-gJD
-gJD
+xxn
 qLb
-gJD
-gJD
+kXI
+qLb
+pQz
+sME
 qLb
 iZB
-aWM
-gJD
-uuj
 jZH
-cfA
-cfA
+jZH
+jZH
+jZH
+ryy
+ryy
 pRW
 jZH
-cfA
-itY
-cfA
+ryy
+jZH
+jZH
 jZH
 jZH
 jZH
@@ -89028,30 +88769,30 @@ uoO
 uoO
 uoO
 jZH
-gvt
+utP
 aVe
-pyn
-jZH
-qmL
-sME
+eoA
 uZG
-uZG
-rfG
-wQy
-wio
-vFa
-uMR
+gJD
+qLb
+gJD
+gJD
+qLb
+gJD
+gJD
+gJD
+iBF
 sFl
 uMR
 jZH
-cIS
+oDP
 jZH
 jZH
 jZH
-cfA
-cfA
-cfA
+ryy
 jZH
+rOj
+rOj
 rOj
 rOj
 rOj
@@ -89286,30 +89027,30 @@ uoO
 uoO
 jZH
 eoA
-oTZ
+aVe
 aVe
 jZH
 rUF
+oTZ
+mDt
+bUn
+gvt
+pyn
 gJD
 gJD
-gJD
-gJD
-gJD
-gmk
-vFa
 erF
-gJD
+qLb
 ygM
 jZH
 ryy
 cfA
 cfA
-oDP
-cfA
-gRE
-cfA
+ryy
+ryy
 jZH
 rOj
+jZH
+jZH
 jZH
 jZH
 jZH
@@ -89542,21 +89283,19 @@ uoO
 uoO
 uoO
 jZH
-kXI
+aVe
 dUW
-pQz
+utP
 jZH
-sql
-tZQ
-xxn
-uoC
-ofY
-wni
-ljP
 jZH
-vgn
-bED
-xug
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
 jZH
 jZH
 jZH
@@ -89567,6 +89306,8 @@ jZH
 jZH
 jZH
 rOj
+jZH
+uoO
 uoO
 uoO
 uoO
@@ -89798,32 +89539,32 @@ eLE
 eLE
 eLE
 eLE
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-iKQ
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
-rOj
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 eLE
 eLE
 eLE

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -16,16 +16,16 @@
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/suture
-	name = "Handmade Suture"
-	result = /obj/item/stack/medical/suture
+	name = "Improvised Suture"
+	result = /obj/item/stack/medical/suture/emergency/five
 	time = 30
 	reqs = list(/obj/item/stack/medical/gauze/improvised = 1,
 				/datum/reagent/consumable/ethanol = 10)
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/ointment
-	name = "Handmade Ointment"
-	result = /obj/item/stack/medical/ointment
+	name = "Improvised Ointment"
+	result = /obj/item/stack/medical/ointment/five
 	time = 30
 	reqs = list(/obj/item/stack/medical/gauze/improvised = 1,
 				/obj/item/reagent_containers/food/snacks/grown/agave = 1)

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -904,6 +904,48 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_PARTS
 	always_availible = FALSE
+
+/datum/crafting_recipe/automatic_sear
+	name = "Automatic Sear"
+	result = /obj/item/attachments/auto_sear
+	reqs = list(
+				/obj/item/stack/sheet/metal = 8,
+				/obj/item/stack/crafting/metalparts = 8,
+				/obj/item/stack/crafting/goodparts = 8
+	)
+	tools = list(TOOL_AWORKBENCH)
+	time = 30
+	category = CAT_WEAPONRY
+	subcategory = CAT_PARTS
+	always_availible = FALSE
+
+/datum/crafting_recipe/ecrecharge
+	name = "Small Energy Cell (recycle)"
+	result = /obj/item/stock_parts/cell/ammo/ec
+	reqs = list(/obj/item/stock_parts/cell/ammo/ec=2)
+	tools = list(TOOL_WORKBENCH)
+	time = 10
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/mfcrecharge
+	name = "Microfusion Cell (recycle)"
+	result = /obj/item/stock_parts/cell/ammo/mfc
+	reqs = list(/obj/item/stock_parts/cell/ammo/mfc=2)
+	tools = list(TOOL_WORKBENCH)
+	time = 10
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/ecprecharge
+	name = "Electron Charge Pack (recycle)"
+	result = /obj/item/stock_parts/cell/ammo/ecp
+	reqs = list(/obj/item/stock_parts/cell/ammo/ecp=2)
+	tools = list(TOOL_WORKBENCH)
+	time = 10
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
 /*
 /datum/crafting_recipe/flux
 	name = "Flux capacitor"

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -663,6 +663,18 @@
 	else
 		. = ..()
 
+/obj/machinery/autolathe/ammo/on_deconstruction()
+	..()
+	if(simple)
+		new /obj/item/book/granter/crafting_recipe/gunsmith_one(src)
+	if(basic)
+		new /obj/item/book/granter/crafting_recipe/gunsmith_two(src)
+	if(intermediate)
+		new /obj/item/book/granter/crafting_recipe/gunsmith_three(src)
+	if(advanced)
+		new /obj/item/book/granter/crafting_recipe/gunsmith_four(src)
+	return
+	
 /obj/machinery/autolathe/ammo/unlocked
 	simple = 1
 	basic = 1

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -243,12 +243,15 @@
 	merge_type = /obj/item/stack/medical/suture
 
 /obj/item/stack/medical/suture/emergency
-	name = "emergency suture"
-	desc = "A value pack of cheap sutures, not very good at repairing damage, but still decent at stopping bleeding."
+	name = "improvised suture"
+	desc = "A set of improvised sutures, not very good at repairing damage, but still decent at stopping bleeding."
 	heal_brute = 5
 	amount = 5
 	max_amount = 5
 	merge_type = /obj/item/stack/medical/suture/emergency
+
+/obj/item/stack/medical/suture/emergency/five
+	amount = 5
 
 /obj/item/stack/medical/suture/one
 	amount = 1
@@ -305,6 +308,9 @@
 	flesh_regeneration = 2.5
 	sanitization = 0.3
 	grind_results = list(/datum/reagent/medicine/kelotane = 10)
+
+/obj/item/stack/medical/ointment/five
+	amount = 5
 
 /obj/item/stack/medical/ointment/heal(mob/living/M, mob/user)
 	if(M.stat == DEAD)

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -787,3 +787,9 @@ Mayor
 		return
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
+
+/datum/outfit/job/den/f13shopkeeper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/automatic_sear)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -978,7 +978,7 @@ Nothing else in the console has ID requirements.
 	if(ls["research_node"])
 		if(!research_control)
 			return				//honestly should call them out for href exploiting :^)
-		if(!SSresearch.science_tech.available_nodes[ls["research_node"]])
+		if(!stored_research.available_nodes[ls["research_node"]])
 			return			//Nope!
 		research_node(ls["research_node"], usr)
 	if(ls["clear_tech"]) //Erase la on the technology disk.
@@ -1161,6 +1161,8 @@ Nothing else in the console has ID requirements.
 	desc = "A console used by the scribes of the Brotherhood of Steel."
 	name = "Archive Terminal"
 	circuit = /obj/item/circuitboard/computer/rdconsole/bos
+	req_access = null
+	req_access_txt = "120"
 
 /obj/machinery/computer/rdconsole/core/vault
 	circuit = /obj/item/circuitboard/computer/rdconsole/vault
@@ -1171,21 +1173,21 @@ Nothing else in the console has ID requirements.
 //lettern's lazy way of adding more channels
 /obj/machinery/computer/rdconsole/core/bos/Initialize()
 	. = ..()
-	stored_research = SSresearch.science_tech //lettern, note about this
+	stored_research = SSresearch.bos_tech //lettern, note about this
 	stored_research.consoles_accessing[src] = TRUE
-	matching_designs = list()
+	matching_design_ids = list()
 	SyncRDevices()
 
 /obj/machinery/computer/rdconsole/core/vault/Initialize()
 	. = ..()
 	stored_research = SSresearch.science_tech //lettern, note about this
 	stored_research.consoles_accessing[src] = TRUE
-	matching_designs = list()
+	matching_design_ids = list()
 	SyncRDevices()
 
 /obj/machinery/computer/rdconsole/core/followers/Initialize()
 	. = ..()
 	stored_research = SSresearch.followers_tech
 	stored_research.consoles_accessing[src] = TRUE
-	matching_designs = list()
+	matching_design_ids = list()
 	SyncRDevices()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes bugs #295, #246, #233, hopefully #133. Plus other stuff.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes some bugs, as well as some QoL stuff.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Allows the Oasis Shopkeep to craft auto-sears.
add: Added back cell recycling in the crafting menu.
tweak: Improvised suture recipe now makes a stack of 5 improvised sutures instead of 15 regular sutures.
tweak: Improvised ointment recipe now makes a stack of 5.
tweak: Ammo benches now return magazines when deconstructed.
fix: Fixed BoS R&D machinery being linked to the Vault techweb.
fix: Fixed certain technologies not being able to be researched on the BoS techweb.
fix: Fixed missing tables.
fix: Fixed bottles in the Ranger office being unable to be consumed.
fix: Fixed the NCR Barracks with some bunks being spawned blocked by tables and crates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
