### PR TITLE
Smithing changes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -74,6 +74,8 @@
 	var/account_id
 	var/last_fire_update
 
+	var/busy= FALSE
+
 /// Unarmed parry data for human
 /datum/block_parry_data/unarmed/human
 	parry_respect_clickdelay = TRUE

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -97,8 +97,12 @@
 		if(!(workpiece_state == WORKPIECE_PRESENT || workpiece_state == WORKPIECE_INPROGRESS))
 			to_chat(user, "You can't work an empty anvil!")
 			return FALSE
+		var/mob/living/carbon/human/F = user
 		if(busy)
 			to_chat(user, "This anvil is already being worked!")
+			return FALSE
+		if(F.busy)
+			to_chat(user, "You are already working another anvil!")
 			return FALSE
 		do_shaping(user, hammertime.qualitymod)
 		return
@@ -111,6 +115,8 @@
 
 
 /obj/structure/anvil/proc/do_shaping(mob/user, qualitychange)
+	var/mob/living/carbon/human/F = user
+	F.busy = TRUE
 	busy = TRUE
 	currentquality += qualitychange
 	var/list/shapingsteps = list("weak hit", "strong hit", "heavy hit", "fold", "draw", "shrink", "bend", "punch", "upset") //weak/strong/heavy hit affect strength. All the other steps shape.
@@ -123,6 +129,7 @@
 	playsound(src, 'sound/effects/clang2.ogg',40, 2)
 	if(!do_after(user, steptime, target = src))
 		busy = FALSE
+		F.busy = FALSE
 		return FALSE
 	switch(stepdone)
 		if("weak hit")
@@ -168,6 +175,7 @@
 	if(length(stepsdone) >= 3)
 		tryfinish(user)
 	busy = FALSE
+	F.busy = FALSE
 
 /obj/structure/anvil/proc/tryfinish(mob/user)
 	var/artifactchance = 0
@@ -223,7 +231,7 @@
 			outrightfailchance = 1
 			artifactrolled = FALSE
 			if(user.mind.skill_holder)
-				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 150, 10000000, silent = FALSE)
+				user.mind.auto_gain_experience(/datum/skill/level/dwarfy/blacksmithing, 100, 10000000, silent = FALSE)
 			break
 
 /obj/structure/anvil/debugsuper

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -153,7 +153,6 @@
 /obj/item/melee/smith/twohand/pike
 	name = "pike"
 	icon_state = "pike"
-	w_class = WEIGHT_CLASS_HUGE
 	overlay_state = "longhandle"
 	reach = 2 //yeah ok
 	wielded_mult = 1.3

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -115,12 +115,14 @@
 	icon_state = "halberd"
 	w_class = WEIGHT_CLASS_HUGE
 	overlay_state = "spearhandle"
+	reach = 2 
 	slot_flags = ITEM_SLOT_BACK
-	wielded_mult = 2.5
+	wielded_mult = 1.8
 
 /obj/item/melee/smith/twohand/halberd/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/jousting)
+	AddComponent(/datum/component/two_handed, require_twohands=TRUE)
 
 /obj/item/melee/smith/twohand/javelin
 	name = "javelin"
@@ -139,8 +141,9 @@
 	name = "glaive"
 	icon_state = "glaive"
 	overlay_state = "longhandle"
+	reach = 2 
 	slot_flags = ITEM_SLOT_BACK
-	wielded_mult = 2
+	wielded_mult = 1.5
 
 /obj/item/melee/smith/twohand/glaive/ComponentInitialize()
 	. = ..()
@@ -153,6 +156,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	overlay_state = "longhandle"
 	reach = 2 //yeah ok
+	wielded_mult = 1.3
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_POINTY
 
@@ -227,7 +231,7 @@
 	overlay_state = "zweihilt"
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2
 	force = 4
-	wielded_mult = 3 //affected more by quality. a -1 is 25% less damage, a +1 is 25% more. These bonuses are tripled when wielded.
+	wielded_mult = 2 //affected more by quality. a -1 is 25% less damage, a +1 is 25% more. These bonuses are tripled when wielded.
 
 /obj/item/melee/smith/twohand/katana
 	name = "katana"

--- a/code/modules/smithing/smithed_items.dm
+++ b/code/modules/smithing/smithed_items.dm
@@ -164,7 +164,7 @@
 
 /obj/item/smithing/scytheblade/startfinish()
 	finalitem = new /obj/item/scythe/smithed(src)
-	finalitem.force += quality*5
+	finalitem.force += quality*3.4
 	finalitem.armour_penetration += quality*0.0375
 	..()
 
@@ -189,7 +189,7 @@
 
 /obj/item/smithing/cogheadclubhead/startfinish()
 	finalitem = new /obj/item/melee/smith/cogheadclub(src)
-	finalitem.force += quality*5
+	finalitem.force += quality*3.4
 	..()
 
 /obj/item/smithing/javelinhead
@@ -199,7 +199,7 @@
 
 /obj/item/smithing/javelinhead/startfinish()
 	var/obj/item/melee/smith/twohand/javelin/finalforreal = new /obj/item/melee/smith/twohand/javelin(src)
-	finalforreal.force += quality*5
+	finalforreal.force += quality*3
 	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
