### PR TITLE
Trait book n plasma rifle

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -847,7 +847,7 @@
 	desc = "Your private diary, reminding you of the knowledge you previously had."
 	granted_trait = null
 
-/obj/item/book/granter/trait/selection/attack_self(mob/user/living/carbon/human/M)
+/obj/item/book/granter/trait/selection/attack_self(mob/user)
 	var/list/choices = list("Hard Yards","Minor Surgery","Power Armor","Chemistry","Salvager","Melee Expert")
 	if(granted_trait == null)	
 		var/choice = input("Choose a trait:") in choices

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -799,6 +799,14 @@
 	traitname = "intermediate surgery"
 	remarks = list("Don't forget your instruments inside patients...", "Be careful when cutting...", "Don't operate with dirty hands...")
 
+/obj/item/book/granter/trait/tinkering
+	name = "Tinkering for Wastelander"
+	desc = "A useful book on tinkering."
+	oneuse = TRUE
+	granted_trait = TRAIT_MASTER_GUNSMITH
+	traitname = "tinkering"
+	remarks = list("Experiment!", "You can always try 3 times...", "Be careful with loaded guns...")
+
 /obj/item/book/granter/trait/spirit_teachings
 	name = "Teachings of the Machine Spirits"
 	desc = "A book all about tribal life among the Machine Spirits."
@@ -848,7 +856,7 @@
 	granted_trait = null
 
 /obj/item/book/granter/trait/selection/attack_self(mob/user)
-	var/list/choices = list("Hard Yards","Minor Surgery","Power Armor","Chemistry","Salvager","Melee Expert")
+	var/list/choices = list("Hard Yards","Minor Surgery","Power Armor","Chemistry","Salvager","Melee Expert", "Tinkerer")
 	if(granted_trait == null)	
 		var/choice = input("Choose a trait:") in choices
 		switch(choice)
@@ -872,6 +880,9 @@
 			if("Power Armor")
 				granted_trait = TRAIT_PA_WEAR
 				traitname = "advanced armor"
+			if("Tinkerer")
+				granted_trait = TRAIT_MASTER_GUNSMITH
+				traitname = "tinkering"
 	else 
 		. = ..()
 		

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -8,6 +8,7 @@
 	var/reading = FALSE //sanity
 	var/oneuse = TRUE //default this is true, but admins can var this to 0 if we wanna all have a pass around of the rod form book
 	var/used = FALSE //only really matters if oneuse but it might be nice to know if someone's used it for admin investigations perhaps
+	var/select = FALSE
 
 /obj/item/book/granter/proc/turn_page(mob/user)
 	playsound(user, pick('sound/effects/pageturn1.ogg','sound/effects/pageturn2.ogg','sound/effects/pageturn3.ogg'), 30, 1)
@@ -787,7 +788,7 @@
 	desc = "A useful book on surgery."
 	oneuse = TRUE
 	granted_trait = TRAIT_SURGERY_LOW
-	traitname = "lowsurgery"
+	traitname = "minor surgery"
 	remarks = list("Don't forget your instruments inside patients...", "Be careful when cutting...", "Don't operate with dirty hands...")
 
 /obj/item/book/granter/trait/midsurgery
@@ -795,7 +796,7 @@
 	desc = "A useful book on surgery."
 	oneuse = TRUE
 	granted_trait = TRAIT_SURGERY_MID
-	traitname = "midsurgery"
+	traitname = "intermediate surgery"
 	remarks = list("Don't forget your instruments inside patients...", "Be careful when cutting...", "Don't operate with dirty hands...")
 
 /obj/item/book/granter/trait/spirit_teachings
@@ -841,3 +842,39 @@
 	remarks = list("Keep your fists up...", "Don't clench your thumb in your fist, or you might break it...", "Turn into your punch, and put your body weight behind it...", "Footwork is everything, make sure to step into your punches...", "Aim for their jaw for an easy K-O...")
 */
 
