### PR TITLE
Bone Mortar fix

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -103,7 +103,7 @@
 	reqs = list(/obj/item/stack/sheet/bone = 3)
 	category = CAT_PRIMAL
 
-/datum/crafting_recipe/bonemortar
+/datum/crafting_recipe/primitive_chem_isolator
 	name = "Bone Chemical Isolator"
 	result = /obj/item/reagent_containers/glass/primitive_chem_isolator
 	time = 20

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -446,10 +446,10 @@
 			to_chat(user, "<span class='notice'>You start grinding...</span>")
 			if((do_after(user, 25, target = src)) && grinded)
 				user.adjustStaminaLoss(20)
-				if(grinded.grind_results) //prioritize juicing - why? what
-					grinded.on_grind()
-					reagents.add_reagent_list(grinded.grind_results)
-					to_chat(user, "<span class='notice'>You grind [grinded] into a its components.</span>")
+				if(grinded.juice_results) //prioritize juicing
+					grinded.on_juice()
+					reagents.add_reagent_list(grinded.juice_results)
+					to_chat(user, "<span class='notice'>You juice [grinded] into a fine liquid.</span>")
 					QDEL_NULL(grinded)
 					return
 				grinded.on_grind()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bone Mortar is now craftable using the Tribal Crafting Menu option once more. The reason behind it not working was caused by an overlay of the recipies for Primitive Chem Isolator and Bone Mortar, both being given the name bonemortar in the recipe. Primitive Chem Isolator is now named primitive_chem_isolator to differentiate them.

The Bone Mortar was reported not being able to grind reagents anymore, and after examining the code, it was caused by an attempt to make it so that grinding was only performed, not juicing: which in the code is prioritized if the item is capable of being juiced. If we want to make mortar only grind and not juice, we'll need to make a new item that only juices to compensate for the loss of the other.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quality of life improvement in terms of crafting, making bones the center of making a bone mortar item, instead of confusing players by requiring wooden planks for the mortar, bones for the pestle.

Bone Mortar was also glitched, which heavily crippled tribal players.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Fixes: 
- Made Bone Mortar craftable using bones through the Tribal crafting menu.
- Fixed issue with Bone Mortar not actually grinding reagents.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
