### PR TITLE
Fixes #379

### DIFF
--- a/code/modules/reagents/chemistry/machinery/alchemy_table.dm
+++ b/code/modules/reagents/chemistry/machinery/alchemy_table.dm
@@ -1,5 +1,5 @@
 /obj/machinery/alchemy_table
-	name = "Alchemy table"
+	name = "alchemy table"
 	desc = "A wooden table with various bone mortars and pistles, as well as other tools."
 	density = TRUE
 	layer = BELOW_OBJ_LAYER

--- a/code/modules/reagents/chemistry/machinery/alchemy_table.dm
+++ b/code/modules/reagents/chemistry/machinery/alchemy_table.dm
@@ -5,7 +5,7 @@
 	layer = BELOW_OBJ_LAYER
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "alchemy_table"
-	use_power = IDLE_POWER_USE
+	use_power = NO_POWER_USE
 	idle_power_usage = 5
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	


### PR DESCRIPTION
## About The Pull Request

Removes power requirement from the alchemy table.

Fixes capitalisation of atom name. That's bad style and causes it to be treated as a proper noun, i.e. it will say "You hit Alchemy table with the crowbar" instead of "You hit the alchemy table with the crowbar".

## Why It's Good For The Game

Fixes #379, also fixes an unreported bug with the name..

## Changelog
:cl: Bak
fix: The alchemy table no longer uses power.
fix: The alchemy table is now "the alchemy table" instead of "Alchemy table".
/:cl: