### PR TITLE
Small Update

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -652,6 +652,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"axX" = (
+/obj/structure/rack,
+/obj/item/storage/pill_bottle/chem_tin/buffout,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aya" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -7728,6 +7733,7 @@
 /area/f13/ncr)
 "fRx" = (
 /obj/structure/table,
+/obj/item/storage/pill_bottle/chem_tin/buffout,
 /turf/open/floor/f13,
 /area/f13/building)
 "fSq" = (
@@ -15160,6 +15166,7 @@
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
 	},
+/obj/item/storage/pill_bottle/chem_tin/buffout,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -62147,7 +62154,7 @@ fyf
 tKZ
 rdc
 rpu
-cSH
+axX
 rpu
 fLN
 rpu

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -550,7 +550,8 @@
 				/obj/item/reagent_containers/pill/patch/turbo,
 				/obj/item/reagent_containers/pill/patch/healingpowder,
 				/obj/item/reagent_containers/pill/stimulant,
-				/obj/item/reagent_containers/syringe/medx
+				/obj/item/reagent_containers/syringe/medx,
+				/obj/item/storage/pill_bottle/chem_tin/buffout
 				)
 /*	------------------------------------------------
 	--------------WEAPON SPAWNERS-------------------

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -871,6 +871,7 @@
 			if("Chemistry")
 				granted_trait = TRAIT_CHEMWHIZ
 				traitname = "chemistry"
+				crafting_recipe_types = list(/datum/crafting_recipe/jet, /datum/crafting_recipe/turbo, /datum/crafting_recipe/psycho, /datum/crafting_recipe/medx, /datum/crafting_recipe/buffout)
 			if("Salvager")
 				granted_trait = TRAIT_TECHNOPHREAK
 				traitname = "salvaging"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -563,7 +563,7 @@
 
 /obj/item/gun/ballistic/automatic/mini_uzi
 	name = "uzi"
-	desc = "A lightweight, burst-fire submachien gun, for when you really want someone dead. Uses 9mm rounds."
+	desc = "A lightweight, burst-fire submachine gun, for when you really want someone dead. Uses 9mm rounds."
 	icon_state = "mini-uzi"
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
 	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
Adds a few set spawns for buffout, and also adds it to the wasteland drug spawn pool. Also fixes a minor bug and an oversight

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As stated above. Also fixes issue #314 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Yes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds three set buffout spawns on the surface of Pahrump
tweak: Adds buffout to the wasteland drugs pool
fix: fixes a spelling error in the uzi description
fix: fixed a small oversight with the private diary chem option, not allowing you to make drugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
