### PR TITLE
Buffs for hydroponics: reduced weed growth: compost now apply changes.

### DIFF
--- a/code/modules/fallout/reagents/other_reagents.dm
+++ b/code/modules/fallout/reagents/other_reagents.dm
@@ -1,10 +1,18 @@
 /datum/reagent/compost
 	name = "compost"
-	description = "A mixture of waste and rotten plant matter that nurtures plants and keeps them free of pests."
+	description = "A mixture of waste and rotten plant matter that nurtures plants and keeps them free of pests. Weak in comparison to other fertilizers."
 	reagent_state = "SOLID"
 	color = "#44341F"
 	taste_description = "rot"
-
+//Compost when used on soil
+/datum/reagent/compost/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
+	. = ..()
+	if(chems.has_reagent(src.type, 1))
+		mytray.adjustPests(-1)
+		if(myseed && chems.has_reagent(src.type, 1))
+			myseed.adjust_yield(round(chems.get_reagent_amount(src.type) * 0.1))
+			myseed.adjust_potency(round(chems.get_reagent_amount(src.type) * 0.25))
+// Compost when drunk..?
 /datum/reagent/compost/on_mob_life(mob/living/carbon/M)
 	M.adjustToxLoss(0.5*REAGENTS_EFFECT_MULTIPLIER, 0)
 	. = TRUE

--- a/code/modules/fallout/reagents/other_reagents.dm
+++ b/code/modules/fallout/reagents/other_reagents.dm
@@ -1,18 +1,10 @@
 /datum/reagent/compost
 	name = "compost"
-	description = "A mixture of waste and rotten plant matter that nurtures plants and keeps them free of pests. Weak in comparison to other fertilizers."
+	description = "A mixture of waste and rotten plant matter that nurtures plants and keeps them free of pests."
 	reagent_state = "SOLID"
 	color = "#44341F"
 	taste_description = "rot"
-//Compost when used on soil
-/datum/reagent/compost/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
-	. = ..()
-	if(chems.has_reagent(src.type, 1))
-		mytray.adjustPests(-1)
-		if(myseed && chems.has_reagent(src.type, 1))
-			myseed.adjust_yield(round(chems.get_reagent_amount(src.type) * 0.1))
-			myseed.adjust_potency(round(chems.get_reagent_amount(src.type) * 0.25))
-// Compost when drunk..?
+
 /datum/reagent/compost/on_mob_life(mob/living/carbon/M)
 	M.adjustToxLoss(0.5*REAGENTS_EFFECT_MULTIPLIER, 0)
 	. = TRUE

--- a/code/modules/fallout/reagents/other_reagents.dm
+++ b/code/modules/fallout/reagents/other_reagents.dm
@@ -5,6 +5,15 @@
 	color = "#44341F"
 	taste_description = "rot"
 
+//Compost when used on soil
+/datum/reagent/compost/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
+	. = ..()
+	if(chems.has_reagent(src.type, 1))
+		mytray.adjustPests(-1)
+		if(myseed && chems.has_reagent(src.type, 1))
+			myseed.adjust_yield(round(chems.get_reagent_amount(src.type) * 0.1))
+			myseed.adjust_potency(round(chems.get_reagent_amount(src.type) * 0.25))
+// Compost when drunk..?
 /datum/reagent/compost/on_mob_life(mob/living/carbon/M)
 	M.adjustToxLoss(0.5*REAGENTS_EFFECT_MULTIPLIER, 0)
 	. = TRUE

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -9,7 +9,7 @@
 	idle_power_usage = 0
 	var/waterlevel = 100	//The amount of water in the tray (max 100)
 	var/maxwater = 100		//The maximum amount of water in the tray