+/obj/item/book/granter/trait/selection
+	name = "Private Diary"
+	desc = "Your private diary, reminding you of the knowledge you previously had."
+	granted_trait = null
+
+/obj/item/book/granter/trait/selection/attack_self(mob/user/living/carbon/human/M)
+	var/list/choices = list("Hard Yards","Minor Surgery","Power Armor","Chemistry","Salvager","Melee Expert")
+	if(granted_trait == null)	
+		var/choice = input("Choose a trait:") in choices
+		switch(choice)
+			if(null)
+				return 0
+			if("Hard Yards")
+				granted_trait = TRAIT_HARD_YARDS
+				traitname = "trekking"
+			if("Minor Surgery")
+				granted_trait = TRAIT_SURGERY_LOW
+				traitname = "intermediate surgery"
+			if("Chemistry")
+				granted_trait = TRAIT_CHEMWHIZ
+				traitname = "chemistry"
+			if("Salvager")
+				granted_trait = TRAIT_TECHNOPHREAK
+				traitname = "salvaging"
+			if("Melee Expert")
+				granted_trait = TRAIT_BIG_LEAGUES
+				traitname = "hitting things"
+			if("Power Armor")
+				granted_trait = TRAIT_PA_WEAR
+				traitname = "advanced armor"
+	else 
+		. = ..()
+		
+/obj/item/book/granter/trait/selection/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_GENERIC)

--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -594,6 +594,7 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Spray bottle",					/obj/item/reagent_containers/spray,									35),
 		new /datum/data/wasteland_equipment("Bottle of E-Z-Nutrient",		/obj/item/reagent_containers/glass/bottle/nutrient/ez,				40),
 		new /datum/data/wasteland_equipment("Craftsmanship Monthly",		/obj/item/book/granter/trait/techno,								600),
+		new /datum/data/wasteland_equipment("Tinkering for Wastelanders"	/obj/item/book/granter/trait/tinkering,								600)
 		)
 	highpop_list = list(
 		new /datum/data/wasteland_equipment("Drinking glass",				/obj/item/reagent_containers/food/drinks/drinkingglass,				5),
@@ -602,6 +603,7 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Spray bottle",					/obj/item/reagent_containers/spray,									35),
 		new /datum/data/wasteland_equipment("Bottle of E-Z-Nutrient",		/obj/item/reagent_containers/glass/bottle/nutrient/ez,				40),
 		new /datum/data/wasteland_equipment("Craftsmanship Monthly",		/obj/item/book/granter/trait/techno,								600),
+		new /datum/data/wasteland_equipment("Tinkering for Wastelanders"	/obj/item/book/granter/trait/tinkering,								600)
 		)
 
 /obj/machinery/mineral/wasteland_vendor/camp

--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -594,7 +594,7 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Spray bottle",					/obj/item/reagent_containers/spray,									35),
 		new /datum/data/wasteland_equipment("Bottle of E-Z-Nutrient",		/obj/item/reagent_containers/glass/bottle/nutrient/ez,				40),
 		new /datum/data/wasteland_equipment("Craftsmanship Monthly",		/obj/item/book/granter/trait/techno,								600),
-		new /datum/data/wasteland_equipment("Tinkering for Wastelanders"	/obj/item/book/granter/trait/tinkering,								600)
+		new /datum/data/wasteland_equipment("Tinkering for Wastelanders",	/obj/item/book/granter/trait/tinkering,								600)
 		)
 	highpop_list = list(
 		new /datum/data/wasteland_equipment("Drinking glass",				/obj/item/reagent_containers/food/drinks/drinkingglass,				5),
@@ -603,7 +603,7 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Spray bottle",					/obj/item/reagent_containers/spray,									35),
 		new /datum/data/wasteland_equipment("Bottle of E-Z-Nutrient",		/obj/item/reagent_containers/glass/bottle/nutrient/ez,				40),
 		new /datum/data/wasteland_equipment("Craftsmanship Monthly",		/obj/item/book/granter/trait/techno,								600),
-		new /datum/data/wasteland_equipment("Tinkering for Wastelanders"	/obj/item/book/granter/trait/tinkering,								600)
+		new /datum/data/wasteland_equipment("Tinkering for Wastelanders",	/obj/item/book/granter/trait/tinkering,								600)
 		)
 
 /obj/machinery/mineral/wasteland_vendor/camp

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -625,6 +625,7 @@ Mayor
 	shoes = /obj/item/clothing/shoes/jackboots
 	backpack = /obj/item/storage/backpack/satchel/explorer
 	r_pocket = /obj/item/flashlight/flare
