### PR TITLE
research buff

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -23468,6 +23468,17 @@
 /obj/machinery/smartfridge/food,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
+"xrA" = (
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/blueprint/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xsk" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Proctor's Office";
@@ -83943,7 +83954,7 @@ aVe
 aVe
 ulZ
 fDi
-gnY
+xrA
 vid
 aVe
 qii

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -83,7 +83,10 @@
 		return ..()
 	if(istype(W,/obj/item/salvage))
 		var/obj/item/salvage/S = W
-		if(do_after(user,50,target = src))
+		if(do_after(user,50,target = src))		
+			if(HAS_TRAIT(user, TRAIT_TECHNOPHREAK))
+				var/obj/I = pick(S.Loot)
+				new I (src.loc)
 			var/obj/I = pick(S.Loot)
 			new I (src.loc)
 			if(prob(50))

--- a/code/modules/research/techweb/nodes/engineering_nodes.dm
+++ b/code/modules/research/techweb/nodes/engineering_nodes.dm
@@ -9,7 +9,7 @@
 	"atmosalerts", "atmos_control", "recycler", "autolathe", "autolathe_secure", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
 	"apc_control", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine", "rcd_ammo","oxygen_tank",
 	"plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 6000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
 
 /datum/techweb_node/adv_engi
 	id = "adv_engi"
@@ -19,7 +19,7 @@
 	design_ids = list("engine_goggles", "forcefield_projector", "weldingmask" , "rcd_loaded", "rpd",
 	"tray_goggles_prescription", "engine_goggles_prescription", "mesons_prescription", "rcd_upgrade_frames",
 	"rcd_upgrade_simple_circuits", "rcd_ammo_large", "sheetifier")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
 
 /datum/techweb_node/anomaly
 	id = "anomaly_research"

--- a/code/modules/vehicles/rubbish.dm
+++ b/code/modules/vehicles/rubbish.dm
@@ -95,6 +95,10 @@
 			user.visible_message("[user] slices through a [fake_dismantle].")
 			I.play_tool_sound(src, 100)
 		var/turf/usr_turf = get_turf(user)
+		if(HAS_TRAIT(user,TRAIT_TECHNOPHREAK))
+			for(var/i3 in 1 to 5) //this is just less lines for the same thing
+				if(prob(10))
+					new /obj/item/salvage/high(usr_turf)
 		for(var/i2 in 1 to rand(3,5)) //also changing this a little. IDEA: perhaps a mechanic skill could affect the amount dropped instead
 			if(prob(25))
 				if(prob(50))


### PR DESCRIPTION
Buffed % chance to get adv salvage from cars to characters with the technophreak perk from 9% to 59%.
Doubled the base salvage from advanced salvage for users with the technophreak perk.
Added 15k worth of items to the brothood to start with.