### PR TITLE
Farming Extension

### DIFF
--- a/code/modules/fallout/obj/food_and_drinks/wastefood.dm
+++ b/code/modules/fallout/obj/food_and_drinks/wastefood.dm
@@ -77,7 +77,7 @@
 	icon_grow = "coyote-grow"
 	icon_dead = "coyote-dead"
 	icon_harvest = "coyote-harvest"
-	reagents_add = list(/datum/reagent/drug/nicotine = 0.03,  /datum/reagent/consumable/nutriment/vitamin = 0.03)
+	reagents_add = list(/datum/reagent/drug/nicotine = 0.1,  /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/coyotetobacco
 	seed = /obj/item/seeds/coyotetobacco
@@ -264,7 +264,7 @@
 	icon_dead = "pinyon-dead"
 	icon_harvest = "pinyon-harvest"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.04)
+	reagents_add = list( /datum/reagent/consumable/nutriment = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/pinyon
 	seed = /obj/item/seeds/pinyon
@@ -639,7 +639,7 @@
 	icon_grow = "agave-grow"
 	icon_dead = "agave-dead"
 	icon_harvest = "agave-harvest"
-	reagents_add = list(/datum/reagent/medicine/kelotane = 0.1, /datum/reagent/toxin/lipolicide = 0.1, /datum/reagent/consumable/nutriment = 0.05)
+	reagents_add = list(/datum/reagent/medicine/kelotane = 0.1, /datum/reagent/toxin/lipolicide = 0.1, /datum/reagent/consumable/nutriment = 0.1)
 
 
 /obj/item/reagent_containers/food/snacks/grown/agave

--- a/code/modules/fallout/obj/food_and_drinks/wastefood.dm
+++ b/code/modules/fallout/obj/food_and_drinks/wastefood.dm
@@ -219,8 +219,8 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/mesquite
 	lifespan = 80
 	endurance = 50
-	maturation = 15
-	production = 1
+	maturation = 6
+	production = 5
 	yield = 5
 	potency = 50
 	growthstages = 4
@@ -254,8 +254,8 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/pinyon
 	lifespan = 80
 	endurance = 50
-	maturation = 12
-	production = 1
+	maturation = 9
+	production = 6
 	yield = 5
 	potency = 50
 	growthstages = 4
@@ -333,8 +333,8 @@
 	plantname = "Datura"
 	product = /obj/item/reagent_containers/food/snacks/grown/datura
 	lifespan = 30
-	maturation = 10
-	production = 1
+	maturation = 6
+	production = 5
 	yield = 4
 	growthstages = 5
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
@@ -363,8 +363,8 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/pungafruit
 	lifespan = 100
 	endurance = 30
-	maturation = 15
-	production = 1
+	maturation = 10
+	production = 5
 	yield = 3
 	potency = 30
 	growthstages = 4
@@ -424,8 +424,8 @@
 	plantname = "Tato Plants"
 	product = /obj/item/reagent_containers/food/snacks/grown/tato
 	lifespan = 30
-	maturation = 10
-	production = 1
+	maturation = 7
+	production = 3
 	yield = 4
 	growthstages = 4
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'

--- a/code/modules/fallout/obj/food_and_drinks/wastefood.dm
+++ b/code/modules/fallout/obj/food_and_drinks/wastefood.dm
@@ -36,7 +36,7 @@
 	desc = "These seeds grow into buffalo vines."
 	icon_state = "seed-gourd"
 	species = "buffalo gourd"
-	plantname = "buffalo vines"
+	plantname = "Buffalo Vines"
 	product = /obj/item/reagent_containers/food/snacks/grown/buffalogourd
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	icon_grow = "gourd-grow"
@@ -98,7 +98,7 @@
 	icon_dead = "feracactus-dead"
 	icon_harvest = "feracactus-harvest"
 	species = "barrel cactus"
-	plantname = "barrel cactus"
+	plantname = "Barrel Cactus"
 	product = /obj/item/reagent_containers/food/snacks/grown/feracactus
 	lifespan = 60
 	endurance = 20
@@ -106,7 +106,7 @@
 	growthstages = 2
 	production = 5
 	maturation = 5
-
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1, /datum/reagent/medicine/calomel = 0.05, /datum/reagent/radium = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/feracactus
 	seed = /obj/item/seeds/feracactus
@@ -117,19 +117,13 @@
 	juice_results = list(/datum/reagent/consumable/tea/feratea = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/yellowpulque
 
-/obj/item/reagent_containers/food/snacks/grown/feracactus/add_juice()
-	if(..())
-		reagents.add_reagent( /datum/reagent/consumable/nutriment/vitamin, 3 + round((seed.potency / 20), 1))
-		reagents.add_reagent(/datum/reagent/medicine/calomel, 3 + round((seed.potency / 20), 1))
-		reagents.add_reagent(/datum/reagent/radium, 0 + round((seed.potency / 20), 1))
-		bitesize = 3 + round(reagents.total_volume / 3, 1)
 
 /obj/item/seeds/poppy/broc
 	name = "pack of broc seeds"
 	desc = "These seeds grow into broc flowers."
 	icon_state = "seed-broc"
 	species = "broc"
-	plantname = "broc flowers"
+	plantname = "Broc Flowers"
 	product = /obj/item/reagent_containers/food/snacks/grown/broc
 	lifespan = 25
 	endurance = 10
@@ -142,6 +136,7 @@
 	icon_grow = "broc-grow"
 	icon_dead = "broc-dead"
 	//mutatelist = list(/obj/item/seeds/geraniumseed, /obj/item/seeds/lilyseed)
+	reagents_add = list(/datum/reagent/medicine/dexalin = 0.2, /datum/reagent/medicine/salglu_solution = 0.05, /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/broc
 	seed = /obj/item/seeds/poppy/broc
@@ -154,18 +149,12 @@
 	distill_reagent = /datum/reagent/consumable/ethanol/brocbrew
 
 
-/obj/item/reagent_containers/food/snacks/grown/broc/add_juice()
-	if(..())
-		reagents.add_reagent(/datum/reagent/medicine/dexalin, 1 + round((seed.potency / 5), 1))
-		reagents.add_reagent(/datum/reagent/medicine/salglu_solution, 1 + round((seed.potency / 20), 1))
-		bitesize = 1 + round(reagents.total_volume / 3, 1)
-
 /obj/item/seeds/xander
 	name = "pack of xander seeds"
 	desc = "These seeds grow into xander roots."
 	icon_state = "seed-xander"
 	species = "xander"
-	plantname = "xander roots"
+	plantname = "Xander Roots"
 	product = /obj/item/reagent_containers/food/snacks/grown/xander
 	lifespan = 25
 	endurance = 10
@@ -177,6 +166,7 @@
 	icon_grow = "xander-grow"
 	icon_harvest = "xander-harvest"
 	icon_dead = "xander-dead"
+	reagents_add = list(/datum/reagent/medicine/antitoxin = 0.2, /datum/reagent/medicine/salglu_solution = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/xander
 	seed = /obj/item/seeds/xander
@@ -186,12 +176,6 @@
 	filling_color = "#FF6347"
 	juice_results = list(/datum/reagent/consumable/tea/xandertea = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/salgam
-
-/obj/item/reagent_containers/food/snacks/grown/xander/add_juice()
-	if(..())
-		reagents.add_reagent(/datum/reagent/medicine/antitoxin, 1 + round((seed.potency / 5), 1))
-		reagents.add_reagent(/datum/reagent/medicine/salglu_solution, 1 + round((seed.potency / 20), 1))
-		bitesize = 1 + round(reagents.total_volume / 3, 1)
 
 /*HRP*/
 
@@ -211,7 +195,7 @@
 	icon_dead = "horsenettle-dead"
 	icon_harvest = "horsenettle-harvest"
 	genes = list(/datum/plant_gene/trait/plant_type/weed_hardy)
-	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.04,  /datum/reagent/consumable/nutriment/vitamin = 0.1)
+	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.04,  /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/horsenettle
 	seed = /obj/item/seeds/horsenettle
@@ -231,7 +215,7 @@
 	desc = "These seeds grows into a mesquite plant."
 	icon_state = "mycelium-tower"
 	species = "honey mesquite"
-	plantname = "honey mesquite"
+	plantname = "Honey Mesquite"
 	product = /obj/item/reagent_containers/food/snacks/grown/mesquite
 	lifespan = 80
 	endurance = 50
@@ -245,7 +229,7 @@
 	icon_dead = "mesquite-dead"
 	icon_harvest = "mesquite-harvest"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list(/datum/reagent/consumable/honey = 0.1)
+	reagents_add = list(/datum/reagent/consumable/honey = 0.1, /datum/reagent/consumable/nutriment = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/mesquite
 	seed = /obj/item/seeds/mesquite
@@ -270,7 +254,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/pinyon
 	lifespan = 80
 	endurance = 50
-	maturation = 15
+	maturation = 12
 	production = 1
 	yield = 5
 	potency = 50
@@ -303,10 +287,10 @@
 	icon_dead = "prickly-dead"
 	icon_harvest = "prickly-harvest"
 	species = "prickly pear"
-	plantname = "prickly pear"
+	plantname = "Prickly pear cactus"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	product = /obj/item/reagent_containers/food/snacks/grown/pricklypear
-	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.2, /datum/reagent/water = 0.04)
+	reagents_add = list( /datum/reagent/consumable/nutriment = 0.2, /datum/reagent/water = 0.1, /datum/reagent/consumable/vitamin = 0.05)
 	lifespan = 60
 	endurance = 20
 	yield = 2
@@ -357,7 +341,7 @@
 	icon_grow = "datura-grow"
 	icon_dead = "datura-dead"
 	icon_harvest = "datura-harvest"
-	reagents_add = list(/datum/reagent/medicine/morphine = 0.35, /datum/reagent/drug/mushroomhallucinogen = 0.12, /datum/reagent/toxin = 0.3,  /datum/reagent/consumable/nutriment/vitamin = 0.05)
+	reagents_add = list(/datum/reagent/medicine/morphine = 0.35, /datum/reagent/drug/mushroomhallucinogen = 0.12, /datum/reagent/toxin = 0.1,  /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/datura
 	seed = /obj/item/seeds/datura
@@ -375,7 +359,7 @@
 	desc = "These small black pits grow into a punga bush"
 	icon_state = "seed-punga"
 	species = "punga"
-	plantname = "punga bush"
+	plantname = "Punga Bush"
 	product = /obj/item/reagent_containers/food/snacks/grown/pungafruit
 	lifespan = 100
 	endurance = 30
@@ -390,7 +374,7 @@
 	icon_dead = "punga-dead"
 	icon_harvest = "punga-harvest"
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list(/datum/reagent/medicine/charcoal = 0.1, /datum/reagent/phosphorus = 0.1,  /datum/reagent/consumable/nutriment/vitamin = 0.04)
+	reagents_add = list(/datum/reagent/medicine/charcoal = 0.1, /datum/reagent/phosphorus = 0.1,  /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/medicine/radaway = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/pungafruit
 	seed = /obj/item/seeds/punga
@@ -400,20 +384,13 @@
 	filling_color = "#FF6347"
 	distill_reagent = /datum/reagent/consumable/ethanol/pungajuice
 
-/obj/item/reagent_containers/food/snacks/grown/pungafruit/add_juice()
-	if(..())
-		reagents.add_reagent(/datum/reagent/medicine/charcoal, 1 + round((seed.potency / 20), 1))
-		reagents.add_reagent(/datum/reagent/medicine/mutadone, 1 + round((seed.potency / 20), 1))
-		reagents.add_reagent(/datum/reagent/medicine/radaway, 1 + round((seed.potency / 20), 1))
-		bitesize = 1 + round(reagents.total_volume / 3, 1)
-
 /obj/item/seeds/yucca
 	name = "pack of banana yucca seeds"
 	desc = "These seeds grow into a yucca plant."
 	icon = 'icons/obj/hydroponics/seeds.dmi'
 	icon_state = "seed-yucca"
 	species = "banna yucca"
-	plantname = "banana yucca plant"
+	plantname = "Banana Yucca plant"
 	product = /obj/item/reagent_containers/food/snacks/grown/yucca
 	lifespan = 50
 	endurance = 30
@@ -426,7 +403,7 @@
 	icon_dead = "yucca-dead"
 	icon_harvest = "yucca-harvest"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.2, /datum/reagent/consumable/sugar = 0.1,  /datum/reagent/consumable/nutriment/vitamin = 0.2)
+	reagents_add = list( /datum/reagent/consumable/nutriment = 0.2, /datum/reagent/consumable/sugar = 0.1,  /datum/reagent/consumable/nutriment/vitamin = 0.2)
 
 
 /obj/item/reagent_containers/food/snacks/grown/yucca
@@ -456,7 +433,7 @@
 	icon_dead = "tato-dead"
 	icon_harvest = "tato-harvest"
 	genes = list(/datum/plant_gene/trait/battery, /datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.04,  /datum/reagent/consumable/nutriment/vitamin = 0.1)
+	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.04,  /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/tato
 	seed = /obj/item/seeds/tato
@@ -488,7 +465,7 @@
 	desc = "These seeds grow into a mutfruit sapling."
 	icon_state = "seed-mutfruit"
 	species = "mutfruit"
-	plantname = "mutfruit sapling"
+	plantname = "Mutfruit Sapling"
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_grow = "mutfruit-grow"
 	icon_dead = "mutfruit-dead"
@@ -499,6 +476,7 @@
 	growthstages = 3
 	production = 5
 	maturation = 5
+	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.05, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/radium = 0.15)
 
 /obj/item/reagent_containers/food/snacks/grown/mutfruit
 	seed = /obj/item/seeds/mutfruit
@@ -509,293 +487,9 @@
 	distill_reagent = /datum/reagent/consumable/ethanol/purplecider
 	juice_results = list(/datum/reagent/consumable/mutjuice = 0)
 
-/obj/item/reagent_containers/food/snacks/grown/mutfruit/add_juice()
-	if(..())
-		reagents.add_reagent( /datum/reagent/consumable/nutriment/vitamin, 3 + round((seed.potency / 20), 1))
-		reagents.add_reagent(/datum/reagent/radium, 1 + round((seed.potency / 20), 1))
-		bitesize = 1 + round(reagents.total_volume / 3, 1)
 
 /*HRP*/
 
-/obj/item/reagent_containers/food/snacks/grown/mushroom
-	name = "mushroom"
-	bitesize_mod = 2
-	foodtype = VEGETABLES
-	wine_power = 40
-
-// Reishi
-/obj/item/seeds/reishi
-	name = "pack of reishi mycelium"
-	desc = "This mycelium grows into something medicinal and relaxing."
-	icon_state = "mycelium-reishi"
-	species = "reishi"
-	plantname = "Reishi"
-	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/reishi
-	lifespan = 35
-	endurance = 35
-	maturation = 10
-	production = 5
-	yield = 4
-	potency = 15
-	growthstages = 4
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list(/datum/reagent/medicine/morphine = 0.35, /datum/reagent/medicine/charcoal = 0.35,  /datum/reagent/consumable/nutriment/vitamin = 0)
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/reishi
-	seed = /obj/item/seeds/reishi
-	name = "reishi"
-	desc = "<I>Ganoderma lucidum</I>: A special fungus known for its medicinal and stress relieving properties."
-	icon_state = "reishi"
-	filling_color = "#FF4500"
-
-// Fly Amanita
-/obj/item/seeds/amanita
-	name = "pack of fly amanita mycelium"
-	desc = "This mycelium grows into something horrible."
-	icon_state = "mycelium-amanita"
-	species = "amanita"
-	plantname = "Fly Amanitas"
-	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/amanita
-	lifespan = 50
-	endurance = 35
-	maturation = 10
-	production = 5
-	yield = 4
-	growthstages = 3
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	mutatelist = list(/obj/item/seeds/angel)
-	reagents_add = list(/datum/reagent/drug/mushroomhallucinogen = 0.04, /datum/reagent/toxin/amatoxin = 0.35,  /datum/reagent/consumable/nutriment/vitamin = 0, /datum/reagent/growthserum = 0.1)
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/amanita
-	seed = /obj/item/seeds/amanita
-	name = "fly amanita"
-	desc = "<I>Amanita Muscaria</I>: Learn poisonous mushrooms by heart. Only pick mushrooms you know."
-	icon_state = "amanita"
-	filling_color = "#FF0000"
-
-// Destroying Angel
-/obj/item/seeds/angel
-	name = "pack of destroying angel mycelium"
-	desc = "This mycelium grows into something devastating."
-	icon_state = "mycelium-angel"
-	species = "angel"
-	plantname = "Destroying Angels"
-	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/angel
-	lifespan = 50
-	endurance = 35
-	maturation = 12
-	production = 5
-	yield = 2
-	potency = 35
-	growthstages = 3
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list(/datum/reagent/drug/mushroomhallucinogen = 0.04, /datum/reagent/toxin/amatoxin = 0.1,  /datum/reagent/consumable/nutriment/vitamin = 0, /datum/reagent/toxin/amanitin = 0.2)
-	rarity = 30
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/angel
-	seed = /obj/item/seeds/angel
-	name = "destroying angel"
-	desc = "<I>Amanita Virosa</I>: Deadly poisonous basidiomycete fungus filled with alpha amatoxins."
-	icon_state = "angel"
-	filling_color = "#C0C0C0"
-	wine_power = 60
-
-// Liberty Cap
-/obj/item/seeds/liberty
-	name = "pack of liberty-cap mycelium"
-	desc = "This mycelium grows into liberty-cap mushrooms."
-	icon_state = "mycelium-liberty"
-	species = "liberty"
-	plantname = "Liberty-Caps"
-	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/libertycap
-	maturation = 7
-	production = 1
-	yield = 5
-	potency = 15
-	growthstages = 3
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list(/datum/reagent/drug/mushroomhallucinogen = 0.25,  /datum/reagent/consumable/nutriment/vitamin = 0.02)
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/libertycap
-	seed = /obj/item/seeds/liberty
-	name = "liberty-cap"
-	desc = "<I>Psilocybe Semilanceata</I>: Liberate yourself!"
-	icon_state = "libertycap"
-	filling_color = "#DAA520"
-	wine_power = 80
-
-// Plump Helmet
-/obj/item/seeds/plump
-	name = "pack of plump-helmet mycelium"
-	desc = "This mycelium grows into helmets... maybe."
-	icon_state = "mycelium-plump"
-	species = "plump"
-	plantname = "Plump-Helmet Mushrooms"
-	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet
-	maturation = 8
-	production = 1
-	yield = 4
-	potency = 15
-	growthstages = 3
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	mutatelist = list(/obj/item/seeds/plump/walkingmushroom)
-	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.04,  /datum/reagent/consumable/nutriment/vitamin = 0.1)
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet
-	seed = /obj/item/seeds/plump
-	name = "plump-helmet"
-	desc = "<I>Plumus Hellmus</I>: Plump, soft and s-so inviting~"
-	icon_state = "plumphelmet"
-	filling_color = "#9370DB"
-	distill_reagent = /datum/reagent/consumable/ethanol/manly_dorf
-
-// Walking Mushroom
-/obj/item/seeds/plump/walkingmushroom
-	name = "pack of walking mushroom mycelium"
-	desc = "This mycelium will grow into huge stuff!"
-	icon_state = "mycelium-walkingmushroom"
-	species = "walkingmushroom"
-	plantname = "Walking Mushrooms"
-	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/walkingmushroom
-	lifespan = 30
-	endurance = 30
-	maturation = 5
-	yield = 1
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	mutatelist = list()
-	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.05,  /datum/reagent/consumable/nutriment/vitamin = 0.15)
-	rarity = 30
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/walkingmushroom
-	seed = /obj/item/seeds/plump/walkingmushroom
-	name = "walking mushroom"
-	desc = "<I>Plumus Locomotus</I>: The beginning of the great walk."
-	icon_state = "walkingmushroom"
-	filling_color = "#9370DB"
-	can_distill = FALSE
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/walkingmushroom/attack_self(mob/user)
-	if(isspaceturf(user.loc))
-		return
-	var/mob/living/simple_animal/hostile/mushroom/M = new /mob/living/simple_animal/hostile/mushroom(user.loc)
-	M.maxHealth += round(seed.endurance / 4)
-	M.melee_damage_lower += round(seed.potency / 20)
-	M.melee_damage_upper += round(seed.potency / 20)
-	M.move_to_delay -= round(seed.production / 50)
-	M.health = M.maxHealth
-	qdel(src)
-	to_chat(user, "<span class='notice'>You plant the walking mushroom.</span>")
-
-// Glowshroom
-/obj/item/seeds/glowshroom
-	name = "pack of glowshroom mycelium"
-	desc = "This mycelium -glows- into mushrooms!"
-	icon_state = "mycelium-glowshroom"
-	species = "glowshroom"
-	plantname = "Glowshrooms"
-	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom
-	lifespan = 100 //ten times that is the delay
-	endurance = 30
-	maturation = 15
-	production = 1
-	yield = 3 //-> spread
-	potency = 30 //-> brightness
-	growthstages = 4
-	rarity = 20
-	genes = list(/datum/plant_gene/trait/glow, /datum/plant_gene/trait/plant_type/fungal_metabolism)
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	mutatelist = list(/obj/item/seeds/glowshroom/glowcap, /obj/item/seeds/glowshroom/shadowshroom)
-	reagents_add = list(/datum/reagent/radium = 0.1, /datum/reagent/phosphorus = 0.1,  /datum/reagent/consumable/nutriment/vitamin = 0.04)
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom
-	seed = /obj/item/seeds/glowshroom
-	name = "glowshroom cluster"
-	desc = "<I>Mycena Bregprox</I>: This species of mushroom glows in the dark."
-	icon_state = "glowshroom"
-	filling_color = "#00FA9A"
-	wine_power = 50
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/attack_self(mob/user)
-	if(isspaceturf(user.loc))
-		return FALSE
-	if(!isturf(user.loc))
-		to_chat(user, "<span class='warning'>You need more space to plant [src].</span>")
-		return FALSE
-	var/count = 0
-	var/maxcount = 1
-	for(var/tempdir in GLOB.cardinals)
-		var/turf/closed/wall = get_step(user.loc, tempdir)
-		if(istype(wall))
-			maxcount++
-	for(var/obj/structure/glowshroom/G in user.loc)
-		count++
-	if(count >= maxcount)
-		to_chat(user, "<span class='warning'>There are too many shrooms here to plant [src].</span>")
-		return FALSE
-	new effect_path(user.loc, seed)
-	to_chat(user, "<span class='notice'>You plant [src].</span>")
-	qdel(src)
-	return TRUE
-
-
-// Glowcap
-/obj/item/seeds/glowshroom/glowcap
-	name = "pack of glowcap mycelium"
-	desc = "This mycelium -powers- into mushrooms!"
-	icon_state = "mycelium-glowcap"
-	species = "glowcap"
-	icon_dead = "glowshroom-dead"
-	icon_grow = "glowshroom-grow"
-	plantname = "Glowcaps"
-	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap
-	genes = list(/datum/plant_gene/trait/glow/red, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/plant_type/fungal_metabolism)
-	mutatelist = list()
-	reagents_add = list(/datum/reagent/teslium = 0.1,  /datum/reagent/consumable/nutriment/vitamin = 0.04)
-	rarity = 30
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap
-	seed = /obj/item/seeds/glowshroom/glowcap
-	name = "glowcap cluster"
-	desc = "<I>Mycena Ruthenia</I>: This species of mushroom glows in the dark, but isn't actually bioluminescent. They're warm to the touch..."
-	icon_state = "glowcap"
-	filling_color = "#00FA9A"
-	effect_path = /obj/structure/glowshroom/glowcap
-	tastes = list("glowcap" = 1)
-
-
-//Shadowshroom
-/obj/item/seeds/glowshroom/shadowshroom
-	name = "pack of shadowshroom mycelium"
-	desc = "This mycelium will grow into something shadowy."
-	icon_state = "mycelium-shadowshroom"
-	species = "shadowshroom"
-	icon_grow = "shadowshroom-grow"
-	icon_dead = "shadowshroom-dead"
-	plantname = "Shadowshrooms"
-	product = /obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/shadowshroom
-	genes = list(/datum/plant_gene/trait/glow/shadow, /datum/plant_gene/trait/plant_type/fungal_metabolism)
-	mutatelist = list()
-	reagents_add = list(/datum/reagent/radium = 0.2,  /datum/reagent/consumable/nutriment/vitamin = 0.04)
-	rarity = 30
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/shadowshroom
-	seed = /obj/item/seeds/glowshroom/shadowshroom
-	name = "shadowshroom cluster"
-	desc = "<I>Mycena Umbra</I>: This species of mushroom emits shadow instead of light."
-	icon_state = "shadowshroom"
-	effect_path = /obj/structure/glowshroom/shadowshroom
-	tastes = list("shadow" = 1, "mushroom" = 1)
-	wine_power = 60
-
-/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/shadowshroom/attack_self(mob/user)
-	. = ..()
-	if(.)
-		investigate_log("was planted by [key_name(user)] at [AREACOORD(user)]", INVESTIGATE_BOTANY)
 
 //// LAVALAND MUSHROOMS ////
 
@@ -869,7 +563,7 @@
 	desc = "This mycelium grows into cave fungi, an edible variety of mushroom with anti-toxic properties."
 	icon_state = "seed-fungus"
 	species = "cave fungus"
-	plantname = "cave fungi"
+	plantname = "Cave fungi"
 	product = /obj/item/reagent_containers/food/snacks/grown/fungus
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	icon_grow = "cave_fungus-grow"
@@ -882,6 +576,7 @@
 	yield = 6
 	potency = 20
 	growthstages = 2
+	reagents_add = list(/datum/reagent/medicine/charcoal = 0.05, /datum/reagent/medicine/mutadone = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/fungus
 	seed = /obj/item/seeds/fungus
@@ -889,12 +584,6 @@
 	desc = "Cave fungus is an edible mushroom which has the ability to purge bodily toxins."
 	icon_state = "fungus"
 	filling_color = "#FF6347"
-
-/obj/item/reagent_containers/food/snacks/grown/fungus/add_juice()
-	if(..())
-		reagents.add_reagent(/datum/reagent/medicine/charcoal, 1 + round((seed.potency / 20), 1))
-		reagents.add_reagent(/datum/reagent/medicine/mutadone, 1 + round((seed.potency / 20), 1))
-		bitesize = 1 + round(reagents.total_volume / 3, 1)
 
 /obj/item/seeds/glow
 	name = "pack of glowing fungus seeds"
@@ -934,7 +623,7 @@
 	icon = 'icons/obj/hydroponics/seeds.dmi'
 	icon_state = "seed-agave"
 	species = "agave"
-	plantname = "agave plant"
+	plantname = "Agave plant"
 	product = /obj/item/reagent_containers/food/snacks/grown/agave
 	lifespan = 60
 	endurance = 10
@@ -946,7 +635,7 @@
 	icon_grow = "agave-grow"
 	icon_dead = "agave-dead"
 	icon_harvest = "agave-harvest"
-	reagents_add = list(/datum/reagent/medicine/kelotane = 0.05, /datum/reagent/toxin/lipolicide = 0.05)
+	reagents_add = list(/datum/reagent/medicine/kelotane = 0.1, /datum/reagent/toxin/lipolicide = 0.1, /datum/reagent/consumable/nutriment = 0.05)
 
 
 /obj/item/reagent_containers/food/snacks/grown/agave

--- a/code/modules/fallout/obj/food_and_drinks/wastefood.dm
+++ b/code/modules/fallout/obj/food_and_drinks/wastefood.dm
@@ -374,7 +374,7 @@
 	icon_dead = "punga-dead"
 	icon_harvest = "punga-harvest"
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list(/datum/reagent/medicine/charcoal = 0.1, /datum/reagent/phosphorus = 0.1,  /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/medicine/radaway = 0.05)
+	reagents_add = list(/datum/reagent/medicine/charcoal = 0.1, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/medicine/radaway = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/pungafruit
 	seed = /obj/item/seeds/punga
@@ -382,7 +382,7 @@
 	desc = "Punga fruit plants flower at a single point at the terminus of their stems, gradually developing into large, fleshy fruits with a yellow/brown, thick skin. They are common throughout Point Lookout, due to the unique conditions offered by the swamps, and scrub radiation when ingested."
 	icon_state = "Punga Fruit"
 	filling_color = "#FF6347"
-	distill_reagent = /datum/reagent/consumable/ethanol/pungajuice
+	juice_results = list(/datum/reagent/consumable/ethanol/pungajuice = 0)
 
 /obj/item/seeds/yucca
 	name = "pack of banana yucca seeds"
@@ -454,11 +454,15 @@
 	bitesize = 100
 
 /obj/item/reagent_containers/food/snacks/grown/tato/attackby(obj/item/W, mob/user, params)
+	if(W.get_sharpness())
 		to_chat(user, "<span class='notice'>You cut the tato into wedges with [W].</span>")
 		var/obj/item/reagent_containers/food/snacks/grown/tato/wedges/Wedges = new /obj/item/reagent_containers/food/snacks/grown/tato/wedges
 		remove_item_from_storage(user)
 		qdel(src)
 		user.put_in_hands(Wedges)
+	else
+		return ..()
+
 
 /obj/item/seeds/mutfruit
 	name = "pack of mutfruit seeds"

--- a/code/modules/fallout/obj/food_and_drinks/wastefood.dm
+++ b/code/modules/fallout/obj/food_and_drinks/wastefood.dm
@@ -290,7 +290,7 @@
 	plantname = "Prickly pear cactus"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	product = /obj/item/reagent_containers/food/snacks/grown/pricklypear
-	reagents_add = list( /datum/reagent/consumable/nutriment = 0.2, /datum/reagent/water = 0.1, /datum/reagent/consumable/vitamin = 0.05)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.2, /datum/reagent/water = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.05)
 	lifespan = 60
 	endurance = 20
 	yield = 2

--- a/code/modules/fallout/reagents/other_reagents.dm
+++ b/code/modules/fallout/reagents/other_reagents.dm
@@ -13,8 +13,103 @@
 		if(myseed && chems.has_reagent(src.type, 1))
 			myseed.adjust_yield(round(chems.get_reagent_amount(src.type) * 0.1))
 			myseed.adjust_potency(round(chems.get_reagent_amount(src.type) * 0.25))
+
 // Compost when drunk..?
 /datum/reagent/compost/on_mob_life(mob/living/carbon/M)
 	M.adjustToxLoss(0.5*REAGENTS_EFFECT_MULTIPLIER, 0)
 	. = TRUE
 	..()
+
+// Left-4-Zed Tribal edition
+/datum/reagent/reactive_compost
+	name = "reactive compost"
+	description = "Compost mixed with mutjuice and daturatea. The resulting mixture is capable of drawing forth the inner potential of plants, at the expense of it's well being."
+	reagent_state = "LIQUID"
+	color = "#8181E9"
+	taste_description = "sizzling rot"
+
+// Making Left-4-Zed Tribal edition
+/datum/chemical_reaction/reactive_compost
+	id = /datum/reagent/reactive_compost
+	results = list(/datum/reagent/reactive_compost = 3)
+	required_reagents = list(/datum/reagent/compost = 1, /datum/reagent/consumable/mutjuice = 1, /datum/reagent/consumable/ethanol/daturatea = 1)
+	mix_message = "The compost emits a noxious scent"
+
+//If used on trays
+/datum/reagent/reactive_compost/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
+	. = ..()
+	if(myseed && chems.has_reagent(src.type, 1))
+		mytray.adjustHealth(-round(chems.get_reagent_amount(src.type) * 0.025))
+		myseed.adjust_instability(round(chems.get_reagent_amount(src.type) * 0.3))
+
+// Enduro Grow Tribal Edition
+/datum/reagent/fortifying_compost
+	name = "fortifying compost"
+	description = "Compost mixed with tatojuice and yucca juice. The resulting mixture will fortify the plant from weed infestations, toxins and the toils of gardening."
+	reagent_state = "LIQUID"
+	color = "#AD462C"
+	taste_description = "earthy rot"
+	
+// Making Enduro Grow Tribal edition
+/datum/chemical_reaction/fortifying_compost
+	id = /datum/reagent/fortifying_compost
+	results = list(/datum/reagent/fortifying_compost = 3)
+	required_reagents = list(/datum/reagent/compost = 1, /datum/reagent/consumable/yuccajuice = 1, /datum/reagent/consumable/tato_juice = 1)
+	mix_message = "The compost emits an earthy armora"
+	
+//If used on trays
+/datum/reagent/fortifying_compost/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
+	. = ..()
+	if(myseed && chems.has_reagent(src.type, 1))
+		myseed.adjust_endurance(round(chems.get_reagent_amount (src.type) * 0.35))
+		myseed.adjust_weed_chance(-round(chems.get_reagent_amount (src.type) * 0.2))
+		mytray.adjustHealth(round(chems.get_reagent_amount (src.type) * 0.2))
+
+// Saltpetre Tribal Edition
+/datum/reagent/alacritous_compost
+	name = "alacritous compost"
+	description = "A strange mixture of compost, ashes and pungajuice. This potent mixture will hasten the plant's harvest while increasing the yield."
+	reagent_state = "LIQUID"
+	color = "#4CB529"
+	taste_description = "cool, salty rot"
+
+//Making Saltpetre Tribal Edition
+/datum/chemical_reaction/alacritous_compost
+	id = /datum/reagent/alacritous_compost
+	results = list(/datum/reagent/alacritous_compost = 3)
+	required_reagents = list(/datum/reagent/ash = 1, /datum/reagent/consumable/ethanol/pungajuice = 1, /datum/reagent/compost = 1)
+	mix_message = "The compost starts smelling like manure"
+
+// If added to tray
+/datum/reagent/alacritous_compost/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
+	. = ..()
+	if(chems.has_reagent(src.type, 1))	
+		var/acompost = chems.get_reagent_amount(src.type)
+		if(myseed)
+			myseed.adjust_production(-round(acompost/8)-prob(acompost%10))
+			myseed.adjust_potency(round(acompost*1.2))
+			myseed.adjust_yield(round(acompost*0.1))
+
+// Stabilizing Compost
+/datum/reagent/stabilizing_compost
+	name = "stabilizing compost"
+	description = "A soothing mixture of compost, milk and honey. The resulting mixture will stabilize a soil at the cost of potency."
+	reagent_state = "LIQUID"
+	color = "#B5ABAB"
+	taste_description = "sweet rot"
+
+//Making Stabilizing Compost
+/datum/chemical_reaction/stabilizing_compost
+	id = /datum/reagent/stabilizing_compost
+	results = list(/datum/reagent/stabilizing_compost = 3)
+	required_reagents = list(/datum/reagent/compost = 1, /datum/reagent/consumable/honey = 1, /datum/reagent/consumable/milk = 1)
+	mix_message= "A sweet smell comes over the compost"
+	
+// If added to tray
+/datum/reagent/stabilizing_compost/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
+	. = ..()
+	if(chems.has_reagent(src.type, 1))
+		var/scompost =chems.get_reagent_amount(src.type)
+		if(myseed)
+			myseed.adjust_instability(-round(scompost*1.2))
+			myseed.adjust_potency(-round(scompost*0.5))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -326,8 +326,95 @@
 		to_chat(user, "<span class='warning'>It's filled with tiny worms!</span>")
 	to_chat(user, "" )
 
-
-
+// Examining more a plant will yield a rough estimation of it's stats. 
+// Intended for use by Wayfarer's and Legion to allow their farmers to gauge roughly how it's going.
+/obj/machinery/hydroponics/examine_more(user)
+	if(myseed && (in_range(user, src) || isobserver(user)))
+		to_chat(user, "<span class=info>You examine the plant to get a better view of it's harvest...</span>")
+		switch(src.myseed.potency)	// Check potency
+			if(0 to 20)
+				to_chat(user, "<span class='warning'>The harvest's size is questioned, the fruits are small and insignificant.</span>")
+			if(21 to 40)
+				to_chat(user, "<span class='notice'>The harvest's size is moderate, small but capable of feeding a singular person.</span>")
+			if(41 to 60)
+				to_chat(user, "<span class='notice'>The harvest's size is good, well sized and fit for a family.</span>")
+			if(61 to 80)
+				to_chat(user, "<span class='notice'>The harvest's size is great! It's capable of providing a good feast!</span>")
+			if(81 to 100)
+				to_chat(user, "<span class='nicegreen'>The harvest's size is huge and unmistakable!</span>")
+		switch(src.myseed.yield) 	// Check yield
+			if(0 to 2)
+				to_chat(user, "<span class='warning'>The plant will bear but a few fruits, if any at that.</span>")
+			if(3 to 5)
+				to_chat(user, "<span class='notice'>The plant will bear a handful of fruit at most.</span>")
+			if(5 to 7)
+				to_chat(user, "<span class='notice'>The plant will yield an ample amount.</span>")
+			if(8 to 10)
+				to_chat(user, "<span class='nicegreen'>The plant is high yielding and fertile!</span>")
+		switch(src.myseed.production) // Check production speed
+			if(1 to 3)
+				to_chat(user, "<span class='nicegreen'>The plant'll be ready for harvest within a minute once it's matured!</span>")
+			if(4 to 7)
+				to_chat(user, "<span class='notice'>The plant'll be ready for harvest in around a few minutes after reaching maturation.</span>")
+			if(8 to 10)
+				to_chat(user, "<span class='warning'>The plant's harvest is going to take a while after it's matured.'</span>")
+		switch(src.myseed.endurance)	// Check endurance
+			if(10 to 30)
+				to_chat(user, "<span class='warning'>The plant's endurance is faltering, a breeze is capable of causing it to buckle.</span>")
+			if(31 to 50)
+				to_chat(user, "<span class='notice'>The plant is durable, capable of taking the rough environment for a while.</span>")
+			if(51 to 70)
+				to_chat(user, "<span class='notice'>The plant's fortitude is remarkable, it's able to withstand harsh toxins and stay alive.</span>")
+			if(71 to 90)
+				to_chat(user, "<span class='notice'>The plant's endurance is as solid as an oak!</span>")
+			if(90 to 100)
+				to_chat(user, "<span class='nicegreen'>The plant's endurance is herculean, capable of surviving far longer than any man!</span>")
+		switch(src.myseed.lifespan)		// Checks lifespan
+			if(10 to 30)
+				to_chat(user, "<span class='warning'>The plant's lifespan is counted in minutes, look away, and it will be nevermore.</span>")
+			if(31 to 50)
+				to_chat(user, "<span class='notice'>The plant's lifespan is counted in hours, do not let it go so simply.</span>")
+			if(51 to 70)
+				to_chat(user, "<span class='notice'>The plant's lifespan is counted in days.</span>")
+			if(71 to 90)
+				to_chat(user, "<span class='notice'>The plant's lifepsan is counted in weeks.</span>")
+			if(90 to 100)
+				to_chat(user, "<span class='nicegreen'>The plant's lifespan is forevermore. Treat it well, and it will not abandon you.</span>")
+		switch(src.myseed.instability)
+			if(0 to 20)
+				to_chat(user, "<span class='nicegreen'>The plant's stability is solid, the foundation secure.</span>")
+			if(21 to 40)
+				to_chat(user, "<span class='notice'>The plant's stability is shifting, the harvest uncertain.</span>")
+			if(41 to 60)
+				to_chat(user, "<span class='notice'>The plant's stability is loose, the harvest producing ancient relatives.</span>")
+			if(61 to 80)
+				to_chat(user, "<span class='notice'>The plant's unstable, it actively morphs and tries to push itself to something greater.</span>")
+			if(81 to 100)
+				to_chat(user, "<span class='warning'>The plant's unstable, the earth beneath moans and croaks, roots bend and insidious liquids seep from the skin.</span>")
+		switch(src.myseed.weed_rate)
+			if(0 to 2)
+				to_chat(user, "<span class='nicegreen'>The weed growth around the plant appear to be of a miniscule amount...</span>")
+			if(3 to 5)
+				to_chat(user, "<span class='notice'>The weed growth could overwhelm the plant in a matter of minutes...</span>")
+			if(5 to 7)
+				to_chat(user, "<span class='notice'>The weed growth would in but a few moments overwhelm the plant...</span>")
+			if(8 to 10)
+				to_chat(user, "<span class='warning'>The weed growth could instantly put down the plant..!</span>")
+		switch(src.myseed.weed_chance)
+			if(0 to 20)
+				to_chat(user, "<span class='nicegreen'>... and the chance of the weeds to grow are highly unlikely.</span>")
+			if(21 to 40)
+				to_chat(user, "<span class='notice'>... and there's a coinflip's chance for the weeds to come forth.</span>")
+			if(41 to 60)
+				to_chat(user, "<span class='notice'>... and the weeds are more likely to spew forth than not.</span>")
+			if(61 to 80)
+				to_chat(user, "<span class='notice'>... and the weeds are very likely to come!</span>")
+			if(81 to 100)
+				to_chat(user, "<span class='warning'>... and the weeds will bloom.</span>")
+	else if(!myseed)
+		to_chat(user, "<span class='notice'>... nothing seems to be growing there.</span>")
+	else
+		to_chat(user, "<span class='notice'>... You can't see anything in particular. Maybe you need to get closer to examine it closely?</span>")
 /obj/machinery/hydroponics/proc/weedinvasion() // If a weed growth is sufficient, this happens.
 	dead = 0
 	var/oldPlantName
@@ -747,3 +834,9 @@
 /obj/machinery/hydroponics/soil/crafted
 	waterlevel = 0
 //	nutrilevel = 0
+
+/obj/machinery/hydroponics/soil/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'><b>Alt-Click</b> to empty the tray's nutrients.</span>"
+	if(in_range(user, src) || isobserver(user))
+		. += "<span class='notice'>You might be able to discern a plant's harvest by examining it <b>closer</b>.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pull request intends to make it so that farming can be performed by anybody who has the knowledge of what's needed to craft the four new composts that have been added. These composts will range in ability and use, such as increasing instability, lowering instability, increasing potency and yield while speeding up production rate, and increasing endurance while reducing weed chance. It also intends to remove excessive code and remove some bullshit reagent code that's been a headache for a long time, while adding nutriments to plants to allow them to be juiced to retrieve their respective juices.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This will finally add more options to the Wayfarer's Tribesmen and Legion farmers in a unique sense, that'll reward them for planning ahead and making the right juices in a greater way than regular commerical fertilizers that's used by the majority of the factions and regular farmers. It also will add back some of the juices that were meant to always be in the game, meaning you can now craft some tonics and drinks that normally wasn't capable of being made.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Stabilizing Compost
add: Reactive Compost
add: Fortifying Compost
add: Alacritous Compost
del: Duplicate mushroom code.
code: Examine on a soil will either yield a rough estimate of a plant's harvest (if performed on a soil that's within 1 tile of you, has a seed in it, is visible), tell you to get closer to examine it, or tell you there's nothing planted.
code: Wasteland seeds will now actually produce the reagents in question when ground.
Spelling: Fixed some capitalizations here and there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
