### PR TITLE
Unarmed Update #2

### DIFF
--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -62,15 +62,28 @@
 //	distro = 1
 	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot
 
+/obj/item/melee/unarmed
+	var/can_adjust_unarmed = TRUE
+	var/unarmed_adjusted = TRUE
+
 /obj/item/melee/unarmed/equipped(mob/user, slot)
 	. = ..()
 	var/mob/living/carbon/human/H = user
+	if(unarmed_adjusted)
+		mob_overlay_icon = righthand_file
+	if(!unarmed_adjusted)
+		mob_overlay_icon = lefthand_file
 	if(ishuman(user) && slot == SLOT_GLOVES)
 		ADD_TRAIT(user, TRAIT_UNARMED_WEAPON, "glove")
 		if(HAS_TRAIT(user, TRAIT_UNARMED_WEAPON))
 			H.dna.species.punchdamagehigh = force + 8 //The +8 damage is what brings up your punch damage to the unarmed weapon's force fully
 			H.dna.species.punchdamagelow = force + 8
-	if(ishuman(user) && slot != SLOT_GLOVES)
+			H.dna.species.attack_sound = hitsound
+			if(sharpness == SHARP_POINTY || sharpness ==  SHARP_EDGED)
+				H.dna.species.attack_verb = pick("slash","slice","rip","tear","cut","dice")
+			if(sharpness == SHARP_NONE)
+				H.dna.species.attack_verb = pick("punch","jab","whack")
+	if(ishuman(user) && slot != SLOT_GLOVES && !H.gloves)
 		REMOVE_TRAIT(user, TRAIT_UNARMED_WEAPON, "glove")
 		if(!HAS_TRAIT(user, TRAIT_UNARMED_WEAPON))
 			H.dna.species.punchdamagehigh = 1
@@ -78,6 +91,27 @@
 		if(HAS_TRAIT(user, TRAIT_IRONFIST))
 			H.dna.species.punchdamagehigh = 4
 			H.dna.species.punchdamagelow = 11
+		H.dna.species.attack_sound = 'sound/weapons/punch1.ogg'
+		H.dna.species.attack_verb = "punch"
+
+/obj/item/melee/unarmed/examine(mob/user)
+	. = ..()
+	if(can_adjust_unarmed == TRUE)
+		if(unarmed_adjusted == TRUE)
+			. += "<span class='notice'>Alt-click on [src] to wear it on a different hand. You must take it off first, then put it on again.</span>"
+		else
+			. += "<span class='notice'>Alt-click on [src] to wear it on a different hand. You must take it off first, then put it on again.</span>"
+
+/obj/item/melee/unarmed/AltClick(mob/user)
+	. = ..()
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ishuman(user)))
+		return
+	if(can_adjust_unarmed == TRUE)
+		toggle_unarmed_adjust()
+
+/obj/item/melee/unarmed/proc/toggle_unarmed_adjust()
+	unarmed_adjusted = !unarmed_adjusted
+	to_chat(usr, "<span class='notice'>[src] is ready to be worn on another hand.</span>")
 
 /obj/item/melee/unarmed/brass
 	name = "brass knuckles"


### PR DESCRIPTION
Unarmed weapons now appear on your character when worn in the glove slot, and the sounds they make when you hit someone with them now play while they're in your glove slot as well

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
My last update to unarmed weapons allowed them to be used while in your glove slot, but it was really barebones. Now, you can see the weapon sprite on your mob while it's worn in your glove slot, and you can even switch what hand you're wearing them on too. Pictures below:

![Screenshot (2922)](https://user-images.githubusercontent.com/51186688/114255893-5a9e7900-9984-11eb-87d8-e3ac9e7adeab.png)

![Screenshot (2923)](https://user-images.githubusercontent.com/51186688/114255895-638f4a80-9984-11eb-9a2e-1d9d0a6e93fb.png)

You would also only hear the stock sound effect of punches even if you had an unarmed weapon in the glove slot. Now, you'll hear that specific weapon's hitsound if you were to punch someone while that weapon was in your glove slot.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
QoL improvements for unarmed weapons, also provides some clarity for what weapon a person is using in unarmed weapon combat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: unarmed weapon sprites now appear while in your glove slot
tweak: unarmed weapon hitsounds now trigger while in your glove slot
fix: fixed a bug where if you had an unarmed weapon in your hands and in your glove slot, you'd lose the damage of the one in your glove slot
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