-	var/nutridrain = 0.5      // How many units of nutrient will be drained in the tray //test
+	var/nutridrain = 0.3      // How many units of nutrient will be drained in the tray //test // lowering it further
 	var/maxnutri = 10		//The maximum nutrient of water in the tray
 	var/pestlevel = 0		//The amount of pests in the tray (max 10)
 	var/weedlevel = 0		//The amount of weeds in the tray (max 10)
@@ -119,7 +119,7 @@
 			// Nutrients deplete at a constant rate, since new nutrients can boost stats far easier.
 			apply_chemicals(lastuser)
 			if(self_sustaining)
-				reagents.remove_any(min(0.5, nutridrain))
+				reagents.remove_any(min(0.3, nutridrain))
 			else
 				reagents.remove_any(nutridrain)
 
@@ -230,7 +230,7 @@
 			if(prob(5))  // On each tick, there's a 5 percent chance the pest population will increase
 				adjustPests(1 / rating)
 		else
-			if(waterlevel > 10 && reagents.total_volume > 0 && prob(10))  // If there's no plant, the percentage chance is 10%
+			if(waterlevel > 10 && reagents.total_volume > 0 && prob(3))  // If there's no plant, the percentage chance is 10% / SIKE, THAT'S WHAT YOU THOUGHT. 3% NOW.
 				adjustWeeds(1 / rating)
 
 		// Weeeeeeeeeeeeeeedddssss
@@ -697,7 +697,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!
 	name = "soil"
-	desc = "A patch of dirt."
+	desc = "A patch of dirt. <b>Alt-Click</b> to empty the soil's nutrients."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "soil"
 	circuit = null
@@ -722,7 +722,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!
 	name = "soil"
-	desc = "A patch of dirt."
+	desc = "A patch of dirt. <b>Alt-Click</b> to empty the soil's nutrients."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "soil"
 	circuit = null

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -9,7 +9,7 @@
 	idle_power_usage = 0
 	var/waterlevel = 100	//The amount of water in the tray (max 100)
 	var/maxwater = 100		//The maximum amount of water in the tray
-	var/nutridrain = 0.3      // How many units of nutrient will be drained in the tray //test // lowering it further
+	var/nutridrain = 0.5      // How many units of nutrient will be drained in the tray //test
 	var/maxnutri = 10		//The maximum nutrient of water in the tray
 	var/pestlevel = 0		//The amount of pests in the tray (max 10)
 	var/weedlevel = 0		//The amount of weeds in the tray (max 10)
@@ -119,7 +119,7 @@
 			// Nutrients deplete at a constant rate, since new nutrients can boost stats far easier.
 			apply_chemicals(lastuser)
 			if(self_sustaining)
-				reagents.remove_any(min(0.3, nutridrain))
+				reagents.remove_any(min(0.5, nutridrain))
 			else
 				reagents.remove_any(nutridrain)
 
@@ -230,7 +230,7 @@
 			if(prob(5))  // On each tick, there's a 5 percent chance the pest population will increase
 				adjustPests(1 / rating)
 		else
-			if(waterlevel > 10 && reagents.total_volume > 0 && prob(3))  // If there's no plant, the percentage chance is 10% / SIKE, THAT'S WHAT YOU THOUGHT. 3% NOW.
+			if(waterlevel > 10 && reagents.total_volume > 0 && prob(10))  // If there's no plant, the percentage chance is 10%
 				adjustWeeds(1 / rating)
 
 		// Weeeeeeeeeeeeeeedddssss
@@ -697,7 +697,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!
 	name = "soil"
-	desc = "A patch of dirt. <b>Alt-Click</b> to empty the soil's nutrients."
+	desc = "A patch of dirt."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "soil"
 	circuit = null
@@ -722,7 +722,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!
 	name = "soil"
-	desc = "A patch of dirt. <b>Alt-Click</b> to empty the soil's nutrients."
+	desc = "A patch of dirt."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "soil"
 	circuit = null

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -9,7 +9,7 @@
 	idle_power_usage = 0
 	var/waterlevel = 100	//The amount of water in the tray (max 100)
 	var/maxwater = 100		//The maximum amount of water in the tray
