### PR TITLE
Fixes & Bunker Stuff

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -46953,7 +46953,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -47210,7 +47210,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -47467,7 +47467,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -47724,7 +47724,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -47981,7 +47981,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -48238,7 +48238,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -48495,7 +48495,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -48752,7 +48752,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -49009,7 +49009,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -49266,7 +49266,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -49523,7 +49523,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -49780,7 +49780,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -50037,7 +50037,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -50294,7 +50294,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -50551,7 +50551,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -50808,7 +50808,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -51065,7 +51065,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -51322,7 +51322,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -51579,7 +51579,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -51836,7 +51836,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -52093,7 +52093,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -52350,7 +52350,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -52607,7 +52607,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -52864,7 +52864,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -53121,7 +53121,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -53378,7 +53378,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO
@@ -53635,7 +53635,7 @@ uoO
 uoO
 uoO
 uoO
-eLE
+uoO
 uoO
 uoO
 uoO

--- a/_maps/map_files/templates/dungeons/north_sewer_1.dmm
+++ b/_maps/map_files/templates/dungeons/north_sewer_1.dmm
@@ -29,6 +29,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"dP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
 "es" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -84,6 +90,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
 	},
+/mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gM" = (
@@ -201,6 +208,10 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
+/area/f13/tunnel)
+"mT" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/turf/open/floor/plasteel/grimy,
 /area/f13/tunnel)
 "mU" = (
 /obj/machinery/conveyor/auto{
@@ -380,6 +391,13 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
+/area/f13/tunnel)
+"vE" = (
+/obj/machinery/button/door{
+	id = "pain";
+	name = "Door Control"
+	},
+/turf/closed/wall/r_wall/f13/vault,
 /area/f13/tunnel)
 "wa" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -704,6 +722,10 @@
 	dir = 8
 	},
 /area/f13/tunnel)
+"QO" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
 "QT" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating/tunnel,