+	r_hand = /obj/item/book/granter/trait/selection
 	backpack_contents = list(
 			/obj/item/storage/bag/money/small/settler = 1, \
 			/obj/item/kitchen/knife/combat = 1, \

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -66,7 +66,7 @@ Great Khan
 	minimal_access = list(ACCESS_KHAN)
 
 	loadout_options = list(
-	/datum/outfit/loadout/pusher,
+	///datum/outfit/loadout/pusher,
 	/datum/outfit/loadout/enforcer,
 	/datum/outfit/loadout/brawler)
 
@@ -83,6 +83,7 @@ Great Khan
 
 /datum/outfit/job/wasteland/f13pusher/pre_equip(mob/living/carbon/human/H)
 	..()
+	r_hand = /obj/item/book/granter/trait/selection
 	r_pocket = /obj/item/flashlight/flare
 	l_pocket = /obj/item/storage/bag/money/small/khan
 	backpack_contents = list(
@@ -110,13 +111,13 @@ Great Khan
 		GLOB.all_gangs |= GK
 		GK.add_member(H)
 		H.gang = GK
-
+/*
 /datum/outfit/loadout/pusher
 	name = "Chemist"
 	backpack_contents = list(
 		/obj/item/reagent_containers/glass/beaker/large=2, \
 		/obj/item/book/granter/trait/chemistry=1)
-
+*/
 /datum/outfit/loadout/enforcer
 	name = "Enforcer"
 	suit_store = /obj/item/gun/ballistic/shotgun/trench
@@ -177,6 +178,7 @@ Raider
 	belt = null
 	backpack = /obj/item/storage/backpack/satchel/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer
+	r_hand = /obj/item/book/granter/trait/selection
 
 /datum/outfit/job/wasteland/f13raider/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -401,11 +403,7 @@ Raider
 
 /datum/outfit/job/wasteland/f13wastelander/pre_equip(mob/living/carbon/human/H)
 	..()
-	r_hand = pick(
-		/obj/item/claymore/machete/pipe, \
-		/obj/item/claymore/machete/golf, \
-		/obj/item/switchblade, \
-		/obj/item/kitchen/knife)
+	r_hand = /obj/item/book/granter/trait/selection
 	uniform = pick(
 		/obj/item/clothing/under/f13/settler, \
 		/obj/item/clothing/under/f13/brahminm, \
@@ -423,7 +421,8 @@ Raider
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=2, \
 		/obj/item/reagent_containers/pill/radx=1, \
-		/obj/item/storage/bag/money/small/wastelander)
+		/obj/item/storage/bag/money/small/wastelander, \
+		/obj/item/kitchen/knife)
 	suit_store = pick(
 	/obj/item/gun/ballistic/revolver/detective, \
 	/obj/item/gun/ballistic/shotgun/remington, \

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -2,7 +2,7 @@
 	projectile_type = /obj/item/projectile/f13plasma
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
-	delay = 15
+	delay = 4.5
 	e_cost = 25
 
 /obj/item/ammo_casing/energy/plasma/adv

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -2,7 +2,6 @@
 	projectile_type = /obj/item/projectile/f13plasma
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
-	delay = 4.5
 	e_cost = 25
 
 /obj/item/ammo_casing/energy/plasma/adv

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -384,7 +384,7 @@
 	name ="plasma rifle"
 	item_state = "plasma"
 	icon_state = "plasma"
-	fire_delay = 2.5
+	fire_delay = 4.5
 	desc = "A top of line miniaturized plasma caster built by REPCONN in the wake of the Z43-521P failure. It is supperior to all previous rifles to enter service in the USCC."
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds one new item to the game, the private diary. Also removing the chem master loadout from the khans in place of all khans spawning with the private diary. Also buffing the plasma rifle's firing rate to be almost on par with the colt range-master since their damage numbers are similar.

Private Diary - A trait book that allows you to choose one singular trait from a vast selection. The book will be available for khans, outlaws, and wasters to allow them for more personal customization and freedom. The traits that the private diary allow someone to select are as follows: hard yards, mid surgery, PA wear, chemwiz, technofreak, and big leagues. They can only choose one of these traits, the book will be used.
## Why It's Good For The Game
uhhhhhhhhhh more specialization and variety for wasters and stuff
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Private Diary book thing
balance: Plasma rifle fire rate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
