### PR TITLE
Purple's Loadout

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -129,6 +129,7 @@
 						"shoi87",
 						"svenja",
 						"panzer1944",
+						"purplepineapple",
 						"topbirb")
 	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
 
@@ -198,6 +199,7 @@
 						"shoi87",
 						"svenja",
 						"panzer1944",
+						"purplepineapple",
 						"topbirb")
 	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
 


### PR DESCRIPTION
### About
Purple got their Vet Ranger W/L accepted, it's only right they get the Sequoia and Pins for their character so they dont have to Ahelp every round for them.
### Why
Because they got their W/L accepted, and by consequence needed their Sequoia and Ranger LT pins available,
### Changes
- Gives Purple access to the Sequoia and Ranger LT pins for their Veteran Ranger.