### PR TITLE
Makes it impossible to recharge energy weapons ammos & add energy ammo printing to the ammolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -570,7 +570,8 @@
 	allowed_materials = list(
 		/datum/material/iron,
 		/datum/material/titanium,
-		/datum/material/blackpowder)
+		/datum/material/blackpowder,
+		/datum/material/uranium)
 	var/simple = 0
 	var/basic = 0
 	var/intermediate = 0
@@ -674,7 +675,7 @@
 	if(advanced)
 		new /obj/item/book/granter/crafting_recipe/gunsmith_four(src)
 	return
-	
+
 /obj/machinery/autolathe/ammo/unlocked
 	simple = 1
 	basic = 1

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -33,7 +33,7 @@
 		. += "<span class='notice'>The status display reads: Charge rate at <b>[charge_rate]J</b> per cycle.</span>"
 
 /obj/machinery/cell_charger/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/stock_parts/cell) && !panel_open)
+	if(istype(W, /obj/item/stock_parts/cell) && !panel_open && !istype(W, /obj/item/stock_parts/cell/ammo))
 		if(stat & BROKEN)
 			to_chat(user, "<span class='warning'>[src] is broken!</span>")
 			return

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -13,7 +13,6 @@
 	var/using_power = FALSE //Did we put power into "charging" last process()?
 
 	var/static/list/allowed_devices = typecacheof(list(
-		/obj/item/gun/energy,
 		/obj/item/melee/baton,
 		/obj/item/ammo_box/magazine/recharge,
 		/obj/item/modular_computer,

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -343,7 +343,7 @@
 	name = "energy cell"
 	id = "ec-full"
 	build_path = /obj/item/stock_parts/cell/ammo/ec
-	materials = list(/datum/material/iron = 10000, /datum/material/uranium = 1500)
+	materials = list(/datum/material/iron = 10000, /datum/material/uranium = 300)
 	category = list("initial", "Basic Ammo")
 
 /* --Tier 3 Ammo and Magazines -- */
@@ -493,7 +493,7 @@
 /datum/design/ammolathe/mfc
 	name = "microfusion cell"
 	id = "mfc-full"
-	materials = list(/datum/material/iron = 15000, /datum/material/uranium = 3000)
+	materials = list(/datum/material/iron = 15000, /datum/material/uranium = 600)
 	build_path = /obj/item/stock_parts/cell/ammo/mfc
 	category = list("initial", "Intermediate Ammo")
 
@@ -595,6 +595,6 @@
 /datum/design/ammolathe/ecp
 	name = "electron charge pack"
 	id = "icell"
-	materials = list(/datum/material/iron = 25000, /datum/material/uranium = 3500)
+	materials = list(/datum/material/iron = 25000, /datum/material/uranium = 750)
 	build_path = /obj/item/stock_parts/cell/ammo/ecp
 	category = list("initial", "Advanced Ammo")

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -22,7 +22,7 @@
 	build_path = /obj/item/stack/ore/blackpowder
 	category = list("initial", "Materials")
 	maxstack = 50
-	
+
 /datum/design/ammolathe/titanium
 	name = "Titanium"
 	id = "titanium"
@@ -31,6 +31,13 @@
 	category = list("initial", "Materials")
 	maxstack = 50
 
+/datum/design/ammolathe/uranium
+	name = "Uranium"
+	id = "uranium"
+	materials = list(/datum/material/uranium = 2000)
+	build_path = /obj/item/stack/sheet/mineral/uranium
+	category = list("initial", "Materials")
+	maxstack = 50
 
 /* --Tier 1 Ammo and Magazines-- */
 //Tier 1 Magazines
@@ -332,6 +339,13 @@
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
 	category = list("initial", "Basic Ammo")
 
+/datum/design/ammolathe/ec
+	name = "energy cell"
+	id = "ec-full"
+	build_path = /obj/item/stock_parts/cell/ammo/ec
+	materials = list(/datum/material/iron = 10000, /datum/material/uranium = 1500)
+	category = list("initial", "Basic Ammo")
+
 /* --Tier 3 Ammo and Magazines -- */
 //Tier 3 Magazines
 
@@ -476,6 +490,13 @@
 	build_path = /obj/item/ammo_box/c45/op
 	category = list("initial", "Intermediate Ammo")
 
+/datum/design/ammolathe/mfc
+	name = "microfusion cell"
+	id = "mfc-full"
+	materials = list(/datum/material/iron = 15000, /datum/material/uranium = 3000)
+	build_path = /obj/item/stock_parts/cell/ammo/mfc
+	category = list("initial", "Intermediate Ammo")
+
 /* --Tier 4 Ammo and Magazines-- */
 //Tier 4 Magazines
 /datum/design/ammolathe/mg34mag
@@ -569,4 +590,11 @@
 	id = "a556match"
 	materials = list(/datum/material/iron = 28000, /datum/material/blackpowder = 3500)
 	build_path = /obj/item/ammo_box/a556/match
+	category = list("initial", "Advanced Ammo")
+
+/datum/design/ammolathe/ecp
+	name = "electron charge pack"
+	id = "icell"
+	materials = list(/datum/material/iron = 25000, /datum/material/uranium = 3500)
+	build_path = /obj/item/stock_parts/cell/ammo/ecp
 	category = list("initial", "Advanced Ammo")


### PR DESCRIPTION
Changed the recharger and cell charger so they don't accept cells anymore.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changed what can be put to charge inside the cell charger and recharger.
Ammolathe can now print energy ammo from iron and uranium (values were taken from the closest ammo type damage wise, with gunpowder and titanium --> uranium. Will likely need tweaking).
Tested locally with most MFcs, ECs, ECPs and the AERs and wattz, worked fine.

## Why It's Good For The Game

Gets the meta around energy weapons closer to what it was on legacy.
Streamline ammo production for non high tech factions.
High tech factions still make ammo for FAR cheaper in their lathe (maybe remove or make it cost more? Idk).

## Changelog
:cl:
del: one line from rechargerer.dm
added: an old piece of code from legacy to cell_charger.dm
added: energy ammo crafting to the ammolathe (autolathe.dm and ammolathe_design.dm)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
