### PR TITLE
GNB4 for crafting stuff

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -899,6 +899,66 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
+//12.7 pistol
+/datum/crafting_recipe/pistol127
+	name = "12.7mm pistol"
+	result = /obj/item/gun/ballistic/automatic/pistol/pistol127
+	reqs = list(/obj/item/advanced_crafting_components/assembly = 1,
+				/obj/item/advanced_crafting_components/conductors  = 1,
+				/obj/item/advanced_crafting_components/flux = 1,
+				/obj/item/stack/f13Cash/caps = 400,
+				/obj/item/stack/crafting/metalparts = 5,
+				/obj/item/stack/crafting/electronicparts = 3,
+				/datum/reagent/blackpowder = 240)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_availible = FALSE
+
+//12.7 pistol tactical
+/datum/crafting_recipe/pistol127tackit
+	name = "12.7mm pistol tactical conversion"
+	result = /obj/item/gun/ballistic/automatic/pistol/pistol127/lildevil
+	reqs = list(/obj/item/stack/sheet/metal = 10,
+				/datum/reagent/blackpowder = 60,
+				/obj/item/stack/crafting/goodparts = 3,
+				/obj/item/gun/ballistic/automatic/pistol/pistol127)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_availible = FALSE
+
+//auto beretta
+/datum/crafting_recipe/berettaauto
+	name = "Automatic Beretta"
+	result = /obj/item/gun/ballistic/automatic/pistol/beretta/automatic
+	reqs = list(/obj/item/attachments/burst_improvement = 1,
+				/obj/item/advanced_crafting_components/alloys = 1,
+				/obj/item/gun/ballistic/automatic/pistol/beretta = 1,
+				/obj/item/stack/f13Cash/caps = 200,
+				/obj/item/stack/crafting/metalparts = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_availible = FALSE
+
+//hunting revolver
+/datum/crafting_recipe/huntingrevolver
+	name = "Hunting Revolver"
+	result = /obj/item/gun/ballistic/revolver/hunting
+	reqs = list(/obj/item/advanced_crafting_components/assembly = 1,
+				/obj/item/advanced_crafting_components/alloys = 2,
+				/obj/item/stack/crafting/metalparts = 10,
+				/datum/reagent/blackpowder = 180)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_availible = FALSE
+
 //////////////////////////////////
 ///GUN ATTACHMENT/PARTS CRAFTING//
 //////////////////////////////////

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -605,6 +605,7 @@
 	icon_state = "gab4"
 	oneuse = TRUE
 	remarks = list("Always keep your gun well lubricated...", "Keep your barrel free of grime...", "Perfect fitment is the key to a good firearm...", "Maintain a proper trigger pull length...", "Keep your sights zeroed to proper range...")
+	crafting_recipe_types = list(/datum/crafting_recipe/pistol127, /datum/crafting_recipe/berettaauto, /datum/crafting_recipe/huntingrevolver)
 	//crafting_recipe_types = list(/datum/crafting_recipe/flux, /datum/crafting_recipe/lenses, /datum/crafting_recipe/conductors, /datum/crafting_recipe/receiver, /datum/crafting_recipe/assembly, /datum/crafting_recipe/alloys)
 
 // New Blueprints, yay! -Superballs
@@ -871,7 +872,6 @@
 			if("Chemistry")
 				granted_trait = TRAIT_CHEMWHIZ
 				traitname = "chemistry"
-				crafting_recipe_types = list(/datum/crafting_recipe/jet, /datum/crafting_recipe/turbo, /datum/crafting_recipe/psycho, /datum/crafting_recipe/medx, /datum/crafting_recipe/buffout)
 			if("Salvager")
 				granted_trait = TRAIT_TECHNOPHREAK
 				traitname = "salvaging"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -871,6 +871,7 @@
 				traitname = "intermediate surgery"
 			if("Chemistry")
 				granted_trait = TRAIT_CHEMWHIZ
+				crafting_recipe_types = list(crafting_recipe_types = list(/datum/crafting_recipe/jet, /datum/crafting_recipe/turbo, /datum/crafting_recipe/psycho, /datum/crafting_recipe/medx, /datum/crafting_recipe/buffout)
 				traitname = "chemistry"
 			if("Salvager")
 				granted_trait = TRAIT_TECHNOPHREAK

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -239,6 +239,7 @@ Raider
 	..()
 	if(visualsOnly)
 		return
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/pistol127tackit)	
 
 	H.social_faction = "Raiders"
 	H.verbs |= /mob/living/proc/creategang

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -55,17 +55,21 @@
 // 12.7mm
 /obj/item/projectile/bullet/a127mm
 	name = "12.7mm FMJ bullet"
-	damage = 55
-	armour_penetration = 0.35
+	damage = 30 //55
+	armour_penetration = 0.4 // 0.35
 	wound_bonus = 28
 	bare_wound_bonus = -28
+	pixels_per_second = TILES_TO_PIXELS(100)
 
 /obj/item/projectile/bullet/a127mm/jhp
 	name = "12.7mm JHP bullet"
-	damage = 66
+	damage = 43 //66
 	armour_penetration = -1
 	wound_bonus = -56
 	bare_wound_bonus = 56
+	pixels_per_second = TILES_TO_PIXELS(100)
+
+
 
 // 22 long rifle (lmao)
 /obj/item/projectile/bullet/c22


### PR DESCRIPTION

## About The Pull Request

Adds in four crafting recipies: hunting revolver, automatic beretta, 12.7 pistol. Tactical version of the 12.7 pistol for outlaws. The first three recipes are found by reading a guns and bullets 4 book. They're all really expensive for what they give, so I doubt it's gonna cause any problems with the current blueprints. The 12.7 pistol for example, takes 3 advanced crafting parts, 400 caps and 4 bottles of gunpowder.
The second change was to the 12.7 ammo type. Gives it very fast bullet speed and a minor AP buff (cuz bullet go faster), but a massive damage nerf to keep things cool and balanced.

## Why It's Good For The Game

It's a nice little novelty mainly. Outlaws can have a special gun even tho it takes a huge amount of effort and work to make. You can read that spare book 4 you bought by mistake now and not cry because you just realized you wasted 400 caps. Machine pistol is cool. Big revolver is also cool.

## Changelog
:cl:
add:
12.7 gun grafting recipe
hunting revolver crafting recipe
automatic beretta crafting recipe
GNB4 gives access to the above recipes
tactical conversion for 12.7 recipe

balance: 
12.7 bullets are fast with decent AP, but relatively low damage.