-	var/nutridrain = 0.5      // How many units of nutrient will be drained in the tray //test
+	var/nutridrain = 0.3      // How many units of nutrient will be drained in the tray //test //lowering it even further
 	var/maxnutri = 10		//The maximum nutrient of water in the tray
 	var/pestlevel = 0		//The amount of pests in the tray (max 10)
 	var/weedlevel = 0		//The amount of weeds in the tray (max 10)
@@ -119,7 +119,7 @@
 			// Nutrients deplete at a constant rate, since new nutrients can boost stats far easier.
 			apply_chemicals(lastuser)
 			if(self_sustaining)
-				reagents.remove_any(min(0.5, nutridrain))
+				reagents.remove_any(min(0.3, nutridrain))
 			else
 				reagents.remove_any(nutridrain)
 
@@ -230,7 +230,7 @@
 			if(prob(5))  // On each tick, there's a 5 percent chance the pest population will increase
 				adjustPests(1 / rating)
 		else
-			if(waterlevel > 10 && reagents.total_volume > 0 && prob(10))  // If there's no plant, the percentage chance is 10%
+			if(waterlevel > 10 && reagents.total_volume > 0 && prob(3))  // If there's no plant, the percentage chance is 10% // Nerfing down to 3%
 				adjustWeeds(1 / rating)
 
 		// Weeeeeeeeeeeeeeedddssss
@@ -697,7 +697,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!
 	name = "soil"
-	desc = "A patch of dirt."
+	desc = "A patch of dirt. <b>Alt-Click</b> to empty the soil's nutrients."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "soil"
 	circuit = null
@@ -722,7 +722,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!
 	name = "soil"
-	desc = "A patch of dirt."
+	desc = "A patch of dirt. <b>Alt-Click</b> to empty the soil's nutrients."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "soil"
 	circuit = null

--- a/config/config.txt
+++ b/config/config.txt
@@ -78,7 +78,7 @@ ENABLE_LOCALHOST_RANK
 #USE_AGE_RESTRICTION_FOR_JOBS
 
 ## Uncomment the following line to enable the role whitelisting system.  You will also need the table from role_whitelist.sql in the SQL directory.
-#USE_ROLE_WHITELIST
+USE_ROLE_WHITELIST
 
 ## Uncomment this to have the job system use the player's account creation date, rather than the when they first joined the server for job timers.
 #USE_ACCOUNT_AGE_FOR_JOBS

--- a/config/config.txt
+++ b/config/config.txt
@@ -78,7 +78,7 @@ ENABLE_LOCALHOST_RANK
 #USE_AGE_RESTRICTION_FOR_JOBS
 
 ## Uncomment the following line to enable the role whitelisting system.  You will also need the table from role_whitelist.sql in the SQL directory.
-USE_ROLE_WHITELIST
+#USE_ROLE_WHITELIST
 
 ## Uncomment this to have the job system use the player's account creation date, rather than the when they first joined the server for job timers.
 #USE_ACCOUNT_AGE_FOR_JOBS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Compost now boosts yield and potency, albeit weaker in comparison to robust harvest and EZ-nutriment, while lowering pests by a static 1 per plant age.
- The chance of an empty soil to have an increase in weed growth is reduced from 10% to 3% to lower the amount of stress felt by farmers.
- Nutridrain is lowered from 0.5 to 0.3 in an effort to allow more flexibility to farmers to leave their crops unattended for longer periods of time. May need a new fertilizer or other change to the system to properly realize this.
- Soil now has a description informing the player that they can drain the nutrilevels by using Alt-Click.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These changes will hopefully allow farming for people in the wastes without a high amount of tech to atleast have a chance to get some improvements, as prior tribals and legionnaires couldn't get anything done with what they had. More changes will be required in the future to bring them up to the same levels.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced something
fix: fixed a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
