### PR TITLE
Drug crafting and vendors

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -17219,6 +17219,11 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/city)
+"mCS" = (
+/obj/machinery/mineral/wasteland_vendor/special,
+/obj/machinery/mineral/wasteland_vendor/medical,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "mDf" = (
 /obj/structure/wreck/trash/machinepiletwo{
 	layer = 3
@@ -20893,6 +20898,11 @@
 	icon_state = "skin"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"pts" = (
+/obj/machinery/mineral/wasteland_vendor/general,
+/obj/machinery/mineral/wasteland_vendor/clothing,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "ptP" = (
 /obj/structure/tires/two,
@@ -95375,11 +95385,11 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+mrq
+pts
+nsE
+mCS
+mrq
 fyf
 fyf
 fyf
@@ -95632,11 +95642,11 @@ fyf
 fyf
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+mrq
+gEr
+sNz
+gEr
+mrq
 gcK
 fyf
 fyf
@@ -95889,11 +95899,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+mrq
+mrq
+mrq
+mrq
+mrq
 gcK
 gcK
 fyf

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -277,7 +277,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ajX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
@@ -291,7 +291,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ako" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -390,7 +390,7 @@
 "anb" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "anl" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_l,
@@ -412,7 +412,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "aof" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -465,7 +465,7 @@
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "aqD" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
@@ -572,7 +572,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "auH" = (
 /obj/structure/table,
 /obj/item/ammo_casing/shotgun/buckshot,
@@ -1212,7 +1212,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "aVq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -1247,7 +1247,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "aWz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -1358,7 +1358,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "aYY" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -1395,7 +1395,7 @@
 "bav" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "baS" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/f13/stage_tr,
@@ -1418,7 +1418,7 @@
 /area/f13/wasteland)
 "bbS" = (
 /turf/closed/wall/f13/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "bbU" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalleft"
@@ -1731,7 +1731,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "bnm" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -1941,7 +1941,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "buD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -2246,7 +2246,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "bEZ" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -2364,7 +2364,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "bIV" = (
 /obj/structure/chair/bench,
 /obj/effect/landmark/start/f13/settler,
@@ -2555,7 +2555,7 @@
 	icon_state = "warningline_red"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "bQL" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/spring,
@@ -2670,7 +2670,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "bXw" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood{
@@ -2784,7 +2784,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "cfn" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -2926,7 +2926,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ckJ" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -2958,7 +2958,7 @@
 "ckZ" = (
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "clL" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -2988,7 +2988,7 @@
 "cmR" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "cnt" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/bed/dogbed,
@@ -3133,7 +3133,7 @@
 /obj/structure/barricade/bars,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ctE" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -3272,7 +3272,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "czx" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -3468,7 +3468,7 @@
 "cKg" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "cKC" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -3518,7 +3518,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "cLZ" = (
 /obj/item/candle/infinite,
 /turf/open/floor/f13/wood,
@@ -3561,7 +3561,7 @@
 	desc = "Deep, poorly filtered gardening water.";
 	name = "stagnant water"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "cOg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3626,7 +3626,7 @@
 	layer = 6
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "cQs" = (
 /obj/structure/simple_door/tent,
 /turf/open/floor/f13/wood{
@@ -3704,7 +3704,7 @@
 /area/f13/wasteland)
 "cSU" = (
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "cTc" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
@@ -3845,7 +3845,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "cYz" = (
 /obj/item/target,
 /turf/open/floor/f13{
@@ -3925,7 +3925,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "daM" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert{
@@ -4126,7 +4126,7 @@
 /obj/structure/fluff/paper/stack,
 /obj/item/pen,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "dhB" = (
 /obj/machinery/light/sign,
 /obj/structure/barricade/wooden,
@@ -4554,7 +4554,7 @@
 "dvQ" = (
 /obj/structure/wreck/trash/engine,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "dwx" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/f13/wood,
@@ -4608,7 +4608,7 @@
 	icon_state = "tree_2"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "dys" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -4686,7 +4686,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "dAB" = (
 /obj/structure/car/rubbish3,
 /turf/closed/wall/r_wall/rust,
@@ -4782,7 +4782,7 @@
 "dER" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "dEW" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -5031,7 +5031,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "dRo" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/desert,
@@ -5236,7 +5236,7 @@
 /area/f13/wasteland)
 "edB" = (
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "edF" = (
 /obj/machinery/light/small,
 /obj/structure/bed/mattress{
@@ -5343,7 +5343,7 @@
 "eiB" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ejk" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5464,7 +5464,7 @@
 "enL" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "eoi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -5578,7 +5578,7 @@
 /obj/machinery/light/small,
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "esE" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -5669,7 +5669,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "exj" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -5925,7 +5925,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "eHB" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/desert,
@@ -6131,7 +6131,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "eOd" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6368,7 +6368,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "eUI" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -6417,7 +6417,7 @@
 	icon_state = "bench"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "eXa" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -6505,7 +6505,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "eZI" = (
 /obj/structure/spirit_board,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6716,7 +6716,7 @@
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "fiB" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -6767,14 +6767,14 @@
 	},
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "fkP" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "fkU" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/remains/human,
@@ -6869,7 +6869,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "foz" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -7240,7 +7240,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "fzW" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7264,6 +7264,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/city)
+"fAZ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/landmark/start/f13/priestess,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "fBl" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -7560,7 +7566,7 @@
 /area/f13/wasteland)
 "fMu" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "fMO" = (
 /obj/item/ammo_casing/c10mm/ap{
 	dir = 5
@@ -7606,7 +7612,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "fOu" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7623,7 +7629,7 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "fPN" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -7891,7 +7897,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "fZm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7972,7 +7978,7 @@
 	pixel_y = -33
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gdN" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/desert,
@@ -8101,7 +8107,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gip" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/fprostitute,
@@ -8262,7 +8268,7 @@
 "gnU" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gof" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
@@ -8302,7 +8308,7 @@
 "goO" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "goU" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -8389,7 +8395,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "grf" = (
 /obj/structure/chair/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -8611,7 +8617,7 @@
 "gyd" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gyf" = (
 /obj/item/clothing/under/soviet,
 /obj/structure/displaycase,
@@ -8674,7 +8680,7 @@
 	icon_state = "fence_wood"
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gBj" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
@@ -8705,7 +8711,7 @@
 	pixel_y = 27
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gCd" = (
 /obj/structure/fence{
 	dir = 4
@@ -8780,7 +8786,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gEr" = (
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
@@ -8998,7 +9004,7 @@
 	desc = "Deep, poorly filtered gardening water.";
 	name = "stagnant water"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gNA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 10;
@@ -9014,7 +9020,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gOf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -9079,7 +9085,7 @@
 	icon_state = "warningline_red"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gPQ" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/desert,
@@ -9195,7 +9201,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "gTz" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/combat,
@@ -9400,7 +9406,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "haD" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/desert,
@@ -9411,7 +9417,7 @@
 /area/f13/wasteland)
 "hbm" = (
 /turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hbx" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/sneakers/black{
@@ -9435,7 +9441,7 @@
 	layer = 2.1
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hbK" = (
 /obj/machinery/light{
 	dir = 4
@@ -9533,7 +9539,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hfz" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light{
@@ -9621,7 +9627,7 @@
 	icon_state = "tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hhG" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -9664,7 +9670,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hjb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
@@ -9740,7 +9746,7 @@
 "hlM" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hlQ" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle,
@@ -9921,7 +9927,7 @@
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hsh" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -9931,7 +9937,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hsy" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -10020,7 +10026,7 @@
 	pixel_y = 13
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hvu" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -10100,11 +10106,11 @@
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hxv" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hxy" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pestspray,
@@ -10208,7 +10214,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hzG" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -10299,7 +10305,7 @@
 "hDf" = (
 /obj/structure/simple_door/interior,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hDE" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -10459,7 +10465,7 @@
 	},
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hJd" = (
 /obj/structure/rack,
 /obj/item/seeds/poppy/broc,
@@ -10591,7 +10597,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hNL" = (
 /obj/structure/table/wood/fancy,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -10761,7 +10767,7 @@
 	name = "vines"
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hUV" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
@@ -10822,7 +10828,7 @@
 	icon_state = "mattress4"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "hWk" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerouter"
@@ -11186,7 +11192,7 @@
 	pixel_y = -33
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ijm" = (
 /obj/structure/simple_door/metal/fence,
 /obj/structure/decoration/rag,
@@ -11208,7 +11214,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ikV" = (
 /obj/structure/table/wood,
 /obj/item/binoculars{
@@ -11237,7 +11243,7 @@
 "ill" = (
 /obj/item/flag/bos,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ilq" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
@@ -11371,7 +11377,7 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iqN" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -11468,7 +11474,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "itm" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -11505,7 +11511,7 @@
 	pixel_y = 10
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "itY" = (
 /obj/structure/table/wood,
 /obj/item/lighter,
@@ -11555,7 +11561,7 @@
 "iwd" = (
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iwm" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -11594,7 +11600,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iyg" = (
 /mob/living/simple_animal/hostile/wolf/alpha,
 /turf/open/indestructible/ground/outside/desert,
@@ -11622,14 +11628,14 @@
 	pixel_y = 11
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iyy" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
 	pixel_x = 33
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iyD" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -11763,7 +11769,7 @@
 /area/f13/city)
 "iFI" = (
 /turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iFR" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/trash,
@@ -11817,7 +11823,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iGM" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -11904,12 +11910,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iHS" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iHV" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -12081,7 +12087,7 @@
 "iNp" = (
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iNx" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12460,7 +12466,7 @@
 "iYw" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "iYF" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12515,7 +12521,7 @@
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jbr" = (
 /obj/structure/table/wood,
 /obj/structure/window/spawner/west,
@@ -12567,7 +12573,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jdg" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
@@ -12600,10 +12606,10 @@
 /area/f13/village)
 "jem" = (
 /turf/closed/wall/f13/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jeO" = (
 /turf/closed/wall/f13/wood/house/broken,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jeV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -12684,7 +12690,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/coffee,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jha" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -12706,7 +12712,7 @@
 "jix" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jiP" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -13141,7 +13147,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jAZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -13431,7 +13437,7 @@
 	icon_state = "warningline_red"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jRn" = (
 /obj/machinery/light{
 	dir = 4;
@@ -13443,7 +13449,7 @@
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jRU" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/road{
@@ -13522,7 +13528,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jUo" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13,
@@ -13580,7 +13586,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jWx" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -13612,7 +13618,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "jXj" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
@@ -13942,7 +13948,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "khB" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14100,7 +14106,7 @@
 /obj/structure/closet/crate/large,
 /obj/item/stack/f13Cash/random/low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "kmQ" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/condiment/yeast,
@@ -14345,7 +14351,7 @@
 "kvB" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "kvT" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -14633,11 +14639,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "kFH" = (
 /obj/item/clothing/gloves/boxing,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "kGc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 7;
@@ -14663,7 +14669,7 @@
 "kGV" = (
 /obj/structure/window/fulltile/house,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "kHn" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -14740,7 +14746,7 @@
 	light_color = "red"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "kLQ" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14837,7 +14843,7 @@
 "kQq" = (
 /obj/structure/wreck/trash/one_tire,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "kQC" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt{
@@ -14955,7 +14961,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "kVS" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -15006,7 +15012,7 @@
 	id = "bosdoorshutter"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "kXM" = (
 /obj/structure/toilet{
 	dir = 8
@@ -15099,7 +15105,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lcx" = (
 /obj/machinery/alchemy_table,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15119,7 +15125,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ldy" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15248,7 +15254,7 @@
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lhN" = (
 /obj/item/flashlight/flare/torch,
 /obj/item/flashlight/flare/torch,
@@ -15411,7 +15417,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "loF" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -15500,7 +15506,7 @@
 	pixel_y = 18
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lqV" = (
 /obj/structure/pondlily_big,
 /turf/open/indestructible/ground/outside/water,
@@ -15587,7 +15593,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lsS" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -15640,7 +15646,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lun" = (
 /obj/machinery/door/airlock/glass_large{
 	name = "Followers Clinic"
@@ -15654,7 +15660,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "luD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15769,7 +15775,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lyk" = (
 /obj/effect/landmark/start/f13/prospector,
 /turf/open/floor/f13{
@@ -15802,7 +15808,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lzV" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -15869,7 +15875,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lCe" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -15926,7 +15932,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lDd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/iv_drip,
@@ -15942,7 +15948,7 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lDx" = (
 /obj/structure/barricade/bars,
 /obj/structure/fence,
@@ -16128,7 +16134,7 @@
 "lKO" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lKV" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/trash,
@@ -16288,7 +16294,7 @@
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lRW" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
@@ -16325,7 +16331,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lTx" = (
 /obj/machinery/mineral/wasteland_vendor/attachments{
 	icon_state = "weapon_idle"
@@ -16347,7 +16353,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lTZ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -16374,7 +16380,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lUf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -16500,7 +16506,7 @@
 	pixel_x = -1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "lZP" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -16848,7 +16854,7 @@
 	pixel_x = -3
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "moi" = (
 /obj/item/ammo_casing/caseless{
 	dir = 10;
@@ -16880,7 +16886,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "moD" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16932,7 +16938,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "mqy" = (
 /obj/machinery/mineral/wasteland_trader/general{
 	icon_state = "trade_idle"
@@ -16964,7 +16970,7 @@
 	icon_state = "brokenstore"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "mrl" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -17124,7 +17130,7 @@
 /area/f13/tunnel)
 "mwt" = (
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "mwO" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
@@ -17197,7 +17203,7 @@
 "mBh" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "mCf" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -17219,11 +17225,6 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/city)
-"mCS" = (
-/obj/machinery/mineral/wasteland_vendor/special,
-/obj/machinery/mineral/wasteland_vendor/medical,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
 "mDf" = (
 /obj/structure/wreck/trash/machinepiletwo{
 	layer = 3
@@ -17238,7 +17239,7 @@
 	layer = 5
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "mDr" = (
 /obj/machinery/trading_machine/armor,
 /turf/open/floor/f13/wood,
@@ -17250,7 +17251,7 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "mEn" = (
 /obj/structure/lamp_post{
 	dir = 4
@@ -17607,7 +17608,7 @@
 "mUo" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "mUx" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17866,7 +17867,7 @@
 /obj/machinery/workbench,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ndx" = (
 /obj/structure/chair/booth{
 	dir = 4
@@ -17977,7 +17978,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "nhp" = (
 /obj/machinery/door/poddoor/preopen{
 	id = 42
@@ -18095,7 +18096,7 @@
 "nmZ" = (
 /obj/item/flag/bos,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "nnh" = (
 /obj/structure/wreck/trash/machinepile{
 	layer = 3
@@ -18267,7 +18268,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "nvL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -18457,13 +18458,13 @@
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "nDk" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "nDJ" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/slab/burnt,
@@ -18793,7 +18794,7 @@
 /obj/structure/rack,
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "nSf" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
@@ -18874,7 +18875,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "nUF" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19167,7 +19168,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ogj" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -19384,7 +19385,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ooh" = (
 /obj/structure/table/wood,
 /obj/item/roller,
@@ -19420,7 +19421,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "oqa" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
@@ -19450,7 +19451,7 @@
 	icon_state = "bench"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "oqu" = (
 /obj/structure/wreck/trash/two_barrels{
 	layer = 4
@@ -19573,7 +19574,7 @@
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ovR" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -19678,7 +19679,7 @@
 "oAB" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "oAS" = (
 /obj/structure/fireplace,
 /turf/open/floor/carpet/black,
@@ -19954,7 +19955,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "oMA" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -20150,7 +20151,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "oSC" = (
 /obj/item/caution{
 	desc = "A sign denoting the presence of a likely very moist molerat.";
@@ -20162,7 +20163,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "oTn" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/f13/wood,
@@ -20242,7 +20243,7 @@
 	desc = "Deep, poorly filtered gardening water.";
 	name = "stagnant water"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "oVF" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20385,7 +20386,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "paS" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20412,7 +20413,7 @@
 /obj/structure/table,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "pck" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
@@ -20454,7 +20455,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "pcY" = (
 /obj/structure/simple_door/glass,
 /turf/open/floor/wood,
@@ -20687,7 +20688,7 @@
 	icon_state = "warningline_red"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "pnw" = (
 /obj/machinery/light/sign/oasis_sign,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20781,7 +20782,7 @@
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "pqs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/closed/wall/f13/wood,
@@ -20849,7 +20850,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "prP" = (
 /obj/structure/table,
 /obj/item/ammo_box/c10mm,
@@ -20865,7 +20866,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "psI" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -20898,11 +20899,6 @@
 	icon_state = "skin"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"pts" = (
-/obj/machinery/mineral/wasteland_vendor/general,
-/obj/machinery/mineral/wasteland_vendor/clothing,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "ptP" = (
 /obj/structure/tires/two,
@@ -21175,7 +21171,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "pEs" = (
 /obj/machinery/light{
 	dir = 4
@@ -21465,7 +21461,7 @@
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "pOL" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -21505,7 +21501,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "pRd" = (
 /obj/structure/table/wood,
 /obj/item/storage/backpack{
@@ -21779,7 +21775,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qbe" = (
 /obj/structure/table,
 /obj/item/storage/box/drinkingglasses,
@@ -21856,7 +21852,7 @@
 "qdm" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qdD" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -21922,7 +21918,7 @@
 "qfo" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qfV" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -21940,7 +21936,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qgZ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22420,11 +22416,11 @@
 /obj/item/mining_scanner,
 /obj/item/mining_scanner,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qzM" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qAc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -22475,7 +22471,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qCn" = (
 /obj/structure/noticeboard{
 	name = "bounty board"
@@ -22643,7 +22639,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qHZ" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3";
@@ -22840,7 +22836,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qOV" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -22877,10 +22873,10 @@
 	name = "gate"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qPL" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qPQ" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -22916,7 +22912,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qQQ" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -22938,7 +22934,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qRl" = (
 /obj/machinery/workbench,
 /obj/machinery/light/small/broken{
@@ -22959,7 +22955,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "qSM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/bars,
@@ -23441,7 +23437,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "rns" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -23538,7 +23534,7 @@
 	desc = "Deep, poorly filtered gardening water.";
 	name = "stagnant water"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "rrE" = (
 /obj/structure/window/spawner,
 /obj/structure/chair/sofa/corp/corner{
@@ -23659,7 +23655,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ryO" = (
 /obj/structure/rack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24007,7 +24003,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "rOp" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -24098,7 +24094,7 @@
 "rRT" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "rSc" = (
 /obj/structure/decoration/rag,
 /obj/machinery/door/unpowered/wooddoor{
@@ -24153,7 +24149,7 @@
 "rTG" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "rTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -24229,7 +24225,7 @@
 	name = "vines"
 	},
 /turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "rXj" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/barber{
@@ -24400,7 +24396,7 @@
 	desc = "Deep, poorly filtered gardening water.";
 	name = "stagnant water"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "seQ" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/cleaner,
@@ -24424,7 +24420,7 @@
 	pixel_y = 16
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "sfA" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/button{
@@ -24461,7 +24457,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "sgr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24474,7 +24470,7 @@
 	desc = "Deep, poorly filtered gardening water.";
 	name = "stagnant water"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "sgz" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2"
@@ -24645,7 +24641,7 @@
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "slM" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -24723,7 +24719,7 @@
 "snR" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "soh" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -24969,7 +24965,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "swU" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/wood,
@@ -25063,6 +25059,11 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"sAg" = (
+/obj/machinery/mineral/wasteland_vendor/special,
+/obj/machinery/mineral/wasteland_vendor/medical,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "sAH" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -25285,6 +25286,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/city)
+"sKB" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/orator,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "sKH" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -25301,7 +25309,7 @@
 	desc = "Deep, poorly filtered gardening water.";
 	name = "stagnant water"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "sLm" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
@@ -25379,7 +25387,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "sNC" = (
 /obj/machinery/door/airlock/wood/glass{
 	req_access_txt = "121"
@@ -25477,7 +25485,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "sQC" = (
 /obj/structure/table/wood,
 /obj/item/pen/fountain,
@@ -25849,7 +25857,7 @@
 "tcX" = (
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tdn" = (
 /obj/machinery/door/unpowered/wooddoor{
 	name = "Commanding Officer"
@@ -25884,7 +25892,7 @@
 	dir = 5
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "teO" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -26024,7 +26032,7 @@
 /area/f13/village)
 "tka" = (
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tkh" = (
 /obj/structure/chair,
 /turf/open/floor/f13{
@@ -26075,7 +26083,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tlD" = (
 /obj/structure/fence/corner{
 	dir = 9
@@ -26221,7 +26229,7 @@
 	icon_state = "mattress2"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tqS" = (
 /turf/open/floor/f13{
 	icon_state = "bar"
@@ -26427,7 +26435,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tyd" = (
 /obj/docking_port/stationary{
 	area_type = /area/f13;
@@ -26526,7 +26534,7 @@
 	desc = "Deep, poorly filtered gardening water.";
 	name = "stagnant water"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tAS" = (
 /obj/effect/landmark/start/f13/preacher,
 /turf/open/floor/f13/wood,
@@ -26685,17 +26693,17 @@
 "tGg" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tGk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tGY" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tHw" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -26759,7 +26767,7 @@
 "tJv" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tJx" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/f13/wood,
@@ -27121,7 +27129,7 @@
 "tXY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tYd" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -27159,7 +27167,7 @@
 "tYV" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "tZh" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_l,
@@ -27414,7 +27422,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "uhi" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/water,
@@ -27494,7 +27502,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ulC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -27600,7 +27608,7 @@
 	icon_state = "mattress6"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "uoK" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
@@ -27712,6 +27720,11 @@
 "urN" = (
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"urV" = (
+/obj/machinery/mineral/wasteland_vendor/general,
+/obj/machinery/mineral/wasteland_vendor/clothing,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "urW" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/cow/brahmin,
@@ -28040,7 +28053,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "uEK" = (
 /obj/structure/table/wood,
 /obj/item/pda,
@@ -28068,7 +28081,7 @@
 	icon_state = "floor5"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "uFp" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -28089,7 +28102,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "uFD" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -28508,7 +28521,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "uTn" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -29074,7 +29087,7 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "voC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -29089,7 +29102,7 @@
 	pixel_x = -15
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "voV" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -29315,7 +29328,7 @@
 "vye" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "vzb" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/trash,
@@ -29391,7 +29404,7 @@
 "vAM" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "vBr" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/f13/wood,
@@ -29435,7 +29448,7 @@
 "vCw" = (
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "vCF" = (
 /obj/structure/bonfire/prelit,
 /obj/item/stack/rods,
@@ -29609,7 +29622,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "vIr" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/dirt,
@@ -29748,7 +29761,7 @@
 	icon_state = "bench"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "vNG" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/vomit,
@@ -29871,7 +29884,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "vTr" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick,
@@ -29910,7 +29923,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "vVI" = (
 /obj/machinery/shower{
 	dir = 4
@@ -29998,7 +30011,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "vYp" = (
 /obj/structure/dresser,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30175,7 +30188,7 @@
 	pixel_x = 12
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "why" = (
 /obj/item/reagent_containers/food/condiment/soymilk,
 /turf/open/floor/f13/wood,
@@ -30269,7 +30282,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wmJ" = (
 /obj/item/toy/beach_ball/holoball,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -30336,7 +30349,7 @@
 	name = "shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wpf" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -30431,7 +30444,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wsC" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -30446,7 +30459,7 @@
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wtj" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalcorroded"
@@ -30604,7 +30617,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wzN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/wasteland{
@@ -30726,7 +30739,7 @@
 "wEv" = (
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wEO" = (
 /obj/machinery/shower{
 	dir = 4
@@ -30777,7 +30790,7 @@
 /obj/item/clothing/head/hardhat,
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wGz" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt,
@@ -30821,7 +30834,7 @@
 "wIO" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wIP" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -30864,7 +30877,7 @@
 "wLy" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wLB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30875,7 +30888,7 @@
 "wLO" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wLU" = (
 /obj/structure/closet,
 /obj/item/lighter,
@@ -31028,7 +31041,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wPl" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13/wood,
@@ -31051,7 +31064,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wPG" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -31339,7 +31352,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "wYv" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
@@ -31388,7 +31401,7 @@
 	icon_state = "tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xbA" = (
 /obj/structure/sign/poster/prewar/poster83,
 /turf/closed/wall/f13/supermart,
@@ -31480,7 +31493,7 @@
 /obj/structure/table,
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xdD" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood{
@@ -31524,7 +31537,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xes" = (
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/legion)
@@ -31983,7 +31996,7 @@
 	pixel_y = 16
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xsz" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -32021,7 +32034,7 @@
 "xtG" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xtV" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -32098,11 +32111,11 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xwl" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xws" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -32112,7 +32125,7 @@
 "xwN" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xwW" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/knife/cosmicdirty,
@@ -32162,7 +32175,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xzn" = (
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/ground/inside/mountain,
@@ -32237,7 +32250,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xDA" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/f13{
@@ -32364,7 +32377,7 @@
 "xHg" = (
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xIh" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -32637,7 +32650,7 @@
 "xQL" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xRg" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -32692,7 +32705,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xTj" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
@@ -32716,7 +32729,7 @@
 "xTw" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xTB" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table/wood,
@@ -32793,7 +32806,7 @@
 "xVC" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "xVI" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -33011,7 +33024,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "yci" = (
 /mob/living/simple_animal/hostile/wolf{
 	desc = "The dogs that survived the Great War are a larger, and tougher breed, size of a wolf.<br>This one looks mangy, with mud stuck to his hair and flies buzzing around him.";
@@ -33079,7 +33092,7 @@
 	icon_state = "bench"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "yeJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
@@ -33091,7 +33104,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "yfI" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -33103,7 +33116,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ygv" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -33190,7 +33203,7 @@
 "yjt" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "yjA" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/dirt,
@@ -33254,7 +33267,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ylP" = (
 /obj/structure/fence{
 	dir = 1
@@ -33270,7 +33283,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/surface)
 "ymd" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
@@ -72635,11 +72648,11 @@ wYn
 wYn
 ceT
 wYn
-vaA
-vaA
-vaA
-vaA
-vaA
+jem
+jem
+jem
+jem
+jem
 tUh
 mfD
 mfD
@@ -72892,11 +72905,11 @@ oSH
 kGV
 hbm
 hbm
-vaA
+jem
 gcK
 gcK
 gcK
-vaA
+jem
 jWO
 cTp
 fyf
@@ -84928,7 +84941,7 @@ pck
 xNm
 xNm
 hom
-oHR
+fAZ
 pck
 oWU
 hom
@@ -85411,7 +85424,7 @@ vYv
 gts
 ktB
 hom
-qCv
+sKB
 oMY
 hom
 fcI
@@ -95386,9 +95399,9 @@ fyf
 fyf
 fyf
 mrq
-pts
+urV
 nsE
-mCS
+sAg
 mrq
 fyf
 fyf

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -86,3 +86,34 @@
 	time = 20
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_MEDICAL
+
+
+/datum/crafting_recipe/jet
+	name = "Jet"
+	result = /obj/item/reagent_containers/pill/patch/jet
+	reqs = list(/obj/item/clothing/mask/cigarette = 2,
+				/datum/reagent/consumable/soymilk = 15,
+				/obj/item/toy/crayon/spraycan = 1)
+	time = 35
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
+
+/datum/crafting_recipe/turbo
+	name = "Turbo"
+	result = /obj/item/reagent_containers/pill/patch/turbo
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/feracactus = 2,
+				/obj/item/reagent_containers/food/snacks/grown/agave = 2,
+				/datum/reagent/consumable/ethanol/whiskey = 15)
+	time = 35
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
+
+/datum/crafting_recipe/psycho
+	name = "Psycho"
+	result = /obj/item/reagent_containers/hypospray/medipen/psycho
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/feracactus = 2,
+				/obj/item/reagent_containers/food/snacks/grown/fungus = 2,
+				/datum/reagent/consumable/nuka_cola = 10)
+	time = 35
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL


### PR DESCRIPTION
- Adds in three new recipes for drugs based on the old ones that existed pre-rebase (Jet, Turbo, Psycho).
- Adds in two vendors that were previously missing (clothing, medical)

Tested on a local host. Everything worked out and no errors compiling.
