### PR TITLE
Smithing Balance

### DIFF
--- a/code/modules/smithing/smithed_items.dm
+++ b/code/modules/smithing/smithed_items.dm
@@ -165,7 +165,7 @@
 /obj/item/smithing/scytheblade/startfinish()
 	finalitem = new /obj/item/scythe/smithed(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.1
+	finalitem.armour_penetration += quality*0.05
 	..()
 
 /obj/item/smithing/shovelhead
@@ -200,7 +200,7 @@
 /obj/item/smithing/javelinhead/startfinish()
 	var/obj/item/melee/smith/twohand/javelin/finalforreal = new /obj/item/melee/smith/twohand/javelin(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.1
+	finalforreal.armour_penetration += quality*0.05
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
 	finalforreal.throwforce = finalforreal.force*2
@@ -235,7 +235,7 @@
 		finalforreal.toolspeed *= max(1, (quality * -1))
 	switch(quality)
 		if(10 to INFINITY)
-			finalforreal.digrange = 4
+			finalforreal.digrange = 3
 		if(5 to 9)
 			finalforreal.digrange = 3
 		if(3,4)
@@ -269,7 +269,7 @@
 /obj/item/smithing/shortswordblade/startfinish()
 	finalitem = new /obj/item/melee/smith/shortsword(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.1
+	finalitem.armour_penetration += quality*0.05
 	..()
 
 /obj/item/smithing/scimitarblade
@@ -281,7 +281,7 @@
 /obj/item/smithing/scimitarblade/startfinish()
 	finalitem = new /obj/item/melee/smith/shortsword/scimitar(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.1
+	finalitem.armour_penetration += quality*0.05
 	..()
 
 /obj/item/smithing/wakiblade
@@ -293,7 +293,7 @@
 /obj/item/smithing/wakiblade/startfinish()
 	finalitem = new /obj/item/melee/smith/wakizashi(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.1
+	finalitem.armour_penetration += quality*0.05
 	..()
 
 /obj/item/smithing/sabreblade
@@ -305,7 +305,7 @@
 /obj/item/smithing/sabreblade/startfinish()
 	finalitem = new /obj/item/melee/smith/sabre(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.1
+	finalitem.armour_penetration += quality*0.05
 	..()
 
 /obj/item/smithing/rapierblade
@@ -317,7 +317,7 @@
 /obj/item/smithing/rapierblade/startfinish()
 	finalitem = new /obj/item/melee/smith/sabre/rapier(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.1
+	finalitem.armour_penetration += quality*0.05
 	..()
 
 /obj/item/smithing/knifeblade
@@ -329,7 +329,7 @@
 /obj/item/smithing/knifeblade/startfinish()
 	finalitem = new /obj/item/kitchen/knife(src)
 	finalitem.force = 4 + quality/2
-	finalitem.armour_penetration += quality*0.1
+	finalitem.armour_penetration += quality*0.05
 	finalitem.icon = 'icons/obj/smith.dmi'
 	finalitem.icon_state = "dagger"
 	finalitem.name = "dagger"
@@ -351,7 +351,7 @@
 /obj/item/smithing/broadblade/startfinish()
 	var/obj/item/melee/smith/twohand/broadsword/finalforreal = new /obj/item/melee/smith/twohand/broadsword(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.1
+	finalforreal.armour_penetration += quality*0.05
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
 	finalitem = finalforreal
@@ -366,7 +366,7 @@
 /obj/item/smithing/zweiblade/startfinish()
 	var/obj/item/melee/smith/twohand/zweihander/finalforreal = new /obj/item/melee/smith/twohand/zweihander(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.1
+	finalforreal.armour_penetration += quality*0.05
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
 	finalitem = finalforreal
@@ -380,7 +380,7 @@
 /obj/item/smithing/halberdhead/startfinish()
 	var/obj/item/melee/smith/twohand/halberd/finalforreal = new /obj/item/melee/smith/twohand/halberd(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.1
+	finalforreal.armour_penetration += quality*0.05
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.throwforce = finalforreal.force/3
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
@@ -395,7 +395,7 @@
 /obj/item/smithing/glaivehead/startfinish()
 	var/obj/item/melee/smith/twohand/glaive/finalforreal = new /obj/item/melee/smith/twohand/glaive(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.1
+	finalforreal.armour_penetration += quality*0.05
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.throwforce = finalforreal.force
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
@@ -412,7 +412,7 @@
 /obj/item/smithing/katanablade/startfinish()
 	var/obj/item/melee/smith/twohand/katana/finalforreal = new /obj/item/melee/smith/twohand/katana(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.1
+	finalforreal.armour_penetration += quality*0.05
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
 	finalitem = finalforreal

--- a/code/modules/smithing/smithed_items.dm
+++ b/code/modules/smithing/smithed_items.dm
@@ -165,7 +165,7 @@
 /obj/item/smithing/scytheblade/startfinish()
 	finalitem = new /obj/item/scythe/smithed(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.05
+	finalitem.armour_penetration += quality*0.0375
 	..()
 
 /obj/item/smithing/shovelhead
@@ -200,7 +200,7 @@
 /obj/item/smithing/javelinhead/startfinish()
 	var/obj/item/melee/smith/twohand/javelin/finalforreal = new /obj/item/melee/smith/twohand/javelin(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.05
+	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
 	finalforreal.throwforce = finalforreal.force*2
@@ -235,9 +235,9 @@
 		finalforreal.toolspeed *= max(1, (quality * -1))
 	switch(quality)
 		if(10 to INFINITY)
-			finalforreal.digrange = 3
+			finalforreal.digrange = 2
 		if(5 to 9)
-			finalforreal.digrange = 3
+			finalforreal.digrange = 2
 		if(3,4)
 			finalforreal.digrange = 2
 		else
@@ -269,7 +269,7 @@
 /obj/item/smithing/shortswordblade/startfinish()
 	finalitem = new /obj/item/melee/smith/shortsword(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.05
+	finalitem.armour_penetration += quality*0.0375
 	..()
 
 /obj/item/smithing/scimitarblade
@@ -281,7 +281,7 @@
 /obj/item/smithing/scimitarblade/startfinish()
 	finalitem = new /obj/item/melee/smith/shortsword/scimitar(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.05
+	finalitem.armour_penetration += quality*0.0375
 	..()
 
 /obj/item/smithing/wakiblade
@@ -293,7 +293,7 @@
 /obj/item/smithing/wakiblade/startfinish()
 	finalitem = new /obj/item/melee/smith/wakizashi(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.05
+	finalitem.armour_penetration += quality*0.0375
 	..()
 
 /obj/item/smithing/sabreblade
@@ -305,7 +305,7 @@
 /obj/item/smithing/sabreblade/startfinish()
 	finalitem = new /obj/item/melee/smith/sabre(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.05
+	finalitem.armour_penetration += quality*0.0375
 	..()
 
 /obj/item/smithing/rapierblade
@@ -317,7 +317,7 @@
 /obj/item/smithing/rapierblade/startfinish()
 	finalitem = new /obj/item/melee/smith/sabre/rapier(src)
 	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.05
+	finalitem.armour_penetration += quality*0.0375
 	..()
 
 /obj/item/smithing/knifeblade
@@ -329,7 +329,7 @@
 /obj/item/smithing/knifeblade/startfinish()
 	finalitem = new /obj/item/kitchen/knife(src)
 	finalitem.force = 4 + quality/2
-	finalitem.armour_penetration += quality*0.05
+	finalitem.armour_penetration += quality*0.0375
 	finalitem.icon = 'icons/obj/smith.dmi'
 	finalitem.icon_state = "dagger"
 	finalitem.name = "dagger"
@@ -351,7 +351,7 @@
 /obj/item/smithing/broadblade/startfinish()
 	var/obj/item/melee/smith/twohand/broadsword/finalforreal = new /obj/item/melee/smith/twohand/broadsword(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.05
+	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
 	finalitem = finalforreal
@@ -366,7 +366,7 @@
 /obj/item/smithing/zweiblade/startfinish()
 	var/obj/item/melee/smith/twohand/zweihander/finalforreal = new /obj/item/melee/smith/twohand/zweihander(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.05
+	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
 	finalitem = finalforreal
@@ -380,7 +380,7 @@
 /obj/item/smithing/halberdhead/startfinish()
 	var/obj/item/melee/smith/twohand/halberd/finalforreal = new /obj/item/melee/smith/twohand/halberd(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.05
+	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.throwforce = finalforreal.force/3
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
@@ -395,7 +395,7 @@
 /obj/item/smithing/glaivehead/startfinish()
 	var/obj/item/melee/smith/twohand/glaive/finalforreal = new /obj/item/melee/smith/twohand/glaive(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.05
+	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.throwforce = finalforreal.force
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
@@ -412,7 +412,7 @@
 /obj/item/smithing/katanablade/startfinish()
 	var/obj/item/melee/smith/twohand/katana/finalforreal = new /obj/item/melee/smith/twohand/katana(src)
 	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.05
+	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
 	finalitem = finalforreal


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This changes the smithing weapons so they are not blatanly overpowered, but a very viable option beyond the weapons we can craft in the base game. For example, a crafted gladius is almost on part with an actual gladius, it just has AP to make up for it's lost damage. A smithed glaive has more damage and a touch of AP, but isn't too much different from a regular glaive.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Keeps the smithing weapons balanced so we don't have to remove them entirely, and allows us to tweak them/add new things in the future.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Blanket nerf to all wielded weapons, reducing it's maximum armor pen from 0.8 to 0.3. At most with a halberd, it now takes 7 hits to down a paladin in t-51b instead of two.

Smithed Halberd - The cost of it hitting harder then both the glaive and the pike, it is now a two handed weapon only.
Smithed Pike - It is like the base Glaive, only it has more AP
Smithed Glaive - Does slightly more damage then the Pike, but has less AP
 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
