### PR TITLE
Rebalancing 7.62

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -916,7 +916,7 @@
 	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'
 	can_suppress = FALSE
 	burst_size = 1
-	fire_delay = 4
+	fire_delay = 3
 	burst_shot_delay = 3
 	slowdown = 1.0
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -845,7 +845,7 @@
 	item_state = "rifle"
 	mag_type = /obj/item/ammo_box/magazine/garand308
 	fire_sound = 'sound/f13weapons/hunting_rifle.ogg'
-	fire_delay = 6
+	fire_delay = 4
 	burst_size = 1
 	en_bloc = 1
 	auto_eject = 1
@@ -916,7 +916,7 @@
 	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'
 	can_suppress = FALSE
 	burst_size = 1
-	fire_delay = 3
+	fire_delay = 4
 	burst_shot_delay = 3
 	slowdown = 1.0
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -1,42 +1,42 @@
 // 7.62
 /obj/item/projectile/bullet/a762
 	name = "7.62 FMJ bullet"
-	damage = 40 //42
-	armour_penetration = 0.20 //0.22
+	damage = 44 //42
+	armour_penetration = 0.25 //0.22
 	wound_bonus = 20
 	bare_wound_bonus = -20
 
 /obj/item/projectile/bullet/a762/ap
 	name = "7.62 AP bullet"
-	damage = 30 //32
-	armour_penetration = 0.5
+	damage = 37 //32
+	armour_penetration = 0.6
 	wound_bonus = 30
 	bare_wound_bonus = -30
 
 /obj/item/projectile/bullet/a762/jhp
 	name = "7.62 JHP bullet"
-	damage = 50 //48
+	damage = 55 //48
 	armour_penetration = -1
 	wound_bonus = -40
 	bare_wound_bonus = 40
 
 /obj/item/projectile/bullet/a762/sport //.308 Winchester
 	name = ".308 bullet"
-	damage = 32
+	damage = 35
 	armour_penetration = 0.08
 	wound_bonus = 10
 	bare_wound_bonus = -10
 
 /obj/item/projectile/bullet/a762/jsp
 	name = "7.62 JSP bullet"
-	damage = 50 //48
+	damage = 55 //48
 	armour_penetration = 0.1 //0.5
 	wound_bonus = 20
 	bare_wound_bonus = 20
 
 /obj/item/projectile/bullet/a762/match
 	name = "7.62 match bullet"
-	damage = 43 //50
+	damage = 47 //50
 	armour_penetration = 0.4
 	wound_bonus = 25
 	bare_wound_bonus = 25


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, 5.56 and 7.62 have nearly identical stats in game, however the weapons that fire 7.62 usually have less than 9 rounds in their magazine while 5.56 can hold 30-50 rounds.

This PR increases the damage of 7.62 rounds to be more of a middle ground between 5.56 and 45-70. It is now slightly more powerful than 5.56 to accommodate for the fact that almost every weapon that fires 7.62 is either very low capacity (hunting rifles, Kar98k, M1 Garand) or has speed penalties (R84 LMG).  

To balance two common weapons as well, the R84 LMG now has a fire rate of 4 rather than 3 to accommodate for the higher damage. The M1 Garand has had its terribly slow fire rate of 6 shifted to 4 as well to make it more useful as an 8 round rifle. Currently the hunting rifle could fire faster, and that's a bolt action.

## Why It's Good For The Game

7.62 weapons will be more viable in game as weapons that reward accuracy over volume of fire. With a magazine of only 5-10 rounds and generally slower fire rates than 5.56 rifles, they hit harder but require you to land shots rather than use bursts, with the notable exception of the 7.62 LMG.

## Changelog
:cl:
balance: Increases the damage for all base 7.62 rounds. Decreases the fire rate of the R84 and increases the fire rate of the M1 Garand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