@@ -843,6 +865,9 @@
 "Yr" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/timeddoor/sixtyminute,
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
 /turf/open/water,
 /area/f13/tunnel)
 "YH" = (
@@ -1376,7 +1401,7 @@ iY
 iY
 iY
 iY
-iY
+vE
 iY
 iY
 iY
@@ -1490,7 +1515,7 @@ rU
 rU
 hA
 Qs
-Oe
+QO
 Qs
 hA
 Qs
@@ -1686,7 +1711,7 @@ iY
 Qs
 nz
 Qs
-Qs
+QO
 Qs
 iY
 QU
@@ -2019,7 +2044,7 @@ BH
 QU
 iY
 rU
-rU
+mT
 iY
 Oe
 Qs
@@ -2311,7 +2336,7 @@ Ev
 ZL
 Rj
 Rj
-Aw
+dP
 tO
 DW
 BH

--- a/_maps/map_files/templates/dungeons/north_sewer_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_sewer_2.dmm
@@ -14,9 +14,8 @@
 "aD" = (
 /obj/machinery/door/airlock/grunge,
 /obj/structure/barricade/wooden/planks/pregame,
-/obj/machinery/door/poddoor/shutters{
-	id = "pain";
-	name = "door shutters"
+/obj/machinery/door/poddoor{
+	id = "hell"
 	},
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -82,6 +81,14 @@
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
+"bx" = (
+/obj/machinery/button/door{
+	id = "hell";
+	name = "Door Control"
+	},
+/obj/structure/table/reinforced,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/bunker)
 "by" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -124,6 +131,12 @@
 "cA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"cB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
 /area/f13/caves)
 "cI" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -178,6 +191,13 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/radiation)
+"dj" = (
+/obj/machinery/button/door{
+	id = "hell";
+	name = "Door Control"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
 "dk" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/inside/subway,
@@ -227,6 +247,16 @@
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"eg" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "en" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder/reinforced,
@@ -259,11 +289,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "eY" = (
-/mob/living/simple_animal/hostile/handy/protectron{
-	faction = list("raider")
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "soup";
+	name = "Door Control"
 	},
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fg" = (
@@ -280,6 +310,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
+"fn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/deathclaw,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -407,9 +442,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ik" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "pain";
-	name = "door shutters"
+/obj/machinery/door/poddoor{
+	id = "pain"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
@@ -747,11 +781,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "oO" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "pain";
-	name = "door shutters"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "oV" = (
@@ -796,7 +829,9 @@
 /area/f13/bunker)
 "pE" = (
 /obj/structure/simple_door/metal/ventilation,
-/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/poddoor{
+	id = "okay"
+	},
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -893,6 +928,7 @@
 "qZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shovel/spade,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "rb" = (
@@ -912,6 +948,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"rh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "rj" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old"
@@ -947,6 +987,12 @@
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"sr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "st" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -1090,6 +1136,13 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"uP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "uX" = (
 /obj/effect/decal/remains/robot,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -1162,6 +1215,13 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"vo" = (
+/obj/machinery/button/door{
+	id = "soup";
+	name = "Door Control"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
 "vu" = (
 /obj/structure/closet/crate{
 	anchored = 1;
@@ -1229,6 +1289,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wx" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "wy" = (
 /obj/machinery/light/broken,
 /obj/machinery/chem_dispenser,
@@ -1333,6 +1401,15 @@
 "yu" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"yw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "okay";
+	name = "Door Control"
+	},
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "yI" = (
 /obj/effect/decal/fakelattice,
@@ -1446,6 +1523,7 @@
 "Af" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -1543,6 +1621,11 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"Cs" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "Cx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/blackbox_recorder,
@@ -1712,6 +1795,15 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"FJ" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "FP" = (
 /obj/item/wrench/crude,
 /turf/open/indestructible/ground/inside/subway,
@@ -1750,10 +1842,9 @@
 /area/f13/bunker)
 "Gt" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw{
-	speed = -2
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
 	},
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "Gw" = (
 /obj/structure/girder/reinforced,
@@ -1855,6 +1946,13 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/radiation)
+"IN" = (
+/obj/machinery/button/door{
+	id = "okay";
+	name = "Door Control"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "IR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
@@ -2072,7 +2170,7 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/item/gun/ballistic/automatic/pistol/pistol127/compact,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/bunker)
 "LG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -2166,6 +2264,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"Nz" = (
+/obj/machinery/door/poddoor{
+	id = "soup"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "NN" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -2375,6 +2481,11 @@
 "Sy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper,
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "hate";
+	name = "Door Control"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "Sz" = (
@@ -2541,9 +2652,9 @@
 	name = "M1 Garand"
 	},
 /obj/item/clothing/suit/armor/f13/battlecoat,
-/obj/item/ammo_box/a762box,
-/obj/item/ammo_box/a762box,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
 /area/f13/caves)
 "VL" = (
 /obj/structure/girder/reinforced,
@@ -2568,6 +2679,15 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"Wi" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/door/poddoor{
+	id = "hate"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "Wj" = (
@@ -2628,11 +2748,23 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"XA" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/door/poddoor{
+	id = "pain"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "XC" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/decoration/rag{
 	icon_state = "skin"
+	},
+/obj/machinery/door/poddoor{
+	id = "malice"
 	},
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -2661,13 +2793,10 @@
 /area/f13/tunnel)
 "Yg" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/meat/slab/human,
-/obj/item/reagent_containers/food/snacks/meat/slab/human,
-/obj/item/reagent_containers/food/snacks/meat/slab/human,
-/obj/item/reagent_containers/food/snacks/meat/slab/human,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/centaur,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
+/obj/machinery/button/door{
+	id = "malice";
+	name = "Door Control"
+	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "Yk" = (
@@ -2712,6 +2841,9 @@
 /area/f13/bunker)
 "YU" = (
 /obj/item/cultivator,
+/mob/living/simple_animal/hostile/handy/protectron{
+	faction = list("raider")
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "Za" = (
@@ -2725,6 +2857,11 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"Zv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ZB" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/sentrybot{
@@ -2768,6 +2905,7 @@
 	faction = list("raider");
 	obj_damage = 300
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 
@@ -3047,7 +3185,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
+IN
 Yn
 Yn
 Yn
@@ -3389,7 +3527,7 @@ Xf
 Yn
 Yn
 Yn
-aJ
+XA
 Yn
 ve
 Yn
@@ -3657,7 +3795,7 @@ Yn
 Cc
 Xn
 Yn
-op
+eg
 WO
 Yn
 mx
@@ -4082,7 +4220,7 @@ ts
 kO
 bl
 uw
-aJ
+Wi
 vc
 ki
 Za
@@ -4167,7 +4305,7 @@ Jj
 eU
 Jt
 dp
-Yn
+wx
 aU
 qb
 vh
@@ -4205,7 +4343,7 @@ TZ
 Yg
 Yn
 ZZ
-Yn
+FJ
 Qj
 aK
 LH
@@ -4243,7 +4381,7 @@ fg
 FT
 Yn
 yI
-Yn
+wx
 tG
 rE
 RU
@@ -4281,7 +4419,7 @@ eF
 Uz
 Yn
 pJ
-Yn
+FJ
 gB
 Ce
 RU
@@ -4319,7 +4457,7 @@ Yn
 Yn
 Yn
 cI
-Yn
+aN
 rb
 He
 qG
@@ -4434,7 +4572,7 @@ pC
 ka
 YP
 zZ
-BH
+QU
 BH
 BH
 in
@@ -4472,7 +4610,7 @@ PI
 KA
 EO
 vN
-BH
+QU
 BH
 BH
 HM
@@ -4552,7 +4690,7 @@ QU
 Dn
 MX
 DD
-nQ
+dj
 QU
 BH
 BH
@@ -4619,7 +4757,7 @@ en
 WG
 ck
 Vw
-BH
+bx
 BH
 QU
 QU
@@ -4676,7 +4814,7 @@ QU
 BH
 BH
 BH
-ck
+yw
 ck
 BH
 BH
@@ -4843,7 +4981,7 @@ DD
 Wj
 DD
 DD
-Wj
+DD
 sR
 sR
 sR
@@ -4876,8 +5014,8 @@ BH
 BH
 BH
 BH
-cA
-sR
+rh
+Hr
 DD
 lP
 lP
@@ -4913,11 +5051,11 @@ BH
 BH
 QU
 QU
+QU
+QU
+QU
 BH
-BH
-sR
-sR
-cA
+fn
 cA
 sR
 DD
@@ -4949,14 +5087,14 @@ PF
 BH
 BH
 QU
-QU
-Hr
-cA
+nQ
+Cs
+uP
 Gt
-sR
-BH
-BH
-BH
+Nz
+sr
+cB
+Zv
 sR
 sR
 DD
@@ -4987,14 +5125,14 @@ BH
 BH
 BH
 QU
-QU
-BH
+nQ
+vo
 VE
-BH
-BH
+nQ
+QU
 QU
 BH
-BH
+rh
 BH
 sR
 sR

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -452,10 +452,10 @@
 
 /obj/item/clothing/head/beret/ncr_recon_ranger
 	name = "NCR Ranger scout beret"
-	desc = "(III) A brown beret, issued to members of the NCR Recon Rangers."
+	desc = "(IV) A brown beret, issued to members of the NCR Recon Rangers."
 	icon_state = "scoutberet"
 	item_state = "scoutberet"
-	armor = list("tier" = 3, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
 /obj/item/clothing/head/f13/trailranger
 	name = "NCR trail ranger hat"
@@ -466,10 +466,10 @@
 
 /obj/item/clothing/head/f13/ranger
 	name = "NCR ranger campaign hat"
-	desc = "(VI) An NCR ranger hat, standard issue amongst all but the most elite rangers."
+	desc = "(V) An NCR ranger hat, standard issue amongst all but the most elite rangers."
 	icon_state = "drillhat"
 	item_state = "drill_hat"
-	armor = list("tier" = 6, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)
+	armor = list("tier" = 5, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)
 
 /obj/item/clothing/head/helmet/f13/combat/ncr_patrol
 	name = "NCR patrol helmet"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -568,7 +568,7 @@
 	scope_state = "AEP7_scope"
 	scope_x_offset = 12
 	scope_y_offset = 20
-	fire_delay = 3.5
+	fire_delay = 8
 	equipsound = 'sound/f13weapons/equipsounds/aer14equip.ogg'
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/aer14)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
@@ -591,7 +591,7 @@
 	desc = "Wattz 2000 Laser Rifle. Uses micro fusion cells for more powerful lasers, and an extended barrel for additional range."
 	icon_state = "wattz2k"
 	item_state = "sniper_rifle"
-	fire_delay = 3.5
+	fire_delay = 8
 	equipsound = 'sound/f13weapons/equipsounds/aer14equip.ogg'
 	ammo_type = list(/obj/item/ammo_casing/energy/wattz2k)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc


### PR DESCRIPTION
## About The Pull Request
Fixes Ranger Helmet armour values since I forgot to do so in my prior PR - luckily the server still hasn't restarted - in addition, after some chat with Myrios and active testing, provides both the Wattz 2k and AER14 a Firedelay of 8 for balance purposes given how strong they are. This PR also edits the North Sewer Bunkers (again) by doing what was done to the Raider Bunker as to encourage clearing everything if the T5 Armour is desired.
![image](https://user-images.githubusercontent.com/76075239/114708098-ddc42400-9d22-11eb-9f5f-d172587f8535.png)
![image](https://user-images.githubusercontent.com/76075239/114708217-fdf3e300-9d22-11eb-8ad1-025b785bcc09.png)
## Why It's Good For The Game
It's good for balance - the Ranger stuff as a part of the LM approved Ranger Loadout changes, the Bunker stuff as to prevent le rush for T-45d as soon as is possible atleast slightly, and the AER14 and Wattz 2000 changes for balance as they're still super strong even with the prior nerfs I applied.
## Changelog
- Diffiuclty Tweaks NSB #2 by adding various blast-doors which have buttons around the bunker
- Difficulty Tweaks NSB #1 by adding some Legendary Mutants and a button-blastdoor for the claw cave.
- Adds 2 more claws to NSB #1's claw cave
- Fixes Ranger Helmets that were T6 to T5
- Fixes Ranger Helmets that were T3 to T4
- Gives AER14 and Wattz 2000 an 8 Firedelay.
- Fixes Alternate NSB #2 entry not working due to a mapping issue