@@ -214,7 +214,8 @@
 
 /obj/item/smithing/pikehead/startfinish()
 	var/obj/item/melee/smith/twohand/pike/finalforreal = new /obj/item/melee/smith/twohand/pike(src)
-	finalforreal.force += quality*5
+	finalforreal.force += quality*3
+	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
 	finalforreal.throwforce = finalforreal.force/10 //its a pike not a javelin
@@ -239,7 +240,7 @@
 		if(5 to 9)
 			finalforreal.digrange = 2
 		if(3,4)
-			finalforreal.digrange = 2
+			finalforreal.digrange = 1
 		else
 			finalforreal.digrange = 1
 	finalitem = finalforreal
@@ -268,7 +269,7 @@
 
 /obj/item/smithing/shortswordblade/startfinish()
 	finalitem = new /obj/item/melee/smith/shortsword(src)
-	finalitem.force += quality*5
+	finalitem.force += quality*3.4
 	finalitem.armour_penetration += quality*0.0375
 	..()
 
@@ -280,8 +281,8 @@
 
 /obj/item/smithing/scimitarblade/startfinish()
 	finalitem = new /obj/item/melee/smith/shortsword/scimitar(src)
-	finalitem.force += quality*5
-	finalitem.armour_penetration += quality*0.0375
+	finalitem.force += quality*3.4
+	finalitem.armour_penetration += quality*0.0025
 	..()
 
 /obj/item/smithing/wakiblade
@@ -292,7 +293,7 @@
 
 /obj/item/smithing/wakiblade/startfinish()
 	finalitem = new /obj/item/melee/smith/wakizashi(src)
-	finalitem.force += quality*5
+	finalitem.force += quality*3.4
 	finalitem.armour_penetration += quality*0.0375
 	..()
 
@@ -304,7 +305,7 @@
 
 /obj/item/smithing/sabreblade/startfinish()
 	finalitem = new /obj/item/melee/smith/sabre(src)
-	finalitem.force += quality*5
+	finalitem.force += quality*3.4
 	finalitem.armour_penetration += quality*0.0375
 	..()
 
@@ -316,7 +317,7 @@
 
 /obj/item/smithing/rapierblade/startfinish()
 	finalitem = new /obj/item/melee/smith/sabre/rapier(src)
-	finalitem.force += quality*5
+	finalitem.force += quality*3.4
 	finalitem.armour_penetration += quality*0.0375
 	..()
 
@@ -350,7 +351,7 @@
 
 /obj/item/smithing/broadblade/startfinish()
 	var/obj/item/melee/smith/twohand/broadsword/finalforreal = new /obj/item/melee/smith/twohand/broadsword(src)
-	finalforreal.force += quality*5
+	finalforreal.force += quality*3
 	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
@@ -365,7 +366,7 @@
 
 /obj/item/smithing/zweiblade/startfinish()
 	var/obj/item/melee/smith/twohand/zweihander/finalforreal = new /obj/item/melee/smith/twohand/zweihander(src)
-	finalforreal.force += quality*5
+	finalforreal.force += quality*3
 	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
@@ -379,8 +380,8 @@
 
 /obj/item/smithing/halberdhead/startfinish()
 	var/obj/item/melee/smith/twohand/halberd/finalforreal = new /obj/item/melee/smith/twohand/halberd(src)
-	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.0375
+	finalforreal.force += quality*3
+	finalforreal.armour_penetration += quality*0.025
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.throwforce = finalforreal.force/3
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
@@ -394,8 +395,8 @@
 
 /obj/item/smithing/glaivehead/startfinish()
 	var/obj/item/melee/smith/twohand/glaive/finalforreal = new /obj/item/melee/smith/twohand/glaive(src)
-	finalforreal.force += quality*5
-	finalforreal.armour_penetration += quality*0.0375
+	finalforreal.force += quality*3
+	finalforreal.armour_penetration += quality*0.0025
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.throwforce = finalforreal.force
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
@@ -411,7 +412,7 @@
 
 /obj/item/smithing/katanablade/startfinish()
 	var/obj/item/melee/smith/twohand/katana/finalforreal = new /obj/item/melee/smith/twohand/katana(src)
-	finalforreal.force += quality*5
+	finalforreal.force += quality*3
 	finalforreal.armour_penetration += quality*0.0375
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Finishing my smithing balance changes AND making it so you can't work on two anvils at once. Anyone doing this should be ashamed of themselves for meta-crafting super good masterworks in about ten minutes. No, none of that, shame on you. Also makes it so that the glaive and pike can fit in the suit storage slot.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops you dirty smithing-meta-rushers and makes smithing still viable but not outrageously OP
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

Balance: Blanket changes of damage numbers, as well as wield multipliers, 
Balance: Zweihander reduced from a 3.0 wield to a 2.0, subject to change in the future to make it more balanced
Bugfix: Pike and Gladius can for sure fit on both backpack and suit storage
Balance: Can only work on ONE anvil at a time, dirty meta rushers. 
Balance: Makes Smithing melee still viable, and better for those who put the work in 
Balance: Reduced XP gain by fifty, but it should take a reasonable amount of time to reach masterwork status.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
