### PR TITLE
Ranger + Weapon Changes

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -386,18 +386,18 @@
 
 /obj/item/projectile/beam/laser/aer14 //AER14
 	name = "laser beam"
-	damage = 40
-	armour_penetration = 0.75
+	damage = 38
+	armour_penetration = 0.6
 	icon_state = "omnilaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/laser/wattz2k
 	name = "laser bolt"
-	damage = 40
+	damage = 35
 	armour_penetration = 0.5
 
 /obj/item/projectile/beam/laser/musket //musket
 	name = "laser bolt"
-	damage = 55
+	damage = 40
 	armour_penetration = 0.6

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -97,3 +97,4 @@
 /obj/item/projectile/bullet/c2mm
 	damage = 55
 	armour_penetration = 0.85
+	pixels_per_second = TILES_TO_PIXELS(100)

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -47,8 +47,8 @@
 	range = 16
 
 /obj/item/projectile/bullet/a50MG
-	damage = 60
-	armour_penetration = 0.9
+	damage = 55
+	armour_penetration = 0.85
 	pixels_per_second = TILES_TO_PIXELS(100)
 
 /obj/item/projectile/bullet/a50MG/incendiary

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -107,6 +107,7 @@
 						"usotsukihime",
 						"melarinn",
 						"jackofoak",
+						"muhsollini",
 						"lynuahsororitas",
 						"prawn04",
 						"nokele")
@@ -160,6 +161,15 @@
 						"topbirb")
 	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
 
+/datum/gear/donator/rangersergeantpins
+	name = "Ranger-Sergeant Pins"
+	slot = SLOT_IN_BACKPACK
+	path = /obj/item/clothing/accessory/ranger/SGT
+	ckeywhitelist = list("usotsukihime",
+						"seabass390",
+						"panzer1944")
+	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
+
 /datum/gear/donator/rangerpins
 	name = "Ranger Pins"
 	slot = SLOT_IN_BACKPACK
@@ -183,6 +193,7 @@
 						"edisnij",
 						"melarinn",
 						"someonewithapen",
+						"muhsollini",
 						"lynuahsororitas")
 	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
 


### PR DESCRIPTION
- Gives Kainat their ranger pins + chosen service revolver
- Gives myself, Hannan and Wolf ranger sgt pins
- Nerfs .50 MG to be on-par with 2MM EC
- Fixes 2MM EC Projectile Speed
- Nerfs AER14 Dam and AP
- Nerfs Wattz 2000 Dam. to keep it the middleground between AER9 and AER14
- Nerfs Lasermusket Damage, since for some reason it did 55 damage.