### PR TITLE
BoS Bunker QoL Remapping

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -1603,10 +1603,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "biN" = (
-/obj/item/radio/intercom{
-	frequency = 1891
-	},
-/turf/closed/wall/f13/tunnel,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/machinery/light,
+/turf/open/water,
 /area/f13/brotherhood)
 "bjg" = (
 /obj/structure/rack,
@@ -5437,6 +5438,7 @@
 	desc = "It doesn't look very healthy...";
 	name = "Dead potted plant"
 	},
+/obj/machinery/light,
 /turf/open/water,
 /area/f13/brotherhood)
 "elF" = (
@@ -9026,11 +9028,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gNe" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -9968,13 +9970,6 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
-"hsq" = (
-/obj/machinery/light/small,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
 /area/f13/brotherhood)
 "hsy" = (
 /obj/structure/barricade/sandbags,
@@ -11944,12 +11939,11 @@
 	},
 /area/f13/building)
 "iHR" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 9
-	},
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "iHS" = (
@@ -12764,6 +12758,10 @@
 /area/f13/legion)
 "jix" = (
 /obj/machinery/autolathe/constructionlathe,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jiP" = (
@@ -17334,9 +17332,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "mEh" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17990,13 +17985,9 @@
 /obj/machinery/button/door{
 	id = "bosdoorshutter2";
 	name = "shutters button";
-	pixel_x = -25;
-	pixel_y = -9;
+	pixel_x = -23;
+	pixel_y = -4;
 	req_access_txt = "120"
-	},
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = -28
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
@@ -20342,11 +20333,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "oVv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/workbench,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -23650,12 +23641,11 @@
 "rrl" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
 /obj/item/kirbyplants/dead{
 	desc = "It doesn't look very healthy...";
 	name = "Dead potted plant"
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/brotherhood)
 "rrE" = (
@@ -24122,7 +24112,7 @@
 /area/f13/village)
 "rOo" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -24839,7 +24829,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/city)
 "snR" = (
-/obj/machinery/light/small,
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "soh" = (
@@ -25416,12 +25408,12 @@
 	},
 /area/f13/building)
 "sLi" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/constructable,
 /obj/structure/lattice/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/water,
 /area/f13/brotherhood)
 "sLm" = (
@@ -27143,6 +27135,16 @@
 /obj/structure/safe,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tUh" = (
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_y = 24
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "tUk" = (
 /obj/machinery/light{
 	dir = 8
@@ -68399,7 +68401,7 @@ iFI
 anP
 qPL
 qPL
-snR
+qPL
 iFI
 gcK
 ktB
@@ -68913,7 +68915,7 @@ daH
 qPL
 uFn
 qPL
-qPL
+snR
 iFI
 gcK
 gbL
@@ -72775,8 +72777,8 @@ jem
 jem
 jem
 jem
-biN
-mfD
+jem
+tUh
 mfD
 mfD
 mfD
@@ -75071,7 +75073,7 @@ nUm
 nUm
 nUm
 nUm
-hsq
+kAh
 dvQ
 ahh
 mwt
@@ -75328,7 +75330,7 @@ nUm
 nUm
 nUm
 nUm
-kAh
+biN
 qRg
 lDv
 wYn

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -121,6 +121,7 @@
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pda,
+/obj/item/pda,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "afL" = (
@@ -183,6 +184,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"ahh" = (
+/obj/item/kirbyplants,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "ahs" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced,
@@ -276,7 +284,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ajX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
@@ -285,15 +293,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
 "akm" = (
-/obj/structure/table/glass,
 /obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ako" = (
 /obj/structure/rack,
-/obj/item/flashlight/lantern,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "aku" = (
@@ -387,7 +398,7 @@
 "anb" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "anl" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_l,
@@ -409,12 +420,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "aof" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/effect/landmark/start/f13/explorer,
+/obj/effect/landmark/start/f13/venator,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "aoD" = (
@@ -462,7 +473,7 @@
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "aqD" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
@@ -569,7 +580,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "auH" = (
 /obj/structure/table,
 /obj/item/ammo_casing/shotgun/buckshot,
@@ -652,11 +663,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"axX" = (
-/obj/structure/rack,
-/obj/item/storage/pill_bottle/chem_tin/buffout,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "aya" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -782,8 +788,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aDb" = (
-/obj/structure/destructible/tribal_torch/wall/lit,
-/obj/effect/landmark/start/f13/venator,
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/landmark/start/f13/explorer,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "aDk" = (
@@ -969,15 +976,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"aLs" = (
-/obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/workbench,
-/obj/item/book/granter/crafting_recipe/blueprint/r84,
-/obj/item/book/granter/crafting_recipe/blueprint/r82,
-/obj/item/book/granter/crafting_recipe/blueprint/service,
-/obj/item/book/granter/crafting_recipe/blueprint/m1garand,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/ncr)
 "aLA" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -1218,11 +1216,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "aVo" = (
-/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "aVq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -1257,7 +1256,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "aWz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -1358,17 +1357,13 @@
 	},
 /area/f13/village)
 "aYV" = (
-/obj/structure/wreck/car/bike{
-	pixel_x = -12;
-	pixel_y = 1
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "aYY" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -1403,9 +1398,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bav" = (
-/obj/structure/wreck/trash/two_tire,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/brotherhood)
 "baS" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/f13/stage_tr,
@@ -1426,9 +1423,16 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"bbN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/dead,
+/obj/structure/lattice/catwalk,
+/obj/item/kirbyplants,
+/turf/open/water,
+/area/f13/brotherhood)
 "bbS" = (
 /turf/closed/wall/f13/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "bbU" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalleft"
@@ -1598,6 +1602,12 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"biN" = (
+/obj/item/radio/intercom{
+	frequency = 1891
+	},
+/turf/closed/wall/f13/tunnel,
+/area/f13/brotherhood)
 "bjg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -1741,7 +1751,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "bnm" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -1917,6 +1927,14 @@
 "brH" = (
 /turf/closed/wall/f13/store,
 /area/f13/city)
+"brR" = (
+/obj/machinery/button/door{
+	id = "bosvillage";
+	pixel_x = 30;
+	req_access_txt = "120"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/brotherhood)
 "brZ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -1951,7 +1969,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "buD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -2256,7 +2274,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "bEZ" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -2374,7 +2392,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "bIV" = (
 /obj/structure/chair/bench,
 /obj/effect/landmark/start/f13/settler,
@@ -2529,6 +2547,7 @@
 /area/f13/legion)
 "bPH" = (
 /obj/structure/rack,
+/obj/item/flashlight/lantern,
 /obj/item/claymore/machete/training,
 /obj/item/claymore/machete/training,
 /obj/item/claymore/machete/training,
@@ -2564,7 +2583,7 @@
 	icon_state = "warningline_red"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "bQL" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/spring,
@@ -2679,7 +2698,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "bXw" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood{
@@ -2793,7 +2812,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "cfn" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -2935,7 +2954,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ckJ" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -2967,7 +2986,7 @@
 "ckZ" = (
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "clL" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -2997,7 +3016,7 @@
 "cmR" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "cnt" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/bed/dogbed,
@@ -3142,7 +3161,7 @@
 /obj/structure/barricade/bars,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ctE" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -3163,6 +3182,10 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
+"ctZ" = (
+/obj/item/flag/bos,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "cuv" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
@@ -3281,7 +3304,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "czx" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -3477,7 +3500,7 @@
 "cKg" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "cKC" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -3527,7 +3550,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "cLZ" = (
 /obj/item/candle/infinite,
 /turf/open/floor/f13/wood,
@@ -3556,21 +3579,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
-"cOd" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood/surface)
 "cOg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3635,7 +3643,7 @@
 	layer = 6
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "cQs" = (
 /obj/structure/simple_door/tent,
 /turf/open/floor/f13/wood{
@@ -3713,7 +3721,7 @@
 /area/f13/wasteland)
 "cSU" = (
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "cTc" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
@@ -3854,7 +3862,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "cYz" = (
 /obj/item/target,
 /turf/open/floor/f13{
@@ -3934,7 +3942,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "daM" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert{
@@ -4130,12 +4138,6 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
-"dhj" = (
-/obj/structure/table/wood,
-/obj/structure/fluff/paper/stack,
-/obj/item/pen,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
 "dhB" = (
 /obj/machinery/light/sign,
 /obj/structure/barricade/wooden,
@@ -4467,6 +4469,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dsL" = (
+/obj/machinery/trading_machine/ammo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "dsW" = (
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4561,9 +4568,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "dvQ" = (
-/obj/structure/wreck/trash/engine,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/house,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "dwx" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/f13/wood,
@@ -4617,7 +4631,7 @@
 	icon_state = "tree_2"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "dys" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -4695,7 +4709,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "dAB" = (
 /obj/structure/car/rubbish3,
 /turf/closed/wall/r_wall/rust,
@@ -4791,7 +4805,7 @@
 "dER" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "dEW" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -4875,6 +4889,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2left"
 	},
+/area/f13/wasteland)
+"dIW" = (
+/obj/structure/chair/bench,
+/obj/item/trash/f13/porknbeans,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "dJg" = (
 /obj/structure/decoration/clock/old/active,
@@ -5039,8 +5058,9 @@
 /obj/item/seeds/potato/sweet,
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "dRo" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/desert,
@@ -5167,13 +5187,6 @@
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"dYv" = (
-/obj/structure/rack,
-/obj/item/clothing/under/f13/legslave,
-/obj/item/clothing/under/f13/legslavef,
-/obj/item/clothing/head/f13/legion/servant,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "dZk" = (
 /obj/structure/table/wood,
 /obj/item/stack/f13Cash/random/ncr/low,
@@ -5252,7 +5265,7 @@
 /area/f13/wasteland)
 "edB" = (
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "edF" = (
 /obj/machinery/light/small,
 /obj/structure/bed/mattress{
@@ -5359,7 +5372,7 @@
 "eiB" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ejk" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5417,6 +5430,15 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"ely" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/item/kirbyplants/dead{
+	desc = "It doesn't look very healthy...";
+	name = "Dead potted plant"
+	},
+/turf/open/water,
+/area/f13/brotherhood)
 "elF" = (
 /obj/structure/table/wood/fancy,
 /obj/item/vending_refill/boozeomat,
@@ -5480,7 +5502,7 @@
 "enL" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "eoi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -5592,9 +5614,13 @@
 /area/f13/building)
 "esD" = (
 /obj/machinery/light/small,
-/obj/structure/closet/crate/bin,
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_y = -33
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "esE" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -5671,6 +5697,11 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"evU" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "evV" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -5685,7 +5716,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "exj" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -5941,7 +5972,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "eHB" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/desert,
@@ -6147,7 +6178,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "eOd" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6384,7 +6415,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "eUI" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -6433,7 +6464,7 @@
 	icon_state = "bench"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "eXa" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -6521,7 +6552,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "eZI" = (
 /obj/structure/spirit_board,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6732,7 +6763,7 @@
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "fiB" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -6778,19 +6809,21 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "fkj" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/house,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "fkP" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "fkU" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/remains/human,
@@ -6879,13 +6912,12 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "for" = (
-/obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/biogenerator,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "foz" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -7077,13 +7109,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
-"ftR" = (
-/obj/item/flag/bos,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "fuc" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -7251,12 +7276,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "fzT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/fans/tiny,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/brotherhood/surface)
+/turf/closed/wall/r_wall/rust,
+/area/f13/brotherhood)
 "fzW" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7280,12 +7305,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/city)
-"fAZ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/f13/priestess,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "fBl" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -7582,7 +7601,7 @@
 /area/f13/wasteland)
 "fMu" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "fMO" = (
 /obj/item/ammo_casing/c10mm/ap{
 	dir = 5
@@ -7628,7 +7647,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "fOu" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7640,12 +7659,14 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "fPL" = (
-/obj/item/circuitboard/machine/hydroponics,
-/obj/item/circuitboard/machine/hydroponics,
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/hydroponics{
+	desc = "A locker that smells of soil.";
+	name = "gardening locker";
+	req_access = list(120)
+	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "fPN" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -7733,7 +7754,6 @@
 /area/f13/ncr)
 "fRx" = (
 /obj/structure/table,
-/obj/item/storage/pill_bottle/chem_tin/buffout,
 /turf/open/floor/f13,
 /area/f13/building)
 "fSq" = (
@@ -7906,15 +7926,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/legion)
 "fYP" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
+"fYW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "fZm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7989,13 +8010,6 @@
 /obj/item/reagent_containers/food/snacks/kebab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"gdv" = (
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = -33
-	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
 "gdN" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/desert,
@@ -8124,7 +8138,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "gip" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/fprostitute,
@@ -8285,7 +8299,7 @@
 "gnU" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "gof" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
@@ -8325,7 +8339,7 @@
 "goO" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "goU" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -8412,7 +8426,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "grf" = (
 /obj/structure/chair/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -8634,7 +8648,7 @@
 "gyd" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "gyf" = (
 /obj/item/clothing/under/soviet,
 /obj/structure/displaycase,
@@ -8697,7 +8711,7 @@
 	icon_state = "fence_wood"
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "gBj" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
@@ -8727,8 +8741,9 @@
 /obj/structure/sign/poster/prewar/poster90{
 	pixel_y = 27
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "gCd" = (
 /obj/structure/fence{
 	dir = 4
@@ -8803,7 +8818,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "gEr" = (
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
@@ -9011,17 +9026,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gNe" = (
-/obj/structure/lattice{
-	layer = 3
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "gNA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 10;
@@ -9037,7 +9050,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "gOf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -9102,7 +9115,7 @@
 	icon_state = "warningline_red"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "gPQ" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/desert,
@@ -9214,11 +9227,12 @@
 	},
 /area/f13/wasteland)
 "gSv" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/vending/sustenance{
+	req_access_txt = "120"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "gTz" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/combat,
@@ -9423,7 +9437,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "haD" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/desert,
@@ -9434,7 +9448,7 @@
 /area/f13/wasteland)
 "hbm" = (
 /turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hbx" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/sneakers/black{
@@ -9458,7 +9472,7 @@
 	layer = 2.1
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hbK" = (
 /obj/machinery/light{
 	dir = 4
@@ -9482,8 +9496,10 @@
 	},
 /area/f13/wasteland)
 "hcr" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "hcx" = (
@@ -9554,7 +9570,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hfz" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light{
@@ -9642,7 +9658,7 @@
 	icon_state = "tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hhG" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -9685,7 +9701,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hjb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
@@ -9761,7 +9777,7 @@
 "hlM" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hlQ" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle,
@@ -9942,7 +9958,7 @@
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hsh" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -9952,7 +9968,14 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
+"hsq" = (
+/obj/machinery/light/small,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/brotherhood)
 "hsy" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -10041,7 +10064,7 @@
 	pixel_y = 13
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hvu" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -10121,11 +10144,11 @@
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hxv" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hxy" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pestspray,
@@ -10159,9 +10182,15 @@
 /area/f13/city)
 "hxX" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar/explosive,
+/obj/item/key/bcollar,
+/obj/item/key/collar,
+/obj/item/key/collar,
+/obj/item/key/collar,
+/obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "hyf" = (
@@ -10222,8 +10251,11 @@
 /obj/structure/bed/pod,
 /obj/structure/lattice/catwalk,
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hzG" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -10314,7 +10346,7 @@
 "hDf" = (
 /obj/structure/simple_door/interior,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hDE" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -10468,13 +10500,11 @@
 /turf/open/floor/carpet/green,
 /area/f13/ncr)
 "hIJ" = (
-/obj/structure/barricade/sandbags,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/brotherhood)
 "hJd" = (
 /obj/structure/rack,
 /obj/item/seeds/poppy/broc,
@@ -10606,7 +10636,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hNL" = (
 /obj/structure/table/wood/fancy,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -10776,7 +10806,7 @@
 	name = "vines"
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hUV" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
@@ -10837,7 +10867,7 @@
 	icon_state = "mattress4"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hWk" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerouter"
@@ -11142,16 +11172,24 @@
 	},
 /area/f13/wasteland)
 "igU" = (
-/obj/structure/rack,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ihm" = (
 /obj/effect/landmark/start/f13/shopkeeper,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"iic" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "iik" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11203,7 +11241,7 @@
 	pixel_y = -33
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ijm" = (
 /obj/structure/simple_door/metal/fence,
 /obj/structure/decoration/rag,
@@ -11225,7 +11263,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ikV" = (
 /obj/structure/table/wood,
 /obj/item/binoculars{
@@ -11252,9 +11290,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ill" = (
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ilq" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
@@ -11350,6 +11389,11 @@
 /obj/structure/chair/wood/modern,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ioi" = (
+/obj/machinery/trading_machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "ioU" = (
 /obj/structure/chair/stool,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -11388,7 +11432,7 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "iqN" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -11485,7 +11529,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "itm" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -11510,19 +11554,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"itU" = (
-/obj/machinery/button/door{
-	id = "bosvillage";
-	pixel_x = 30;
-	req_access_txt = "120"
-	},
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = 33;
-	pixel_y = 10
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
 "itY" = (
 /obj/structure/table/wood,
 /obj/item/lighter,
@@ -11572,7 +11603,7 @@
 "iwd" = (
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "iwm" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -11611,7 +11642,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "iyg" = (
 /mob/living/simple_animal/hostile/wolf/alpha,
 /turf/open/indestructible/ground/outside/desert,
@@ -11639,14 +11670,14 @@
 	pixel_y = 11
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "iyy" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
 	pixel_x = 33
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "iyD" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -11780,7 +11811,7 @@
 /area/f13/city)
 "iFI" = (
 /turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "iFR" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/trash,
@@ -11834,7 +11865,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "iGM" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -11913,20 +11944,19 @@
 	},
 /area/f13/building)
 "iHR" = (
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = -30
-	},
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	pixel_y = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "iHS" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "iHV" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -12096,9 +12126,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iNp" = (
-/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "iNx" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12475,9 +12505,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iYw" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 4;
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/machinery/computer/terminal{
+	dir = 4;
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "iYF" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12532,7 +12574,7 @@
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jbr" = (
 /obj/structure/table/wood,
 /obj/structure/window/spawner/west,
@@ -12584,7 +12626,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jdg" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
@@ -12617,10 +12659,10 @@
 /area/f13/village)
 "jem" = (
 /turf/closed/wall/f13/tunnel,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jeO" = (
 /turf/closed/wall/f13/wood/house/broken,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jeV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -12698,10 +12740,10 @@
 	},
 /area/f13/wasteland)
 "jgY" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/coffee,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/obj/machinery/trading_machine/armor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "jha" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -12723,7 +12765,7 @@
 "jix" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jiP" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -12961,6 +13003,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"jtc" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = "bosdoorshutter2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "jth" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/table/wood/settler,
@@ -13158,7 +13208,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jAZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -13448,7 +13498,7 @@
 	icon_state = "warningline_red"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jRn" = (
 /obj/machinery/light{
 	dir = 4;
@@ -13460,7 +13510,7 @@
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jRU" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/road{
@@ -13539,7 +13589,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jUo" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13,
@@ -13570,6 +13620,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"jVO" = (
+/obj/structure/sign/poster/prewar/poster73,
+/turf/closed/wall/f13/tunnel,
+/area/f13/brotherhood)
 "jWa" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -13597,7 +13651,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jWx" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -13611,7 +13665,6 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "jWO" = (
-/obj/structure/tires/five,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -13629,7 +13682,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "jXj" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
@@ -13959,7 +14012,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "khB" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14117,7 +14170,7 @@
 /obj/structure/closet/crate/large,
 /obj/item/stack/f13Cash/random/low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "kmQ" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/condiment/yeast,
@@ -14362,7 +14415,7 @@
 "kvB" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "kvT" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -14462,18 +14515,6 @@
 "kzu" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/structure/rack,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/radio/headset/headset_ncr,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "kzB" = (
@@ -14502,6 +14543,12 @@
 /obj/item/seeds/punga,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"kAh" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/brotherhood)
 "kAl" = (
 /obj/structure/rack,
 /obj/item/seeds/ambrosia,
@@ -14657,16 +14704,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "kFw" = (
-/obj/machinery/vending/hydroseeds,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "kFH" = (
 /obj/item/clothing/gloves/boxing,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "kGc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 7;
@@ -14692,7 +14739,7 @@
 "kGV" = (
 /obj/structure/window/fulltile/house,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "kHn" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -14763,13 +14810,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "kLv" = (
-/obj/machinery/smartfridge/bottlerack/gardentool,
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "red"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "kLQ" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14864,9 +14912,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kQq" = (
-/obj/structure/wreck/trash/one_tire,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/brotherhood)
 "kQC" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt{
@@ -14984,7 +15033,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "kVS" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -15035,7 +15084,7 @@
 	id = "bosdoorshutter"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "kXM" = (
 /obj/structure/toilet{
 	dir = 8
@@ -15128,7 +15177,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lcx" = (
 /obj/machinery/alchemy_table,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15144,11 +15193,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ldb" = (
-/obj/machinery/biogenerator,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/fulltile/house/broken,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ldy" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15166,7 +15217,6 @@
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
 	},
-/obj/item/storage/pill_bottle/chem_tin/buffout,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -15278,7 +15328,7 @@
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lhN" = (
 /obj/item/flashlight/flare/torch,
 /obj/item/flashlight/flare/torch,
@@ -15441,7 +15491,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "loF" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -15455,6 +15505,12 @@
 /area/f13/ncr)
 "loU" = (
 /obj/machinery/chem_heater,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	layer = 6;
+	pixel_x = -6;
+	pixel_y = 13
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -15524,7 +15580,7 @@
 	pixel_y = 18
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lqV" = (
 /obj/structure/pondlily_big,
 /turf/open/indestructible/ground/outside/water,
@@ -15602,16 +15658,12 @@
 	},
 /area/f13/building)
 "lsG" = (
-/obj/structure/closet/secure_closet/hydroponics{
-	desc = "A locker that smells of soil.";
-	name = "gardening locker";
-	req_access = list(120)
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lsS" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -15664,7 +15716,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lun" = (
 /obj/machinery/door/airlock/glass_large{
 	name = "Followers Clinic"
@@ -15678,7 +15730,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "luD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15793,7 +15845,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lyk" = (
 /obj/effect/landmark/start/f13/prospector,
 /turf/open/floor/f13{
@@ -15826,7 +15878,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lzV" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -15893,7 +15945,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lCe" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -15950,7 +16002,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lDd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/iv_drip,
@@ -15966,7 +16018,7 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lDx" = (
 /obj/structure/barricade/bars,
 /obj/structure/fence,
@@ -16152,7 +16204,7 @@
 "lKO" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lKV" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/trash,
@@ -16176,8 +16228,11 @@
 	},
 /area/f13/building)
 "lMn" = (
+/obj/machinery/workbench,
 /obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/autolathe/ammo,
+/obj/item/book/granter/crafting_recipe/blueprint/service,
+/obj/item/book/granter/crafting_recipe/blueprint/r82,
+/obj/item/book/granter/crafting_recipe/blueprint/r84,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "lMp" = (
@@ -16232,8 +16287,8 @@
 	},
 /area/f13/building)
 "lOY" = (
+/obj/machinery/workbench/forge,
 /obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "lPu" = (
@@ -16272,12 +16327,7 @@
 	},
 /area/f13/wasteland)
 "lRd" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "lRB" = (
@@ -16314,7 +16364,7 @@
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lRW" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
@@ -16351,7 +16401,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lTx" = (
 /obj/machinery/mineral/wasteland_vendor/attachments{
 	icon_state = "weapon_idle"
@@ -16373,7 +16423,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lTZ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -16395,12 +16445,12 @@
 	},
 /area/f13/village)
 "lUe" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "lUf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -16500,10 +16550,22 @@
 /area/f13/wasteland)
 "lZl" = (
 /obj/effect/turf_decal/stripes/white/box,
+/obj/structure/rack,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/photocopier,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/radio/headset/headset_ncr,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "lZw" = (
@@ -16513,8 +16575,13 @@
 	network = list("BoS");
 	pixel_x = -1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "lZP" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -16580,6 +16647,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"mcp" = (
+/obj/machinery/trading_machine/weapon,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "mcz" = (
 /obj/machinery/vending/nukacolavend,
 /obj/effect/decal/cleanable/dirt,
@@ -16862,7 +16934,7 @@
 	pixel_x = -3
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "moi" = (
 /obj/item/ammo_casing/caseless{
 	dir = 10;
@@ -16894,7 +16966,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "moD" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16942,11 +17014,20 @@
 /obj/machinery/button/door{
 	id = "bosdoorshutter";
 	name = "shutters button";
-	pixel_y = -30;
+	pixel_x = 10;
+	pixel_y = -25;
 	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "bosvillage";
+	name = "gate button";
+	pixel_x = -10;
+	pixel_y = -25;
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "mqy" = (
 /obj/machinery/mineral/wasteland_trader/general{
 	icon_state = "trade_idle"
@@ -16978,7 +17059,7 @@
 	icon_state = "brokenstore"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "mrl" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -17138,7 +17219,7 @@
 /area/f13/tunnel)
 "mwt" = (
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "mwO" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
@@ -17211,7 +17292,7 @@
 "mBh" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "mCf" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -17247,7 +17328,7 @@
 	layer = 5
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "mDr" = (
 /obj/machinery/trading_machine/armor,
 /turf/open/floor/f13/wood,
@@ -17259,7 +17340,7 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "mEn" = (
 /obj/structure/lamp_post{
 	dir = 4
@@ -17616,7 +17697,7 @@
 "mUo" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "mUx" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17875,7 +17956,7 @@
 /obj/machinery/workbench,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ndx" = (
 /obj/structure/chair/booth{
 	dir = 4
@@ -17900,6 +17981,25 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"neo" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "bosdoorshutter2";
+	name = "shutters button";
+	pixel_x = -25;
+	pixel_y = -9;
+	req_access_txt = "120"
+	},
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "neN" = (
 /obj/structure/destructible/tribal_torch{
 	pixel_x = 10
@@ -17986,7 +18086,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "nhp" = (
 /obj/machinery/door/poddoor/preopen{
 	id = 42
@@ -18102,9 +18202,11 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
 "nmZ" = (
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	dir = 1;
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood)
 "nnh" = (
 /obj/structure/wreck/trash/machinepile{
 	layer = 3
@@ -18276,7 +18378,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "nvL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -18466,13 +18568,13 @@
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "nDk" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "nDJ" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/slab/burnt,
@@ -18802,7 +18904,7 @@
 /obj/structure/rack,
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "nSf" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
@@ -18883,7 +18985,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "nUF" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19113,9 +19215,12 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
 "odW" = (
+/obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/light,
-/obj/machinery/workbench/forge,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "odZ" = (
@@ -19168,12 +19273,12 @@
 	},
 /area/f13/wasteland)
 "ogc" = (
-/obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ogj" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -19209,8 +19314,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "ohV" = (
-/obj/effect/turf_decal/stripes/white/box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/stamp/denied,
+/obj/item/stamp,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "oic" = (
 /obj/structure/kitchenspike,
@@ -19353,11 +19462,7 @@
 	},
 /area/f13/wasteland)
 "onx" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/stamp,
-/obj/item/stamp/denied,
+/obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "onz" = (
@@ -19389,8 +19494,9 @@
 	name = "gardening toolbox"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ooh" = (
 /obj/structure/table/wood,
 /obj/item/roller,
@@ -19421,12 +19527,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "opY" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/wood,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "oqa" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
@@ -19456,7 +19560,7 @@
 	icon_state = "bench"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "oqu" = (
 /obj/structure/wreck/trash/two_barrels{
 	layer = 4
@@ -19579,7 +19683,7 @@
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ovR" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -19684,7 +19788,7 @@
 "oAB" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "oAS" = (
 /obj/structure/fireplace,
 /turf/open/floor/carpet/black,
@@ -19960,7 +20064,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "oMA" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -20156,7 +20260,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "oSC" = (
 /obj/item/caution{
 	desc = "A sign denoting the presence of a likely very moist molerat.";
@@ -20165,10 +20269,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "oSH" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "oTn" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/f13/wood,
@@ -20235,20 +20342,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "oVv" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "oVF" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20391,7 +20493,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "paS" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20418,7 +20520,7 @@
 /obj/structure/table,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "pck" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
@@ -20460,7 +20562,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "pcY" = (
 /obj/structure/simple_door/glass,
 /turf/open/floor/wood,
@@ -20693,7 +20795,7 @@
 	icon_state = "warningline_red"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "pnw" = (
 /obj/machinery/light/sign/oasis_sign,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20787,7 +20889,7 @@
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "pqs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/closed/wall/f13/wood,
@@ -20855,7 +20957,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "prP" = (
 /obj/structure/table,
 /obj/item/ammo_box/c10mm,
@@ -20871,7 +20973,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "psI" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -21165,18 +21267,6 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
-"pEo" = (
-/obj/machinery/button/door{
-	id = "bosvillage";
-	name = "gate button";
-	pixel_x = 30;
-	req_access_txt = "120"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
 "pEs" = (
 /obj/machinery/light{
 	dir = 4
@@ -21385,6 +21475,12 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"pLJ" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "pMf" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -21466,7 +21562,7 @@
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "pOL" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -21506,7 +21602,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "pRd" = (
 /obj/structure/table/wood,
 /obj/item/storage/backpack{
@@ -21684,6 +21780,12 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"pWx" = (
+/obj/structure/simple_door/interior{
+	req_access_txt = "120"
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "pWH" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block,
@@ -21757,10 +21859,15 @@
 	},
 /area/f13/wasteland)
 "qaf" = (
-/obj/structure/bonfire,
-/obj/item/stack/rods,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "qai" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -21780,7 +21887,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qbe" = (
 /obj/structure/table,
 /obj/item/storage/box/drinkingglasses,
@@ -21857,7 +21964,7 @@
 "qdm" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qdD" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -21923,7 +22030,7 @@
 "qfo" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qfV" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -21941,7 +22048,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qgZ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22421,11 +22528,11 @@
 /obj/item/mining_scanner,
 /obj/item/mining_scanner,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qzM" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qAc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -22476,7 +22583,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qCn" = (
 /obj/structure/noticeboard{
 	name = "bounty board"
@@ -22575,6 +22682,13 @@
 "qFk" = (
 /turf/closed/wall/f13/wood,
 /area/f13/village)
+"qFF" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "qFM" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/light/small/broken{
@@ -22644,7 +22758,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qHZ" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3";
@@ -22741,6 +22855,10 @@
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ncr)
+"qLa" = (
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "qLr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22841,7 +22959,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qOV" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -22878,10 +22996,10 @@
 	name = "gate"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qPL" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qPQ" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -22916,8 +23034,9 @@
 /obj/structure/simple_door/interior{
 	req_access_txt = "120"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qQQ" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -22935,11 +23054,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "qRg" = (
-/obj/structure/window/fulltile,
+/obj/structure/barricade/bars,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/fulltile/house/broken,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qRl" = (
 /obj/machinery/workbench,
 /obj/machinery/light/small/broken{
@@ -22960,7 +23084,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qSM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/bars,
@@ -23436,13 +23560,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/f13/caves)
-"rmY" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/vending/sustenance{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
 "rns" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -23531,15 +23648,16 @@
 	},
 /area/f13/village)
 "rrl" = (
-/obj/structure/lattice{
-	layer = 3
-	},
 /obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/obj/item/kirbyplants/dead{
+	desc = "It doesn't look very healthy...";
+	name = "Dead potted plant"
 	},
-/area/f13/brotherhood/surface)
+/turf/open/water,
+/area/f13/brotherhood)
 "rrE" = (
 /obj/structure/window/spawner,
 /obj/structure/chair/sofa/corp/corner{
@@ -23660,7 +23778,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ryO" = (
 /obj/structure/rack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23930,6 +24048,10 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"rLH" = (
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "rLP" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small{
@@ -24004,7 +24126,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "rOp" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -24030,9 +24152,7 @@
 	},
 /area/f13/wasteland)
 "rPR" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "rQe" = (
@@ -24097,7 +24217,7 @@
 "rRT" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "rSc" = (
 /obj/structure/decoration/rag,
 /obj/machinery/door/unpowered/wooddoor{
@@ -24150,9 +24270,12 @@
 	},
 /area/f13/building)
 "rTG" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack/gardentool,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood)
 "rTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -24224,11 +24347,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "rXe" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -12
 	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "rXj" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/barber{
@@ -24270,8 +24394,9 @@
 	},
 /area/f13/radiation)
 "rZK" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/obj/effect/turf_decal/stripes/white/box,
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "saf" = (
 /obj/structure/simple_door/wood,
@@ -24388,17 +24513,15 @@
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/city)
 "seE" = (
-/obj/structure/lattice{
-	layer = 3
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/obj/structure/lattice/catwalk,
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/water,
+/area/f13/brotherhood)
 "seQ" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/cleaner,
@@ -24422,7 +24545,7 @@
 	pixel_y = 16
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "sfA" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/button{
@@ -24454,12 +24577,9 @@
 	},
 /area/f13/wasteland)
 "sgn" = (
-/obj/item/kirbyplants,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/surface)
+/obj/structure/simple_door/bunker/glass,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "sgr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24467,12 +24587,12 @@
 	},
 /area/f13/wasteland)
 "sgw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
 /obj/structure/lattice/catwalk,
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/water,
+/area/f13/brotherhood)
 "sgz" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2"
@@ -24643,7 +24763,7 @@
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "slM" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -24721,7 +24841,7 @@
 "snR" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "soh" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -24967,7 +25087,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "swU" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/wood,
@@ -25061,10 +25181,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
-"sAg" = (
-/obj/machinery/mineral/wasteland_vendor/medical,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
 "sAH" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -25108,6 +25224,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"sCj" = (
+/obj/item/kirbyplants,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/brotherhood)
 "sCu" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25287,30 +25410,20 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/city)
-"sKB" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/orator,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "sKH" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
 "sLi" = (
-/obj/structure/lattice{
-	layer = 3
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/brotherhood)
 "sLm" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
@@ -25388,7 +25501,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "sNC" = (
 /obj/machinery/door/airlock/wood/glass{
 	req_access_txt = "121"
@@ -25486,7 +25599,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "sQC" = (
 /obj/structure/table/wood,
 /obj/item/pen/fountain,
@@ -25858,7 +25971,7 @@
 "tcX" = (
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tdn" = (
 /obj/machinery/door/unpowered/wooddoor{
 	name = "Commanding Officer"
@@ -25893,7 +26006,7 @@
 	dir = 5
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "teO" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -26033,7 +26146,7 @@
 /area/f13/village)
 "tka" = (
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tkh" = (
 /obj/structure/chair,
 /turf/open/floor/f13{
@@ -26084,13 +26197,17 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tlD" = (
 /obj/structure/fence/corner{
 	dir = 9
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"tlI" = (
+/obj/structure/sign/poster/contraband/revolver,
+/turf/closed/wall/f13/tunnel,
+/area/f13/brotherhood)
 "tlR" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
@@ -26230,7 +26347,7 @@
 	icon_state = "mattress2"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tqS" = (
 /turf/open/floor/f13{
 	icon_state = "bar"
@@ -26436,7 +26553,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tyd" = (
 /obj/docking_port/stationary{
 	area_type = /area/f13;
@@ -26528,14 +26645,15 @@
 	},
 /area/f13/building)
 "tAN" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 10
 	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
+/obj/structure/railing{
+	dir = 4
 	},
-/area/f13/brotherhood/surface)
+/turf/open/water,
+/area/f13/brotherhood)
 "tAS" = (
 /obj/effect/landmark/start/f13/preacher,
 /turf/open/floor/f13/wood,
@@ -26694,17 +26812,17 @@
 "tGg" = (
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tGk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tGY" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tHw" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -26768,7 +26886,7 @@
 "tJv" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tJx" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/f13/wood,
@@ -26803,20 +26921,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"tKT" = (
-/obj/structure/rack,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar/explosive,
-/obj/item/key/bcollar,
-/obj/item/key/collar,
-/obj/item/key/collar,
-/obj/item/key/collar,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "tKZ" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building)
@@ -26998,6 +27102,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tSA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "tSQ" = (
 /obj/structure/closet,
 /obj/item/storage/box/gloves,
@@ -27034,13 +27143,6 @@
 /obj/structure/safe,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tUh" = (
-/obj/item/flag/bos,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "tUk" = (
 /obj/machinery/light{
 	dir = 8
@@ -27144,7 +27246,7 @@
 "tXY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tYd" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -27182,7 +27284,7 @@
 "tYV" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/f13/wood/house,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tZh" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_l,
@@ -27437,7 +27539,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "uhi" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/water,
@@ -27517,7 +27619,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ulC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -27623,7 +27725,7 @@
 	icon_state = "mattress6"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "uoK" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
@@ -27735,10 +27837,6 @@
 "urN" = (
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"urV" = (
-/obj/machinery/mineral/wasteland_vendor/clothing,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
 "urW" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/cow/brahmin,
@@ -28067,7 +28165,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "uEK" = (
 /obj/structure/table/wood,
 /obj/item/pda,
@@ -28084,6 +28182,7 @@
 /area/f13/village)
 "uEY" = (
 /obj/structure/rack,
+/obj/item/clothing/head/bunnyhead,
 /obj/item/clothing/head/nursehat,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -28094,7 +28193,7 @@
 	icon_state = "floor5"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "uFp" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -28115,7 +28214,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "uFD" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -28534,7 +28633,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "uTn" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -29100,7 +29199,7 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "voC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -29110,12 +29209,13 @@
 /area/f13/building)
 "voF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -15
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "voV" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -29137,6 +29237,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vpM" = (
+/obj/structure/sign/poster/official/twelve_gauge,
+/turf/closed/wall/f13/tunnel,
+/area/f13/brotherhood)
 "vqc" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29341,7 +29445,7 @@
 "vye" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "vzb" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/trash,
@@ -29417,7 +29521,7 @@
 "vAM" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "vBr" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/f13/wood,
@@ -29461,7 +29565,7 @@
 "vCw" = (
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "vCF" = (
 /obj/structure/bonfire/prelit,
 /obj/item/stack/rods,
@@ -29635,7 +29739,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "vIr" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/dirt,
@@ -29774,7 +29878,7 @@
 	icon_state = "bench"
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "vNG" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/vomit,
@@ -29897,7 +30001,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "vTr" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick,
@@ -29936,7 +30040,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "vVI" = (
 /obj/machinery/shower{
 	dir = 4
@@ -30023,8 +30127,9 @@
 /obj/machinery/door/airlock/survival_pod/glass{
 	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "vYp" = (
 /obj/structure/dresser,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30196,12 +30301,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "whm" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 12
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "why" = (
 /obj/item/reagent_containers/food/condiment/soymilk,
 /turf/open/floor/f13/wood,
@@ -30295,7 +30400,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wmJ" = (
 /obj/item/toy/beach_ball/holoball,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -30362,7 +30467,7 @@
 	name = "shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wpf" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -30455,9 +30560,11 @@
 /area/f13/city)
 "wsA" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/vending/nukacolavendfull,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wsC" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -30472,7 +30579,7 @@
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wtj" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalcorroded"
@@ -30630,7 +30737,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wzN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/wasteland{
@@ -30752,7 +30859,7 @@
 "wEv" = (
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wEO" = (
 /obj/machinery/shower{
 	dir = 4
@@ -30803,7 +30910,7 @@
 /obj/item/clothing/head/hardhat,
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wGz" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt,
@@ -30847,7 +30954,7 @@
 "wIO" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wIP" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -30890,7 +30997,7 @@
 "wLy" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wLB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30901,7 +31008,7 @@
 "wLO" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wLU" = (
 /obj/structure/closet,
 /obj/item/lighter,
@@ -31054,7 +31161,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wPl" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13/wood,
@@ -31077,7 +31184,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wPG" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -31365,7 +31472,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wYv" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
@@ -31414,7 +31521,7 @@
 	icon_state = "tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xbA" = (
 /obj/structure/sign/poster/prewar/poster83,
 /turf/closed/wall/f13/supermart,
@@ -31506,7 +31613,7 @@
 /obj/structure/table,
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xdD" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood{
@@ -31550,7 +31657,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xes" = (
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/legion)
@@ -32009,7 +32116,7 @@
 	pixel_y = 16
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xsz" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -32047,7 +32154,7 @@
 "xtG" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xtV" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -32124,11 +32231,11 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xwl" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xws" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -32136,9 +32243,12 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "xwN" = (
-/obj/item/flag/bos,
+/obj/machinery/mineral/wasteland_trader/general{
+	icon_state = "trade_idle"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xwW" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/knife/cosmicdirty,
@@ -32188,7 +32298,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xzn" = (
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/ground/inside/mountain,
@@ -32263,7 +32373,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xDA" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/f13{
@@ -32274,6 +32384,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/effect/landmark/start/f13/venator,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
@@ -32389,7 +32500,7 @@
 "xHg" = (
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xIh" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -32604,6 +32715,11 @@
 /obj/item/pda,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"xOt" = (
+/obj/machinery/vending/nukacolavendfull,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/brotherhood)
 "xOZ" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -32662,7 +32778,7 @@
 "xQL" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xRg" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -32707,17 +32823,12 @@
 	},
 /area/f13/wasteland)
 "xSV" = (
-/obj/structure/table,
-/obj/item/storage/box/drinkingglasses{
-	pixel_x = -10
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 1;
-	pixel_x = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/surface)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xTj" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
@@ -32741,7 +32852,7 @@
 "xTw" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xTB" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table/wood,
@@ -32818,7 +32929,7 @@
 "xVC" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xVI" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -33036,7 +33147,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "yci" = (
 /mob/living/simple_animal/hostile/wolf{
 	desc = "The dogs that survived the Great War are a larger, and tougher breed, size of a wolf.<br>This one looks mangy, with mud stuck to his hair and flies buzzing around him.";
@@ -33104,7 +33215,7 @@
 	icon_state = "bench"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "yeJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
@@ -33116,7 +33227,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "yfI" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -33128,7 +33239,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ygv" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -33215,7 +33326,7 @@
 "yjt" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "yjA" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/dirt,
@@ -33279,7 +33390,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ylP" = (
 /obj/structure/fence{
 	dir = 1
@@ -33295,7 +33406,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ymd" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
@@ -39291,8 +39402,8 @@ sTa
 etV
 ybI
 ybI
-ybI
-onk
+cpK
+unI
 hbW
 wGJ
 apk
@@ -39548,9 +39659,9 @@ aJb
 tUb
 idu
 hOl
-idu
-hBN
-erY
+cpK
+unI
+hbW
 erY
 ubg
 koD
@@ -39805,9 +39916,9 @@ sgz
 sgz
 kjQ
 ehN
-xzM
-sgz
-erY
+cpK
+unI
+hbW
 wGJ
 snB
 koD
@@ -40062,9 +40173,9 @@ dmL
 fvz
 kaM
 kaM
-kaM
-qoS
-erY
+cpK
+unI
+hbW
 wGJ
 snB
 koD
@@ -40319,8 +40430,8 @@ gQv
 jgx
 fsm
 fsm
-ees
-muk
+cpK
+unI
 hbW
 cdc
 snB
@@ -42596,13 +42707,13 @@ qQf
 qQf
 qQf
 wVT
-aLs
+wVT
 wVT
 wVT
 oVQ
 wVT
 wVT
-rPR
+nGs
 ezX
 cpK
 dMW
@@ -42859,7 +42970,7 @@ odW
 ezX
 pRS
 wVT
-rPR
+nGs
 rhr
 cpK
 dMW
@@ -43110,13 +43221,13 @@ qQf
 qQf
 qQf
 wVT
-wVT
+lRd
 wVT
 ohV
 pfb
 wVT
 wVT
-rPR
+nGs
 ezX
 cpK
 dMW
@@ -43373,7 +43484,7 @@ dcj
 pfp
 wVT
 wVT
-rPR
+rLH
 rhr
 cpK
 jkJ
@@ -43622,7 +43733,7 @@ ezX
 qQf
 iGU
 qQf
-lRd
+qQf
 kzu
 lZl
 rZK
@@ -46230,7 +46341,7 @@ fyf
 fyf
 fyf
 kGc
-uCW
+cpK
 unI
 hbW
 mmK
@@ -46487,7 +46598,7 @@ fyf
 fyf
 fyf
 kGc
-uCW
+cpK
 pBv
 box
 erY
@@ -46744,7 +46855,7 @@ fyf
 fyf
 fyf
 kGc
-uCW
+cpK
 ajD
 lSD
 erY
@@ -47001,8 +47112,8 @@ fyf
 fyf
 fyf
 kGc
-uaf
-unI
+sJw
+onk
 hbW
 erY
 erY
@@ -47258,9 +47369,9 @@ fyf
 fyf
 fyf
 kGc
-uaf
-unI
-hbW
+idu
+idu
+ehN
 dFQ
 gmX
 geM
@@ -47515,9 +47626,9 @@ fyf
 fyf
 fyf
 kGc
-uaf
-unI
-hbW
+hOl
+ehN
+ehN
 cdc
 dFQ
 koD
@@ -47772,9 +47883,9 @@ fyf
 fyf
 fyf
 kGc
-uaf
-jIB
-hbW
+kaM
+kaM
+ehN
 cdc
 snB
 koD
@@ -48029,8 +48140,8 @@ fyf
 fyf
 fyf
 kGc
-uCW
-ajD
+fsm
+muk
 dXy
 cdc
 vnc
@@ -62154,7 +62265,7 @@ fyf
 tKZ
 rdc
 rpu
-axX
+cSH
 rpu
 fLN
 rpu
@@ -64425,7 +64536,7 @@ gcK
 gcK
 gcK
 iFI
-fMu
+qLa
 qOR
 fMu
 wEv
@@ -64942,7 +65053,7 @@ iFI
 fMu
 fMu
 fMu
-ill
+fMu
 iFI
 gcK
 gbL
@@ -67768,7 +67879,7 @@ iFI
 iFI
 iFI
 goO
-hIJ
+goO
 iFI
 iFI
 iFI
@@ -68281,7 +68392,7 @@ xtG
 qPL
 yev
 iFI
-nmZ
+qPL
 qPL
 hlM
 iFI
@@ -68802,7 +68913,7 @@ daH
 qPL
 uFn
 qPL
-dvQ
+qPL
 iFI
 gcK
 gbL
@@ -69316,7 +69427,7 @@ iFI
 jix
 qPL
 qPL
-bav
+qPL
 iFI
 gcK
 gcK
@@ -69573,7 +69684,7 @@ iFI
 nda
 qPL
 qPL
-rTG
+qPL
 iFI
 gcK
 gcK
@@ -70085,7 +70196,7 @@ mwt
 uhh
 jem
 iFI
-kQq
+qPL
 qPL
 qPL
 iFI
@@ -70862,8 +70973,8 @@ mwt
 iFI
 tka
 vYf
-fMu
-fMu
+fYW
+fYW
 xSV
 jem
 gcK
@@ -71101,7 +71212,7 @@ mwt
 mwt
 hDf
 cSU
-cSU
+rXe
 hab
 cSU
 eWH
@@ -71119,8 +71230,8 @@ mwt
 eUz
 tka
 vYf
-fMu
-fMu
+fYW
+fYW
 lZw
 jem
 fyf
@@ -71363,7 +71474,7 @@ xHg
 cSU
 xHg
 xHg
-hbm
+opY
 hsj
 mwt
 mwt
@@ -71377,12 +71488,12 @@ gND
 tka
 jem
 gCb
-pEo
+ill
 mqp
 jem
 rKS
 iGM
-fyf
+ctZ
 shF
 cQs
 oFP
@@ -71637,7 +71748,7 @@ pQX
 jem
 kXK
 jem
-ftR
+cWG
 cWG
 cWG
 qXo
@@ -71870,7 +71981,7 @@ enL
 hsj
 mwt
 gND
-hbm
+opY
 fhr
 cSU
 xHg
@@ -72127,7 +72238,7 @@ enL
 hsj
 mwt
 gND
-hbm
+opY
 lRV
 cSU
 xHg
@@ -72138,7 +72249,7 @@ hbm
 wPE
 mwt
 mwt
-vAM
+mwt
 mwt
 mwt
 mwt
@@ -72391,7 +72502,7 @@ xHg
 cSU
 xHg
 xHg
-hbm
+opY
 hsj
 mwt
 mwt
@@ -72404,9 +72515,9 @@ mwt
 mwt
 mwt
 iyy
+brR
 mwt
-mwt
-itU
+brR
 mwt
 mvv
 mvv
@@ -72643,13 +72754,13 @@ mwt
 gND
 hbm
 vUX
-whm
+cSU
 luc
 cSU
 eWH
 vNv
 hbm
-hsj
+xCo
 mwt
 mwt
 grc
@@ -72664,8 +72775,8 @@ jem
 jem
 jem
 jem
-jem
-tUh
+biN
+mfD
 mfD
 mfD
 mfD
@@ -72900,10 +73011,10 @@ mwt
 hft
 hbm
 hbm
+sgn
 hbm
-hbm
-hbm
-hbm
+opY
+opY
 hbm
 hbm
 gin
@@ -72912,19 +73023,19 @@ mwt
 gND
 hbm
 hbm
-kGV
-oSH
-kGV
 hbm
 hbm
-jem
-gcK
-gcK
-gcK
-jem
+pWx
+pWx
+hbm
+vpM
+fYW
+neo
+evU
+jtc
 jWO
-cTp
 fyf
+ctZ
 fyf
 uJr
 cTp
@@ -73169,20 +73280,20 @@ mwt
 sNB
 hbm
 fkP
-cSU
+xOt
 gSv
-xHg
+iNp
 esD
 hbm
-gcK
-gcK
-gcK
-gbL
-gcK
-pEv
-cTp
+tlI
+fYW
+fYW
+evU
+jtc
 fyf
-qaf
+fyf
+fyf
+wrg
 fyf
 cTp
 gCh
@@ -73407,41 +73518,41 @@ ktB
 ktB
 gcK
 mwt
-iFI
-iFI
-qRg
-qRg
-iFI
-fOf
+bav
+fzT
+dvQ
+ldb
 iFI
 fOf
 iFI
-qRg
-qRg
+fOf
 iFI
+dvQ
+dvQ
+vCw
 iFI
 wPE
 mwt
 mwt
 mwt
 qQD
-cSU
-cSU
-cSU
-cSU
-gdv
-hbm
+iNp
+iNp
+iNp
+iNp
+iNp
+iNp
+vYf
+fYW
+fYW
+tSA
+jem
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-cTp
+fyf
 mNU
 fyf
 mKm
-cTp
+dIW
 oFP
 jVq
 sYV
@@ -73664,40 +73775,40 @@ ktB
 ktB
 gcK
 kvB
-vCw
+dvQ
 seE
-tAN
-seE
+nUm
+nmZ
 rOo
 gyd
 gyd
 gyd
 rOo
-tAN
-seE
-seE
-vCw
+wsM
+nUm
+bbN
+ldb
 hsj
 mwt
 mwt
 mwt
 qQD
-cSU
-cSU
-cSU
 iNp
-dhj
-hbm
-gcK
-gcK
-gcK
-gcK
-gcK
+iNp
+iNp
+iNp
+iNp
+iNp
+vYf
+fYW
+fYW
+tSA
+jem
 gcK
 gcK
 vQS
-fyf
-fyf
+pLJ
+pLJ
 fyf
 oFP
 xGg
@@ -73922,34 +74033,34 @@ ktB
 gcK
 mwt
 qRg
-seE
-sgn
+hIJ
 nUm
-gyd
-rmY
+nmZ
+wsA
+wsA
 hzt
 wsA
-gyd
+wsA
 wsM
 nUm
-seE
-qRg
+ely
+dvQ
 hsj
 hhC
 mwt
 vSH
 hbm
 xwN
-cSU
-luc
-iNp
+ioi
+mcp
+dsL
 jgY
 hbm
-gcK
-gcK
-gcK
-gcK
-gcK
+jem
+jem
+jVO
+jem
+jem
 gcK
 gcK
 gcK
@@ -74178,20 +74289,20 @@ ktB
 ktB
 gcK
 mwt
-qRg
+dvQ
 sLi
-ogc
+nUm
 nUm
 for
-nUm
+oSH
 fYP
 lUe
 lsG
 nUm
 nUm
 rrl
-qRg
-hsj
+dvQ
+sCj
 mwt
 mwt
 gND
@@ -74446,9 +74557,9 @@ nUm
 nUm
 nUm
 nUm
-tAN
-iFI
-hsj
+nUm
+qFF
+mwt
 mwt
 mwt
 hft
@@ -74693,19 +74804,19 @@ ktB
 gcK
 mwt
 iFI
-tAN
+kFw
 nUm
 nUm
 nUm
-nUm
+qaf
 aVo
 akm
-ldb
 nUm
 nUm
-tAN
-iFI
-hsj
+nUm
+nUm
+qFF
+mwt
 mwt
 mwt
 mwt
@@ -74950,19 +75061,19 @@ ktB
 gcK
 mwt
 qRg
-cOd
-ogc
-nUm
-ogc
+sLi
 nUm
 nUm
 nUm
 nUm
 nUm
 nUm
-rrl
-qRg
-hsj
+nUm
+nUm
+nUm
+hsq
+dvQ
+ahh
 mwt
 mwt
 mwt
@@ -75206,18 +75317,18 @@ ktB
 ktB
 gcK
 mwt
-qRg
-seE
-sgn
+fkj
+kQq
 nUm
 nUm
 nUm
 nUm
-opY
-kFw
-fzT
 nUm
-tAN
+nUm
+nUm
+nUm
+nUm
+kAh
 qRg
 lDv
 wYn
@@ -75463,19 +75574,19 @@ ktB
 ktB
 gcK
 kvB
-vCw
+dvQ
 sgw
-sgw
-sgw
+nUm
+ogc
 gNe
-tAN
-gyd
-seE
+rTG
+nUm
+voF
 oVv
-tAN
-tAN
-seE
-vCw
+whm
+iic
+kAh
+qRg
 uSZ
 iGG
 iGG
@@ -75721,18 +75832,18 @@ ktB
 gcK
 mwt
 iFI
-iFI
-iFI
-fkj
-rXe
-iFI
-mri
-rXe
+vCw
 iFI
 vCw
 iFI
 iFI
+mri
 iFI
+iFI
+vCw
+bav
+fzT
+bav
 qgO
 kFH
 mwt
@@ -75985,11 +76096,11 @@ tXY
 tXY
 tXY
 tXY
-voF
 tXY
-iFI
+tXY
+bav
 xVC
-iFI
+bav
 qgO
 mwt
 mwt
@@ -76244,9 +76355,9 @@ fPL
 pqr
 kLv
 lhA
-iFI
+bav
 xVC
-iFI
+bav
 qgO
 mwt
 mwt
@@ -76494,13 +76605,13 @@ gcK
 hsj
 mwt
 iFI
+fzT
+bav
 iFI
 iFI
 iFI
 iFI
-iFI
-iFI
-iFI
+vCw
 iFI
 tka
 iFI
@@ -84953,7 +85064,7 @@ pck
 xNm
 xNm
 hom
-fAZ
+oHR
 pck
 oWU
 hom
@@ -85436,7 +85547,7 @@ vYv
 gts
 ktB
 hom
-sKB
+qCv
 oMY
 hom
 fcI
@@ -86452,7 +86563,7 @@ fyf
 fyf
 fyf
 fyf
-jxH
+igU
 fyf
 fyf
 fyf
@@ -87501,7 +87612,7 @@ wxR
 xNm
 dvo
 xNm
-aDb
+vHe
 hom
 syr
 syr
@@ -88015,7 +88126,7 @@ hzr
 nbD
 hom
 aBk
-oHR
+aDb
 hom
 syr
 syr
@@ -92910,7 +93021,7 @@ hom
 hom
 hom
 hom
-hom
+gcK
 gcK
 dRs
 wzm
@@ -93164,10 +93275,10 @@ pIz
 frY
 hom
 uhW
-hcr
-uhW
-hxX
+oMY
+ako
 hom
+gcK
 gcK
 dRs
 gfY
@@ -93420,11 +93531,11 @@ eXO
 pIz
 frY
 hom
-ako
+uhW
 xNm
-oMY
-igU
+hcr
 hom
+gcK
 gcK
 dRs
 dRs
@@ -93679,9 +93790,9 @@ rbJ
 hom
 bPH
 eQH
-oMY
-dYv
+uhW
 hom
+gcK
 gcK
 gcK
 gcK
@@ -93936,9 +94047,9 @@ frY
 dvo
 xNm
 xNm
-xNm
-tKT
+hxX
 hom
+gcK
 gcK
 gcK
 gcK
@@ -94195,7 +94306,7 @@ hom
 hom
 hom
 hom
-hom
+gcK
 gcK
 gcK
 gcK
@@ -95410,11 +95521,11 @@ fyf
 fyf
 fyf
 fyf
-mrq
-urV
-nsE
-sAg
-mrq
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -95667,11 +95778,11 @@ fyf
 fyf
 gcK
 gcK
-mrq
-gEr
-sNz
-gEr
-mrq
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 fyf
 fyf
@@ -95924,11 +96035,11 @@ gcK
 gcK
 gcK
 gcK
-mrq
-mrq
-mrq
-mrq
-mrq
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 fyf

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -46,20 +46,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "abY" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/simple_door/bunker{
+	name = "Changing Room"
 	},
-/obj/structure/fluff/railing,
-/obj/structure/fluff/railing{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "acc" = (
 /obj/structure/sink{
 	pixel_y = 19
@@ -180,6 +173,7 @@
 	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -193,12 +187,11 @@
 	},
 /area/f13/followers)
 "ahx" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "ahB" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
@@ -233,8 +226,10 @@
 /area/f13/bunker)
 "ajJ" = (
 /obj/structure/flora/junglebush,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/turf/open/indestructible/ground/outside/water{
+	density = 1;
+	desc = "Deep lake water, filled with who knows what...";
+	name = "lake water"
 	},
 /area/f13/caves)
 "ajM" = (
@@ -280,6 +275,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "alw" = (
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -295,16 +293,6 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"anf" = (
-/obj/machinery/workbench/forge{
-	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
-	icon_state = "generator_on";
-	name = "superheating forge"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "aoj" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
@@ -324,6 +312,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"apA" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
+	dir = 1
+	},
+/area/f13/brotherhood/mining)
 "aqn" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/f13/vault,
@@ -338,6 +334,20 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"aqR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/power/smes/engineering,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "aqX" = (
 /obj/structure/chair/f13foldupchair,
 /obj/machinery/light/small{
@@ -359,11 +369,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"asx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
 "atb" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/yellow/side{
@@ -408,13 +413,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/tunnel)
-"awF" = (
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "awR" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -426,13 +424,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"axA" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/rnd)
 "axQ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -473,14 +464,15 @@
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/brotherhood/offices1st)
 "azD" = (
-/obj/structure/table{
-	layer = 2.9
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/offices2nd)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "aBb" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
@@ -514,15 +506,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "aBQ" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/pda/heads/cmo{
-	name = "Head Scribe PipBoy"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "aCf" = (
 /turf/closed/wall/f13/supermart,
@@ -551,17 +541,18 @@
 	},
 /area/f13/tunnel)
 "aCO" = (
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer/terminal{
 	dir = 4;
-	icon_state = "computer"
+	termtag = "Secret"
 	},
+/obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "aCS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "aDN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -621,12 +612,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aHj" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/debris/v4,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "aHn" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosdorm2";
@@ -646,8 +636,16 @@
 	},
 /area/f13/brotherhood/leisure)
 "aHM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/paladin,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -742,15 +740,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "aOT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/roller,
+/obj/item/roller,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/medical)
 "aQg" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -761,11 +759,11 @@
 /area/f13/brotherhood/mining)
 "aRj" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -785,8 +783,15 @@
 	},
 /area/f13/tunnel)
 "aSI" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
+/obj/structure/bookcase/random/reference{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Archival References"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "aSJ" = (
@@ -819,11 +824,12 @@
 	},
 /area/f13/tunnel)
 "aVV" = (
+/obj/item/ship_in_a_bottle{
+	pixel_x = -5;
+	pixel_y = 5
+	},
 /obj/structure/table/wood/fancy/black,
-/obj/item/construction/rcd/loaded,
-/obj/item/construction/rld,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "aWq" = (
@@ -857,9 +863,10 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "aXP" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "aXW" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
@@ -871,20 +878,31 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "aYI" = (
-/obj/machinery/vending/tool,
-/obj/structure/sign/poster/contraband/rip_badger{
-	pixel_x = 14;
-	pixel_y = 31
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Head Paladin on duty.";
+	name = "Head Paladin's Office"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices1st)
+"aYO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "aYS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/landmark/start/f13/Knight,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "aYY" = (
 /obj/machinery/hydroponics/constructable{
 	anchored = 0
@@ -896,12 +914,11 @@
 /area/f13/brotherhood/offices1st)
 "aZl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Backup Power";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -914,42 +931,22 @@
 	},
 /area/f13/brotherhood/leisure)
 "baZ" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
+/obj/structure/fence/handrail_end/non_dense{
+	dir = 1;
 	pixel_x = -16
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "bbq" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_2";
-	name = "Level 2: Engineering";
-	width = 5
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/rnd)
+/obj/machinery/computer/terminal{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "bbs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -1063,14 +1060,12 @@
 	},
 /area/f13/tunnel)
 "bdP" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/obj/machinery/computer/terminal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "bdV" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -1093,6 +1088,9 @@
 	layer = 3
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "beY" = (
@@ -1104,12 +1102,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "bfh" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "bfL" = (
 /obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt,
@@ -1137,6 +1135,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
+"bgZ" = (
+/obj/structure/flora/junglebush/large,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bhe" = (
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -1155,21 +1157,23 @@
 /area/f13/followers)
 "biy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/camera_advanced/abductor{
-	desc = "One day, we'll get that dish working. Not today.";
-	name = "Inactive Radar Console";
-	pixel_y = 17
-	},
-/obj/item/wrench/advanced{
-	pixel_x = 2
-	},
-/obj/effect/decal/cleanable/robot_debris/down,
+/obj/machinery/vending/sustenance,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "biW" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/light/small,
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper_bin{
+	pixel_x = 7
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/operations)
 "bje" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -1213,15 +1217,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"bki" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
-/area/f13/brotherhood/rnd)
 "bkU" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -1248,30 +1243,25 @@
 /turf/open/floor/wood,
 /area/f13/tunnel)
 "bmv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Star Knight's that walk these halls and may make use of this office.";
+	name = "Star Knight's Office"
 	},
-/area/f13/brotherhood/rnd)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices1st)
 "bmx" = (
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "bmF" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/turf/open/water,
-/area/f13/brotherhood/rnd)
-"bmK" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/landmark/start/f13/scribe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/medical)
+"bmK" = (
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster81"
+	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "bnW" = (
 /obj/machinery/light{
@@ -1306,8 +1296,9 @@
 	layer = 3.1;
 	pixel_x = -16
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	layer = 2.9
 	},
 /obj/structure/lattice{
 	density = 1
@@ -1332,9 +1323,6 @@
 /area/f13/tunnel)
 "bpH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/table/wood,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -1355,7 +1343,6 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bqU" = (
-/obj/effect/landmark/start/f13/Knight,
 /obj/effect/landmark/start/f13/initiate,
 /obj/machinery/light/small{
 	dir = 8
@@ -1374,9 +1361,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bri" = (
-/obj/effect/temp_visual/steam_release,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices1st)
 "brp" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -1413,12 +1403,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "bsF" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
-	},
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
+/obj/structure/table{
+	layer = 2.9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -1528,23 +1514,18 @@
 	},
 /area/f13/brotherhood/operations)
 "bwd" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices1st)
 "bxq" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/no_erp{
-	pixel_y = 32
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/leisure)
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices1st)
 "bxz" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -1571,18 +1552,15 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "bxX" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "byA" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/machinery/autolathe/constructionlathe,
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -1670,20 +1648,12 @@
 	},
 /area/f13/tunnel)
 "bDi" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/item/storage/box/lights/tubes,
-/obj/item/storage/box/lights/bulbs,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/lipstick/black,
-/obj/item/storage/box/bodybags{
-	pixel_x = -9;
-	pixel_y = 12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "bDG" = (
 /obj/structure/sign/poster/prewar/poster76,
 /turf/closed/wall/r_wall,
@@ -1709,41 +1679,42 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bEz" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices1st)
 "bEK" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
 "bFa" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
+/obj/structure/window/reinforced/spawner{
+	color = "#777777";
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/lattice{
+	density = 1
 	},
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "bFi" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Star Paladin's that walk these halls and may make use of this office.";
+	name = "Star Paladin's Office"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices1st)
 "bGf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1768,14 +1739,29 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
+"bGL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "AUX"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "bGU" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "bHd" = (
@@ -1850,20 +1836,6 @@
 /obj/item/paper_bin/bundlenatural,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"bJO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "bKi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1871,15 +1843,15 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "bKG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light/small{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 5
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/mining)
 "bKT" = (
@@ -1925,11 +1897,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "bMA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance{
-	name = "Power"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
 "bMC" = (
 /obj/machinery/button/door{
@@ -1955,7 +1924,17 @@
 	},
 /area/f13/brotherhood/operations)
 "bOf" = (
-/obj/machinery/rnd/production/protolathe,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "A console used by the scribes of the Brotherhood of Steel.";
+	dir = 4;
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal";
+	name = "Archive Terminal"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "bPh" = (
@@ -1977,18 +1956,16 @@
 	},
 /area/f13/tunnel)
 "bPW" = (
-/obj/structure/sign/poster/prewar/poster64,
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
+	name = "Armoury"
+	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "bRf" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bRk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "bRN" = (
 /obj/structure/sign/poster/prewar/poster90,
 /turf/closed/wall/r_wall,
@@ -2057,22 +2034,19 @@
 	},
 /area/f13/tunnel)
 "bVb" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
+/obj/structure/simple_door/bunker{
+	name = "Paladin Halls";
+	req_access = 120;
+	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
-	},
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices1st)
 "bVO" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
 	},
+/obj/effect/landmark/start/f13/Knight,
 /turf/open/floor/f13{
 	icon_state = "redmark"
 	},
@@ -2120,13 +2094,6 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bYQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "bYZ" = (
 /obj/structure/rack,
 /obj/item/stack/crafting/electronicparts/five,
@@ -2173,15 +2140,17 @@
 	},
 /area/f13/tunnel)
 "ccb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
+/obj/structure/simple_door/bunker{
+	name = "Paladin Halls";
+	req_access = 120;
 	req_access_txt = "120"
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices1st)
 "ccq" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -2193,14 +2162,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "cej" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/fulltile/store,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "engine"
 	},
 /area/f13/brotherhood/mining)
 "cek" = (
@@ -2299,6 +2265,10 @@
 	desc = "The RobCo PipBoy. This one is only issued to the acting Armory Warden.";
 	name = "Armory Warden PDA"
 	},
+/obj/item/pda/warden{
+	desc = "The RobCo PipBoy. This one is only issued to the acting Armory Warden.";
+	name = "Armory Warden PDA"
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -2325,12 +2295,17 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "cmy" = (
-/obj/structure/flora/junglebush/b,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Paladin's that walk these halls and may make use of this office.";
+	name = "Paladins Offices"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices1st)
 "cmE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/bronze,
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
+	},
 /area/f13/brotherhood/rnd)
 "cna" = (
 /obj/structure/cable{
@@ -2339,19 +2314,17 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "cnm" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/operations)
 "cnq" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
-/obj/effect/landmark/start/f13/seniorknight,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "cnF" = (
@@ -2368,14 +2341,12 @@
 	},
 /area/f13/bunker)
 "coe" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/pda/medical{
-	name = "Scribe-Medic Pip-Boy 3000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/stairs,
+/area/f13/brotherhood/offices1st)
 "cof" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
@@ -2383,11 +2354,19 @@
 	},
 /area/f13/tunnel)
 "coQ" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/lattice{
+	density = 1
 	},
+/obj/structure/fluff/railing,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "coX" = (
 /obj/structure/simple_door/wood,
@@ -2435,15 +2414,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cqY" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "bosengine";
-	name = "Radiation Shutters";
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "crg" = (
@@ -2504,6 +2478,7 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
+/obj/effect/landmark/start/f13/Knight,
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark"
@@ -2525,6 +2500,7 @@
 "cus" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -2534,7 +2510,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "cvb" = (
@@ -2586,13 +2561,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "cyA" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike_frame{
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
 	},
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/caves)
+/area/f13/brotherhood/offices1st)
 "cyG" = (
 /obj/structure/table/glass,
 /obj/item/pen,
@@ -2618,6 +2595,14 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/sewer)
+"cAt" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
+	},
+/area/f13/caves)
 "cAB" = (
 /obj/structure/chair/f13chair1{
 	dir = 1
@@ -2651,22 +2636,27 @@
 	},
 /area/f13/clinic)
 "cCv" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "cCx" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = 2;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "cCQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pool/ladder{
@@ -2685,8 +2675,11 @@
 /area/f13/brotherhood/offices1st)
 "cEF" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
 	},
 /area/f13/brotherhood/rnd)
 "cFd" = (
@@ -2701,12 +2694,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "cFj" = (
-/obj/machinery/button/door{
-	id = "floor2elevatordoors";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "cFE" = (
 /obj/structure/table/optable/abductor,
@@ -2739,10 +2733,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "cGq" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "cHA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -2771,9 +2771,10 @@
 	},
 /area/f13/sewer)
 "cIS" = (
-/obj/structure/grille,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
+	},
+/area/f13/brotherhood/medical)
 "cJp" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /mob/living/simple_animal/hostile/ghoul,
@@ -2801,31 +2802,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "cLp" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/medical)
 "cLJ" = (
-/obj/machinery/button/door{
-	id = "headscribedorm";
-	normaldoorcontrol = 1;
-	pixel_x = -8;
-	pixel_y = -24;
-	specialfunctions = 4
-	},
-/obj/structure/chair/sofa/corp/corner{
+/obj/structure/chair/sofa/corp{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
@@ -2844,16 +2835,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"cLV" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
-	},
-/obj/item/pen/fountain/captain{
-	name = "elder's fountain pen"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "cMl" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/f13{
@@ -2888,6 +2869,9 @@
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/glass/rag/towel,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/walk{
+	pixel_y = 32
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -2909,12 +2893,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "cQR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
 /obj/structure/lattice{
 	layer = 3
-	},
-/obj/machinery/light/floor{
-	critical_machine = 1;
-	flicker_chance = 0
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
@@ -3025,9 +3008,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "cXG" = (
-/obj/item/flag/bos,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/obj/structure/sign/poster/prewar/poster89,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "cYr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/hatch,
@@ -3040,16 +3023,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "cZm" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/computer/terminal{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/offices1st)
 "cZA" = (
 /obj/machinery/telecomms/server/presets/vault,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -3155,7 +3139,6 @@
 /area/f13/tunnel)
 "dgH" = (
 /obj/structure/chair/bench,
-/obj/effect/landmark/start/f13/Knight,
 /obj/effect/landmark/start/f13/initiate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
@@ -3178,6 +3161,9 @@
 /obj/structure/grille,
 /obj/structure/grille,
 /obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "dhN" = (
@@ -3204,11 +3190,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "djs" = (
-/obj/machinery/vending/robotics,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/storage/belt/holster,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/senior,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/senior,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/storage/belt/military,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices1st)
 "djR" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -3218,8 +3209,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "dkT" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/bus_door,
+/obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dlz" = (
@@ -3235,15 +3225,15 @@
 	},
 /area/f13/bunker)
 "dlT" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
+/obj/effect/landmark/start/f13/seniorpaladin,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/chair/comfy/black{
+	dir = 1
 	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "dmH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -3255,14 +3245,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dnM" = (
-/obj/machinery/conveyor/auto{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+/obj/structure/filingcabinet/employment,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/offices1st)
 "dod" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Kitchen";
@@ -3276,8 +3267,9 @@
 /area/f13/tunnel)
 "dok" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
-/obj/structure/spider/stickyweb,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/operations)
 "doL" = (
 /obj/structure/dresser,
@@ -3364,11 +3356,14 @@
 	},
 /area/f13/tunnel)
 "dtm" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster69"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "dtO" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
@@ -3384,21 +3379,26 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "dur" = (
-/obj/structure/flora/grass/wasteland,
-/obj/structure/flora/rock/jungle,
+/obj/structure/flora/rock/pile/largejungle,
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
+	},
 /area/f13/caves)
 "dvK" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "dvP" = (
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "120"
@@ -3407,10 +3407,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood/operations)
-"dwW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
-/area/f13/brotherhood/mining)
 "dxi" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -3425,9 +3421,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dxx" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
+/obj/effect/landmark/start/f13/elder,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
@@ -3465,17 +3463,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
-"dyO" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "dyQ" = (
 /obj/structure/ore_box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -3485,6 +3472,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/mining)
+"dzH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
 /area/f13/brotherhood/mining)
 "dzJ" = (
 /obj/machinery/light{
@@ -3508,9 +3503,18 @@
 	},
 /area/f13/tunnel)
 "dDE" = (
-/obj/structure/sign/poster/prewar/poster93,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Secret"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices1st)
 "dEa" = (
 /obj/machinery/telecomms/server/presets/den,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -3524,7 +3528,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dEm" = (
-/obj/effect/decal/remains/human,
 /obj/machinery/light/small{
 	dir = 8;
 	light_color = "#d8b1b1"
@@ -3576,6 +3579,11 @@
 	icon_state = "r_wall"
 	},
 /area/f13/brotherhood/medical)
+"dFw" = (
+/obj/structure/glowshroom/single,
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "dFz" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/f13/wood{
@@ -3601,22 +3609,18 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/leisure)
 "dGu" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/bronze{
+	name = "floor"
+	},
 /area/f13/brotherhood/rnd)
 "dGD" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/bed,
+/obj/item/bedsheet/ce,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices1st)
 "dGR" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/xeno/larva,
@@ -3630,12 +3634,13 @@
 /area/f13/brotherhood/medical)
 "dHq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"dIu" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/mining)
 "dID" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/f13/tunnel,
@@ -3688,9 +3693,6 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"dJL" = (
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "dJQ" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -3702,25 +3704,25 @@
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"dKc" = (
-/obj/structure/simple_door/bunker{
-	name = "Junior Paladin Offices";
-	req_access = 120;
-	req_access_txt = "120"
+"dKk" = (
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Secret"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"dKk" = (
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/medical)
 "dKm" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
+/obj/effect/landmark/start/f13/seniorknight,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "dKn" = (
@@ -3731,29 +3733,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dKo" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
 /obj/structure/fence/handrail{
 	density = 0;
 	dir = 4;
 	layer = 3.1;
 	pixel_x = -16
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/item/flag/bos,
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/turf/open/water,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "dKx" = (
 /obj/item/chair,
@@ -3761,17 +3751,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"dKC" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/storage/belt/holster,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/senior,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/senior,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/storage/belt/military,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "dKX" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -3951,17 +3930,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "dRm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/computer/shuttle/boselevator{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "dRA" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	id_tag = null;
+	req_access_txt = "120"
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices2nd)
 "dRM" = (
 /turf/open/floor/f13{
@@ -3972,7 +3959,6 @@
 /obj/item/flag/bos{
 	pixel_x = 16
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -4005,6 +3991,9 @@
 	},
 /area/f13/brotherhood/leisure)
 "dSr" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floordirty"
 	},
@@ -4031,12 +4020,14 @@
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/item/flashlight/lamp{
-	pixel_x = 5;
-	pixel_y = 9
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/paper_bin{
+	pixel_x = 7
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/operations)
 "dTE" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -4047,17 +4038,39 @@
 	},
 /area/f13/tunnel)
 "dTR" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster82";
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/t_scanner/adv_mining_scanner{
+	pixel_x = 9
+	},
+/obj/item/t_scanner/adv_mining_scanner{
+	pixel_x = -9
+	},
+/obj/item/gps/mining{
+	gpstag = "BOSMINE1";
+	pixel_x = -10;
+	pixel_y = 22
+	},
+/obj/item/gps/mining{
+	gpstag = "BOSMINE2";
+	pixel_x = 1;
+	pixel_y = 22
+	},
+/obj/item/pickaxe/drill/diamonddrill{
+	pixel_x = 32;
+	pixel_y = -9
+	},
+/obj/item/pickaxe/drill/diamonddrill{
 	pixel_x = 32
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/chair/stool/f13stool,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -4089,20 +4102,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"dUG" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "A console used by the scribes of the Brotherhood of Steel.";
-	dir = 8;
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal";
-	name = "Archive Terminal"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "dUL" = (
 /obj/structure/curtain{
 	color = "#5c131b"
@@ -4114,19 +4113,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "dUW" = (
-/obj/machinery/light/small/broken{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/crafting/wonderglue,
-/obj/item/crafting/wonderglue,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/operations)
 "dVj" = (
-/obj/structure/filingcabinet/filingcabinet,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/rnd)
+/obj/structure/closet/crate/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "dVs" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -4134,6 +4134,13 @@
 /obj/structure/window/fulltile/store,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
+"dVv" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "dVB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
@@ -4153,11 +4160,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dWN" = (
-/obj/item/statuebust,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/machinery/button/crematorium{
+	pixel_x = 22
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "dWT" = (
-/obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/plating/ashplanet/wateryrock{
 	baseturfs = /turf/open/floor/plating/f13/outside/desert
@@ -4213,29 +4223,44 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/tunnel)
-"dZz" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_left"
-	},
-/area/f13/brotherhood/rnd)
 "dZE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
 	anchored = 1;
 	name = "formal attire closet"
 	},
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -4275,41 +4300,34 @@
 	},
 /area/f13/tunnel)
 "eaz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/sleeper{
+	density = 1;
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/medical)
 "eaR" = (
+/obj/structure/frame/machine,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "ecp" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
-"ecD" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Secret"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
 "ede" = (
 /obj/machinery/shower{
 	pixel_y = 32
@@ -4339,10 +4357,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"edY" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "eew" = (
 /obj/machinery/door/airlock/wood{
 	name = "Ranger Quarters";
@@ -4351,8 +4365,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "eez" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced/spawner/north{
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
@@ -4391,7 +4407,9 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
 "efS" = (
-/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "yellowrustysolid"
@@ -4457,7 +4475,9 @@
 "eiN" = (
 /obj/structure/chair/stool/retro,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/operations)
 "ejr" = (
 /obj/structure/barricade/wooden,
@@ -4478,24 +4498,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"ekb" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
-	},
-/obj/item/documents/syndicate/blue,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"ekD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "ekK" = (
 /obj/structure/decoration/vent{
 	pixel_x = -7;
@@ -4518,7 +4520,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -4529,10 +4531,18 @@
 	},
 /area/f13/bunker)
 "emg" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/paladin,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "emX" = (
 /obj/structure/table/glass,
 /obj/item/pda,
@@ -4540,13 +4550,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"ene" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "enl" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -4566,12 +4569,6 @@
 "eoy" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
-"eoA" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/crafting/timer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "eoC" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -4583,21 +4580,15 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"eoE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "epa" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "epH" = (
 /obj/machinery/light/small{
@@ -4646,12 +4637,9 @@
 "eqD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/f13/inside,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "eqU" = (
 /obj/item/chair/stool/retro/black,
@@ -4681,6 +4669,12 @@
 /obj/structure/sign/poster/prewar/poster60,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
+"etu" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "etN" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -4690,16 +4684,14 @@
 	},
 /area/f13/tunnel)
 "eub" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/computer/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/medical)
 "eug" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -4708,17 +4700,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "euS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/kitchenspike_frame{
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
 "euY" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
@@ -4815,9 +4807,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "eAw" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/bed/pod,
+/obj/item/bedsheet/ce,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "eAO" = (
 /obj/item/flag/bos,
 /obj/machinery/light/small{
@@ -4861,23 +4856,27 @@
 	},
 /area/f13/building)
 "eBP" = (
-/obj/structure/debris/v1,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices1st)
 "eCr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
+/obj/structure/lattice{
+	layer = 3
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/offices1st)
 "eCE" = (
 /obj/structure/barricade/bars{
 	layer = 5
@@ -4929,6 +4928,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"eDN" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "eDV" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
@@ -4937,26 +4943,35 @@
 	},
 /area/f13/bunker)
 "eEL" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/sink/kitchen{
+	desc = "Strictly for filling up mop buckets.";
+	dir = 1;
+	name = "Mop Sink";
+	pixel_y = 13
 	},
-/turf/open/floor/plating/f13/inside,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "eER" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/bodycontainer/crematorium{
+	dir = 8
 	},
-/area/f13/brotherhood/rnd)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/offices1st)
 "eFE" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/ash/crematorium,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "eFS" = (
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/decal/cleanable/dirt,
@@ -4968,38 +4983,11 @@
 	},
 /area/f13/sewer)
 "eGI" = (
-/obj/item/am_containment{
-	pixel_x = 3
-	},
-/obj/structure/table/reinforced,
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/structure/window/plasma/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1
-	},
-/obj/item/am_containment,
-/obj/item/am_containment{
-	pixel_x = -3
-	},
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "eGW" = (
 /obj/machinery/light/small{
@@ -5023,6 +5011,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"eHg" = (
+/obj/structure/flora/junglebush,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "eHh" = (
 /obj/structure/decoration/smokeold{
 	pixel_y = -31
@@ -5078,8 +5070,30 @@
 /turf/closed/indestructible/rock,
 /area/f13/caves)
 "eLG" = (
-/obj/effect/decal/cleanable/ash/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/storage/box/lights/tubes,
+/obj/item/storage/box/lights/bulbs,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/lipstick/black,
+/obj/item/storage/box/bodybags{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/item/pda/medical{
+	name = "Scribe-Medic Pip-Boy 3000"
+	},
+/obj/item/pda/medical{
+	name = "Scribe-Medic Pip-Boy 3000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "eLI" = (
 /mob/living/simple_animal/hostile/raider/ranged,
@@ -5094,12 +5108,7 @@
 	},
 /area/f13/tunnel)
 "eME" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "eMM" = (
@@ -5125,29 +5134,17 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"eNT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/clockwork/fulltile,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "eOh" = (
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/offices1st)
 "eOx" = (
-/obj/structure/bookcase/random,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/item/toy/figure/miner{
+	desc = "A strangely dressed Knight figure, holding a pickaxe in one hand, sword in the other!";
+	name = "The Lonesome Knight";
+	toysay = "In case anyone's wondering, i'm still alive out here..."
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/mining)
 "eOW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5187,10 +5184,9 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "eRg" = (
-/obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
+/obj/structure/flora/junglebush,
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "eRs" = (
 /obj/structure/closet/crate,
@@ -5206,8 +5202,17 @@
 	},
 /area/f13/brotherhood/operations)
 "eSC" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/wood,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "eSD" = (
 /obj/structure/handrail/g_central{
@@ -5227,6 +5232,12 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
+"eSS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 10
+	},
+/area/f13/brotherhood/reactor)
 "eTv" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -5261,21 +5272,21 @@
 /area/f13/caves)
 "eVi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
 	dir = 8
 	},
 /area/f13/brotherhood/reactor)
 "eVA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/item/kirbyplants{
+	pixel_y = 14
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "eWj" = (
 /turf/open/floor/f13{
 	icon_state = "redmark"
@@ -5297,29 +5308,26 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"eXg" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
+	},
+/area/f13/caves)
 "eXJ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/medical)
 "eXS" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"eZf" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 7
-	},
-/obj/item/flashlight/lamp{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "eZh" = (
 /obj/structure/table/reinforced,
 /obj/structure/table/reinforced{
@@ -5331,11 +5339,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "eZX" = (
-/obj/structure/simple_door/bunker{
-	name = "Cleaning Closet"
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/item/hemostat,
+/obj/item/retractor,
+/obj/item/scalpel,
+/obj/item/circular_saw,
+/obj/item/surgicaldrill,
+/obj/item/cautery,
+/obj/item/bonesetter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
 "faa" = (
@@ -5351,6 +5366,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/radiation{
 	anchored = 1
+	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -5377,34 +5395,21 @@
 	},
 /area/f13/brotherhood/reactor)
 "fcn" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/medical)
+"fdN" = (
+/obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/computer/shuttle/boselevator{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/rnd)
-"fdN" = (
-/obj/structure/frame/machine,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/offices2nd)
 "feo" = (
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -5470,15 +5475,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "fhk" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
 "fhn" = (
@@ -5498,10 +5496,8 @@
 	},
 /area/f13/tunnel)
 "fkd" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster90"
-	},
-/turf/closed/wall/r_wall,
+/obj/machinery/rnd/production/protolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fkf" = (
 /turf/open/floor/f13{
@@ -5593,8 +5589,10 @@
 	},
 /area/f13/tunnel)
 "fna" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/maintenance{
+	name = "Power"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fnv" = (
 /obj/effect/decal/remains{
@@ -5603,17 +5601,7 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fnD" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "A console used by the scribes of the Brotherhood of Steel.";
-	dir = 4;
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal";
-	name = "Archive Terminal"
-	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fnZ" = (
@@ -5624,33 +5612,42 @@
 	},
 /area/f13/bunker)
 "fou" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"fpv" = (
-/obj/structure/wreck/trash/machinepile,
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
+"fox" = (
+/obj/structure/debris/v2,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
+"fpv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/operations)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "fqz" = (
-/obj/structure/janitorialcart,
-/obj/item/mop,
-/obj/structure/sink/kitchen{
-	desc = "Strictly for filling up mop buckets.";
-	name = "Mop Sink";
-	pixel_y = 25
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/surgical_drapes,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/stack/sticky_tape/surgical{
+	pixel_x = -11;
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
 "fqK" = (
@@ -5659,9 +5656,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
 "fqM" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "fqU" = (
 /obj/item/flag/bos,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -5682,89 +5678,28 @@
 /area/f13/tunnel)
 "frn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/junglebush/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
+/turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
+"frL" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "frS" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
-"fsQ" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/shuttle_manipulator{
-	desc = "You have no idea what this shows.";
-	name = "old hologram";
-	pixel_x = 16;
-	pixel_y = -16
-	},
-/obj/machinery/shuttle_manipulator{
-	desc = "You have no idea what this shows.";
-	icon_state = "hologram_ship";
-	name = "old hologram";
-	pixel_x = 14;
-	pixel_y = 9
-	},
-/obj/machinery/shuttle_manipulator{
-	desc = "You have no idea what this shows.";
-	icon_state = "hologram_on";
-	name = "old hologram";
-	pixel_x = 16;
-	pixel_y = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "ftt" = (
-/obj/structure/table{
-	layer = 2.9
+/turf/closed/indestructible/opshuttle{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
 	},
-/obj/item/t_scanner/adv_mining_scanner{
-	pixel_x = 9
-	},
-/obj/item/t_scanner/adv_mining_scanner{
-	pixel_x = -9
-	},
-/obj/item/gps/mining{
-	gpstag = "BOSMINE1";
-	pixel_x = -10;
-	pixel_y = 22
-	},
-/obj/item/gps/mining{
-	gpstag = "BOSMINE2";
-	pixel_x = 1;
-	pixel_y = 22
-	},
-/obj/item/pickaxe/drill/diamonddrill{
-	pixel_x = 32;
-	pixel_y = -9
-	},
-/obj/item/pickaxe/drill/diamonddrill{
-	pixel_x = 32
-	},
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
+/area/f13/caves)
 "ftF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -5788,11 +5723,16 @@
 	dir = 2;
 	icon_state = "storewindowtop"
 	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -5807,46 +5747,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "fuQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
 "fvp" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -5854,17 +5755,12 @@
 	},
 /area/f13/tunnel)
 "fwX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 10
-	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/offices2nd)
 "fwZ" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
@@ -5879,12 +5775,10 @@
 "fxu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/offices2nd)
 "fxA" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 4;
@@ -5905,6 +5799,17 @@
 	},
 /area/f13/brotherhood/leisure)
 "fxM" = (
+/obj/structure/table/survival_pod,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/obj/item/newspaper{
+	pixel_x = 6;
+	pixel_y = -5
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -5914,8 +5819,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fzR" = (
-/obj/machinery/rnd/server/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/prewar/poster93,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "fAs" = (
 /obj/structure/rack,
@@ -5926,11 +5831,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "fAJ" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/lattice{
+	density = 1
 	},
+/obj/structure/fluff/railing,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "fBi" = (
 /obj/structure/closet/crate/large,
@@ -5950,12 +5863,23 @@
 	},
 /area/f13/brotherhood/offices1st)
 "fCf" = (
-/obj/structure/simple_door/bunker/glass{
-	name = "Archives";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/offices2nd)
 "fCi" = (
 /obj/machinery/door/window/eastright{
 	dir = 2;
@@ -5964,20 +5888,28 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
+"fDa" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fDi" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"fDp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/machinery/computer/terminal{
+	icon = 'icons/obj/machines/particle_accelerator.dmi';
+	icon_keyboard = "generic_key";
+	icon_screen = "generic";
+	icon_state = "control_boxp"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"fDp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/offices2nd)
 "fDw" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/f13{
@@ -5985,7 +5917,31 @@
 	},
 /area/f13/clinic)
 "fDW" = (
-/obj/structure/lattice/catwalk/clockwork,
+/obj/machinery/computer/terminal{
+	density = 0;
+	desc = "A pre-war high security terminal. There's virtually no way to hack into this thing; it holds the most secure information the Brotherhood has to offer.";
+	doc_content_1 = "The preservation of technology is our primary goal, all others are secondary. <br> <br>  Shield yourself from those not bound to you by steel, for they are the blind. Aid them when you can, but lose not sight of yourself.";
+	doc_content_2 = "Give way your suspicions to the wisdom of thine Elder. Where he shows trust, so shall you. <br> <br> Fear those who do not pledge to the Brotherhood for though their eyes may be opened through service, they are now blind. ";
+	doc_content_3 = "Through discourse, we gain the strength of our Brothers' minds. Deceit and lies of all ilk serve only to harm that strength. <br> <br> Your caste and duties mean everything, you will follow your leader and your leader will lead you. <br> <br> You may only follow the orders of another if it will save the life of a brother. ";
+	doc_content_4 = "Theft is for lesser men, the Brotherhood provides for you and you provide for the Brotherhood. <br> <br>  What lesser men see as fashionable shall be shunned. Foreign garment and practice will do nothing but shame your fellow brothers.  ";
+	doc_content_5 = "The Blind can not read, only those who have taken the Oath of Fraternity may read this text.";
+	doc_title_1 = "Doctrine pt. 1";
+	doc_title_2 = "Doctrine pt. 2";
+	doc_title_3 = "Doctrine pt. 3";
+	doc_title_4 = "Doctrine pt. 4";
+	doc_title_5 = "Doctrine pt. 5";
+	icon_screen = null;
+	icon_state = "ratvarcomputer1";
+	idle_power_usage = 1;
+	light_color = "#6e1722";
+	light_power = 2;
+	light_range = 3;
+	max_integrity = 1000;
+	name = "The Codex";
+	note = "Scribe Note of the Week:";
+	pixel_y = 16;
+	termtag = "Codex"
+	},
 /turf/open/floor/bronze{
 	name = "floor"
 	},
@@ -6029,9 +5985,7 @@
 /area/f13/brotherhood/rnd)
 "fFV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6080,10 +6034,28 @@
 /area/f13/brotherhood/leisure)
 "fIV" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
+"fJm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/structure/sink/kitchen{
+	desc = "Strictly For filling Up mop buckets.";
+	dir = 8;
+	name = "Mop Sink";
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "fJw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
@@ -6111,14 +6083,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "fKn" = (
-/obj/item/candle{
-	pixel_x = -7
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/offices2nd)
 "fKq" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -6134,18 +6105,15 @@
 	},
 /area/f13/tunnel)
 "fLF" = (
-/obj/structure/decoration/hatch{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/shower{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 5
 	},
 /area/f13/brotherhood/mining)
 "fLK" = (
@@ -6172,20 +6140,14 @@
 	},
 /area/f13/brotherhood/operations)
 "fME" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"fMZ" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
 /area/f13/brotherhood/rnd)
 "fNk" = (
 /obj/machinery/autolathe,
@@ -6227,12 +6189,17 @@
 	},
 /area/f13/brotherhood/operations)
 "fOH" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
 "fOQ" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fOZ" = (
@@ -6313,6 +6280,8 @@
 	},
 /area/f13/bunker)
 "fSW" = (
+/obj/structure/window/reinforced/clockwork/fulltile,
+/obj/structure/grille,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6350,28 +6319,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "fXs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "fYf" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
-	},
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/item/pen/fountain{
-	pixel_x = 15;
-	pixel_y = 5
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "fYq" = (
@@ -6408,7 +6363,7 @@
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "gbA" = (
-/obj/structure/flora/junglebush/b,
+/obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "gbG" = (
@@ -6444,11 +6399,13 @@
 	},
 /area/f13/followers)
 "gcD" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/offices2nd)
 "gcK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6456,13 +6413,8 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "gcY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/closed/mineral/random/low_chance,
+/area/f13/brotherhood/offices2nd)
 "geb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -6479,16 +6431,11 @@
 /turf/open/water,
 /area/f13/tunnel)
 "gfy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/photosynthetic,
-/obj/structure/decoration/hatch{
-	desc = "That's pretty nifty.";
-	dir = 1;
-	name = "Plant Water Drain";
-	pixel_y = -13
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/rack,
+/obj/item/clothing/under/misc/bathrobe,
+/obj/item/clothing/under/misc/bathrobe,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices2nd)
 "gfz" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/rd{
@@ -6507,9 +6454,6 @@
 /obj/structure/grille,
 /obj/structure/cable{
 	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -6558,14 +6502,10 @@
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
 "gim" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
-	},
-/area/f13/brotherhood/reactor)
+/obj/structure/destructible/clockwork/wall_gear,
+/obj/item/projectile/magic/animate,
+/turf/closed/wall/f13/wood,
+/area/f13/brotherhood/rnd)
 "giA" = (
 /obj/structure/table/snooker{
 	dir = 10
@@ -6580,8 +6520,13 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "gjB" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/carpet/black,
+/obj/structure/chair/bench,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
+	},
 /area/f13/brotherhood/offices2nd)
 "gjQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6605,13 +6550,21 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/brotherhood/operations)
 "glq" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice{
-	layer = 2
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = -9
+	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "gly" = (
@@ -6641,32 +6594,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "gnw" = (
-/obj/structure/table/wood/fancy/black{
-	desc = "A set of thin pipes that no longer function.";
-	icon_state = "latticefull";
-	layer = 2.4;
-	name = "pipes"
+/obj/machinery/light/fo13colored/Aqua{
+	brightness = 3;
+	critical_machine = 1;
+	flicker_chance = 0;
+	icon_state = "bulb";
+	name = "Light Bulb"
 	},
-/obj/item/statuebust,
-/obj/structure/table{
-	icon_state = "1-f"
-	},
-/obj/structure/table{
-	icon_state = "2-f"
-	},
-/obj/structure/table{
-	icon_state = "3-f"
-	},
-/obj/structure/table{
-	icon_state = "4-f"
-	},
-/obj/structure/window/reinforced/clockwork/fulltile,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "gnY" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light/floor{
+	critical_machine = 1;
+	flicker_chance = 0
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "goi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6675,18 +6620,20 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "goG" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
-/area/f13/brotherhood/reactor)
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "goQ" = (
 /obj/structure/sign/poster/prewar/poster77,
 /turf/closed/wall/r_wall,
@@ -6701,12 +6648,13 @@
 	},
 /area/f13/brotherhood/operations)
 "gpl" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/hos,
 /obj/machinery/light/small{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices2nd)
 "gpM" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6725,12 +6673,9 @@
 	},
 /area/f13/brotherhood/operations)
 "gsc" = (
-/obj/machinery/libraryscanner{
-	desc = "This device scans books and other documents for entry into the Archives.";
-	name = "archive scanner";
-	pixel_y = 7
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "gse" = (
@@ -6741,12 +6686,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "gsw" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
+/obj/structure/dresser,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "gsQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice{
@@ -6755,14 +6697,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"gsV" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
-	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "gta" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -6778,7 +6712,9 @@
 /area/f13/brotherhood/offices2nd)
 "guw" = (
 /obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "guL" = (
 /obj/structure/bodycontainer/crematorium,
@@ -6811,19 +6747,13 @@
 	},
 /area/f13/tunnel)
 "gxj" = (
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "gyf" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/closed/wall/r_wall/rust,
@@ -6858,7 +6788,6 @@
 	},
 /area/f13/tunnel)
 "gzy" = (
-/obj/effect/landmark/start/f13/Knight,
 /obj/effect/landmark/start/f13/initiate,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -6873,14 +6802,9 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/item/stack/sheet/prewar/five,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -6951,6 +6875,10 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
+"gEy" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "gED" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/supermart,
@@ -7023,6 +6951,16 @@
 /obj/effect/landmark/start/f13/prospector,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"gJW" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
+	},
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "gKc" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -7031,9 +6969,14 @@
 	},
 /area/f13/tunnel)
 "gKJ" = (
-/obj/machinery/door/unpowered/wooddoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/obj/structure/falsewall/reinforced{
+	layer = 3
+	},
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster74"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "gLS" = (
 /obj/structure/window/spawner,
@@ -7078,21 +7021,13 @@
 	},
 /area/f13/clinic)
 "gNG" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
+/obj/item/candle{
+	pixel_x = 7
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -33
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
 	},
-/obj/structure/sign/warning/fire{
-	pixel_x = 23;
-	pixel_y = 30
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "gNP" = (
 /obj/item/clothing/head/helmet/roman/fake,
@@ -7169,15 +7104,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "gSN" = (
-/obj/structure/debris/v3{
-	layer = 2
+/obj/item/candle{
+	pixel_x = 7;
+	pixel_y = 7
 	},
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
 	},
-/area/f13/caves)
+/area/f13/brotherhood/rnd)
 "gTv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -7191,14 +7126,15 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "gTT" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/item/candle{
+	pixel_x = -6;
+	pixel_y = 7
 	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
+	},
+/area/f13/brotherhood/rnd)
 "gUf" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
@@ -7250,6 +7186,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
+"gWU" = (
+/obj/structure/bookcase/random,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood/mining)
 "gXb" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -7257,10 +7197,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gXH" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/paper_bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "gYI" = (
@@ -7281,6 +7221,17 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"gZt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "gZx" = (
 /obj/structure/table/wood,
 /obj/item/toy/crayon/spraycan,
@@ -7293,13 +7244,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "hac" = (
-/obj/effect/decal/cleanable/robot_debris/limb,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/candle{
+	pixel_x = -7
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/operations)
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
+	},
+/area/f13/brotherhood/rnd)
 "han" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light/small/broken{
@@ -7344,16 +7296,15 @@
 /area/f13/brotherhood/leisure)
 "hcC" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
-/obj/machinery/power/smes/engineering,
-/obj/machinery/light/small,
+/obj/machinery/power/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "hdd" = (
@@ -7466,12 +7417,18 @@
 	anchored = 1;
 	name = "formal attire closet"
 	},
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -7486,14 +7443,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "hhZ" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Elder's Office";
-	req_access_txt = "120"
+/obj/machinery/shower{
+	pixel_y = 27
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/offices2nd)
 "hil" = (
 /obj/structure/table/wood/settler,
@@ -7539,7 +7496,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "hlS" = (
-/obj/structure/dresser,
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "hmk" = (
@@ -7565,11 +7527,16 @@
 	},
 /area/f13/sewer)
 "hmP" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/obj/machinery/computer/camera_advanced/abductor{
+	desc = "One day, we'll get that dish working. Not today.";
+	name = "Inactive Radar Console";
+	pixel_y = 17
 	},
+/obj/item/wrench/advanced{
+	pixel_x = 2
+	},
+/obj/effect/decal/cleanable/robot_debris/down,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "hmZ" = (
@@ -7592,7 +7559,9 @@
 	light_color = "#d8b1b1"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/operations)
 "hoh" = (
 /obj/item/chair/stool/retro/black{
@@ -7657,7 +7626,12 @@
 /area/f13/tunnel)
 "hpI" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "hpM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7669,11 +7643,13 @@
 /area/f13/brotherhood/leisure)
 "hpT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/operations)
 "hqg" = (
 /obj/machinery/light,
@@ -7710,23 +7686,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "hro" = (
-/obj/structure/filingcabinet/employment,
-/obj/machinery/light/small,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/terminal{
+	termtag = "Secret"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "hrq" = (
-/obj/structure/simple_door/bunker{
-	name = "Star Paladin Office";
-	req_access = 120;
-	req_access_txt = "120"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/offices2nd)
 "hrv" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
 "hsv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7772,11 +7748,14 @@
 /turf/open/water,
 /area/f13/tunnel)
 "huh" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/toilet{
+	pixel_y = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/offices2nd)
 "huv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
@@ -7803,22 +7782,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
-"hwR" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/medical)
-"hxe" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "hxB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -7842,11 +7805,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hyR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
-	dir = 1
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/offices2nd)
 "hzg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -7884,11 +7848,15 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/leisure)
 "hBC" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "hBF" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -7973,15 +7941,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "hGF" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Star Knight's that walk these halls and may make use of this office.";
-	name = "Star Knight's Office"
+/obj/machinery/light/floor{
+	critical_machine = 1;
+	flicker_chance = 0
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/wood,
+/area/f13/brotherhood/rnd)
 "hHc" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_right"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
 	},
 /area/f13/brotherhood/rnd)
 "hHw" = (
@@ -8021,12 +7989,16 @@
 	},
 /area/f13/followers)
 "hIt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/destructible/clockwork/wall_gear{
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/item/projectile/magic/animate{
+	pixel_x = 32
+	},
+/turf/open/floor/bronze{
+	name = "floor"
+	},
+/area/f13/brotherhood/rnd)
 "hIy" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plastic/fifty,
@@ -8069,20 +8041,36 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "hKI" = (
-/obj/effect/decal/cleanable/ash/large,
-/obj/effect/decal/cleanable/ash/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "hKS" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
+/obj/structure/rack,
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = -7
 	},
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = -3
 	},
-/area/f13/brotherhood/rnd)
+/obj/item/reagent_containers/rag/towel,
+/obj/machinery/button/door{
+	id = "proctorbathroom";
+	name = "Bathroom Lock";
+	normaldoorcontrol = 1;
+	pixel_y = -32;
+	req_one_access_txt = "120";
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "hLd" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8099,9 +8087,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "hLL" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
-	},
 /obj/effect/turf_decal/caution/stand_clear/white{
 	dir = 8
 	},
@@ -8172,9 +8157,8 @@
 	},
 /area/f13/brotherhood/operations)
 "hNS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -8185,15 +8169,13 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "hOJ" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
 	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/offices2nd)
 "hOR" = (
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -8204,23 +8186,26 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"hOX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "hPn" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "hPD" = (
-/obj/structure/chair/office/dark{
+/obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/light/small{
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/obj/structure/sign/poster/contraband/tools{
-	pixel_y = 31
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices2nd)
 "hPF" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -8243,10 +8228,11 @@
 /area/f13/caves)
 "hQt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 5
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/mining)
 "hQE" = (
@@ -8266,27 +8252,24 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"hSq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "hSU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "hUn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/f13stool,
+/obj/structure/rack,
+/obj/item/storage/box/lights/tubes{
+	pixel_x = 8
+	},
+/obj/item/storage/box/lights/bulbs{
+	pixel_x = -8
+	},
+/obj/structure/sign/poster/official/hydro_ad{
+	pixel_y = 31
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -8317,13 +8300,15 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices1st)
 "hVy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase/manuals/engineering,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/bookcase/random,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "hVV" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -8358,21 +8343,20 @@
 	},
 /area/f13/bunker)
 "hXf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/candle{
+	pixel_y = -7
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
+/turf/open/floor/circuit/red/anim{
+	light_range = 2.5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "hXn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "hYh" = (
 /obj/docking_port/stationary/bosaway,
 /turf/closed/wall/f13/tunnel,
@@ -8385,32 +8369,56 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "hYI" = (
-/obj/item/multitool,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
+	},
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/item/pen/fountain{
+	pixel_x = 15;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "hYS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
 "hYT" = (
-/obj/structure/sign/poster/prewar/poster87,
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/surgical_drapes,
+/obj/item/stack/sticky_tape/surgical{
+	pixel_x = -11;
+	pixel_y = 8
+	},
+/obj/machinery/light,
+/obj/structure/sign/poster/prewar/poster87{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
 "hZN" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = 32
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "ias" = (
 /obj/structure/rack,
@@ -8435,6 +8443,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "iaI" = (
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
 /obj/structure/lattice{
 	density = 1
 	},
@@ -8471,18 +8486,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "icI" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp{
-	pixel_x = 3;
-	pixel_y = 12
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/obj/machinery/light/small,
 /obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_y = -32;
-	req_one_access_txt = "120"
+	id = "bosengineaccess";
+	name = "Engineering Lockdown";
+	pixel_x = 34;
+	pixel_y = -4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "ide" = (
@@ -8542,12 +8555,14 @@
 	},
 /area/f13/tunnel)
 "ifX" = (
-/obj/machinery/button/door{
-	id = "bosshop";
-	pixel_x = -32
+/obj/machinery/door/airlock/grunge{
+	id_tag = "proctorbathroom";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "igo" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -8556,7 +8571,7 @@
 "igr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "igC" = (
 /obj/item/flashlight/flare/torch,
@@ -8584,15 +8599,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "igV" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowhorizontal"
 	},
-/obj/machinery/light/small,
-/obj/structure/lattice{
-	density = 1
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "ihg" = (
 /obj/structure/bed,
@@ -8617,15 +8630,15 @@
 	},
 /area/f13/clinic)
 "iiE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/grunge{
-	id_tag = null;
+	name = "Proctor's Office";
 	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/rnd)
 "iiZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -8637,6 +8650,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
+"iki" = (
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ikD" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -8683,29 +8700,23 @@
 /turf/open/floor/plating/f13,
 /area/f13/followers)
 "ill" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	dir = 8;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "ilw" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	dir = 4;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "imc" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -8753,20 +8764,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ioQ" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
 "ipv" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
@@ -8810,7 +8818,22 @@
 	},
 /area/f13/tunnel)
 "irr" = (
+/obj/item/reagent_containers/food/snacks/grown/poppy{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/snacks/grown/poppy/geranium{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/snacks/grown/poppy/lily{
+	pixel_y = -5
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/blackred,
+/obj/item/candle{
+	pixel_x = -6;
+	pixel_y = 13
+	},
 /turf/open/floor/clockwork/reebe{
 	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
 	name = "cool metal floor"
@@ -8839,14 +8862,14 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "isG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/grille,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "isJ" = (
 /obj/machinery/shower{
 	layer = 2.8;
@@ -8860,6 +8883,7 @@
 /area/f13/tunnel)
 "isU" = (
 /obj/structure/flora/junglebush/large,
+/obj/structure/flora/junglebush/b,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "itI" = (
@@ -8874,9 +8898,12 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "itP" = (
-/obj/machinery/button/crematorium,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/obj/effect/landmark/start/f13/seniorscribe,
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "itV" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13{
@@ -8897,24 +8924,26 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "iuL" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Business"
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "iuX" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/machinery/door/airlock/grunge{
+	name = "Proctor's Office";
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "ivj" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -8940,13 +8969,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "iwO" = (
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "ixT" = (
@@ -8966,31 +8993,35 @@
 	},
 /area/f13/tunnel)
 "iyJ" = (
-/obj/structure/table/survival_pod,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 12
+/obj/structure/table/wood,
+/obj/item/lighter{
+	color = "#3e4821";
+	desc = "That's one fancy Zippo!";
+	heat = 2500;
+	icon_state = "lighter_overlay_plain";
+	light_power = 2;
+	light_range = 1;
+	name = "Pre-War Military Lighter";
+	pixel_x = 7;
+	pixel_y = -6
 	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
+/obj/item/storage/fancy/candle_box{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = -5
+/obj/item/storage/fancy/candle_box{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/turf/open/floor/circuit/red/anim{
+	light_range = 2.5
 	},
 /area/f13/brotherhood/rnd)
 "izo" = (
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/structure/bed/pod,
+/obj/item/bedsheet/hos,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "izq" = (
 /obj/machinery/light{
 	dir = 4
@@ -9012,12 +9043,14 @@
 	},
 /area/f13/tunnel)
 "iAm" = (
-/obj/item/ship_in_a_bottle{
-	pixel_x = -5;
-	pixel_y = 5
-	},
 /obj/structure/table/wood/fancy/black,
+/obj/item/pda/heads/cmo{
+	name = "Head Scribe PipBoy"
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "iAs" = (
@@ -9033,14 +9066,10 @@
 	start_charge = 500
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plating/f13/inside,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"iAt" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
 "iAv" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice,
@@ -9091,12 +9120,17 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "iEg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/area/f13/brotherhood/rnd)
+/obj/item/clothing/accessory/bos/elder,
+/obj/item/clothing/suit/f13/elder,
+/obj/item/pda/heads/hop{
+	name = "Elder's PDA"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "iER" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -9106,19 +9140,14 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"iFz" = (
-/turf/closed/wall/mineral/iron,
-/area/f13/brotherhood/rnd)
 "iFL" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "iGY" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
-	},
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/glowshroom/single,
 /turf/open/floor/plating/ashplanet/wateryrock{
 	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
@@ -9156,12 +9185,15 @@
 	},
 /area/f13/clinic)
 "iJD" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	name = "Armoury"
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/obj/item/pen/fountain/captain{
+	name = "elder's fountain pen"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "iJK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/right{
@@ -9181,17 +9213,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "iKq" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
 	},
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Secret"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
+/obj/item/documents/syndicate/blue,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "iKB" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/chemistry,
@@ -9206,19 +9234,19 @@
 	},
 /area/f13/brotherhood/offices1st)
 "iLO" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
 "iMc" = (
-/obj/structure/simple_door/metal/ventilation,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/f13/inside,
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "iMs" = (
 /obj/item/pickaxe,
@@ -9230,14 +9258,6 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
-"iML" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
-/area/f13/brotherhood/rnd)
 "iMP" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small{
@@ -9255,12 +9275,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iOt" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/table/wood/fancy,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "iOJ" = (
@@ -9291,8 +9306,8 @@
 /area/f13/followers)
 "iPu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -9307,9 +9322,14 @@
 /area/f13/followers)
 "iQt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/secway,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/machinery/door/airlock/grunge{
+	id_tag = null;
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "iQC" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/f13{
@@ -9379,9 +9399,12 @@
 /area/f13/bunker)
 "iST" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "iTb" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -9421,27 +9444,14 @@
 	},
 /area/f13/bunker)
 "iVj" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
 	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	layer = 3.1;
-	pixel_x = 12;
-	pixel_y = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 12
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices2nd)
 "iVx" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -9484,33 +9494,10 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/tunnel)
-"iWJ" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen/fourcolor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "iWR" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	pixel_y = 27
-	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 4
-	},
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/dresser,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/rnd)
 "iXC" = (
 /obj/machinery/conveyor/auto{
 	dir = 1
@@ -9533,9 +9520,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"iYf" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/rnd)
 "iYk" = (
 /obj/structure/table,
 /obj/item/phone,
@@ -9549,11 +9533,10 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "iYI" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/obj/item/bedsheet/hos,
+/obj/structure/bed/pod,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/rnd)
 "iYX" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood,
@@ -9588,8 +9571,28 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "iZQ" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/rnd)
+"iZT" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "jak" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9640,10 +9643,8 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "jdN" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+/turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
@@ -9694,9 +9695,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "jfW" = (
-/obj/structure/simple_door/bunker/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/bookcase/random,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "jga" = (
 /obj/structure/bed/mattress{
@@ -9708,10 +9710,10 @@
 	},
 /area/f13/tunnel)
 "jgd" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/landmark/start/f13/paladin,
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
@@ -9725,13 +9727,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "jgL" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = 32
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "jgP" = (
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9767,18 +9771,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"jim" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "jiL" = (
 /obj/effect/landmark/map_load_mark/dungeons/northsewer,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"jjJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "jkb" = (
 /obj/item/storage/trash_stack,
 /turf/open/water,
@@ -9835,25 +9835,29 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "jnO" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "jpg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"jpM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 6
+	},
+/area/f13/brotherhood/mining)
 "jqx" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -9894,9 +9898,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jrA" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
+/obj/effect/decal/cleanable/oil/streak,
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "jrV" = (
@@ -9919,13 +9926,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"jtk" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+"jsL" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jtx" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10040,30 +10045,20 @@
 	},
 /area/f13/followers)
 "jyc" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
 	},
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/surgical_drapes,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/stack/sticky_tape/surgical{
-	pixel_x = -11;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "jyg" = (
-/obj/structure/simple_door/bunker{
-	name = "Ceremony Room";
-	req_access_txt = "120"
+/obj/item/kirbyplants/photosynthetic,
+/obj/structure/decoration/hatch{
+	desc = "That's pretty nifty.";
+	dir = 1;
+	name = "Plant Water Drain";
+	pixel_y = -13
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "jyZ" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -10078,6 +10073,11 @@
 	},
 /area/f13/tunnel)
 "jzs" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bosengineaccess";
+	name = "Engine Access Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -10086,9 +10086,24 @@
 	},
 /area/f13/brotherhood/reactor)
 "jzX" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/change,
-/turf/closed/wall/r_wall,
+/obj/item/card/id/dogtag{
+	desc = "Never thirsty is the grave of the fallen Brother, for their kin floods the ground with the blood of the blind.";
+	name = "The Fallen Brother's Holotags";
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/sunglasses/blindfold{
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/blackred,
+/obj/item/candle{
+	pixel_x = 7;
+	pixel_y = 13
+	},
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
+	},
 /area/f13/brotherhood/rnd)
 "jAZ" = (
 /obj/structure/rack,
@@ -10097,29 +10112,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jBc" = (
-/obj/structure/chair/bench,
-/obj/machinery/button/door{
-	id = "proctorbathroom";
-	name = "Bathroom Lock";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_one_access_txt = "120";
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
-"jBd" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/vault{
+	name = "Elder'S Office";
+	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices2nd)
 "jBU" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -10127,7 +10128,6 @@
 	},
 /area/f13/tunnel)
 "jCU" = (
-/obj/structure/closet/crate/bin,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -10147,9 +10147,11 @@
 	},
 /area/f13/brotherhood/operations)
 "jEK" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices2nd)
 "jEM" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/item/hand_labeler,
@@ -10219,14 +10221,8 @@
 	},
 /area/f13/brotherhood/rnd)
 "jGX" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/paladin,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "jHN" = (
 /obj/machinery/chem_dispenser,
@@ -10240,16 +10236,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"jIe" = (
-/obj/item/candle{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/rnd)
 "jIm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/comfy/black{
@@ -10261,18 +10247,19 @@
 	},
 /area/f13/brotherhood/rnd)
 "jJd" = (
-/obj/item/candle{
-	pixel_y = 7
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices2nd)
 "jJB" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/table/wood/fancy/black,
+/obj/item/construction/rcd/loaded,
+/obj/item/construction/rld,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "jJM" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -10314,11 +10301,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jLX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "jMM" = (
 /obj/structure/window/fulltile/house{
@@ -10348,20 +10332,12 @@
 	},
 /area/f13/bunker)
 "jNr" = (
-/obj/item/toy/figure/miner{
-	desc = "A strangely dressed Knight figure, holding a pickaxe in one hand, sword in the other!";
-	name = "The Lonesome Knight";
-	toysay = "In case anyone's wondering, i'm still alive out here..."
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
-"jNt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/rnd)
 "jNA" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -10402,43 +10378,44 @@
 	},
 /area/f13/brotherhood/leisure)
 "jOL" = (
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"jOU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/rnd)
+"jOU" = (
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
+	},
+/obj/item/kirbyplants/photosynthetic,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "jPi" = (
-/obj/structure/sign/poster/prewar/poster85,
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
+/obj/structure/closet,
+/obj/item/storage/box/gloves,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/wrench/medical,
+/obj/item/toy/figure/cmo{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	layer = 2;
+	name = "Head Scribe Action Figure";
+	toysay = "Ad astra per aspera."
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"jPx" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "jPz" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -10557,31 +10534,15 @@
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"jSV" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/water,
-/area/f13/brotherhood/rnd)
 "jTD" = (
-/obj/item/bedsheet/hos,
-/obj/structure/bed/pod,
-/turf/open/floor/carpet/black,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "jUe" = (
 /obj/item/reagent_containers/glass/bucket{
@@ -10605,20 +10566,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "jVx" = (
-/obj/structure/chair/office/dark{
-	dir = 1;
-	icon_state = "officechair_dark"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -32;
-	pixel_y = 64
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "A console used by the scribes of the Brotherhood of Steel.";
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal";
+	name = "Archive Terminal"
 	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "jWa" = (
 /obj/structure/chair{
@@ -10638,11 +10597,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jYe" = (
-/obj/structure/closet/crate/large,
-/obj/item/crafting/turpentine,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "jYi" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -10694,11 +10660,35 @@
 	},
 /area/f13/followers)
 "jYP" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/machinery/button/door{
+	id = "headscribedorm";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"jYS" = (
+/obj/structure/destructible/clockwork/wall_gear,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/mining)
+"jYV" = (
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/mining)
 "jZf" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -10711,12 +10701,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jZg" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/tools{
+	pixel_y = 31
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
@@ -10732,6 +10724,13 @@
 /obj/item/statuebust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"kap" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "kaY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -10762,18 +10761,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"kbt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 8
+	},
+/area/f13/brotherhood/mining)
 "kbZ" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "kcD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
 "kcF" = (
@@ -10811,10 +10814,15 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "keR" = (
-/obj/structure/glowshroom/single,
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/machinery/vending/tool,
+/obj/structure/sign/poster/contraband/rip_badger{
+	pixel_x = 14;
+	pixel_y = 31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/rnd)
 "kfQ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -10853,10 +10861,21 @@
 	},
 /area/f13/tunnel)
 "khb" = (
-/obj/structure/sign/poster/prewar/poster88,
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/hemostat,
+/obj/item/retractor,
+/obj/item/scalpel,
+/obj/item/circular_saw,
+/obj/item/surgicaldrill,
+/obj/item/cautery,
+/obj/item/bonesetter,
+/obj/structure/sign/poster/prewar/poster88{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
 "khz" = (
@@ -10878,18 +10897,20 @@
 	},
 /area/f13/clinic)
 "kic" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/integrated_circuit_printer,
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_electronics/detailer,
+/obj/item/integrated_electronics/wirer,
+/obj/item/integrated_electronics/debugger,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/structure/sign/poster/contraband/free_tonto{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 9
-	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/rnd)
 "kiu" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -10923,12 +10944,15 @@
 	},
 /area/f13/brotherhood/operations)
 "kiX" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/computer/terminal,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/rnd)
 "kja" = (
 /obj/structure/table/wood/settler,
@@ -10978,13 +11002,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "klQ" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
+/obj/structure/grille,
+/obj/structure/window/reinforced/clockwork/fulltile,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "klZ" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/f13{
@@ -11001,62 +11022,26 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "koC" = (
-/obj/effect/landmark/start/f13/seniorscribe,
-/obj/structure/chair/office/dark{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"koN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "kpd" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "kpo" = (
-/obj/structure/table/wood,
-/obj/item/lighter{
-	color = "#3e4821";
-	desc = "That's one fancy Zippo!";
-	heat = 2500;
-	icon_state = "lighter_overlay_plain";
-	light_power = 2;
-	light_range = 1;
-	name = "Pre-War Military Lighter";
-	pixel_x = 7;
-	pixel_y = -6
+/obj/machinery/door/airlock/grunge{
+	id_tag = "headscribedorm";
+	name = "Head Scribe's Office";
+	req_access_txt = "120"
 	},
-/obj/item/storage/fancy/candle_box{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/storage/fancy/candle_box{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
-	},
+/turf/open/floor/wood,
 /area/f13/brotherhood/rnd)
 "kqh" = (
 /obj/structure/chair/office{
@@ -11065,7 +11050,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "kqS" = (
-/obj/structure/flora/junglebush,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/bus_door,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "krt" = (
@@ -11092,9 +11078,8 @@
 	},
 /area/f13/followers)
 "ksU" = (
-/obj/item/flag/bos,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
 	},
 /area/f13/brotherhood/rnd)
 "ktE" = (
@@ -11181,11 +11166,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "kxu" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/rnd)
 "kxL" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
@@ -11194,19 +11180,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "kzn" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating/f13/inside,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
 "kzO" = (
 /obj/machinery/vending/nukacolavend,
@@ -11217,24 +11194,23 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"kAb" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "kAm" = (
-/obj/structure/decoration/smokeold,
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/under/rank/medical/green,
+/obj/item/clothing/under/rank/medical/purple,
+/obj/item/clothing/under/rank/medical/blue,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
 "kAp" = (
@@ -11270,13 +11246,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "kBT" = (
-/obj/item/candle{
-	pixel_x = 7
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "kCg" = (
 /obj/machinery/light/small{
@@ -11286,13 +11261,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
-"kCj" = (
-/obj/structure/fluff/railing{
-	dir = 6;
-	pixel_x = 33
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "kCo" = (
 /obj/structure/toilet{
 	dir = 8
@@ -11315,21 +11283,20 @@
 	},
 /obj/structure/fence/handrail_corner{
 	density = 0;
-	dir = 1;
+	dir = 8;
 	layer = 3.1;
 	pixel_x = -12;
-	pixel_y = -9
+	pixel_y = 16
 	},
 /obj/structure/fence/handrail{
 	density = 0;
 	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /obj/structure/fence/handrail{
 	density = 0;
-	dir = 1;
-	pixel_y = -9
+	pixel_x = 3;
+	pixel_y = 16
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
@@ -11357,7 +11324,10 @@
 	},
 /area/f13/brotherhood/operations)
 "kFc" = (
-/obj/structure/window/spawner/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -11392,7 +11362,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"kFP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "kGx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
@@ -11422,10 +11400,8 @@
 	},
 /area/f13/sewer)
 "kKx" = (
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
-	name = "Head Scribe's Archive Terminal"
-	},
+/obj/structure/window/reinforced/clockwork/fulltile,
+/obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "kKy" = (
@@ -11438,21 +11414,24 @@
 	},
 /area/f13/bunker)
 "kLA" = (
-/obj/structure/rack,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/lattice{
+	density = 1
 	},
-/area/f13/brotherhood/offices2nd)
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "kLU" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	icon_state = "conveyor_map"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/carpet,
+/area/f13/brotherhood/rnd)
 "kMF" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
@@ -11476,11 +11455,9 @@
 	},
 /area/f13/clinic)
 "kOa" = (
-/obj/structure/fluff/railing{
-	dir = 10;
-	pixel_x = -33
-	},
-/turf/closed/wall/r_wall,
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "kOc" = (
 /obj/effect/decal/cleanable/blood/bubblegum,
@@ -11512,8 +11489,14 @@
 "kQy" = (
 /obj/structure/curtain,
 /obj/effect/turf_decal/loading_area/white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
+"kQI" = (
+/obj/structure/flora/junglebush/large,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "kQO" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13{
@@ -11608,12 +11591,15 @@
 	},
 /area/f13/tunnel)
 "kWH" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/kitchenspike_frame{
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/rnd)
 "kWK" = (
 /obj/structure/barricade/bars,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -11622,23 +11608,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kXA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
 "kYh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11685,20 +11658,25 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "lbt" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Star Paladin's that walk these halls and may make use of this office.";
-	name = "Star Paladin's Office"
+/obj/structure/kitchenspike_frame{
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/rnd)
 "lbG" = (
-/obj/machinery/door/airlock/vault{
-	desc = "A massive gear set into two heavy slabs of brass.";
-	icon = 'icons/obj/doors/airlocks/clockwork/pinion_airlock.dmi';
-	name = "Codex";
-	req_access_txt = "120"
+/obj/structure/kitchenspike_frame{
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
 	},
-/turf/open/floor/wood,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/rnd)
 "lcn" = (
 /obj/machinery/light,
@@ -11728,15 +11706,12 @@
 /area/f13/ncr)
 "ldA" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/power/terminal,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "ldK" = (
@@ -11745,11 +11720,9 @@
 /area/f13/tunnel)
 "ldP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 6
 	},
 /area/f13/brotherhood/mining)
 "ldY" = (
@@ -11770,15 +11743,15 @@
 	},
 /area/f13/tunnel)
 "lea" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
-	},
-/obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -11805,7 +11778,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "leG" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/structure/lattice{
@@ -11837,12 +11810,11 @@
 	},
 /area/f13/tunnel)
 "lgv" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 8;
-	name = "prewar lounge chair"
+/obj/structure/fluff/railing{
+	dir = 6;
+	pixel_x = 33
 	},
-/turf/open/floor/carpet/black,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "lhh" = (
 /obj/item/assembly/signaler{
@@ -11936,27 +11908,28 @@
 	},
 /area/f13/bunker)
 "lkT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
+/obj/structure/bookcase/manuals/research_and_development{
+	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Brotherhood Historical Archives"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "llp" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
 /obj/structure/lattice{
 	density = 1
 	},
 /obj/structure/fluff/railing{
 	dir = 4
+	},
+/obj/structure/fluff/railing{
+	dir = 1
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/mining)
@@ -11995,8 +11968,7 @@
 	},
 /area/f13/tunnel)
 "llZ" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/glass,
+/obj/structure/simple_door/metal/ventilation,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -12037,9 +12009,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lnF" = (
-/obj/machinery/button/door{
-	id = "bosshop";
-	pixel_x = 32
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -12086,12 +12057,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "lqC" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/crafting/abraxo,
-/obj/item/crafting/transistor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "lre" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/welding,
@@ -12134,6 +12108,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"lvn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "lvr" = (
 /obj/structure/table/optable/abductor,
 /obj/item/restraints/handcuffs,
@@ -12172,6 +12155,14 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
+"lwE" = (
+/obj/machinery/button/door{
+	id = "floor2elevatordoors";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "lyh" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12199,6 +12190,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"lzU" = (
+/obj/structure/table/reinforced,
+/obj/item/pda/engineering{
+	name = "Knight-Engineer Pip-Boy 3000"
+	},
+/obj/item/pda/engineering{
+	name = "Knight-Engineer Pip-Boy 3000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "lzW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
@@ -12209,10 +12210,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"lAp" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "lAr" = (
 /obj/item/trash/f13/dog,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -12285,6 +12282,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
+"lFJ" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
+	},
+/area/f13/caves)
 "lGo" = (
 /obj/structure/sign/poster/prewar/poster88,
 /turf/closed/wall/r_wall,
@@ -12315,7 +12318,10 @@
 	},
 /area/f13/tunnel)
 "lIH" = (
-/obj/structure/flora/junglebush/large,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "lKh" = (
@@ -12349,12 +12355,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lLy" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/animate{
-	layer = 2.5;
-	name = "weird light"
+/obj/structure/bookcase/random,
+/obj/machinery/light/fo13colored/Aqua{
+	brightness = 3;
+	critical_machine = 1;
+	dir = 1;
+	flicker_chance = 0;
+	icon_state = "bulb";
+	name = "Light Bulb"
 	},
-/turf/closed/wall/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "lLA" = (
 /obj/structure/reagent_dispensers/cooking_oil,
@@ -12413,9 +12423,11 @@
 /area/f13/brotherhood/operations)
 "lMT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 6
+	dir = 4
 	},
 /area/f13/brotherhood/mining)
 "lOt" = (
@@ -12463,6 +12475,22 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"lPw" = (
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster82";
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/stool/f13stool,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/mining)
 "lPy" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/subway,
@@ -12495,11 +12523,11 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "lSl" = (
-/obj/machinery/ore_silo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "lSQ" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/cannabis,
@@ -12544,13 +12572,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"lWm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/operations)
 "lWy" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/f13{
@@ -12574,6 +12595,9 @@
 /area/f13/brotherhood/operations)
 "lXy" = (
 /obj/structure/simple_door/bunker,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -12591,14 +12615,12 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "lYu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "boscheckpoint";
-	name = "Checkpoint";
-	req_one_access = "120";
-	req_one_access_txt = "120"
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "lYx" = (
 /obj/machinery/light/small{
@@ -12629,12 +12651,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
 "lZF" = (
-/obj/structure/decoration/warning,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "lZJ" = (
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
 /obj/structure/table/survival_pod,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -12666,10 +12690,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "mcC" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/area/f13/brotherhood/reactor)
+/turf/open/floor/carpet,
+/area/f13/brotherhood/rnd)
 "mdv" = (
 /obj/machinery/light{
 	dir = 4
@@ -12682,15 +12708,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
-"men" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "mfC" = (
 /obj/machinery/light{
 	dir = 1
@@ -12698,11 +12715,8 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "mgt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/structure/window/fulltile/store,
+/turf/open/floor/wood,
 /area/f13/brotherhood/rnd)
 "mgx" = (
 /obj/structure/table/reinforced,
@@ -12766,12 +12780,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mjJ" = (
-/obj/structure/table/wood/poker,
-/obj/item/statuebust,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/machinery/light/floor,
+/obj/structure/lattice{
+	density = 1
 	},
-/area/f13/brotherhood/offices1st)
+/obj/structure/fluff/railing{
+	dir = 9
+	},
+/obj/structure/fluff/railing/corner,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "mjU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/vent{
@@ -12959,20 +12977,21 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "mrx" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -16
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side,
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/obj/structure/fluff/railing,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/mining)
 "mrV" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -13001,26 +13020,16 @@
 "msV" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/brotherhood/operations)
-"msW" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/reagent_containers/food/drinks/mug,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
 "mtG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "mui" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "muA" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
@@ -13052,33 +13061,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mwJ" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "mxa" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "mxh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13093,20 +13080,15 @@
 	},
 /area/f13/clinic)
 "myA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
-	},
+/obj/machinery/light/floor,
 /obj/structure/lattice{
 	density = 1
 	},
 /obj/structure/fluff/railing{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
+/obj/structure/fluff/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
@@ -13121,28 +13103,19 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"mzu" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster70";
-	pixel_x = 31
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "mzR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "mzX" = (
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_x = -32
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "mAa" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/simple_door/metal/barred,
@@ -13172,9 +13145,14 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "mAX" = (
-/obj/item/kirbyplants/photosynthetic,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/rnd)
 "mBn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight/lamp,
@@ -13222,6 +13200,8 @@
 /obj/machinery/autolathe/ammo,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /obj/effect/turf_decal/stripes/box,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -13241,34 +13221,30 @@
 	},
 /area/f13/clinic)
 "mEm" = (
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = 16;
-	pixel_y = 16
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/structure/fluff/railing{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/mining)
 "mEv" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
 /obj/structure/window/reinforced/spawner/north{
 	dir = 8;
 	icon_state = "rwindow"
 	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen/fourcolor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "mEQ" = (
@@ -13353,35 +13329,34 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
+"mIo" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "mII" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/machinery/newscaster,
+/turf/closed/wall/mineral/iron,
+/area/f13/brotherhood/rnd)
 "mJG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "mJJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/wall/mineral/iron,
 /area/f13/brotherhood/rnd)
 "mJZ" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mKE" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/cane,
-/obj/item/cane,
-/obj/item/roller,
-/obj/item/roller,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "mKY" = (
 /obj/effect/decal/cleanable/oil{
@@ -13402,10 +13377,10 @@
 /area/f13/followers)
 "mLN" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 8
 	},
 /area/f13/brotherhood/reactor)
 "mLP" = (
@@ -13440,8 +13415,9 @@
 	},
 /area/f13/followers)
 "mNL" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/r_wall,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "mNM" = (
 /obj/structure/toilet{
@@ -13474,6 +13450,17 @@
 	icon_state = "purplefull"
 	},
 /area/f13/brotherhood/leisure)
+"mQQ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/brotherhood/mining)
 "mQX" = (
 /obj/effect/spawner/lootdrop/trash,
 /mob/living/simple_animal/hostile/gecko,
@@ -13485,28 +13472,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "mRK" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
 	},
-/obj/item/integrated_electronics/debugger,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_circuit_printer,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "mRT" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mSc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/poddoor/shutters{
+	id = "bosshop";
+	name = "brotherhood shutters"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
+	},
 /area/f13/brotherhood/rnd)
 "mSs" = (
 /obj/structure/table,
@@ -13524,34 +13509,29 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mTj" = (
-/obj/machinery/shower{
-	pixel_y = 27
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "mTq" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/tunnel)
 "mTr" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = null;
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices2nd)
 "mTt" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/simple_door/bunker/glass{
+	name = "Archives";
+	req_access_txt = "120"
 	},
-/obj/structure/glowshroom/single,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "mTF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -13570,18 +13550,12 @@
 	},
 /area/f13/tunnel)
 "mUS" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"mUV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "mVw" = (
@@ -13590,27 +13564,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "mWp" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gps/computer{
+	desc = "A large, central database of currently-transmitting GPS signals.";
+	name = "GPS Ping Grabber."
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "mWD" = (
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 16;
-	pixel_y = 35
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
+/obj/structure/decoration/warning,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
 "mWM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13621,12 +13585,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "mXi" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/landmark/start/f13/Knight,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/operations)
 "mXW" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/f13{
@@ -13682,9 +13644,32 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "nby" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/mining)
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/junglebush{
+	pixel_x = -15
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/turf/open/water,
+/area/f13/brotherhood/rnd)
 "nbz" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -13721,26 +13706,51 @@
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
 "neq" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster70"
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = -9
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "neu" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/window/reinforced/spawner{
+	color = "#777777";
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
 	},
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "neP" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
 /obj/structure/rack,
-/obj/item/book/granter/crafting_recipe/blueprint/aep7,
-/obj/item/book/granter/crafting_recipe/blueprint/aer9,
-/obj/item/book/granter/crafting_recipe/blueprint/aer9,
-/obj/item/book/granter/crafting_recipe/blueprint/aep7,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -13818,20 +13828,10 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"njc" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "headscribedorm";
-	name = "Head Scribe's Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
-"njI" = (
-/obj/structure/filingcabinet/employment,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
+"nji" = (
+/obj/structure/sign/poster/contraband/hacking_guide,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "njZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash/crematorium,
@@ -13847,21 +13847,36 @@
 	},
 /area/f13/followers)
 "nkx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
-"nkL" = (
-/obj/structure/flora/rock/jungle{
+/obj/structure/lattice{
 	density = 1
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = -9
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
+"nkL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/brotherhood/rnd)
@@ -13887,8 +13902,8 @@
 /area/f13/brotherhood/operations)
 "nld" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/closet/radiation{
+	anchored = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -13927,11 +13942,11 @@
 /area/f13/brotherhood/operations)
 "nnN" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/plating/f13/inside,
+/turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/offices2nd)
 "noe" = (
 /obj/structure/table/wood/settler,
@@ -13967,13 +13982,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"npl" = (
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "npR" = (
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -13988,16 +13996,23 @@
 /area/f13/tunnel)
 "nqE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/area/f13/brotherhood/operations)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/brotherhood/rnd)
 "nqF" = (
 /obj/structure/lattice{
 	layer = 3
@@ -14040,31 +14055,18 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/item/stack/sheet/prewar/five,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stack/sheet/prewar/five,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
-"nsY" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/accessory/bos/elder,
-/obj/item/clothing/suit/f13/elder,
-/obj/item/pda/heads/hop{
-	name = "Elder's PDA"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "ntS" = (
 /obj/structure/rack,
 /obj/item/shield/riot/bullet_proof,
@@ -14123,11 +14125,13 @@
 	},
 /area/f13/clinic)
 "nwf" = (
-/obj/structure/frame/machine,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 8;
+	name = "prewar lounge chair"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/rnd)
 "nwA" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -14142,7 +14146,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "nxT" = (
-/obj/structure/table,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/book/granter/crafting_recipe/blueprint/aep7,
+/obj/item/book/granter/crafting_recipe/blueprint/aer9,
+/obj/item/book/granter/crafting_recipe/blueprint/aer9,
+/obj/item/book/granter/crafting_recipe/blueprint/aep7,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -14157,9 +14168,22 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "nzl" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = 18
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "nzm" = (
 /obj/structure/closet,
 /turf/open/floor/f13{
@@ -14202,11 +14226,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nBh" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "nBk" = (
 /turf/open/indestructible/ground/inside/subway,
@@ -14230,17 +14257,15 @@
 	},
 /area/f13/followers)
 "nDb" = (
-/obj/structure/simple_door/bunker/glass{
-	name = "Mining Storeroom";
-	req_access_txt = "120"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "nEl" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/store,
@@ -14249,9 +14274,12 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "nEt" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/obj/structure/simple_door/bunker/glass{
+	name = "Archives";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "nEz" = (
 /obj/structure/campfire/barrel,
 /turf/open/floor/f13{
@@ -14284,20 +14312,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"nGb" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster74"
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "nGN" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -14306,12 +14320,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"nHu" = (
-/obj/structure/decoration/vent{
-	layer = 2
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "nHN" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/window/reinforced{
@@ -14328,20 +14336,24 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
 "nHR" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	icon_state = "wooden_chair_settler"
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
-/obj/effect/landmark/start/f13/seniorpaladin,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
 "nIl" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
+	},
+/area/f13/brotherhood/rnd)
 "nIB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -14376,15 +14388,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "nKk" = (
-/obj/structure/rack,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
+/obj/machinery/computer/secure_data{
+	dir = 4;
+	icon_state = "computer"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/rnd)
 "nKZ" = (
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
@@ -14429,15 +14438,13 @@
 	},
 /area/f13/brotherhood/leisure)
 "nMN" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
 	},
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "nMQ" = (
 /obj/structure/toilet{
@@ -14462,12 +14469,13 @@
 	},
 /area/f13/brotherhood/operations)
 "nNi" = (
-/obj/structure/table/wood,
-/obj/machinery/bookbinder{
-	icon_state = "bigscanner";
-	pixel_y = 7
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "nNx" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
@@ -14483,6 +14491,11 @@
 /obj/item/circuitboard/machine/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"nNW" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nOW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_t,
@@ -14562,16 +14575,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nTN" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
+/obj/structure/fence/handrail_end/non_dense{
+	dir = 1;
 	pixel_x = -16
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
-	},
+/obj/machinery/light/floor,
 /obj/structure/lattice{
 	density = 1
 	},
@@ -14583,7 +14591,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/operations)
 "nVP" = (
 /obj/structure/rack,
@@ -14609,14 +14619,16 @@
 	},
 /area/f13/clinic)
 "nWG" = (
-/obj/item/flag/bos,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube"
+/obj/machinery/rnd/destructive_analyzer,
+/obj/machinery/light/fo13colored/Aqua{
+	brightness = 3;
+	critical_machine = 1;
+	dir = 4;
+	flicker_chance = 0;
+	icon_state = "bulb";
+	name = "Light Bulb"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "nWO" = (
 /obj/item/kitchen/knife/butcher,
@@ -14637,11 +14649,12 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "nXh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/wood,
+/obj/machinery/bookbinder{
+	icon_state = "bigscanner";
+	pixel_y = 7
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "nXj" = (
 /turf/open/floor/f13{
@@ -14684,26 +14697,22 @@
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/brotherhood/offices1st)
-"nYh" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_left"
-	},
-/area/f13/brotherhood/rnd)
 "nYw" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/spacevine{
-	name = "vines"
-	},
+/obj/structure/flora/junglebush/c,
+/obj/structure/debris/v4,
 /turf/open/floor/plating/ashplanet/wateryrock{
 	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
 /area/f13/caves)
 "nYD" = (
-/obj/structure/rack,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/under/misc/bathrobe,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
+/obj/machinery/libraryscanner{
+	desc = "This device scans books and other documents for entry into the Archives.";
+	name = "archive scanner";
+	pixel_y = 7
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/rnd)
 "nYR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
@@ -14767,23 +14776,23 @@
 	},
 /area/f13/tunnel)
 "odG" = (
-/obj/structure/bookcase/random,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
+/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/spawner/lootdrop/keg,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/rnd)
 "oeb" = (
 /turf/closed/wall,
 /area/f13/tunnel)
 "oei" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 9
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "oeJ" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mre,
@@ -14799,33 +14808,46 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"ofD" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Power Stores";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "ofI" = (
+/obj/structure/flora/grass/wasteland,
 /obj/structure/flora/rock/jungle,
 /obj/structure/spacevine{
 	name = "vines"
 	},
+/obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ofQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/cell_charger{
+	pixel_y = 6
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "ogl" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/blueprint/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/flashlight/lamp{
+	light_color = "#00FFFF";
+	pixel_x = -14;
+	pixel_y = 9
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "ohv" = (
 /obj/item/gun/ballistic/automatic/marksman/sniper/gold,
 /obj/structure/rack,
@@ -14834,23 +14856,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"ohD" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "ohO" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
 "ois" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 8;
-	pixel_x = 7;
-	pixel_y = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -14865,8 +14878,11 @@
 	},
 /area/f13/tunnel)
 "oja" = (
-/obj/structure/sign/poster/prewar/poster68,
-/turf/closed/wall/r_wall,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "ojR" = (
 /obj/machinery/light/small{
@@ -14876,9 +14892,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "okm" = (
-/obj/structure/debris/v2,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "okO" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -14889,6 +14911,12 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
+"okP" = (
+/obj/structure/falsewall/reinforced{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/mining)
 "olw" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -14899,6 +14927,11 @@
 /area/f13/followers)
 "olK" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/structure/ore_box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "engine"
 	},
@@ -15076,12 +15109,26 @@
 	},
 /area/f13/brotherhood/leisure)
 "ovQ" = (
-/obj/structure/decoration/vent{
-	layer = 2
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/lattice{
 	density = 1
+	},
+/obj/structure/fence/handrail_corner{
+	density = 0;
+	dir = 1;
+	layer = 3.1;
+	pixel_x = -12;
+	pixel_y = -9
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = -9
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
@@ -15116,16 +15163,30 @@
 	},
 /area/f13/tunnel)
 "owX" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/animate,
-/turf/closed/wall/f13/wood,
+/obj/structure/window/reinforced/spawner{
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
+	},
+/obj/structure/window/reinforced/spawner{
+	color = "#777777";
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
+	},
+/obj/machinery/light/floor,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/fluff/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "oxw" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
-	},
-/obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
@@ -15173,6 +15234,12 @@
 	layer = 3
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "ozN" = (
@@ -15183,6 +15250,10 @@
 /turf/open/water,
 /area/f13/tunnel)
 "oAp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/hatch{
 	name = "Power Stores";
 	req_access_txt = "120"
@@ -15203,9 +15274,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "oBP" = (
-/obj/structure/chair/sofa/corp/right{
+/obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "oCn" = (
@@ -15220,24 +15292,32 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"oDg" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 1
+	},
+/area/f13/brotherhood/mining)
 "oDP" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/leisure)
 "oDV" = (
-/obj/item/flag/bos,
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster70"
 	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "oEt" = (
+/obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/rnd)
 "oEC" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
@@ -15343,10 +15423,11 @@
 /area/f13/ncr)
 "oIP" = (
 /obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "oJc" = (
 /obj/machinery/light/small{
@@ -15358,11 +15439,9 @@
 /turf/open/water,
 /area/f13/tunnel)
 "oLf" = (
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/structure/table/survival_pod,
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "oMb" = (
@@ -15374,21 +15453,27 @@
 	},
 /area/f13/tunnel)
 "oMK" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/glowshroom/single,
+/obj/structure/flora/junglebush/large,
 /turf/open/floor/plating/ashplanet/wateryrock{
 	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
 /area/f13/caves)
 "oNj" = (
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -30
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "A console used by the scribes of the Brotherhood of Steel.";
+	dir = 8;
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal";
+	name = "Archive Terminal"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/rnd)
 "oNu" = (
-/obj/structure/flora/junglebush,
+/obj/structure/debris/v1,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "oNM" = (
@@ -15399,8 +15484,12 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices1st)
 "oOw" = (
-/obj/structure/closet/crate/medical,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "oOE" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -15482,24 +15571,33 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "oRM" = (
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/fluff/railing{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/fluff/railing{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/mining)
 "oRZ" = (
+/obj/structure/fence/handrail_corner{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = 16;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/mining)
 "oSc" = (
 /obj/effect/spawner/lootdrop/f13/cash_legion_med,
@@ -15510,7 +15608,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/f13/inside,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "oSx" = (
 /obj/machinery/blackbox_recorder,
@@ -15528,12 +15629,15 @@
 "oTk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "oUK" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -15598,12 +15702,11 @@
 	},
 /area/f13/tunnel)
 "oWc" = (
-/obj/structure/closet/crate/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/crafting/lunchbox,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster69"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "oWl" = (
 /obj/machinery/computer/telecomms/monitor{
 	dir = 4;
@@ -15614,12 +15717,20 @@
 	},
 /area/f13/tcoms)
 "oWr" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_f,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "oWD" = (
 /obj/machinery/door/unpowered/wooddoor,
@@ -15652,12 +15763,7 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "oYG" = (
-/obj/effect/landmark/start/f13/elder,
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	layer = 2.7;
-	name = "prewar lounge chair"
-	},
+/obj/structure/bookcase/random,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "oZd" = (
@@ -15712,13 +15818,8 @@
 /area/f13/brotherhood/mining)
 "paO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/structure/sink/kitchen{
-	desc = "Strictly For filling Up mop buckets.";
-	dir = 8;
-	name = "Mop Sink";
-	pixel_x = 11
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -15752,6 +15853,19 @@
 /obj/item/storage/box/cups,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"pdR" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bosengineaccess";
+	name = "Engine Access Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 4
+	},
+/area/f13/brotherhood/reactor)
 "pez" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15762,20 +15876,13 @@
 	},
 /area/f13/clinic)
 "peK" = (
-/obj/effect/decal/cleanable/robot_debris/limb,
 /obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "pfv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation{
-	anchored = 1
-	},
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
 "pfy" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -15785,10 +15892,13 @@
 	},
 /area/f13/tunnel)
 "pfC" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "pgi" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
@@ -15803,11 +15913,19 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "pgS" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "phh" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
@@ -15852,6 +15970,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"pja" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "pjj" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -15883,9 +16008,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "pld" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "plQ" = (
@@ -15946,6 +16068,10 @@
 /obj/item/mining_scanner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"poJ" = (
+/obj/structure/grille,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "ppt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -16010,10 +16136,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "psA" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "psD" = (
@@ -16090,41 +16219,22 @@
 	},
 /area/f13/followers)
 "pvX" = (
-/obj/machinery/computer/terminal{
-	density = 0;
-	desc = "A pre-war high security terminal. There's virtually no way to hack into this thing; it holds the most secure information the Brotherhood has to offer.";
-	doc_content_1 = "The preservation of technology is our primary goal, all others are secondary. <br> <br>  Shield yourself from those not bound to you by steel, for they are the blind. Aid them when you can, but lose not sight of yourself.";
-	doc_content_2 = "Give way your suspicions to the wisdom of thine Elder. Where he shows trust, so shall you. <br> <br> Fear those who do not pledge to the Brotherhood for though their eyes may be opened through service, they are now blind. ";
-	doc_content_3 = "Through discourse, we gain the strength of our Brothers' minds. Deceit and lies of all ilk serve only to harm that strength. <br> <br> Your caste and duties mean everything, you will follow your leader and your leader will lead you. <br> <br> You may only follow the orders of another if it will save the life of a brother. ";
-	doc_content_4 = "Theft is for lesser men, the Brotherhood provides for you and you provide for the Brotherhood. <br> <br>  What lesser men see as fashionable shall be shunned. Foreign garment and practice will do nothing but shame your fellow brothers.  ";
-	doc_content_5 = "The Blind can not read, only those who have taken the Oath of Fraternity may read this text.";
-	doc_title_1 = "Doctrine pt. 1";
-	doc_title_2 = "Doctrine pt. 2";
-	doc_title_3 = "Doctrine pt. 3";
-	doc_title_4 = "Doctrine pt. 4";
-	doc_title_5 = "Doctrine pt. 5";
-	icon_screen = null;
-	icon_state = "ratvarcomputer1";
-	idle_power_usage = 1;
-	light_color = "#6e1722";
-	light_power = 2;
-	light_range = 3;
-	max_integrity = 1000;
-	name = "The Codex";
-	note = "Scribe Note of the Week:";
-	pixel_y = 16;
-	termtag = "Codex"
+/obj/structure/destructible/clockwork/wall_gear,
+/obj/item/projectile/magic/animate{
+	layer = 2.5;
+	name = "weird light"
 	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
+/turf/closed/wall/f13/wood,
 /area/f13/brotherhood/rnd)
 "pwa" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/rnd)
+"pwF" = (
+/turf/closed/mineral/random/high_chance,
+/area/f13/brotherhood/reactor)
 "pwH" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -16133,11 +16243,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pwP" = (
-/obj/structure/closet/crate/large,
-/obj/item/trash/f13/electronic/toaster/atomics,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
+	icon_state = "generator_on";
+	name = "superheating forge"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "pwY" = (
@@ -16153,7 +16265,7 @@
 /area/f13/brotherhood/offices1st)
 "pxI" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -16238,8 +16350,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pAE" = (
-/obj/structure/sign/poster/official/safety_eye_protection,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "pAK" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -16287,26 +16400,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "pDM" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/obj/machinery/light/floor,
 /obj/structure/lattice{
 	density = 1
 	},
-/obj/structure/fluff/railing/corner{
+/obj/structure/fluff/railing{
 	dir = 4
 	},
-/obj/structure/railing/corner{
-	dir = 1
+/obj/structure/fluff/railing{
+	dir = 8
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
@@ -16335,32 +16439,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "pFn" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"pGd" = (
-/obj/item/card/id/dogtag{
-	desc = "Never thirsty is the grave of the fallen Brother, for their kin floods the ground with the blood of the blind.";
-	name = "The Fallen Brother's Holotags";
-	pixel_y = -2
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/item/clothing/glasses/sunglasses/blindfold{
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/fancy/blackred,
-/obj/item/candle{
-	pixel_x = 7;
-	pixel_y = 13
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "pGw" = (
 /obj/machinery/door/airlock/medical{
@@ -16381,8 +16466,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "pIg" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 16;
+	pixel_y = 35
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/simple_door/bunker{
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/reactor)
 "pIp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16401,12 +16496,7 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "pIx" = (
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -32
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/rnd/server/bos,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "pIX" = (
@@ -16430,18 +16520,26 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "pKf" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
 	},
-/area/f13/caves)
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "pLl" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/decoration/smokeold,
+/turf/closed/indestructible/opshuttle{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
 	},
-/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "pLC" = (
 /obj/structure/table/reinforced,
@@ -16467,20 +16565,40 @@
 	},
 /area/f13/clinic)
 "pNi" = (
-/obj/structure/sign/poster/prewar/poster75,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/obj/structure/fence/handrail_end/non_dense{
+	dir = 1;
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "pNK" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pNT" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/water,
 /area/f13/brotherhood/rnd)
 "pOB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16559,22 +16677,23 @@
 /area/f13/brotherhood/operations)
 "pVA" = (
 /obj/effect/spawner/lootdrop/trash,
-/obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
 "pWc" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster81"
-	},
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "pWr" = (
-/obj/structure/spider/stickyweb,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "pWX" = (
 /obj/structure/chair/wood/modern{
 	icon_state = "wooden_chair_settler"
@@ -16585,10 +16704,28 @@
 /mob/living/simple_animal/hostile/giantant,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"pXf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "pXp" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
+/obj/structure/bookcase/random/religion{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Religious References"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "pXq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/hatch{
@@ -16662,20 +16799,9 @@
 /turf/open/water,
 /area/f13/tunnel)
 "qbK" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/computer/operating/bos{
+	dir = 1
 	},
-/obj/item/clothing/under/rank/medical/green,
-/obj/item/clothing/under/rank/medical/purple,
-/obj/item/clothing/under/rank/medical/blue,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -16696,14 +16822,10 @@
 	},
 /area/f13/tunnel)
 "qci" = (
-/obj/structure/simple_door/bunker{
-	name = "Star Knight Office";
-	req_access = 120;
-	req_access_txt = "120"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/small,
+/turf/open/floor/carpet,
+/area/f13/brotherhood/rnd)
 "qcm" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/centaur,
@@ -16716,18 +16838,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"qcL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "qdj" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"qdU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 8
-	},
-/area/f13/brotherhood/mining)
 "qdZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden{
@@ -16740,16 +16863,13 @@
 	dir = 2;
 	icon_state = "storewindowtop"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/grille,
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -16777,27 +16897,24 @@
 	},
 /area/f13/tunnel)
 "qfu" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
 "qfB" = (
-/obj/structure/simple_door/bunker{
-	name = "Paladin Halls";
-	req_access = 120;
-	req_access_txt = "120"
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster90"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "qfK" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -16811,20 +16928,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qgO" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker{
+	name = "Ceremony Room";
+	req_access_txt = "120"
 	},
-/obj/item/hemostat,
-/obj/item/retractor,
-/obj/item/scalpel,
-/obj/item/circular_saw,
-/obj/item/surgicaldrill,
-/obj/item/cautery,
-/obj/item/bonesetter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet,
+/area/f13/brotherhood/rnd)
 "qgP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
@@ -16865,12 +16975,12 @@
 	},
 /area/f13/followers)
 "qid" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/ce,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/simple_door/bunker{
+	name = "Ceremony Room";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/carpet,
+/area/f13/brotherhood/rnd)
 "qii" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -16906,9 +17016,15 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"qjv" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
+	},
+/area/f13/caves)
 "qjT" = (
-/obj/structure/window/reinforced/clockwork/fulltile,
-/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -16948,8 +17064,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "qnC" = (
-/obj/structure/window/reinforced/clockwork/fulltile,
-/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qnM" = (
@@ -16960,13 +17078,22 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qoi" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 1
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -33
 	},
-/area/f13/brotherhood/mining)
+/obj/structure/sign/warning/fire{
+	pixel_x = 23;
+	pixel_y = 30
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/rnd)
 "qoB" = (
 /obj/effect/landmark/start/f13/followersdoctor,
 /obj/structure/chair/stool/f13stool,
@@ -16975,22 +17102,19 @@
 	},
 /area/f13/followers)
 "qoF" = (
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "qpc" = (
 /obj/structure/sign/poster/prewar/poster73,
 /turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices1st)
 "qpd" = (
 /obj/machinery/button/door{
 	id = "bosarmoryacc";
@@ -17005,9 +17129,8 @@
 /area/f13/brotherhood/operations)
 "qpe" = (
 /obj/structure/closet/crate/large,
+/obj/item/trash/f13/electronic/toaster/atomics,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/spawner/lootdrop/keg,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -17026,12 +17149,14 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "qpX" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/rnd)
 "qpY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17046,16 +17171,10 @@
 	},
 /area/f13/tunnel)
 "qqJ" = (
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/ore_silo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/mining)
 "qqN" = (
 /obj/machinery/button/door{
@@ -17066,8 +17185,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "qrl" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/mineral/iron,
+/obj/structure/bookcase/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qrJ" = (
 /obj/structure/simple_door/bunker{
@@ -17085,8 +17204,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "qsm" = (
@@ -17105,7 +17222,14 @@
 	},
 /area/f13/followers)
 "qsM" = (
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/toilet{
+	pixel_y = 10
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = -10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/offices2nd)
 "qta" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17138,38 +17262,31 @@
 	},
 /area/f13/clinic)
 "qtD" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 1
-	},
-/area/f13/brotherhood/mining)
-"qtL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/rnd)
+"qtL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
 	},
 /area/f13/brotherhood/mining)
 "quB" = (
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "quR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/handrail{
+	density = 0;
+	layer = 3;
+	pixel_y = 16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -17193,9 +17310,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "qwp" = (
-/obj/structure/lattice,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
 /area/f13/brotherhood/rnd)
 "qwP" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -17226,19 +17345,16 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "qyv" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/fluff/railing,
-/obj/structure/fluff/railing{
-	dir = 1
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
 	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -12
-	},
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "qyC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17272,8 +17388,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qBQ" = (
-/obj/structure/bodycontainer/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/atmospherics/components/unary/thermomachine,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "qCu" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -17313,6 +17431,12 @@
 /obj/item/clothing/suit/apron/surgical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
+"qEx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 6
+	},
+/area/f13/brotherhood/reactor)
 "qEO" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress1"
@@ -17322,11 +17446,14 @@
 	},
 /area/f13/tunnel)
 "qFm" = (
-/obj/item/candle{
-	pixel_y = -7
+/obj/structure/destructible/clockwork/wall_gear{
+	pixel_x = -32
 	},
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
+/obj/item/projectile/magic/animate{
+	pixel_x = -32
+	},
+/turf/open/floor/bronze{
+	name = "floor"
 	},
 /area/f13/brotherhood/rnd)
 "qFn" = (
@@ -17341,10 +17468,15 @@
 /turf/closed/wall,
 /area/f13/tcoms)
 "qFQ" = (
-/obj/structure/simple_door/metal/ventilation,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/simple_door/bunker{
+	req_access_txt = "120"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/rnd)
 "qFS" = (
 /obj/structure/sink{
 	dir = 1;
@@ -17375,12 +17507,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "qGz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/flag/bos,
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "qHc" = (
 /obj/structure/flora/wasteplant/wild_fungus,
@@ -17395,6 +17526,13 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
+"qHq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/f13stool,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "qHr" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood{
@@ -17410,28 +17548,11 @@
 	},
 /area/f13/tunnel)
 "qJc" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/fluff/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "qJM" = (
 /obj/machinery/door/unpowered/wooddoor{
@@ -17450,16 +17571,24 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"qKP" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
+"qKt" = (
+/obj/machinery/power/apc{
 	dir = 1;
-	pixel_x = 16;
-	pixel_y = 8;
-	termtag = "Business"
+	pixel_y = 23;
+	start_charge = 500
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
+"qKP" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
+	},
+/obj/effect/landmark/start/f13/headscribe,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
@@ -17493,36 +17622,28 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "qMn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/box/lights/tubes{
-	pixel_x = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/storage/box/lights/bulbs{
-	pixel_x = -8
-	},
-/obj/structure/sign/poster/official/hydro_ad{
-	pixel_y = 31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "qME" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "AUX"
+/obj/structure/chair/sofa/corp/left,
+/obj/structure/window/reinforced/spawner/north{
+	dir = 4;
+	icon_state = "rwindow"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "qMO" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/storage/box/medsprays,
+/obj/item/pda/chemist{
+	name = "Scribe-Chemist Pip-Boy 3000"
+	},
 /obj/item/pda/chemist{
 	name = "Scribe-Chemist Pip-Boy 3000"
 	},
@@ -17577,19 +17698,23 @@
 	},
 /area/f13/tunnel)
 "qOJ" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qOT" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/stairs,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "qPh" = (
 /obj/structure/barricade/bars,
@@ -17607,17 +17732,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "qPN" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "boscheckpoint";
+	name = "Checkpoint";
+	req_one_access = "120";
+	req_one_access_txt = "120"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/rnd)
 "qQF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17633,13 +17755,8 @@
 	},
 /area/f13/brotherhood/operations)
 "qQS" = (
-/obj/structure/bookcase/random/religion{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Religious References"
-	},
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood/rnd)
 "qRc" = (
@@ -17657,12 +17774,15 @@
 /area/f13/tunnel)
 "qRv" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
-/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "qTb" = (
@@ -17700,8 +17820,11 @@
 /area/f13/followers)
 "qUR" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 6
+	dir = 4
 	},
 /area/f13/brotherhood/reactor)
 "qUS" = (
@@ -17725,7 +17848,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "qVt" = (
-/obj/machinery/suit_storage_unit/mining,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -17734,20 +17859,20 @@
 	},
 /area/f13/brotherhood/mining)
 "qVC" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/machinery/light/floor,
-/obj/effect/temp_visual/impact_effect/blue_laser,
-/obj/effect/decal/cleanable/glitter/blue,
-/turf/closed/wall/mineral/iron,
+/obj/structure/decoration/vent{
+	layer = 2
+	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "qVG" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qWa" = (
+/obj/machinery/rnd/production/protolathe,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "qWm" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -17757,50 +17882,37 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qWq" = (
-/obj/item/reagent_containers/food/snacks/grown/poppy{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/snacks/grown/poppy/geranium{
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/food/snacks/grown/poppy/lily{
-	pixel_y = -5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/fancy/blackred,
-/obj/item/candle{
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
+/obj/structure/destructible/clockwork/wall_gear,
+/obj/item/projectile/magic/change,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "qWx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gps/computer{
-	desc = "A large, central database of currently-transmitting GPS signals.";
-	name = "GPS Ping Grabber."
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qXo" = (
-/obj/machinery/sleeper{
-	density = 1;
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
+/obj/machinery/rnd/destructive_analyzer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "qXr" = (
 /obj/structure/barricade/wooden,
 /obj/structure/curtain,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"qXI" = (
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/mining)
 "qXN" = (
 /obj/structure/sign/poster/prewar/poster90,
 /turf/closed/wall/r_wall,
@@ -17822,12 +17934,9 @@
 	},
 /area/f13/ncr)
 "qYS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/item/flag/bos,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/rnd)
 "qZq" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -17846,12 +17955,17 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "qZA" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "qZY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -17882,9 +17996,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rbu" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowhorizontal"
+/obj/structure/rack,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -17943,7 +18058,6 @@
 	},
 /area/f13/tunnel)
 "rcX" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -17953,41 +18067,33 @@
 /turf/closed/indestructible/rock,
 /area/f13/bunker)
 "reN" = (
-/obj/structure/bookcase/random,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/rnd)
 "rfs" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/water,
-/area/f13/brotherhood/rnd)
-"rfD" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
+/obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/flag/bos,
 /obj/structure/lattice{
 	density = 1
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"rfD" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "rfH" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cloth/ten,
@@ -18039,9 +18145,9 @@
 	},
 /area/f13/tunnel)
 "riR" = (
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/reactor)
 "riT" = (
 /obj/structure/mirror{
 	pixel_x = 32
@@ -18054,6 +18160,8 @@
 /obj/effect/turf_decal/caution/stand_clear/white{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
@@ -18077,6 +18185,9 @@
 "rjQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
+	},
+/obj/structure/sign/poster/prewar/poster73{
+	pixel_y = 31
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "engine"
@@ -18143,6 +18254,23 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"roZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
+"rpa" = (
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	icon_state = "conveyor_map"
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
+	},
+/area/f13/brotherhood/mining)
 "rpI" = (
 /obj/structure/chair/right,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -18196,9 +18324,52 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rsj" = (
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/structure/table{
+	layer = 2.9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
@@ -18211,27 +18382,29 @@
 	},
 /area/f13/followers)
 "rsD" = (
-/obj/effect/landmark/start/f13/Knight,
 /obj/effect/landmark/start/f13/initiate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "rsM" = (
-/obj/structure/chair/bench,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
-"rtf" = (
-/obj/item/flag/bos,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
+/area/f13/brotherhood/rnd)
+"rtf" = (
+/obj/item/flag/bos,
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
+	},
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "rtk" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -18280,12 +18453,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rvb" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/mining)
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/structure/window/reinforced/spawner/north{
+	dir = 8;
+	icon_state = "rwindow"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "rvf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -18314,16 +18494,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "rwk" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
 	},
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_x = -32;
+	pixel_y = 64
 	},
-/obj/structure/fluff/railing{
-	dir = 4
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "rwA" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -18355,8 +18539,12 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "ryL" = (
-/obj/structure/sign/poster/contraband/hacking_guide,
-/turf/closed/wall/r_wall,
+/obj/structure/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood/rnd)
 "ryV" = (
 /obj/structure/closet/crate/bin,
@@ -18402,8 +18590,30 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"rzM" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "rzQ" = (
-/turf/open/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/junglebush/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/brotherhood/rnd)
 "rAb" = (
 /turf/open/indestructible/ground/outside/ruins,
@@ -18421,16 +18631,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "rAt" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "bosengineaccess";
-	name = "Engineering Lockdown";
-	pixel_x = 34;
-	pixel_y = -4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "rAx" = (
@@ -18467,12 +18671,33 @@
 	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
 /area/f13/caves)
+"rDB" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Power Stores";
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "rDS" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rEj" = (
-/obj/machinery/workbench/advanced,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/item/stack/sheet/prewar/five,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -18481,17 +18706,15 @@
 /obj/effect/turf_decal/caution/stand_clear/white{
 	dir = 8
 	},
+/obj/effect/turf_decal/caution/stand_clear/white{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "rFc" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "rFz" = (
 /obj/machinery/power/port_gen/pacman/super,
@@ -18522,25 +18745,50 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "rIl" = (
-/obj/structure/sign/poster/prewar/poster75,
-/turf/closed/wall/r_wall,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/paper_bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "rIS" = (
-/obj/structure/sign/poster/prewar/poster89,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood/rnd)
 "rJn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
 "rJv" = (
-/turf/open/floor/carpet/purple,
+/obj/structure/sign/poster/prewar/poster71,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "rJA" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"rKa" = (
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/brotherhood/mining)
 "rKd" = (
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
@@ -18568,10 +18816,12 @@
 	},
 /area/f13/clinic)
 "rKE" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/rnd)
 "rKJ" = (
 /obj/structure/lattice{
 	density = 1
@@ -18592,11 +18842,12 @@
 	},
 /area/f13/tunnel)
 "rKX" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -18660,27 +18911,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "rOb" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/integrated_circuit_printer,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_electronics/debugger,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/machinery/door/airlock/hatch{
+	name = "Backup Power";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/rnd)
-"rOp" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
+"rOp" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood/rnd)
 "rOq" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -18714,7 +18958,7 @@
 "rPG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -18909,6 +19153,11 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -18932,27 +19181,11 @@
 	},
 /area/f13/brotherhood/operations)
 "rWh" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 8;
-	layer = 3.1;
-	pixel_x = -12;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -12
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_x = 3;
-	pixel_y = 16
-	},
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "rWY" = (
 /obj/structure/table,
@@ -18976,8 +19209,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rXl" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "rXA" = (
 /obj/structure/timeddoor,
@@ -18985,13 +19220,16 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "rXR" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/hos,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "rXS" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -19008,7 +19246,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "rZw" = (
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/rnd/destructive_analyzer,
+/obj/machinery/light/fo13colored/Aqua{
+	brightness = 3;
+	critical_machine = 1;
+	dir = 8;
+	flicker_chance = 0;
+	icon_state = "bulb";
+	name = "Light Bulb"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "rZF" = (
@@ -19047,15 +19293,13 @@
 	},
 /area/f13/brotherhood/leisure)
 "saz" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/structure/decoration/hatch{
-	desc = "That's pretty nifty.";
-	dir = 1;
-	name = "Plant Water Drain";
-	pixel_y = -13
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "saC" = (
 /obj/structure/sink{
 	dir = 4;
@@ -19066,19 +19310,21 @@
 	},
 /area/f13/tunnel)
 "saF" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/item/paper_bin{
+	pixel_x = 6
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
 "scG" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "engine"
@@ -19094,7 +19340,12 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "sdz" = (
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "sdI" = (
 /obj/structure/table/wood,
@@ -19103,11 +19354,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sdJ" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
+"sdQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "sef" = (
 /obj/structure/curtain{
 	color = "#5c131b"
@@ -19118,17 +19383,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "seJ" = (
-/obj/effect/landmark/start/f13/scribe,
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "seL" = (
-/obj/machinery/computer/operating/bos{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood/rnd)
 "seP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -19136,13 +19397,9 @@
 	},
 /area/f13/brotherhood/rnd)
 "sfi" = (
-/obj/item/candle{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
+/obj/item/flag/bos,
+/turf/open/floor/circuit/red/anim{
+	light_range = 2.5
 	},
 /area/f13/brotherhood/rnd)
 "sfj" = (
@@ -19198,8 +19455,14 @@
 	},
 /area/f13/bunker)
 "sgm" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/carpet/black,
+/obj/machinery/door/airlock/grunge{
+	id_tag = null;
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space/basic,
 /area/f13/brotherhood/offices2nd)
 "sgn" = (
 /obj/structure/simple_door/bunker,
@@ -19213,22 +19476,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "sgI" = (
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices2nd)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood/rnd)
 "shl" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -19238,25 +19492,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "shO" = (
-/obj/structure/closet,
-/obj/item/storage/box/gloves,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/wrench/medical,
-/obj/item/toy/figure/cmo{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	layer = 2;
-	name = "Head Scribe Action Figure";
-	toysay = "Ad astra per aspera."
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "sic" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -19302,11 +19543,9 @@
 	},
 /area/f13/brotherhood/leisure)
 "sjR" = (
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Secret"
+/obj/machinery/computer/med_data{
+	dir = 4
 	},
-/obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "ska" = (
@@ -19318,11 +19557,6 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "skL" = (
-/obj/effect/decal/cleanable/chem_pile{
-	pixel_x = -12;
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -19339,16 +19573,25 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "sll" = (
-/obj/structure/closet/toolcloset,
+/obj/machinery/button/door{
+	id = "bosshop";
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"slo" = (
+/obj/effect/temp_visual/steam_release,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "slT" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/reactor)
 "slX" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/rock/jungle,
@@ -19374,33 +19617,49 @@
 /area/f13/tunnel)
 "smq" = (
 /obj/structure/rack,
-/obj/item/pda/engineering{
-	name = "Knight-Engineer Pip-Boy 3000"
-	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "smy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_x = -32
-	},
+/obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"smT" = (
+/obj/structure/wreck/car{
+	layer = 2
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "snJ" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/item/flashlight/lamp{
+	pixel_x = -3;
+	pixel_y = 15
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/mining)
+/obj/machinery/computer/terminal{
+	dir = 4;
+	pixel_x = -3;
+	pixel_y = -3;
+	termtag = "Business"
+	},
+/obj/structure/fluff/paper/stack{
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood/rnd)
 "snL" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/decal/cleanable/robot_debris/down,
@@ -19408,7 +19667,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/operations)
 "snP" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -19417,6 +19678,14 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
+"soi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "sor" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -19437,9 +19706,8 @@
 	},
 /area/f13/tunnel)
 "spS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 10
+/turf/open/floor/plasteel/f13/vault_floor/floor{
+	icon_state = "floordirty"
 	},
 /area/f13/brotherhood/reactor)
 "sqr" = (
@@ -19456,9 +19724,7 @@
 	},
 /area/f13/tunnel)
 "srH" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
+/turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/rnd)
 "srZ" = (
 /obj/machinery/light/small{
@@ -19511,7 +19777,6 @@
 /area/f13/brotherhood/operations)
 "suF" = (
 /obj/structure/flora/junglebush,
-/obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "suZ" = (
@@ -19654,15 +19919,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "sHk" = (
-/obj/structure/sign/poster/contraband/smoke{
+/obj/structure/window/reinforced/spawner/north{
+	dir = 4;
+	icon_state = "rwindow"
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
 	pixel_y = -32
 	},
-/obj/machinery/camera/autoname{
-	dir = 1;
-	name = "RnD Checkpoint Camera";
-	network = list("BoS")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "sHo" = (
 /obj/machinery/chem_dispenser,
@@ -19684,15 +19953,14 @@
 	},
 /area/f13/tunnel)
 "sIK" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/structure/fence/handrail_end/non_dense{
+	dir = 1;
+	pixel_x = -16
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "sIN" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -19715,8 +19983,7 @@
 	},
 /area/f13/brotherhood/operations)
 "sJA" = (
-/obj/structure/bed,
-/obj/item/bedsheet/ce,
+/obj/structure/chair/comfy/black,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "sKf" = (
@@ -19769,13 +20036,15 @@
 	},
 /area/f13/tunnel)
 "sLI" = (
-/obj/structure/chair/wood,
-/obj/effect/landmark/start/f13/seniorpaladin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/window/reinforced/spawner/north{
+	dir = 8;
+	icon_state = "rwindow"
 	},
-/area/f13/brotherhood/offices1st)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/rnd)
 "sMc" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -19797,10 +20066,10 @@
 	},
 /area/f13/followers)
 "sNg" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
+/obj/machinery/button/door{
+	id = "bosshop";
+	pixel_x = -32
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "sNu" = (
@@ -19827,24 +20096,16 @@
 "sOf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
 "sOi" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "sOq" = (
@@ -19868,20 +20129,18 @@
 	},
 /area/f13/tunnel)
 "sPa" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
-"sPl" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	dir = 1;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
+"sPl" = (
+/obj/structure/fluff/railing{
+	dir = 10;
+	pixel_x = -33
+	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "sPC" = (
 /obj/structure/fence/handrail{
@@ -19907,23 +20166,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sPZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
-"sRA" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Secret"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "sSF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -19932,15 +20174,9 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "sSP" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Business"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
 "sSS" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -19962,30 +20198,18 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "sUy" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "sUF" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/store,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "engine"
 	},
 /area/f13/brotherhood/mining)
-"sUH" = (
-/obj/structure/toilet{
-	pixel_y = 10
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_x = -10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/rnd)
 "sWb" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosdorm7";
@@ -20004,22 +20228,17 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "sWu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "sWB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
@@ -20032,18 +20251,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "sXi" = (
-/obj/structure/frame/machine,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "sXC" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
@@ -20052,7 +20265,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "sXP" = (
-/obj/structure/glowshroom/single,
+/obj/structure/spacevine{
+	name = "vines"
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "sXV" = (
@@ -20060,9 +20275,19 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "sZn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = -4
+	},
 /obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -20078,17 +20303,17 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"tba" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "tbg" = (
+/obj/machinery/door/unpowered/wooddoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/turf_decal/bot_white,
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "tbE" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -20112,8 +20337,10 @@
 	height = 2;
 	id = "AUX"
 	},
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -20127,14 +20354,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "tcH" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	icon_state = "wooden_chair_settler"
-	},
-/obj/effect/landmark/start/f13/seniorknight,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 10
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/rnd)
 "tda" = (
 /obj/structure/toilet{
 	dir = 8
@@ -20147,9 +20376,11 @@
 /area/f13/tunnel)
 "teh" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "tem" = (
@@ -20194,13 +20425,12 @@
 /area/f13/tunnel)
 "tfd" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
-/obj/machinery/power/smes/engineering,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "tfw" = (
@@ -20247,9 +20477,15 @@
 /area/f13/brotherhood/operations)
 "thr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/sign/poster/contraband/free_tonto{
+	pixel_x = 32;
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 8
+	dir = 9
 	},
 /area/f13/brotherhood/mining)
 "tht" = (
@@ -20264,12 +20500,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "thO" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_right"
 	},
 /area/f13/brotherhood/rnd)
 "tiB" = (
@@ -20336,13 +20568,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "tkU" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
+/obj/item/flag/bos,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube"
 	},
-/area/f13/caves)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "tlc" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/reedbush,
@@ -20358,9 +20592,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "tls" = (
+/obj/item/kirbyplants/photosynthetic,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
@@ -20372,14 +20607,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "tmh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/effect/landmark/start/f13/seniorscribe,
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "tmM" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -20398,15 +20631,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "tna" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "proctorbathroom";
-	req_access_txt = "120"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/offices2nd)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "tnh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/left{
@@ -20420,8 +20653,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
 "tnl" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_right"
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
 	},
 /area/f13/brotherhood/rnd)
 "tnp" = (
@@ -20440,12 +20673,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "toO" = (
-/obj/effect/landmark/start/f13/seniorscribe,
-/obj/structure/chair/office/dark{
-	dir = 4
+/obj/machinery/power/am_control_unit{
+	anchored = 1;
+	dir = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "toP" = (
 /obj/structure/target_stake{
 	anchored = 1
@@ -20488,11 +20727,7 @@
 "trr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
+/obj/structure/table/survival_pod,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "tse" = (
@@ -20514,10 +20749,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "tsq" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster77"
-	},
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood/rnd)
 "tsK" = (
 /obj/structure/table,
@@ -20561,10 +20794,13 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "tuO" = (
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
+/obj/machinery/door/airlock/vault{
+	desc = "A massive gear set into two heavy slabs of brass.";
+	icon = 'icons/obj/doors/airlocks/clockwork/pinion_airlock.dmi';
+	name = "Codex";
+	req_access_txt = "120"
 	},
+/turf/open/floor/wood,
 /area/f13/brotherhood/rnd)
 "tvc" = (
 /obj/structure/rack,
@@ -20576,9 +20812,9 @@
 	},
 /area/f13/tunnel)
 "tvj" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 1;
-	light_color = "#d8b1b1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
@@ -20596,17 +20832,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"tvx" = (
-/obj/structure/destructible/clockwork/wall_gear{
-	pixel_x = -32
-	},
-/obj/item/projectile/magic/animate{
-	pixel_x = -32
-	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood/rnd)
 "tvN" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -20659,12 +20884,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "txU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "tyR" = (
 /obj/machinery/door/airlock/grunge{
@@ -20689,11 +20915,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "tzx" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "tzH" = (
 /obj/structure/table/reinforced,
@@ -20708,6 +20942,21 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/rust,
 /area/f13/tunnel)
+"tzO" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
+	dir = 4
+	},
+/area/f13/brotherhood/mining)
 "tzZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -20726,7 +20975,6 @@
 /obj/structure/fluff/railing{
 	dir = 4
 	},
-/obj/structure/fluff/railing,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/mining)
 "tAD" = (
@@ -20750,8 +20998,8 @@
 /area/f13/tunnel)
 "tCe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
@@ -20830,9 +21078,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "tEG" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/structure/simple_door/bunker{
+	name = "Star Knight Office";
+	req_access = 120;
+	req_access_txt = "120"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "tEH" = (
@@ -20887,21 +21138,14 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
-"tGE" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+"tGt" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/atmos,
+/obj/item/twohanded/fireaxe,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/mining)
 "tHb" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -20926,33 +21170,26 @@
 /turf/closed/indestructible/opshuttle,
 /area/f13/brotherhood/leisure)
 "tHM" = (
-/obj/item/flashlight/lamp{
-	pixel_x = -3;
-	pixel_y = 15
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 4;
-	pixel_x = -3;
-	pixel_y = -3;
-	termtag = "Business"
-	},
-/obj/structure/fluff/paper/stack{
-	pixel_x = 11;
-	pixel_y = 4
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
-"tIz" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
+"tIz" = (
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/junglebush{
+	pixel_x = -15
+	},
+/turf/open/water,
+/area/f13/brotherhood/rnd)
 "tID" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -20987,81 +21224,51 @@
 	},
 /area/f13/tunnel)
 "tJH" = (
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/brotherhood/rnd)
 "tJL" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
+	dir = 9
 	},
 /area/f13/brotherhood/reactor)
 "tJM" = (
-/obj/machinery/light/small,
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
 "tJT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker{
-	name = "Ceremony Room";
-	req_access_txt = "120"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/carpet,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/junglebush{
+	pixel_x = -15
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/brotherhood/rnd)
 "tJU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
+	},
+/area/f13/brotherhood/rnd)
 "tJW" = (
 /obj/structure/rack,
 /obj/item/melee/classic_baton/telescopic{
@@ -21119,11 +21326,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "tKr" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
+/obj/structure/sign/poster/prewar/poster68,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "tKy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21155,10 +21359,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"tLs" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "tLz" = (
 /obj/structure/lattice{
 	density = 1
@@ -21170,6 +21370,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
+"tLB" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "tLS" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/decal/cleanable/dirt,
@@ -21260,11 +21464,30 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "tQe" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/table/wood/fancy/black{
+	desc = "A set of thin pipes that no longer function.";
+	icon_state = "latticefull";
+	layer = 2.4;
+	name = "pipes"
 	},
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/carpet/purple,
+/obj/item/statuebust,
+/obj/structure/table{
+	icon_state = "1-f"
+	},
+/obj/structure/table{
+	icon_state = "2-f"
+	},
+/obj/structure/table{
+	icon_state = "3-f"
+	},
+/obj/structure/table{
+	icon_state = "4-f"
+	},
+/obj/structure/window/reinforced/clockwork/fulltile,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
 "tQw" = (
 /obj/structure/table,
@@ -21292,7 +21515,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tSH" = (
-/obj/structure/sign/poster/prewar/poster71,
+/obj/structure/sign/poster/official/safety_eye_protection,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "tSI" = (
@@ -21330,8 +21553,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "tTB" = (
-/obj/machinery/rnd/destructive_analyzer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
+	},
 /area/f13/brotherhood/rnd)
 "tUk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21377,29 +21604,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tXw" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = 13
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_right"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = 13;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_x = -2;
-	pixel_y = 16
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "tXJ" = (
 /obj/structure/table/reinforced,
@@ -21430,29 +21637,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tYE" = (
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -12
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "tZc" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/operations)
 "tZf" = (
 /obj/structure/sink{
@@ -21490,7 +21685,23 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"uab" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "uay" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bookcase/manuals/engineering,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "uaL" = (
@@ -21500,16 +21711,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"ubJ" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
-	},
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
 "ubN" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -21519,11 +21720,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ucQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+/obj/item/flag/bos,
+/turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
@@ -21588,11 +21786,9 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "ufk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_left"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/rnd)
 "ufo" = (
 /obj/machinery/door/poddoor/shutters{
@@ -21665,9 +21861,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uhT" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
+/obj/machinery/camera/autoname{
+	dir = 5;
+	name = "Reactor Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "uhW" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -21725,39 +21925,27 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "ukP" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"ukT" = (
-/obj/structure/flora/rock/jungle{
+/obj/structure/lattice{
 	density = 1
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
+/obj/structure/fence/handrail{
+	density = 0;
 	dir = 1;
-	layer = 3
+	pixel_y = -9
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
+"ukT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
+	},
 /area/f13/brotherhood/rnd)
 "ulr" = (
 /obj/structure/lattice{
@@ -21765,6 +21953,9 @@
 	},
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "uls" = (
@@ -21785,9 +21976,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/tunnel)
 "ulA" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/statuebust{
+	pixel_y = 15
+	},
+/obj/structure/table{
+	layer = 2.9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
@@ -21811,9 +22005,27 @@
 /obj/structure/lattice{
 	layer = 3
 	},
-/turf/open/floor/bronze{
-	name = "floor"
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = -16
 	},
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	icon_state = "hologram_ship";
+	name = "old hologram";
+	pixel_x = 14;
+	pixel_y = 9
+	},
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	icon_state = "hologram_on";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "uml" = (
 /obj/structure/pool/ladder,
@@ -21823,20 +22035,10 @@
 	},
 /area/f13/brotherhood/leisure)
 "umw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "umG" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -21845,9 +22047,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "umZ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "unV" = (
@@ -21887,16 +22087,11 @@
 	},
 /area/f13/brotherhood/operations)
 "upu" = (
-/obj/structure/wreck/car{
-	layer = 2
-	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/rnd)
 "upA" = (
-/mob/living/simple_animal/hostile/radroach,
+/obj/structure/flora/junglebush,
 /turf/open/floor/plating/ashplanet/wateryrock{
 	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
@@ -21908,11 +22103,12 @@
 /area/f13/tunnel)
 "upI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	icon = 'icons/obj/machines/particle_accelerator.dmi';
-	icon_keyboard = "generic_key";
-	icon_screen = "generic";
-	icon_state = "control_boxp"
+/obj/structure/chair/office/dark,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -21941,11 +22137,15 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "uqU" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
@@ -22000,9 +22200,10 @@
 /area/f13/caves)
 "utP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/operations)
 "uub" = (
 /turf/open/floor/f13{
@@ -22042,15 +22243,26 @@
 	},
 /area/f13/tunnel)
 "uuQ" = (
+/obj/structure/chair/bench,
+/obj/machinery/button/door{
+	id = "proctorbathroom";
+	name = "Bathroom Lock";
+	normaldoorcontrol = 1;
+	pixel_x = 32;
+	req_one_access_txt = "120";
+	specialfunctions = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whiterustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
 "uvd" = (
-/obj/structure/bookcase/random,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/rnd)
 "uvB" = (
 /obj/machinery/jukebox,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -22087,9 +22299,9 @@
 	},
 /area/f13/bunker)
 "uwV" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/rnd)
 "uxq" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/decal/cleanable/cobweb,
@@ -22205,9 +22417,16 @@
 	},
 /area/f13/tunnel)
 "uFO" = (
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "uFQ" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -22215,8 +22434,9 @@
 	},
 /area/f13/tunnel)
 "uGL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/light/floor,
+/obj/structure/lattice{
+	density = 1
 	},
 /obj/structure/lattice{
 	density = 1
@@ -22228,6 +22448,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -22270,17 +22493,15 @@
 	},
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/operations)
 "uIq" = (
-/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/oil/streak,
 /obj/structure/lattice{
 	density = 1
 	},
-/obj/structure/fluff/railing{
-	dir = 9
-	},
-/obj/structure/fluff/railing/corner,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "uIE" = (
@@ -22300,8 +22521,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "uJx" = (
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_left"
 	},
 /area/f13/brotherhood/rnd)
 "uJD" = (
@@ -22315,30 +22536,39 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "uJS" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood/rnd)
-"uKn" = (
 /obj/structure/fence/handrail{
 	density = 0;
-	pixel_y = 16
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
+"uKn" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail_corner{
+	density = 0;
+	dir = 1;
+	layer = 3.1;
+	pixel_x = -12;
+	pixel_y = -16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 2.8;
+	pixel_x = -12
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "uKB" = (
 /obj/structure/barricade/wooden,
@@ -22386,17 +22616,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"uLH" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "uLN" = (
 /obj/structure/simple_door/metal/dirtystore,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -22466,11 +22685,8 @@
 /area/f13/brotherhood/offices1st)
 "uMJ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
+	icon_state = "casino"
 	},
 /area/f13/brotherhood/rnd)
 "uMO" = (
@@ -22537,11 +22753,11 @@
 /area/f13/tunnel)
 "uRE" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "uRG" = (
@@ -22564,11 +22780,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uSG" = (
-/obj/machinery/light/floor{
-	critical_machine = 1;
-	flicker_chance = 0
+/obj/structure/lattice/catwalk/clockwork,
+/turf/open/floor/bronze{
+	name = "floor"
 	},
-/turf/open/floor/wood,
 /area/f13/brotherhood/rnd)
 "uSI" = (
 /obj/structure/chair/wood,
@@ -22643,11 +22858,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "uWA" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/destructible/clockwork/wall_gear,
+/obj/machinery/light/floor,
+/obj/effect/temp_visual/impact_effect/blue_laser,
+/obj/effect/decal/cleanable/glitter/blue,
+/turf/closed/wall/mineral/iron,
 /area/f13/brotherhood/rnd)
 "uWC" = (
 /obj/structure/bed/pod,
@@ -22666,17 +22881,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "uXY" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/structure/lattice{
-	density = 1
-	},
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "uYd" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "uZa" = (
@@ -22692,17 +22906,34 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uZG" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/simple_door/bunker{
+	name = "Locker Room"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/operations)
 "uZS" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/fence/handrail_corner{
+	density = 0;
+	layer = 3.1;
+	pixel_x = 12;
+	pixel_y = -16
+	},
+/obj/structure/lattice{
+	density = 1
+	},
 /obj/structure/fence/handrail{
 	density = 0;
-	layer = 3;
-	pixel_y = 16
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "vaf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22741,11 +22972,15 @@
 	},
 /area/f13/tunnel)
 "vch" = (
+/obj/structure/frame/machine,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "0-4"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -22763,16 +22998,11 @@
 	},
 /area/f13/clinic)
 "vdk" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/robot_debris/limb,
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "ven" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -22831,8 +23061,13 @@
 	},
 /area/f13/tunnel)
 "vfx" = (
+/obj/effect/landmark/start/f13/scribe,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
 "vfL" = (
@@ -22880,7 +23115,9 @@
 	},
 /area/f13/tunnel)
 "vid" = (
-/obj/effect/landmark/start/f13/scribe,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -22949,20 +23186,20 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/radiation,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/operations)
 "vna" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/structure/decoration/vent{
+	layer = 2
 	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "vnJ" = (
 /obj/item/instrument/guitar,
 /obj/structure/rack,
@@ -23030,8 +23267,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "voZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -23051,17 +23286,27 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"vqm" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
+"vqd" = (
+/obj/structure/simple_door/bunker/glass{
+	name = "Mining Storeroom";
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/mining)
+"vqm" = (
+/obj/machinery/conveyor/auto{
+	dir = 8
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
+	},
+/area/f13/brotherhood/mining)
 "vqo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -23083,20 +23328,19 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/item/statuebust{
+	pixel_y = 15
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "vqH" = (
-/obj/structure/chair/sofa/corp{
+/obj/machinery/conveyor/auto{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+	icon_state = "engine"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/mining)
 "vra" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -23110,22 +23354,17 @@
 /area/f13/brotherhood/leisure)
 "vrC" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "vrD" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "vrH" = (
@@ -23166,16 +23405,29 @@
 	},
 /area/f13/brotherhood/operations)
 "vsW" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/turf/open/water,
 /area/f13/brotherhood/rnd)
 "vtz" = (
 /obj/machinery/door/airlock/abandoned,
@@ -23246,7 +23498,6 @@
 	},
 /area/f13/tunnel)
 "vxo" = (
-/obj/structure/flora/junglebush/large,
 /obj/structure/flora/junglebush/b,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -23257,27 +23508,36 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "vxR" = (
-/obj/structure/destructible/clockwork/wall_gear{
-	pixel_x = 32
+/obj/item/candle{
+	pixel_y = 7
 	},
-/obj/item/projectile/magic/animate{
-	pixel_x = 32
-	},
-/turf/open/floor/bronze{
-	name = "floor"
+/turf/open/floor/circuit/red/anim{
+	light_range = 2.5
 	},
 /area/f13/brotherhood/rnd)
 "vyb" = (
-/obj/structure/sign/poster/prewar/poster67,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
-"vyg" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/item/multitool,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
+"vyc" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_x = 3;
+	pixel_y = 12
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_y = -32;
+	req_one_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
+"vyg" = (
+/obj/structure/table,
+/obj/machinery/recharger,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -23334,13 +23594,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vBG" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/effect/decal/cleanable/oil/streak,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "vBO" = (
 /obj/structure/barricade/wooden,
@@ -23374,11 +23631,10 @@
 /area/f13/radiation)
 "vCL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 6
+	dir = 5
 	},
 /area/f13/brotherhood/mining)
 "vCM" = (
@@ -23395,9 +23651,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "vDn" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
+/obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "vDC" = (
@@ -23413,10 +23667,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "vEe" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance{
 	name = "Power"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/reactor)
 "vEA" = (
@@ -23437,8 +23691,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "vFa" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "proctorbathroom";
+	req_access_txt = "120"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/offices2nd)
 "vFl" = (
 /obj/machinery/light{
@@ -23477,10 +23737,11 @@
 	},
 /area/f13/clinic)
 "vHQ" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
+	dir = 1
+	},
+/area/f13/brotherhood/reactor)
 "vIp" = (
 /obj/structure/showcase/horrific_experiment{
 	icon_state = "pod_0"
@@ -23493,16 +23754,53 @@
 /obj/structure/chair/right{
 	dir = 8
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "vIL" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"vIO" = (
+/obj/item/am_containment{
+	pixel_x = 3
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1
+	},
+/obj/item/am_containment,
+/obj/item/am_containment{
+	pixel_x = -3
+	},
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/corner,
+/area/f13/brotherhood/reactor)
 "vJC" = (
 /obj/structure/window/reinforced/tinted/frosted,
 /obj/effect/decal/cleanable/dirt,
@@ -23510,13 +23808,13 @@
 /area/f13/brotherhood/leisure)
 "vJX" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/machinery/power/smes/engineering{
+	charge = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
@@ -23563,9 +23861,8 @@
 	},
 /area/f13/tunnel)
 "vMi" = (
-/obj/structure/chair/office/dark{
-	dir = 1;
-	icon_state = "officechair_dark"
+/obj/structure/table{
+	layer = 2.9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
@@ -23601,37 +23898,46 @@
 	},
 /area/f13/sewer)
 "vNU" = (
-/obj/machinery/camera/autoname{
-	dir = 5;
-	name = "Reactor Camera";
-	network = list("BoS")
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "vOf" = (
-/obj/machinery/door/airlock/grunge{
+/obj/structure/simple_door/bunker{
+	name = "Star Paladin Office";
+	req_access = 120;
 	req_access_txt = "120"
 	},
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
 "vOo" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
+/obj/structure/window/reinforced/spawner{
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/window/reinforced/spawner{
+	color = "#777777";
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
 	},
+/obj/machinery/light/floor,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "vOR" = (
 /turf/open/floor/plating/f13/inside,
@@ -23690,7 +23996,6 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
 "vQJ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -23701,10 +24006,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "vQZ" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/turf/open/water,
+/area/f13/brotherhood/rnd)
 "vSd" = (
 /obj/effect/landmark/start/f13/settler,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23717,6 +24036,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/followers)
 "vTk" = (
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -23726,7 +24051,7 @@
 /obj/machinery/light/fo13colored/Red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "vTH" = (
 /obj/structure/barricade/wooden{
@@ -23760,16 +24085,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "vVg" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/terminal{
 	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
+	pixel_x = 16;
+	pixel_y = 8;
+	termtag = "Business"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "vVz" = (
 /obj/structure/bookcase,
@@ -23840,6 +24166,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Power"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/reactor)
 "vXx" = (
@@ -23877,18 +24204,13 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "vYx" = (
-/obj/machinery/power/am_control_unit{
-	anchored = 1;
-	dir = 8
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "vYC" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23908,13 +24230,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -23993,7 +24309,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "wbM" = (
-/turf/open/floor/wood/f13/stage_t,
+/obj/item/flag/bos,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "wcm" = (
 /obj/machinery/light/small{
@@ -24029,11 +24351,13 @@
 /area/f13/brotherhood/leisure)
 "wef" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/button/door{
+	id = "bosengine";
+	name = "Radiation Shutters";
+	pixel_x = -32
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -24090,20 +24414,7 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
 "wfH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/mug/coco{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
+/obj/structure/bookcase/manuals/engineering,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "wgg" = (
@@ -24118,6 +24429,16 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"wgN" = (
+/obj/structure/debris/v3{
+	layer = 2
+	},
+/turf/open/indestructible/ground/outside/water{
+	density = 1;
+	desc = "Deep lake water, filled with who knows what...";
+	name = "lake water"
+	},
+/area/f13/caves)
 "whp" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -24139,6 +24460,17 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"wiC" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 1;
+	height = 4;
+	id = "bos_level_2";
+	name = "Level 2: Engineering";
+	width = 5
+	},
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/brotherhood/rnd)
 "wjW" = (
 /obj/structure/billboard/cola/pristine,
 /obj/effect/decal/cleanable/dirt,
@@ -24191,14 +24523,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "wmE" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "proctorbathroom";
-	req_access_txt = "120"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "wmT" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -24222,6 +24556,10 @@
 "wox" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/brotherhood/mining)
+"wpH" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wpJ" = (
 /obj/structure/barricade/bars,
 /obj/structure/curtain{
@@ -24326,12 +24664,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "wuE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
+	},
+/area/f13/brotherhood/mining)
 "wuM" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -24351,10 +24691,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "wxb" = (
-/obj/structure/flora/junglebush/large,
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "wyl" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -24363,26 +24701,10 @@
 	},
 /area/f13/followers)
 "wyy" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 1;
-	layer = 3.1;
-	pixel_x = -12;
-	pixel_y = -16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = -12
-	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "wAe" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
@@ -24402,29 +24724,26 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "wCV" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
+	name = "Head Scribe's Archive Terminal"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "wDm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/item/kirbyplants/photosynthetic,
+/obj/structure/decoration/hatch{
+	desc = "That's pretty nifty.";
+	dir = 1;
+	name = "Plant Water Drain";
+	pixel_y = -13
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "wDq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
 "wDz" = (
 /obj/structure/closet/fridge/standard,
@@ -24458,17 +24777,19 @@
 	},
 /area/f13/tunnel)
 "wEX" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "wFj" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "wFu" = (
-/obj/effect/landmark/start/f13/Knight,
 /obj/effect/landmark/start/f13/initiate,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -24482,9 +24803,14 @@
 /area/f13/tunnel)
 "wFF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "wFL" = (
 /obj/structure/chair{
 	dir = 8
@@ -24535,13 +24861,29 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/operations)
 "wKm" = (
 /obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
 	density = 0;
 	dir = 4;
-	layer = 3.1;
 	pixel_x = -16
 	},
 /obj/structure/lattice{
@@ -24594,6 +24936,10 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
+"wLX" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wMr" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -24607,23 +24953,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wNi" = (
-/obj/item/statuebust,
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "wNs" = (
-/obj/effect/decal/cleanable/robot_debris,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "wNJ" = (
 /obj/structure/table/wood/bar,
 /obj/machinery/reagentgrinder{
@@ -24659,6 +25009,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "wPy" = (
+/obj/structure/filingcabinet/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood/rnd)
@@ -24667,13 +25018,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "wPV" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Head Paladin on duty.";
-	dir = 4;
-	name = "Head Paladin's Office"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/mining)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -24697,18 +25046,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wQJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 4;
+	output_dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/mining)
 "wQS" = (
 /obj/machinery/button/door{
 	id = "boscheckpoint";
@@ -24744,7 +25093,9 @@
 /area/f13/ncr)
 "wTF" = (
 /obj/effect/turf_decal/arrows/white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "wUi" = (
 /obj/structure/rack,
@@ -24755,12 +25106,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wUr" = (
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
-	},
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/newscaster,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "wUv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -24776,24 +25123,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wUT" = (
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "wVl" = (
 /turf/open/floor/f13/wood{
@@ -24811,7 +25144,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "wVN" = (
 /obj/effect/decal/cleanable/flour,
@@ -24832,11 +25165,13 @@
 	},
 /area/f13/tunnel)
 "wWM" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "wXG" = (
@@ -24932,12 +25267,14 @@
 	},
 /area/f13/tunnel)
 "xdB" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 8
+	},
+/area/f13/brotherhood/reactor)
 "xdS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -25005,10 +25342,7 @@
 /area/f13/radiation)
 "xgu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/bronze,
 /area/f13/brotherhood/rnd)
 "xgY" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -25053,12 +25387,17 @@
 	},
 /area/f13/tunnel)
 "xiI" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	pixel_y = 27
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 4
 	},
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/offices2nd)
 "xjk" = (
 /obj/structure/chair/bench,
@@ -25070,11 +25409,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xjE" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
 "xkd" = (
 /obj/machinery/light/small{
@@ -25096,11 +25432,9 @@
 	},
 /area/f13/bunker)
 "xks" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "xkx" = (
 /obj/structure/showcase/horrific_experiment,
@@ -25109,20 +25443,13 @@
 	},
 /area/f13/clinic)
 "xkB" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/lattice/catwalk,
 /obj/structure/lattice{
-	density = 1
+	layer = 2
 	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = 18
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "xkH" = (
@@ -25157,24 +25484,15 @@
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/flashlight/lamp{
-	pixel_x = 2;
-	pixel_y = 12
+/obj/machinery/computer/terminal{
+	termtag = "Secret"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
 "xmQ" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	layer = 2.7;
-	name = "prewar lounge chair"
-	},
-/obj/effect/landmark/start/f13/headscribe,
+/obj/structure/bookcase/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
@@ -25187,12 +25505,14 @@
 	},
 /area/f13/tunnel)
 "xnb" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster70";
+	pixel_x = 31
 	},
-/obj/structure/sign/poster/prewar/poster73{
-	pixel_y = 31
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "engine"
 	},
@@ -25218,13 +25538,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "xnV" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/atmos,
-/obj/item/twohanded/fireaxe,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 4
+	},
+/area/f13/brotherhood/reactor)
 "xoo" = (
 /obj/structure/table{
 	layer = 2.9
@@ -25235,30 +25552,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "xoU" = (
-/obj/structure/table/wood/fancy/black{
-	desc = "A set of thin pipes that no longer function.";
-	icon_state = "latticefull";
-	layer = 2.4;
-	name = "pipes"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Aqua{
+	brightness = 3;
+	critical_machine = 1;
+	flicker_chance = 0;
+	icon_state = "bulb";
+	name = "Light Bulb"
 	},
-/obj/item/statuebust,
-/obj/structure/table{
-	icon_state = "1-f"
-	},
-/obj/structure/table{
-	icon_state = "2-f"
-	},
-/obj/structure/table{
-	icon_state = "3-f"
-	},
-/obj/structure/table{
-	icon_state = "4-f"
-	},
-/obj/structure/window/reinforced/clockwork/fulltile,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "xpo" = (
 /obj/structure/closet/crate/large,
@@ -25290,34 +25595,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "xrA" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/blueprint/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/flashlight/lamp{
-	light_color = "#00FFFF";
-	pixel_x = -14;
-	pixel_y = 9
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "xsk" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Proctor's Office";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "xss" = (
-/turf/closed/mineral/random/high_chance,
-/area/f13/brotherhood/reactor)
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/machinery/light/small,
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "xsL" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -25353,7 +25650,6 @@
 	},
 /area/f13/followers)
 "xwI" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -25440,12 +25736,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xCf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "xCv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/booth{
@@ -25469,8 +25768,9 @@
 	},
 /area/f13/followers)
 "xDy" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/hos,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "xEd" = (
@@ -25533,8 +25833,13 @@
 	},
 /area/f13/tunnel)
 "xGl" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/flora/rock/jungle{
+	density = 1
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/brotherhood/rnd)
 "xGp" = (
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -25550,15 +25855,30 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "xGu" = (
-/obj/structure/toilet{
-	pixel_y = 10
+/obj/effect/decal/cleanable/insectguts,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = 13
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_x = -10
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/fence/handrail_corner{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = 13;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_x = -2;
+	pixel_y = 16
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "xGV" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
@@ -25591,9 +25911,16 @@
 	},
 /area/f13/clinic)
 "xIN" = (
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_y = -32
+	},
+/obj/machinery/camera/autoname{
+	dir = 1;
+	name = "RnD Checkpoint Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "xJE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -25641,10 +25968,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "xMa" = (
-/obj/item/flag/bos,
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
 	},
 /obj/structure/lattice{
 	density = 1
@@ -25663,21 +25991,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "xNs" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/rag/towel{
-	pixel_y = -7
-	},
-/obj/item/reagent_containers/rag/towel{
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/rag/towel,
-/obj/machinery/button/door{
-	id = "proctorbathroom";
-	name = "Bathroom Lock";
-	normaldoorcontrol = 1;
-	pixel_y = -32;
-	req_one_access_txt = "120";
-	specialfunctions = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whiterustysolid"
@@ -25699,10 +26014,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "xND" = (
+/obj/effect/landmark/start/f13/scribe,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "xOf" = (
@@ -25778,12 +26091,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "xRU" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/table{
 	layer = 2.9
 	},
+/obj/item/integrated_electronics/debugger,
+/obj/item/integrated_electronics/wirer,
+/obj/item/integrated_electronics/detailer,
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_circuit_printer,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood/rnd)
 "xRW" = (
@@ -25842,15 +26159,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xVV" = (
-/obj/machinery/light/floor,
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/lattice{
 	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 5
-	},
-/obj/structure/fluff/railing/corner{
-	dir = 8
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
@@ -25893,9 +26208,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "xYS" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
+/obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "yellowrustysolid"
@@ -25907,11 +26220,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "xYX" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 10
 	},
 /area/f13/brotherhood/mining)
 "xYY" = (
@@ -25938,23 +26255,29 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xZI" = (
+/obj/structure/table/wood/fancy/black{
+	desc = "A set of thin pipes that no longer function.";
+	icon_state = "latticefull";
+	layer = 2.4;
+	name = "pipes"
+	},
+/obj/item/statuebust,
 /obj/structure/table{
-	layer = 2.9
+	icon_state = "1-f"
 	},
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "A console used by the scribes of the Brotherhood of Steel.";
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal";
-	name = "Archive Terminal"
+/obj/structure/table{
+	icon_state = "2-f"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table{
+	icon_state = "3-f"
+	},
+/obj/structure/table{
+	icon_state = "4-f"
+	},
+/obj/structure/window/reinforced/clockwork/fulltile,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
 "yaO" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -25966,11 +26289,9 @@
 /area/f13/caves)
 "ybF" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/structure/table{
-	layer = 2.9
-	},
+/obj/structure/chair/sofa/corp,
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "ycc" = (
@@ -25990,17 +26311,21 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ydv" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/insectguts,
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "ydE" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	req_access_txt = "120"
+/obj/structure/window/spawner/north,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "ydF" = (
 /obj/structure/table/wood/poker,
@@ -26101,18 +26426,24 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/leisure)
+"yjX" = (
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ykT" = (
-/obj/structure/bookcase/random/reference{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Archival References"
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side,
+/area/f13/brotherhood/mining)
 
 (1,1,1) = {"
 eLE
@@ -78384,6 +78715,7 @@ aoj
 aoj
 aoj
 aoj
+aoj
 uoO
 uoO
 uoO
@@ -78411,7 +78743,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -78642,6 +78973,7 @@ aoj
 aoj
 aoj
 aoj
+aoj
 uoO
 uoO
 uoO
@@ -78668,7 +79000,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -78900,23 +79231,13 @@ uoO
 uoO
 uoO
 uoO
-aoj
-uoO
-uoO
-vHQ
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 aoj
-aoj
 uoO
-aoj
-aoj
-aoj
+uoO
+jsL
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -78924,8 +79245,18 @@ uoO
 uoO
 aoj
 aoj
+uoO
+aoj
+aoj
 aoj
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -79111,6 +79442,7 @@ oeY
 oeY
 oeY
 oeY
+oeY
 uoO
 uoO
 aoj
@@ -79182,7 +79514,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -79367,6 +79698,7 @@ vYw
 vYw
 vYw
 vYw
+vYw
 oeY
 uoO
 uoO
@@ -79437,7 +79769,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -79616,13 +79947,14 @@ isj
 nPp
 vYw
 ulA
-hYS
+tKy
 vYw
-gsw
+tKy
 saF
 tKy
 nHR
-njI
+qfK
+euS
 vYw
 oeY
 uoO
@@ -79697,7 +80029,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -79873,13 +80204,14 @@ aqB
 jYj
 vYw
 tvj
-hYS
+tKy
 vOf
-hYS
 tKy
 xmk
-iKq
-msW
+dlT
+vYw
+qfK
+qfK
 vYw
 oeY
 uoO
@@ -79952,7 +80284,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -80111,7 +80442,7 @@ cFd
 cfk
 uHP
 jZH
-pfC
+oeJ
 hng
 kjU
 dEq
@@ -80129,14 +80460,15 @@ bRN
 hoj
 vYw
 vYw
-qid
-eOh
+tKy
+tKy
+bFi
+tKy
+tKy
+tKy
 vYw
-mjJ
-tKy
-tKy
-tKy
-tKy
+aHM
+eAw
 vYw
 oeY
 uoO
@@ -80209,7 +80541,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -80386,13 +80717,14 @@ ydF
 xwI
 gfz
 vYw
+tKy
+tKy
 vYw
 vYw
 vYw
 vYw
 vYw
 vYw
-hrq
 vYw
 vYw
 oeY
@@ -80466,7 +80798,6 @@ aoj
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -80642,15 +80973,16 @@ vYw
 kbf
 aqB
 tVL
-vyb
-ulA
-hYS
-vYw
-sLI
-ecD
 vYw
 tKy
 tKy
+vYw
+tKy
+saF
+tKy
+nHR
+qfK
+euS
 vYw
 oeY
 uoO
@@ -80723,7 +81055,6 @@ aoj
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -80901,12 +81232,13 @@ mtG
 wdL
 vYw
 tvj
-hYS
+tKy
 vOf
 tKy
 xmk
+dlT
 vYw
-tKy
+qfK
 qfK
 vYw
 oeY
@@ -80959,7 +81291,7 @@ uoO
 aoj
 xVz
 xVz
-qZA
+wpH
 uoO
 uoO
 uoO
@@ -80980,7 +81312,6 @@ aoj
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -81139,7 +81470,7 @@ uHP
 aDN
 uHP
 jZH
-pfC
+oeJ
 oeJ
 fRN
 kbZ
@@ -81157,14 +81488,15 @@ lvt
 lok
 ifR
 vYw
-qid
-eOh
+tKy
+tKy
+bFi
+tKy
+tKy
+tKy
 vYw
-hOJ
-tKy
-hrq
-tKy
 aHM
+eAw
 vYw
 oeY
 uoO
@@ -81190,31 +81522,31 @@ cSG
 vsI
 qmh
 qmh
-nkx
 aZl
+rOb
 xkQ
-wVK
 uYd
 cqY
 wef
+tHM
 xkQ
-lkT
+uFO
 qta
 qta
-eaz
-qta
-qta
-qta
-eaz
 psA
+qta
+qta
+qta
+psA
+kap
 qmh
-cGq
+kFP
 vsI
 vsI
 uoO
 uoO
 uoO
-qZA
+wpH
 xVz
 xVz
 uoO
@@ -81234,7 +81566,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -81406,8 +81737,16 @@ vYw
 vYw
 vYw
 vYw
-wPV
+vYw
 qrJ
+aYI
+vYw
+vYw
+vYw
+vYw
+vYw
+vOf
+vOf
 vYw
 vYw
 vYw
@@ -81415,13 +81754,6 @@ vYw
 vYw
 vYw
 vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-tKy
-tKy
 vYw
 yhT
 yhT
@@ -81431,7 +81763,7 @@ yhT
 yhT
 yhT
 yhT
-yhT
+kKy
 kKy
 kKy
 kKy
@@ -81445,27 +81777,27 @@ kKy
 kKy
 kKy
 vsI
-jnO
 bGU
 aRj
+qZA
 vsI
-xCf
 iPu
+shO
 xkQ
-aOT
+tna
 xkQ
 xkQ
-lkT
+uFO
 qta
 qta
-hIt
+wVK
 qmh
 qmh
 qmh
 qmh
-nld
+rAt
 qmh
-iST
+hOX
 vsI
 vsI
 uoO
@@ -81495,7 +81827,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -81666,18 +81997,19 @@ xXc
 cSH
 uwA
 wOp
-wOp
+bfh
 rFJ
 wOp
 wOp
-rFJ
-lbt
-fXs
-tKy
-eOh
-eOh
+bfh
+wOp
+wOp
+bVb
 eOh
 tKy
+tKy
+dnM
+aHM
 aHM
 vYw
 yhT
@@ -81688,7 +82020,7 @@ gul
 gul
 gul
 gul
-gul
+xhA
 xhA
 xhA
 xhA
@@ -81702,26 +82034,26 @@ xhA
 xhA
 xhA
 vsI
-wWM
 sOi
 lea
+rfD
 vsI
-gcY
+saz
 gWK
 gWK
-vYx
+toO
 gWK
-isG
 hpI
 pfv
 faR
 nld
-ene
+rAt
 eGI
+vIO
 vsI
 vsI
-hXf
 oAp
+ofD
 vsI
 vsI
 vsI
@@ -81752,7 +82084,6 @@ aoj
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -81921,65 +82252,66 @@ cqO
 vKF
 vYw
 aqX
-uwA
-wOp
-wOp
-wOp
-wOp
-wOp
-wOp
-qfB
-tIz
-tKy
-tKy
+azD
+jHR
+jHR
+jHR
+jHR
+jHR
+jHR
+jHR
+jHR
+ccb
+coe
 hYS
+hYS
+dtm
 tKy
 tKy
-qfK
 vYw
 yhT
 gul
-iWR
 xiI
 xNs
+hKS
 gul
-gjB
 iOt
 hlS
+iWR
 xhA
 xhA
 xhA
-fxM
+yaO
 jPB
 jPB
 jPB
 jPB
 jPB
-pwP
 qpe
+odG
 xhA
 vsI
-lZF
 mWD
 pIg
+riR
 vsI
 kYh
 kYh
 pis
 pis
 pis
-vNU
+uhT
 vsI
 vsI
 vsI
-bwd
+wWM
 vsI
 vsI
 vsI
-sXi
 vch
 uRE
-hSq
+vrC
+sdQ
 vsI
 uoO
 uoO
@@ -82005,7 +82337,6 @@ uoO
 uoO
 uoO
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -82177,66 +82508,67 @@ vYw
 dqp
 lSZ
 vYw
-wug
+aXP
 uwA
-vYw
-vYw
-vYw
-dKc
-vYw
-vYw
-vYw
+wOp
+biy
+bdP
 fXs
+bdP
+fXs
+bdP
+fXs
+cmy
+cyA
 tKy
 tKy
+ioQ
 tKy
-tKy
-tKy
-tKy
+cyA
 vYw
 yhT
-nYD
+gfy
 goi
 goi
 goi
-wmE
+ifX
 jrX
 jrX
-jTD
+iYI
 xhA
-iyJ
 fxM
-ubJ
+yaO
+kWH
 jPB
-uIq
+mjJ
 fFK
 fFK
 fFK
 fFK
-umw
 pDM
 vOo
+pgS
 xhA
-gNG
-xhA
+qoi
 vsI
-mui
+vsI
+sdJ
 kYh
 pis
 pis
 pis
-mzX
+umw
 vsI
-hYI
+vyb
 qmh
-nld
+rAt
 qmh
-jEK
+lzU
 vsI
-wQJ
 vJX
 qRv
 tfd
+gZt
 vsI
 vsI
 uoO
@@ -82267,7 +82599,6 @@ uoO
 aoj
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -82436,36 +82767,36 @@ vYw
 vYw
 bfL
 uwA
-vYw
+wOp
 cnm
 dSU
-mAm
+wOp
 dSU
-cnm
+wOp
+dSU
+wOp
 vYw
-xmk
-ioQ
-tKy
-tKy
+cCx
+cZm
 tKy
 ioQ
-xmk
+cZm
+cCx
 vYw
 yhT
 gul
-rsM
+gjB
 goi
-iLO
+hOJ
 gul
 jrX
 jrX
-sgI
+iZQ
 xhA
-hPD
+jZg
 jPB
 jPB
 jPB
-abY
 fAJ
 byA
 vZr
@@ -82473,9 +82804,10 @@ neP
 nxT
 wUT
 neu
+pwa
 xhA
-qsa
-xhA
+qpX
+vsI
 vsI
 kYh
 kYh
@@ -82484,16 +82816,16 @@ pis
 pis
 kYh
 vsI
-hVy
 uay
-nld
+wxb
 rAt
 icI
+vyc
 vsI
-wNs
-vch
+uab
 uRE
 vrC
+aYO
 vsI
 vsI
 uoO
@@ -82524,7 +82856,6 @@ uoO
 aoj
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
@@ -82667,7 +82998,7 @@ auO
 mkc
 oVE
 jZH
-bxq
+vvR
 fQF
 vvR
 nNF
@@ -82693,66 +83024,67 @@ aBq
 vYw
 rFJ
 uwA
-vYw
-mXi
-mAm
-gcD
-mZX
+wOp
 mXi
 vYw
-njI
+vYw
+vYw
+vYw
+vYw
+vYw
 jGX
 tKy
 jgd
-hYS
-jGX
-njI
+tKy
+dvK
+emg
+dtm
 vYw
 yhT
 gul
-jBc
 uuQ
 fhk
+hPD
 gul
-toO
+itP
 jrX
-kLA
+jdN
 xhA
-djs
+kcD
 jPB
+lbt
 yaO
-fxM
-mUV
+mui
 jPB
-bdP
 efS
 xYS
+nMN
 jPB
-rXl
-anf
+hrv
+pwP
 xhA
-wuE
-xhA
+qsa
 vsI
-mui
+vsI
+sdJ
 kYh
 pis
 pis
 pis
-mzX
+umw
 vsI
-mII
 wfH
 sZn
 ois
 fIV
+etu
 vsI
-fdN
 eaR
 ldA
 hcC
+aqR
 vsI
-xss
+pwF
 uoO
 uoO
 uoO
@@ -82781,7 +83113,6 @@ uoO
 aoj
 uoO
 uoO
-aoj
 uoO
 uoO
 aoj
@@ -82930,7 +83261,7 @@ vvR
 nNF
 viv
 cah
-tJU
+jdI
 eJh
 aXW
 nWg
@@ -82950,46 +83281,47 @@ pxy
 vYw
 fXr
 uwA
+aYS
+wOp
 vYw
-vYw
-vYw
-vYw
-vYw
-vYw
+bri
+mZX
+bxq
 rIl
+bEz
 vYw
 vYw
 vYw
 vYw
 vYw
 vYw
-qFQ
+eBP
 vYw
 yhT
 gul
 gul
-tna
 vFa
-asx
+xjE
 sSP
+iuL
 jrX
-jYP
+jfW
 xhA
-aYI
+keR
 jPB
-jZg
+lbG
 jPB
-mUV
+mui
 jPB
-thO
-efS
-jPx
+mUS
+xYS
+nNi
 jPB
-rXl
 hrv
+pAE
 xhA
-wuE
-xhA
+qsa
+vsI
 vsI
 kYh
 kYh
@@ -82998,15 +83330,15 @@ pis
 pis
 kYh
 vsI
-vna
 ggm
 qeh
 fuc
 dhM
+gJW
 vsI
 vsI
-ccb
-oAp
+rDB
+ofD
 vsI
 vsI
 vsI
@@ -83018,7 +83350,6 @@ uoO
 uoO
 xVz
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -83207,36 +83538,36 @@ uXT
 vYw
 wOp
 sGY
-vYw
+bbq
 biW
-tcH
-kxu
+vYw
 mAm
+bwd
 hro
+dKm
+mAm
 vYw
-mZX
-mZX
 uqU
-mZX
+djs
 sJA
+dDE
 vYw
-ozI
+epa
 vYw
 yhT
 gul
-jOL
+goG
 jrX
-gjB
-vFa
+iOt
+xjE
 jrX
-hZN
 agI
+jgL
 xhA
-rOb
+kic
 jPB
-fxM
+yaO
 jPB
-qyv
 coQ
 vyg
 gzD
@@ -83244,9 +83575,10 @@ nsN
 rEj
 tYE
 bFa
+pKf
 xhA
-txU
-xhA
+qtD
+vsI
 vsI
 vsI
 kYh
@@ -83255,16 +83587,16 @@ pis
 pis
 kYh
 vsI
-oei
 tJL
 eVi
+xdB
 poa
 poa
-goG
 jzs
 mLN
 dSr
 spS
+eSS
 vsI
 vsI
 uoO
@@ -83275,7 +83607,6 @@ aoj
 aoj
 xVz
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -83464,64 +83795,65 @@ mAm
 vYw
 wOp
 uwA
-vYw
-eZf
-sRA
-gXH
-mZX
-mZX
-vYw
+wOp
+wOp
+tEG
 mAm
+mAm
+mAm
+mAm
+mAm
+cnq
 mZX
-vYw
 mZX
-uXT
+mZX
+dGD
 vYw
-ozI
+epa
 vYw
 yhT
 gul
-rXR
+gpl
 jrX
-sdJ
+hSU
 gul
-xsk
+iuX
 uAc
-uAc
+jnO
 xhA
-eub
-fxM
+kiX
 yaO
+lbt
 jPB
-xVV
 myA
 glq
 xkB
+nzl
 fFK
 fFK
-qJc
-hrv
+owX
+pAE
 xhA
-sWu
-xhA
+qyv
 xhA
 vsI
+vsI
 kYh
-qYS
+sUy
 kYh
-qYS
+sUy
 kYh
 vsI
-hyR
+vHQ
 fbP
 fbP
-mcC
+xnV
 stU
-bVb
+pdR
 stU
 stU
-gim
 qUR
+qEx
 vsI
 vsI
 uoO
@@ -83552,7 +83884,6 @@ aoj
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 aoj
@@ -83721,58 +84052,59 @@ mAm
 vYw
 wOp
 uwA
-hGF
-mAm
+wOp
+wOp
 tEG
-mZX
 mAm
 mAm
+mAm
+mAm
+mAm
 vYw
-jOU
-mAX
 vYw
-dKC
-qoF
 vYw
-ozI
+vYw
+vYw
+vYw
+epa
 vYw
 yhT
 gul
-hlS
+gsw
 jrX
-nKk
 rbu
+igV
 iKl
-eFE
 oBP
+jyc
 xhA
 xhA
 xhA
 xhA
 jPB
 jPB
-riY
-fMZ
+lnF
 riY
 lnF
 sll
+oei
 xhA
 xhA
 xhA
-wuE
+qsa
 xhA
-xhA
-vsI
-hBC
 vsI
 vsI
+slT
 vsI
 vsI
-pXp
+vsI
+vsI
 bMA
 vEe
 vXr
 fna
+xsk
 xhA
 xhA
 xhA
@@ -83809,7 +84141,6 @@ aoj
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 aoj
@@ -83978,62 +84309,63 @@ uMD
 vYw
 fXr
 uwA
-qci
+wOp
+wOp
+bmv
 mAm
-mAm
-mAm
-mZX
-mAm
+bwd
+hro
 dKm
 mAm
+cnq
 mZX
+mZX
+mZX
+dGD
 vYw
-vYw
-vYw
-vYw
-ozI
+epa
 vYw
 yhT
 gul
-jgL
+gxj
 jrX
-odG
-rbu
+hVy
+igV
 xpu
 iKl
 iKl
-eAw
+jLX
 xhA
 xhA
 xhA
 xhA
 xhA
-hKS
+mSc
 ppw
 ppw
 xhA
 xhA
-neq
+oDV
 xhA
 xhA
-eCv
-xhA
-xhA
-xhA
+qFQ
 xhA
 xhA
 xhA
 xhA
 xhA
-mUS
+xhA
+xhA
+xhA
 pFn
+vIL
 iKl
 iKl
-igV
+xss
 xhA
-jdN
 cus
 smy
+pXf
 kdH
 xhA
 xhA
@@ -84063,7 +84395,6 @@ uoO
 uoO
 uoO
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -84235,36 +84566,36 @@ wOp
 wOp
 rFJ
 uwA
+bdP
+fXs
 vYw
-eZf
-epa
 gXH
-mAm
-hro
+mZX
+bxq
+rIl
+edO
 vYw
-mZX
-mZX
 uqU
-mAm
+djs
 sJA
+dKk
 vYw
-ozI
+epa
 iKQ
 yhT
 gul
-koC
 tmh
+hBC
 jrX
-xsk
+iiE
 iKl
-fDp
+iST
 iKl
 xpu
-eNT
+klQ
 iKl
 seP
 seP
-ifX
 sNg
 hLL
 rEl
@@ -84272,26 +84603,27 @@ ill
 rZw
 fnD
 bOf
+fkd
 xhA
-nXh
+qJc
 eHy
-uhT
+rOp
 rNi
 rNi
 xhA
 xhA
 xhA
 xhA
-uXY
-pFn
+uIq
+vIL
 iKl
-uFO
 rFc
+xCf
 xhA
-qMn
 hUn
+qHq
 kdH
-ucQ
+lvn
 xhA
 xhA
 uoO
@@ -84307,7 +84639,6 @@ uoO
 uoO
 uoO
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -84492,63 +84823,64 @@ yej
 yej
 jHR
 jCU
+dSU
+wOp
 vYw
-biW
-cnq
-gcD
-mAm
-gEZ
+vYw
+vYw
+vYw
 qpc
-gEZ
-gEZ
-gEZ
-mZX
-uXT
 vYw
-ozI
+vYw
+vYw
+vYw
+vYw
+vYw
+vYw
+epa
 iKQ
 gul
 gul
 gul
 gul
 gul
-gul
+xhA
 xhA
 xhA
 iKl
 iKl
-eNT
+klQ
 iKl
 xpu
-edY
+qrl
 iKl
 iKl
 iKl
 iKl
 iKl
 iKl
-vIL
+oEt
 iKl
-mNL
-sPZ
+wUr
+qMn
 eHy
 eHy
-rJv
-rNi
+seL
+seL
 xhA
 xhA
-qOJ
 xGl
-iaI
-jtk
+upu
+vBG
+vNU
 iKl
 iKl
-tXw
+xGu
 xhA
 kdH
 kdH
-kcD
 paO
+fJm
 xhA
 xhA
 uoO
@@ -84560,7 +84892,6 @@ uoO
 aoj
 xVz
 xVz
-uoO
 uoO
 uoO
 uoO
@@ -84749,61 +85080,62 @@ gEZ
 gEZ
 gEZ
 gEZ
-vYw
-vYw
-vYw
-vYw
-vYw
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
 uGO
 oUK
 oUK
 tcv
-gEZ
-dKC
+cGq
 qoF
-vYw
+qoF
+qoF
 ozI
+eCv
 iKQ
 jUB
 jUB
-jJd
-tvx
+vxR
 qFm
+hXf
 jUB
 jUB
 xhA
 iKl
 iKl
 xhA
-jfW
 kOa
 sPl
+lLy
 iKl
-eVA
 ekP
 fFV
-fSW
-rPG
-ekP
-bJO
+nBh
+lSl
+qjT
+fFV
 xoU
 tQe
 ybF
 teh
+rWh
 eHy
-tHM
+snJ
 xhA
 xhA
-bmF
-xGl
-iaI
-pFn
+tIz
+upu
+vBG
+vIL
 iKl
 iKl
 xpu
-bmv
+qcL
 kdH
-qME
+bGL
 xhA
 xhA
 xhA
@@ -84817,7 +85149,6 @@ aoj
 aoj
 xVz
 xVz
-uoO
 uoO
 uoO
 uoO
@@ -85021,44 +85352,45 @@ gEZ
 gEZ
 ulr
 iKQ
+iKQ
 jUB
 xRW
-kBT
-fDW
-sfi
+gNG
+uSG
+gSN
 xRW
 jUB
 xhA
 iKl
 iKl
 xhA
-mSc
+kxu
 xhA
-edY
-iFz
+qrl
 mJJ
 qWx
+mWp
 iKl
-biy
 hmP
-bRk
-xgu
-iFz
-iAt
-eHy
+ofQ
+dHq
+fOQ
+mJJ
+qME
 eez
+rXl
 eHy
-iuL
-iFz
+sHk
+mJJ
 xhA
-nHu
 qVC
-iaI
+uWA
 vBG
 jrA
+wyy
 iKl
 xpu
-ryL
+nji
 xhA
 xhA
 xhA
@@ -85082,7 +85414,6 @@ uoO
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -85268,7 +85599,7 @@ crH
 kxR
 qPC
 gEZ
-rFJ
+sGY
 wOp
 jsD
 dpR
@@ -85276,47 +85607,48 @@ dpR
 dpR
 dpR
 gEZ
-ozI
+epa
+iKQ
 iKQ
 xRW
-owX
+gim
 jUB
 fUJ
 jUB
 xRW
 xRW
 xhA
-saz
+jyg
 iKl
-tzx
+koC
 iKl
-dDE
 fzR
 pIx
-xgu
+mzX
 fOQ
 fou
 cQR
 gnY
 seJ
-quR
+xpu
 mxa
 iaI
-npl
+vBG
 qGz
 hNS
-izo
+kdH
 uGL
 leG
-iaI
-nHu
-men
+txU
+vBG
+qVC
 rfs
+vQZ
 kdH
 kdH
-hNS
 kFc
 ydE
+pja
 bEK
 bEK
 bEK
@@ -85339,7 +85671,6 @@ uoO
 xVz
 uiV
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -85525,7 +85856,7 @@ wOp
 rFJ
 wOp
 wOp
-wOp
+uwA
 rFJ
 qqN
 dpR
@@ -85533,47 +85864,48 @@ dpR
 dpR
 dpR
 gEZ
-ozI
+epa
+iKQ
 iKQ
 xRW
-oDV
 sfi
+gSN
 fUJ
-tuO
+cmE
 xRW
 fUJ
-jzX
 qWq
 irr
-wDm
+jNr
 rPG
 qjT
 fSW
-rPG
-jjJ
+lSl
+qjT
 upI
-fsQ
+fDi
 ulZ
-awF
+dGu
 vid
-dyO
+xND
+pNi
 sPC
 sPC
-dlT
-qGz
+rsM
+hNS
 kdH
-dGD
+sIK
 bvC
 bvC
 bvC
-lYu
 qPN
+uJS
 bvC
-vqm
 vTk
+xks
 kdH
-mWp
 cFj
+lwE
 bEK
 bEK
 bEK
@@ -85592,11 +85924,10 @@ aoj
 aoj
 uoO
 uoO
-gbA
+dkT
 xVz
-upu
+smT
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -85771,18 +86102,18 @@ gEZ
 gEZ
 npR
 wOp
-uwA
-wOp
-wOp
-wOp
-wOp
-wOp
-wOp
-wOp
-rFJ
-wOp
-wOp
-wOp
+azD
+jHR
+jHR
+jHR
+jHR
+jHR
+jHR
+jHR
+yej
+jHR
+jHR
+bDi
 mhc
 swY
 dpR
@@ -85790,47 +86121,48 @@ dpR
 dpR
 dpR
 gEZ
-ozI
+epa
 iKQ
-lLy
+iKQ
 pvX
 fDW
 uSG
+hGF
 fUJ
 fUJ
 fUJ
-lbG
 tuO
 cmE
 xgu
+fOQ
 iKl
-qnC
 kKx
 wCV
+mAX
+fOQ
 iKl
-iKl
-ulZ
-fDi
+dGu
 xrA
-vid
+ogl
 xND
+pWr
 deX
 deX
-euS
 rKX
+rXR
 brt
 brt
 jGQ
 jGQ
 deX
-ufk
+uvd
 jGQ
 jGQ
-fxu
-hNS
+wEX
+kFc
 kdH
-fcn
 dRm
+roZ
 bEK
 bEK
 bEK
@@ -85851,15 +86183,14 @@ uoO
 uoO
 xVz
 xVz
-pgS
 sXP
+iki
 aoj
 aoj
 aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -86049,46 +86380,47 @@ dpR
 gEZ
 beN
 iKQ
+iKQ
 xRW
-oDV
-jIe
+sfi
+gTT
 fUJ
-tuO
+cmE
 xRW
 fUJ
+qWq
 jzX
-pGd
-tuO
-xgu
-bYQ
+cmE
+fOQ
 qnC
-gsV
+kKx
+lYu
 iKl
-aYS
-upI
+mTj
 fDi
-ulZ
+xrA
 dGu
-vid
+oja
+xND
 iKl
 seP
 seP
 kdH
 kdH
 kdH
-vTk
-seP
-seP
-seP
-eXJ
-seP
-iEg
-sOf
 kdH
-jLX
+seP
+seP
+seP
+uwV
+seP
+sOf
+wFF
+kdH
 qZY
+soi
 xhA
-bbq
+wiC
 bEK
 bEK
 bEK
@@ -86117,7 +86449,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -86304,47 +86635,48 @@ dpR
 dpR
 dpR
 gEZ
-ozI
+epa
+iKQ
 iKQ
 xRW
-owX
+gim
 jUB
 fUJ
 jUB
 xRW
 xRW
 xhA
-gfy
 wDm
-jBd
+rPG
 fME
 pWc
 bmK
+lZF
 xpu
-iKl
 fOQ
-ekD
-cQR
+fou
+nDb
 gnY
-vid
-cCx
+seJ
+iKl
 baZ
 wKm
 xMa
+rtf
 kdH
-vTk
-nMN
+kdH
 nTN
 bor
-wKm
-nHu
-kAb
+tzx
+xMa
+qVC
 dKo
 vsW
-vTk
+wNi
+xks
 kdH
-kFc
 ydE
+pja
 bEK
 bEK
 bEK
@@ -86378,7 +86710,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -86561,45 +86892,46 @@ gEZ
 gEZ
 gEZ
 gEZ
-ecp
-dFh
+eub
+iKQ
+iKQ
 jUB
 xRW
-fKn
-fDW
-jIe
+hac
+uSG
+gTT
 xRW
-kpo
+iyJ
 xhA
 iKl
-xgu
+fOQ
 xhA
-kiX
+kBT
 xhA
-edY
 qrl
-iKl
-eoE
+mII
+fOQ
 oLf
 lZJ
 trr
-bRk
+okm
+dHq
 iKl
-iFz
-iWJ
+mJJ
 mEv
+rvb
 iKl
-xpu
-oWr
-iFz
+iKl
+sLI
+mJJ
 xhA
-nHu
 qVC
 uWA
 bxX
-xgu
+vYx
+fOQ
 iKl
-sHk
+xIN
 xhA
 xhA
 xhA
@@ -86635,7 +86967,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -86773,11 +87104,11 @@ gEZ
 gEZ
 uIm
 hog
-dok
+eRI
 wJQ
 dEm
-pWr
-qWa
+eRI
+geb
 xNC
 jbP
 nnH
@@ -86813,55 +87144,56 @@ pyl
 bhq
 boI
 hDX
-bDi
+oVJ
 oIP
-iuX
+hPn
 guw
-sdz
+dVj
 mKE
-dFh
+eER
+iKQ
 jUB
 jUB
-jJd
 vxR
-qFm
+hIt
+hXf
 jUB
 jUB
 xhA
 iKl
-quR
+mxa
 xhA
-jfW
-kCj
-sPl
+kOa
+lgv
+lLy
 xpu
-bRk
-bRk
+qWx
+dHq
 iKl
 iKl
-bRk
 dHq
 iwO
 gnw
 xZI
 jVx
+rwk
 iKl
 iKl
-xpu
-edY
+reN
+sWu
 xhA
-nkL
-xGl
-iaI
-pFn
-xgu
+tJH
+upu
+vBG
+vIL
+fOQ
 iKl
-eAw
-xhA
-cIS
+jLX
+xMi
+poJ
 vOR
 vOR
-nEt
+jim
 xMi
 xMi
 uoO
@@ -86887,7 +87219,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -87033,8 +87364,8 @@ geb
 kPE
 geb
 sJm
-qpX
-hac
+pXB
+dXe
 ttW
 vqo
 btW
@@ -87069,14 +87400,15 @@ nzw
 nzw
 nzw
 nzw
-rRQ
+hPn
 qBQ
-hKI
+oVJ
 sdz
-sdz
-sdz
+oVJ
+oVJ
 tJM
-dFh
+eFE
+jQs
 gul
 gul
 gul
@@ -87084,38 +87416,38 @@ gul
 gul
 gul
 gul
-gul
+xhA
 iKl
-xgu
-eNT
-iKl
-xpu
-edY
-bRk
+fOQ
+klQ
 iKl
 xpu
+qrl
+dHq
+fOQ
+xpu
 iKl
 xpu
 xpu
-nBh
 qwp
 mNL
 wUr
+qOJ
 iKl
 iKl
-edY
-jJB
-axA
+iKl
+reN
+sXi
 xhA
-uJS
-xGl
-iaI
-pFn
-xgu
+tJT
+upu
+vBG
+vIL
+fOQ
 iKl
-sIK
-xhA
-cIS
+xVV
+xMi
+poJ
 xMi
 xMi
 xMi
@@ -87149,7 +87481,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -87288,10 +87619,10 @@ nLM
 geb
 pXB
 rmv
-nqE
+dXe
 hKx
 voZ
-cHA
+skL
 bNA
 bxG
 vgW
@@ -87326,61 +87657,62 @@ eQF
 pzO
 ecp
 hPn
-pNi
+hPn
 oOw
+oVJ
+sdz
+oVJ
+dWN
+oVJ
 eLG
-sdz
-sdz
-sdz
-coe
-dFh
-yhT
-gul
-jNt
+fdN
+fwX
 xjE
-sUs
+xjE
+xjE
 eME
 xDy
-gul
-huh
+izo
+xhA
 pxI
-eNT
+jOL
+klQ
 iKl
 tnF
 tnF
 iKl
+mxa
+qrl
 xpu
-edY
-xpu
-ilw
-rZw
-dUG
-bOf
+nWG
+fnD
+oNj
 fkd
-bOf
+qfB
+qWa
 iKl
 iKl
-edY
-jJB
+iKl
 reN
+sWu
 xhA
 xhA
 xhA
-iaI
-pFn
-xgu
+vBG
+vIL
+fOQ
 xpu
-rFc
-xhA
-aXP
+xCf
+xMi
+tLB
 xMi
 dyR
 dyR
 xMi
 xMi
-riR
+wLX
 uoO
-wEX
+tba
 uoO
 uoO
 uoO
@@ -87397,7 +87729,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -87547,7 +87878,7 @@ goR
 muD
 geb
 lXw
-lWm
+skL
 skL
 gEZ
 wKL
@@ -87573,7 +87904,7 @@ wOp
 uwA
 lpe
 tOi
-lAw
+aOT
 nXm
 lAw
 nXm
@@ -87584,60 +87915,61 @@ jEM
 rsj
 tFl
 hPn
+oVJ
+oVJ
+pzO
+sdz
 hPn
-itP
-hPn
-lAp
 hPn
 hPn
-hPn
-yhT
 gul
-rOp
-gul
-dJL
-pld
-nsY
+fxu
 gul
 hhZ
 gul
+pld
+pld
+iEg
+gul
+jBc
 gul
 xhA
 xhA
 xhA
 xhA
-fCf
 xhA
-fCf
+mTt
 xhA
-xhA
-dtm
+nEt
 xhA
 xhA
-tTB
+oWc
+xhA
+xhA
+qXo
 iKl
 iKl
-edY
-jJB
+iKl
 reN
+sWu
 xhA
 xhA
 xhA
-iVj
 uZS
 quR
+mxa
 iKl
-igV
-xhA
+xss
+xMi
 vOR
-uwV
+dIu
 sAL
 sAL
 xMi
 xMi
 xVz
 uoO
-wEX
+tba
 xVz
 xVz
 xVz
@@ -87654,7 +87986,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -87802,9 +88133,9 @@ gEZ
 vmx
 nUF
 pVA
-qWa
+geb
 snL
-qWa
+geb
 gEZ
 gEZ
 gEZ
@@ -87841,60 +88172,61 @@ lAw
 lAw
 onL
 hPn
-lAw
-oNj
-hPn
-tJH
-hPn
-hPn
-hPn
-yhT
+oVJ
+oVJ
+oVJ
+oVJ
+eaz
+eaz
+eVA
 gul
+fCf
 kzn
-gul
+hrq
 sgm
-sUy
 sUs
-ofQ
+sUs
+sUs
 ipv
+jEK
 vQx
-gul
+xhA
 mnj
-gxj
+lkT
 mnj
 mnj
-uMJ
-jSV
+ukT
 pNT
+nIl
 omp
 omp
-gxj
+lkT
 mnj
 xhA
-dVj
 wPy
-iYf
-xhA
-nGb
+tsq
+tsq
+tsq
+sPa
 xhA
 cZP
 cZP
-emg
-hxe
+peK
+uXY
 iKl
-xgu
+fOQ
 iKl
-rFc
-xhA
-aXP
+xCf
 xMi
-xnV
+tLB
+xMi
+tGt
 dyR
 xMi
 xMi
 xVz
 uoO
-wEX
+tba
 xVz
 xVz
 xVz
@@ -87908,7 +88240,7 @@ uoO
 uoO
 uoO
 xVz
-riR
+wLX
 uoO
 aoj
 uoO
@@ -87917,7 +88249,6 @@ uoO
 qxo
 qxo
 xVz
-uoO
 uoO
 uoO
 uoO
@@ -88099,59 +88430,60 @@ lAw
 lAw
 kQy
 wTF
-lAw
-dKk
 oVJ
-qXo
-shO
-dFh
-yhT
+oVJ
+oVJ
+oVJ
+oVJ
+jPi
 gul
-oEt
+fDp
 gul
-fqM
-dJL
-cLV
+huh
+gul
+oYG
+pld
+iJD
 vQx
 vQx
 vQx
-gul
+xhA
 mnj
-cEF
 uMJ
 cEF
 uMJ
 ukT
-pNT
-cEF
+nby
+nIl
 uMJ
 cEF
+uMJ
 mnj
-oja
 tKr
 vMi
-iYf
+ryL
 tsq
-sUH
+tsq
 gKJ
 cFi
 cFi
-emg
+cFi
 peK
+vdk
 xpu
-xgu
+fOQ
 iKl
-rFc
-xhA
+xCf
+xMi
 vOR
 xMi
 xMi
-kpd
+okP
 xMi
 xMi
 xVz
 uoO
-wEX
+tba
 xVz
 xVz
 xVz
@@ -88174,7 +88506,6 @@ qxo
 qxo
 qxo
 xVz
-uoO
 uoO
 uoO
 uoO
@@ -88356,51 +88687,52 @@ lAw
 lAw
 kQy
 wTF
-iYI
-dKk
+oVJ
+oVJ
 oVJ
 oVJ
 oVJ
 jPi
-jQs
 gul
-rOp
+fxu
 gul
-fqM
+gul
+gul
 oYG
 dxx
 cCv
+iVj
 vQx
 vQx
-nzl
+kpd
 mnj
 mnj
 omp
 omp
-uMJ
-mwJ
-pNT
+ukT
+neq
+nIl
 mnj
 mnj
 mnj
 mnj
 xhA
-mRK
 xRU
+rIS
+rIS
+sgI
 xhA
+tbg
 xhA
+tbg
 xhA
-xhA
-cFi
-eER
-xhA
-wyy
 uKn
-quR
+wmE
+mxa
 iKl
-igV
-xhA
-vdk
+xss
+xMi
+qKt
 xMi
 jFd
 paF
@@ -88408,7 +88740,7 @@ xMi
 xMi
 xVz
 uoO
-wEX
+tba
 xVz
 xVz
 xVz
@@ -88428,7 +88760,6 @@ qxo
 qxo
 qxo
 qxo
-uoO
 uoO
 uoO
 uoO
@@ -88613,51 +88944,52 @@ yeD
 iVx
 hPn
 eZX
-hPn
-qgO
-vfx
-seL
+cIS
 oVJ
+vfx
+oVJ
+cIS
 khb
-jNt
+jQs
 qOT
 oTk
+fwX
 gul
-fqM
-ohD
-ekb
+oYG
+vrD
+iKq
 vQx
-ydv
+jJd
 vQx
-gul
-ykT
-aSI
-uMJ
-cEF
-uMJ
-tGE
-pNT
-cEF
-uMJ
+xhA
 aSI
 qQS
+cEF
+uMJ
+ukT
+nkx
+nIl
+uMJ
+cEF
+qQS
+pXp
 xhA
-pAE
 tSH
+rJv
 xhA
 xhA
-sUH
-gKJ
-cFi
-cFi
 xhA
-uWA
-pFn
-xgu
+tcH
+xhA
+tcH
+xhA
+bxX
+vIL
+fOQ
 iKl
-rFc
-xhA
-kWH
+xCf
+xMi
+dVv
 xMi
 paF
 paF
@@ -88665,14 +88997,14 @@ xMi
 xMi
 xVz
 uoO
-wEX
+tba
 xVz
 xVz
 xVz
 xVz
 xVz
 xVz
-iZQ
+fDa
 xVz
 xVz
 xVz
@@ -88691,7 +89023,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -88849,7 +89180,7 @@ wOp
 wOp
 wOp
 sWB
-jrn
+ahx
 wOp
 kny
 bVY
@@ -88863,36 +89194,37 @@ buZ
 lAw
 qMO
 eRw
-lAw
+bmF
 lAw
 dVs
 lAw
 eHh
 hPn
 fqz
-tlr
-jyc
 oVJ
 jKo
-pwa
+aLN
+jKo
+oVJ
 hYT
-rOp
+jQs
+fxu
 gul
-sPa
-gul
-gul
-gul
+hyR
 gul
 gul
 gul
 gul
-nzl
+gul
+gul
+gul
+kpd
 roa
 roa
 roa
 roa
-rzQ
-koN
+kXA
+nkL
 eeH
 mpY
 mpY
@@ -88908,13 +89240,13 @@ xhA
 xhA
 xhA
 xhA
-ovQ
-jtk
-xgu
+vna
+vNU
+fOQ
 iKl
-rfD
-xhA
-kWH
+ydv
+xMi
+dVv
 xMi
 paF
 paF
@@ -88922,14 +89254,14 @@ xMi
 xMi
 xVz
 uoO
-wEX
+tba
 xVz
-bfh
 lIH
+bgZ
 xVz
 xVz
-eRg
 dWT
+qjv
 xVz
 xVz
 xVz
@@ -88939,7 +89271,6 @@ xVz
 uoO
 uoO
 qxo
-uoO
 uoO
 uoO
 uoO
@@ -89106,14 +89437,14 @@ wOp
 wOp
 wOp
 wOp
-sWB
-hSU
-gEZ
-iJD
-dWN
+ahx
+wOp
+kny
+bVY
+kxR
 vIu
 kkB
-wNi
+xCN
 pHQ
 lrP
 jtx
@@ -89126,69 +89457,70 @@ bdV
 fVx
 uWC
 hPn
-hwR
-hPn
+kAm
+cLp
 qbK
-oVJ
-oVJ
-oVJ
+pzO
+qbK
+cLp
 kAm
 pLl
+fKn
 gul
-vQZ
 tls
-tLs
-iIQ
+hKI
+hXn
 aBQ
 iAm
 aVV
+jJB
 gul
-gul
-rwk
+xhA
+kLA
 rKJ
 rKJ
 nIB
-eeH
 frn
 rzQ
 fuQ
 dZE
 hhn
+oWr
 eeH
-tJT
+qgO
 xcC
-xks
+rKE
 xcC
-xks
+rKE
 xcC
-slT
-dZz
-bki
+hHc
+uJx
+tJU
 xMi
 xMi
 xMi
-bFi
+wNs
 xMi
 xMi
 xMi
-dvK
+rzM
 xMi
 jFd
 jFd
 xMi
 xMi
-gbA
+dkT
 uoO
-wEX
+tba
 xVz
-cyA
+cAt
 qUL
 qUL
 qGe
-tkU
 ajJ
+upA
 rDr
-qZA
+wpH
 xVz
 xVz
 xVz
@@ -89202,7 +89534,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -89384,76 +89715,76 @@ hPn
 hPn
 hPn
 hPn
+cXG
 hPn
 hPn
-rIS
 hPn
-hPn
+cXG
 dFh
-rOp
+jQs
+fxu
 gul
-uvd
-tLs
+xmQ
 fYf
-iIQ
+hYI
 rJn
-iIQ
+iLO
 tCe
 qfu
 eSC
+mgt
 nIB
 jIm
 jIm
 nIB
-rzQ
 kXA
+nqE
 xpu
 xpu
 xpu
 xpu
-rzQ
+fuQ
 xhA
-cXG
+qYS
 cTh
 cTh
 cTh
 xcC
-rtf
 wbM
-iML
+srH
+tTB
 xMi
-lSl
 qqJ
 mEm
 oRZ
 qtL
 bKG
 fLF
+tzO
 xMi
-jNr
 eOx
+gWU
 xMi
 xMi
 xVz
 xVz
-xdB
+iZT
 xVz
-pKf
 oMK
 iGY
+eXg
 otf
 qxo
-oNu
 suF
 eRg
+dWT
 uiV
-qZA
+wpH
 xVz
 xVz
 xVz
 uoO
 qxo
-uoO
 uoO
 uoO
 uoO
@@ -89618,7 +89949,7 @@ gEZ
 gEZ
 gEZ
 gEZ
-gEZ
+bPW
 xSi
 tkD
 hUV
@@ -89626,7 +89957,7 @@ gEZ
 gEZ
 gEZ
 eEL
-pRD
+aCS
 eqD
 gEZ
 msV
@@ -89648,60 +89979,61 @@ hPn
 nWW
 liM
 nnN
+gcD
 gul
-uvd
 xmQ
 qKP
 vVg
-rJn
-iIQ
-rJn
+ilw
 oxw
-eSC
+iIQ
+oxw
+jOU
+mgt
 nIB
 nIB
+mcC
+kLU
+fOH
 eeH
 eeH
-eeH
-eeH
-eeH
-rWh
 kCz
+ovQ
 nIB
-aCS
+qci
 xhA
 xcC
 xYY
 xYY
 xYY
 xcC
-dZz
 uJx
 tnl
+tXw
 xMi
-mrV
 oRM
 llp
 tAi
 mrx
+ykT
 mTF
-qtD
+oDg
 xMi
 xMi
 xMi
 xMi
-nby
+jYS
 xVz
 xVz
 xVz
 xVz
-aHj
 nYw
 dur
 ofI
+eDN
 qxo
 qxo
-okm
+fox
 gTy
 gTy
 oaW
@@ -89713,7 +90045,6 @@ qxo
 uoO
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -89883,7 +90214,7 @@ qpd
 dLF
 gEZ
 iAs
-gEZ
+aHj
 oSq
 gEZ
 gEZ
@@ -89903,51 +90234,52 @@ hPn
 hPn
 hPn
 cna
-dFh
+weF
+jQs
 jQs
 gul
-uvd
-ohD
+xmQ
 vrD
+hZN
+iIQ
+oxw
+iIQ
 iIQ
 rJn
-iIQ
-iIQ
-iIQ
-njc
-eeH
-eeH
-eeH
+kpo
+kLU
+kLU
 fOH
 vDn
 sjR
 aCO
-fOH
-uLH
+nKk
+vDn
+ukP
 nIB
 eeH
-tJT
+qgO
 xcC
 xcC
 xcC
 xcC
 xcC
-wbM
 srH
 ksU
+ucQ
 xMi
-xnb
 rjQ
-dwW
+mrV
 wDq
 lMT
 ldP
 hQt
 vCL
+jpM
 gHi
 gHi
-cZm
-xYX
+rKa
+dzH
 xVz
 xVz
 xVz
@@ -89955,17 +90287,17 @@ uoO
 qxo
 otf
 oaW
-bri
+slo
 qxo
 qxo
 qxo
 qxo
 qxo
-xIN
+gEy
 qxo
 qxo
 qxo
-gSN
+wgN
 aoj
 uoO
 aoj
@@ -89973,7 +90305,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -90123,9 +90454,9 @@ uoO
 uoO
 uoO
 gEZ
-wOp
-wOp
-wOp
+xxn
+xxn
+xxn
 uZG
 xxn
 qLb
@@ -90160,51 +90491,52 @@ ehz
 dtO
 vKT
 cuN
-hPn
+eXJ
+gul
 yhT
 gul
 gul
 gul
 gul
 gul
-iiE
+iQt
 gul
-rJn
 oxw
-eSC
+jTD
+mgt
 pEG
 pEG
 nIB
-bEz
+mRK
 xcC
-lgv
+nwf
 xcC
-nNi
-uLH
+nXh
+ukP
 nIB
-aCS
+qci
 xhA
 xcC
 cTh
 cTh
 cTh
 xcC
-hHc
-uJx
-nYh
+thO
+tnl
+ufk
 xMi
-rjQ
 mrV
+oRM
 mTF
 mTF
-kic
 thr
+kbt
 aQg
-fwX
 xYX
+dzH
 gHi
-ogl
 alw
+mQQ
 xVz
 xVz
 xVz
@@ -90212,7 +90544,7 @@ uoO
 otf
 otf
 oaW
-bri
+slo
 qxo
 qxo
 qxo
@@ -90221,7 +90553,7 @@ qxo
 qxo
 qxo
 qxo
-rKE
+mIo
 uoO
 aoj
 uoO
@@ -90230,7 +90562,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -90381,9 +90712,9 @@ uoO
 uoO
 gEZ
 utP
-wOp
-hXn
-gEZ
+xxn
+xxn
+uZG
 xxn
 xxn
 xxn
@@ -90418,50 +90749,51 @@ hPn
 hPn
 hPn
 hPn
+gul
 yhT
 gul
-xGu
 qsM
 mTr
 dRA
-tLs
+xDy
+fYf
 gul
-azD
 bsF
-eSC
+jYe
 mgt
 bpH
+lqC
 nIB
 xcC
-gpl
 kGx
 umZ
 gsc
-uLH
+nYD
 ukP
+pfC
 eeH
 xhA
-cXG
+qYS
 xYY
 xYY
 xYY
 xcC
-nWG
-wbM
-iML
+tkU
+srH
+tTB
 xMi
-tbg
 olK
-qdU
+sUF
+wPV
 mTF
-qoi
+apA
 xMi
-nDb
-xMi
-xMi
+vqd
 xMi
 xMi
-nby
+xMi
+xMi
+jYS
 xVz
 xVz
 xVz
@@ -90487,7 +90819,6 @@ aoj
 aoj
 aoj
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -90637,9 +90968,9 @@ uoO
 uoO
 uoO
 gEZ
-oWc
-wOp
-lqC
+gEZ
+abY
+gEZ
 gEZ
 dJD
 nMR
@@ -90658,8 +90989,8 @@ gEZ
 gEZ
 gEZ
 tem
-ftF
-ftF
+quB
+quB
 gEZ
 msV
 vXo
@@ -90674,18 +91005,19 @@ keH
 xak
 igo
 weF
-vXo
+weF
+yhT
 yhT
 gul
-mTj
-qsM
+hhZ
+mTr
 gul
-gTT
-xDy
+isG
+izo
 gul
-vqH
 cLJ
-gul
+jYP
+xhA
 xhA
 xhA
 xhA
@@ -90697,40 +91029,40 @@ xhA
 xhA
 xhA
 eeH
-jyg
+qid
 xcC
-umZ
+gsc
 xcC
-umZ
+gsc
 xcC
-slT
 hHc
-bki
+thO
+tJU
 xMi
-rvb
 scG
-olK
-mzu
-olK
+wuE
+sUF
+xnb
 sUF
 cej
+qVt
 aQg
 aQg
-snJ
+jYV
 xMi
 xMi
 xVz
 xVz
 xVz
 xVz
-ahx
+yjX
 otf
 oaW
 qxo
-keR
+dFw
 qxo
-oNu
-dWT
+suF
+qjv
 oaW
 oaW
 oaW
@@ -90738,7 +91070,6 @@ xVz
 xVz
 uoO
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -90894,9 +91225,9 @@ uoO
 uoO
 uoO
 gEZ
-eoA
-iQt
-wOp
+fpv
+xxn
+xxn
 gEZ
 rUF
 xxn
@@ -90916,7 +91247,7 @@ pRD
 hoz
 pjX
 vTF
-ftF
+quB
 gEZ
 msV
 hPn
@@ -90930,8 +91261,8 @@ oGc
 bKi
 xly
 oHT
-nwf
-hPn
+weF
+fcn
 gul
 gul
 gul
@@ -90943,6 +91274,7 @@ gul
 gul
 gul
 gul
+xhA
 xhA
 xhA
 xhA
@@ -90964,36 +91296,35 @@ xhA
 xhA
 xhA
 xMi
-dnM
+vqm
 xMi
-cLp
+wQJ
 xMi
-kLU
+rpa
 xMi
-ftt
 dTR
-cej
+lPw
 qVt
+qXI
 xMi
 xMi
 xVz
-wEX
+tba
 xVz
-wxb
+nNW
 xVz
-nYw
-iGY
-ofI
+dur
+eXg
+eDN
 qxo
-eBP
 oNu
-ajJ
+suF
 upA
+lFJ
 oaW
 xVz
 xVz
-sXP
-uoO
+iki
 uoO
 uoO
 uoO
@@ -91153,7 +91484,7 @@ uoO
 gEZ
 fpv
 dUW
-jYe
+xxn
 gEZ
 lHS
 mrX
@@ -91187,9 +91518,10 @@ pBa
 huv
 eQh
 weF
-wFF
-hPn
-uoO
+weF
+eXJ
+fqM
+gcY
 yhT
 yhT
 yhT
@@ -91199,7 +91531,7 @@ yhT
 yhT
 yhT
 yhT
-yhT
+kKy
 kKy
 kKy
 kKy
@@ -91221,7 +91553,7 @@ kKy
 kKy
 kKy
 wox
-klQ
+vqH
 iXC
 iXC
 iXC
@@ -91233,19 +91565,18 @@ xMi
 xMi
 xMi
 wox
-wEX
+tba
 uoO
-cmy
 vxo
 isU
+kQI
 uoO
-mTt
+frL
 xVz
-nIl
 gbA
 dkT
 kqS
-uoO
+eHg
 uoO
 uoO
 uoO
@@ -91446,6 +91777,7 @@ dFh
 dFh
 dFh
 dFh
+ftt
 eLE
 eLE
 eLE
@@ -91490,7 +91822,6 @@ wox
 wox
 wox
 wox
-eLE
 eLE
 eLE
 eLE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -70,6 +70,22 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"acv" = (
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster82";
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/stool/f13stool,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/mining)
 "acJ" = (
 /obj/structure/sign/poster/prewar/poster74,
 /turf/closed/wall/r_wall,
@@ -112,7 +128,6 @@
 	dir = 1;
 	layer = 3.1
 	},
-/obj/machinery/light/small,
 /turf/open/water,
 /area/f13/brotherhood/offices1st)
 "aeN" = (
@@ -190,7 +205,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
 /area/f13/brotherhood/operations)
 "ahB" = (
 /obj/structure/dresser,
@@ -293,6 +310,10 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"amf" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aoj" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
@@ -312,14 +333,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"apA" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 1
-	},
-/area/f13/brotherhood/mining)
 "aqn" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/f13/vault,
@@ -334,20 +347,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"aqR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/power/smes/engineering,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "aqX" = (
 /obj/structure/chair/f13foldupchair,
 /obj/machinery/light/small{
@@ -614,6 +613,9 @@
 "aHj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
@@ -884,18 +886,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
-"aYO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "aYS" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -1059,6 +1049,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"bdK" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Power Stores";
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "bdP" = (
 /obj/structure/table{
 	layer = 2.9
@@ -1135,10 +1135,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"bgZ" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "bhe" = (
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -1222,6 +1218,19 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"ble" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "blH" = (
 /obj/structure/table,
 /obj/item/multitool,
@@ -1452,6 +1461,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"bum" = (
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/mining)
 "buo" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -1647,6 +1665,12 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
+"bCX" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "bDi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -1739,16 +1763,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
-"bGL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "AUX"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "bGU" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -1842,6 +1856,19 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
+"bKw" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bosengineaccess";
+	name = "Engine Access Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 4
+	},
+/area/f13/brotherhood/reactor)
 "bKG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1988,6 +2015,14 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
+"bTu" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/atmos,
+/obj/item/twohanded/fireaxe,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/mining)
 "bTG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -2290,6 +2325,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"clA" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "clT" = (
 /obj/structure/sign/poster/prewar/poster83,
 /turf/closed/wall/r_wall,
@@ -2584,6 +2626,12 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"czn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 10
+	},
+/area/f13/brotherhood/reactor)
 "czF" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13{
@@ -2595,14 +2643,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/sewer)
-"cAt" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
-/area/f13/caves)
 "cAB" = (
 /obj/structure/chair/f13chair1{
 	dir = 1
@@ -2743,6 +2783,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"cHw" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
+	},
+/area/f13/caves)
 "cHA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -2991,6 +3038,16 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"cUC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "AUX"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "cWd" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/indestructible/ground/inside/subway,
@@ -3052,6 +3109,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/rnd)
+"daK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "dbk" = (
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/pet/dog/pug{
@@ -3070,6 +3139,13 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
+"dcf" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "dcg" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 30;
@@ -3103,6 +3179,21 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"ddQ" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
+	dir = 4
+	},
+/area/f13/brotherhood/mining)
 "dek" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -3210,6 +3301,13 @@
 /area/f13/sewer)
 "dkT" = (
 /obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"dlw" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dlz" = (
@@ -3473,14 +3571,6 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/mining)
-"dzH" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
 "dzJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -3579,11 +3669,6 @@
 	icon_state = "r_wall"
 	},
 /area/f13/brotherhood/medical)
-"dFw" = (
-/obj/structure/glowshroom/single,
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "dFz" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/f13/wood{
@@ -3633,14 +3718,18 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "dHq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Secret"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"dIu" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/offices1st)
 "dID" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/f13/tunnel,
@@ -3705,18 +3794,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dKk" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/closet/crate/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Secret"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/medical)
 "dKm" = (
 /obj/effect/landmark/start/f13/seniorknight,
 /obj/effect/decal/cleanable/dirt,
@@ -4113,16 +4195,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "dUW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/obj/machinery/button/crematorium{
+	pixel_x = 22
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
+"dVj" = (
+/obj/machinery/sleeper{
+	density = 1;
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"dVj" = (
-/obj/structure/closet/crate/medical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -4134,13 +4218,6 @@
 /obj/structure/window/fulltile/store,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
-"dVv" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
 "dVB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
@@ -4160,13 +4237,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dWN" = (
-/obj/machinery/button/crematorium{
-	pixel_x = 22
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/paladin,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "dWT" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/plating/ashplanet/wateryrock{
@@ -4300,14 +4382,15 @@
 	},
 /area/f13/tunnel)
 "eaz" = (
-/obj/machinery/sleeper{
-	density = 1;
-	dir = 4
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/offices1st)
 "eaR" = (
 /obj/structure/frame/machine,
 /obj/structure/cable{
@@ -4391,6 +4474,15 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"eeW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 6
+	},
+/area/f13/brotherhood/mining)
 "eeX" = (
 /obj/effect/decal/fakelattice{
 	density = 0;
@@ -4516,14 +4608,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/tunnel)
-"ekP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "elU" = (
 /obj/effect/decal/cleanable/blood/splats,
 /turf/open/floor/f13{
@@ -4531,18 +4615,14 @@
 	},
 /area/f13/bunker)
 "emg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/paladin,
+/obj/structure/simple_door/metal/ventilation,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/medical)
 "emX" = (
 /obj/structure/table/glass,
 /obj/item/pda,
@@ -4581,15 +4661,22 @@
 	},
 /area/f13/tunnel)
 "epa" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/kitchenspike_frame{
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/offices1st)
+"epe" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "epH" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4669,12 +4756,6 @@
 /obj/structure/sign/poster/prewar/poster60,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
-"etu" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "etN" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -4684,14 +4765,12 @@
 	},
 /area/f13/tunnel)
 "eub" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/bed/pod,
+/obj/item/bedsheet/ce,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/offices1st)
 "eug" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -4700,16 +4779,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "euS" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "euY" = (
 /turf/open/indestructible/ground/inside/dirt,
@@ -4807,11 +4882,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "eAw" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/ce,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/lattice{
+	layer = 3
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "eAO" = (
 /obj/item/flag/bos,
@@ -4856,27 +4934,30 @@
 	},
 /area/f13/building)
 "eBP" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/bodycontainer/crematorium{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/offices1st)
 "eCr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCv" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/ash/crematorium,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "eCE" = (
 /obj/structure/barricade/bars{
 	layer = 5
@@ -4906,6 +4987,18 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
+"eDs" = (
+/obj/structure/simple_door/bunker/glass{
+	name = "Mining Storeroom";
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/mining)
 "eDu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4928,13 +5021,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"eDN" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "eDV" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
@@ -4952,22 +5038,38 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "eER" = (
-/obj/structure/bodycontainer/crematorium{
-	dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/storage/box/lights/tubes,
+/obj/item/storage/box/lights/bulbs,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/lipstick/black,
+/obj/item/storage/box/bodybags{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/item/pda/medical{
+	name = "Scribe-Medic Pip-Boy 3000"
+	},
+/obj/item/pda/medical{
+	name = "Scribe-Medic Pip-Boy 3000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/medical)
 "eFE" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/ash/large,
-/obj/effect/decal/cleanable/ash/crematorium,
+/obj/item/kirbyplants{
+	pixel_y = 14
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -5011,10 +5113,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"eHg" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "eHh" = (
 /obj/structure/decoration/smokeold{
 	pixel_y = -31
@@ -5043,6 +5141,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"eIJ" = (
+/obj/structure/destructible/clockwork/wall_gear,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/mining)
 "eIU" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
@@ -5070,30 +5172,9 @@
 /turf/closed/indestructible/rock,
 /area/f13/caves)
 "eLG" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/box/lights/tubes,
-/obj/item/storage/box/lights/bulbs,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/lipstick/black,
-/obj/item/storage/box/bodybags{
-	pixel_x = -9;
-	pixel_y = 12
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/item/pda/medical{
-	name = "Scribe-Medic Pip-Boy 3000"
-	},
-/obj/item/pda/medical{
-	name = "Scribe-Medic Pip-Boy 3000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "eLI" = (
 /mob/living/simple_animal/hostile/raider/ranged,
@@ -5183,6 +5264,11 @@
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
+"eQL" = (
+/obj/structure/glowshroom/single,
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "eRg" = (
 /obj/structure/flora/junglebush,
 /obj/structure/bus_door,
@@ -5232,12 +5318,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
-"eSS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 10
-	},
-/area/f13/brotherhood/reactor)
 "eTv" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -5277,15 +5357,10 @@
 	},
 /area/f13/brotherhood/reactor)
 "eVA" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/kirbyplants{
-	pixel_y = 14
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "eWj" = (
 /turf/open/floor/f13{
@@ -5308,20 +5383,16 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"eXg" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
-/area/f13/caves)
 "eXJ" = (
+/obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "eXS" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -5362,6 +5433,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"fai" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/power/smes/engineering,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "faR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/radiation{
@@ -5395,21 +5480,14 @@
 	},
 /area/f13/brotherhood/reactor)
 "fcn" = (
-/obj/structure/frame/machine,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "fdN" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/closed/indestructible/opshuttle{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/caves)
 "feo" = (
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -5510,6 +5588,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"fkn" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "fkv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -5616,10 +5701,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"fox" = (
-/obj/structure/debris/v2,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "fpv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -5656,8 +5737,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
 "fqM" = (
-/turf/closed/wall/r_wall,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/offices2nd)
 "fqU" = (
 /obj/item/flag/bos,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -5683,23 +5768,16 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
-"frL" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/structure/glowshroom/single,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "frS" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "ftt" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/caves)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/offices2nd)
 "ftF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -5757,7 +5835,18 @@
 "fwX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
@@ -5777,6 +5866,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/shreds,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "fxA" = (
@@ -5818,10 +5908,20 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"fze" = (
+/obj/structure/falsewall/reinforced{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/mining)
 "fzR" = (
 /obj/structure/sign/poster/prewar/poster93,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
+"fzT" = (
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fAs" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -5863,20 +5963,10 @@
 	},
 /area/f13/brotherhood/offices1st)
 "fCf" = (
+/obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
@@ -5888,10 +5978,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"fDa" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "fDi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/terminal{
@@ -5905,9 +5991,9 @@
 "fDp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/shreds,
+/obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "fDw" = (
@@ -5946,6 +6032,14 @@
 	name = "floor"
 	},
 /area/f13/brotherhood/rnd)
+"fEs" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fEB" = (
 /obj/machinery/light{
 	dir = 1
@@ -5982,14 +6076,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"fFV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fGA" = (
 /turf/open/floor/f13{
@@ -6042,20 +6128,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
-"fJm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/structure/sink/kitchen{
-	desc = "Strictly For filling Up mop buckets.";
-	dir = 8;
-	name = "Mop Sink";
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "fJw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
@@ -6083,12 +6155,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "fKn" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/f13/inside,
+/turf/closed/mineral/random/low_chance,
 /area/f13/brotherhood/offices2nd)
 "fKq" = (
 /obj/structure/chair/booth{
@@ -6194,13 +6261,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
-"fOQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fOZ" = (
 /obj/machinery/door/airlock/abandoned,
@@ -6344,6 +6404,10 @@
 /obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
+"fZB" = (
+/obj/effect/temp_visual/steam_release,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "fZG" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -6399,12 +6463,10 @@
 	},
 /area/f13/followers)
 "gcD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/plating/f13/inside,
+/obj/structure/rack,
+/obj/item/clothing/under/misc/bathrobe,
+/obj/item/clothing/under/misc/bathrobe,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
 "gcK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6413,8 +6475,10 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "gcY" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/destructible/clockwork/wall_gear,
+/obj/item/projectile/magic/animate,
+/turf/closed/wall/f13/wood,
+/area/f13/brotherhood/rnd)
 "geb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -6431,10 +6495,13 @@
 /turf/open/water,
 /area/f13/tunnel)
 "gfy" = (
-/obj/structure/rack,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/under/misc/bathrobe,
-/turf/closed/wall/r_wall,
+/obj/structure/chair/bench,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
+	},
 /area/f13/brotherhood/offices2nd)
 "gfz" = (
 /obj/structure/bed/pod,
@@ -6502,10 +6569,20 @@
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
 "gim" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/animate,
-/turf/closed/wall/f13/wood,
-/area/f13/brotherhood/rnd)
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "giA" = (
 /obj/structure/table/snooker{
 	dir = 10
@@ -6520,13 +6597,12 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "gjB" = (
-/obj/structure/chair/bench,
+/obj/structure/bed/pod,
+/obj/item/bedsheet/hos,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "gjQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6620,18 +6696,7 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "goG" = (
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/obj/structure/dresser,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "goQ" = (
@@ -6648,10 +6713,10 @@
 	},
 /area/f13/brotherhood/operations)
 "gpl" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/hos,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
@@ -6686,9 +6751,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "gsw" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/item/candle{
+	pixel_x = 7
+	},
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
+	},
+/area/f13/brotherhood/rnd)
 "gsQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice{
@@ -6747,13 +6817,15 @@
 	},
 /area/f13/tunnel)
 "gxj" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
+/obj/item/candle{
+	pixel_x = 7;
+	pixel_y = 7
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
+	},
+/area/f13/brotherhood/rnd)
 "gyf" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/closed/wall/r_wall/rust,
@@ -6762,6 +6834,13 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gyp" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "gyB" = (
 /obj/effect/landmark/start/f13/dendoc,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -6875,10 +6954,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
-"gEy" = (
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "gED" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/supermart,
@@ -6951,16 +7026,6 @@
 /obj/effect/landmark/start/f13/prospector,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"gJW" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "gKc" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -7022,7 +7087,8 @@
 /area/f13/clinic)
 "gNG" = (
 /obj/item/candle{
-	pixel_x = 7
+	pixel_x = -6;
+	pixel_y = 7
 	},
 /turf/open/floor/clockwork/reebe{
 	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
@@ -7105,8 +7171,7 @@
 /area/f13/tunnel)
 "gSN" = (
 /obj/item/candle{
-	pixel_x = 7;
-	pixel_y = 7
+	pixel_x = -7
 	},
 /turf/open/floor/clockwork/reebe{
 	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
@@ -7126,15 +7191,15 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "gTT" = (
-/obj/item/candle{
-	pixel_x = -6;
-	pixel_y = 7
+/obj/machinery/shower{
+	pixel_y = 27
 	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/area/f13/brotherhood/rnd)
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/offices2nd)
 "gUf" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
@@ -7186,10 +7251,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
-"gWU" = (
-/obj/structure/bookcase/random,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood/mining)
 "gXb" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -7221,17 +7282,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"gZt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "gZx" = (
 /obj/structure/table/wood,
 /obj/item/toy/crayon/spraycan,
@@ -7244,14 +7294,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "hac" = (
-/obj/item/candle{
-	pixel_x = -7
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/offices2nd)
 "han" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light/small/broken{
@@ -7269,6 +7316,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
+"haW" = (
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/brotherhood/mining)
 "hbQ" = (
 /obj/structure/table/booth,
 /obj/item/flashlight,
@@ -7443,14 +7501,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "hhZ" = (
-/obj/machinery/shower{
-	pixel_y = 27
+/obj/structure/toilet{
+	pixel_y = 10
 	},
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/offices2nd)
 "hil" = (
 /obj/structure/table/wood/settler,
@@ -7550,6 +7607,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"hnU" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
+	},
+/area/f13/caves)
 "hog" = (
 /obj/structure/table{
 	layer = 2.9
@@ -7643,10 +7706,10 @@
 /area/f13/brotherhood/leisure)
 "hpT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -7695,10 +7758,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "hrq" = (
+/obj/structure/simple_door/metal/ventilation,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "hrv" = (
 /obj/structure/lattice/catwalk,
@@ -7748,13 +7812,14 @@
 /turf/open/water,
 /area/f13/tunnel)
 "huh" = (
-/obj/structure/toilet{
-	pixel_y = 10
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4
+	dir = 4;
+	light_color = "red"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/offices2nd)
 "huv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7805,12 +7870,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hyR" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/floor{
+	critical_machine = 1;
+	flicker_chance = 0
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/wood,
+/area/f13/brotherhood/rnd)
 "hzg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -7848,15 +7913,16 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/leisure)
 "hBC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/structure/destructible/clockwork/wall_gear{
+	pixel_x = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/item/projectile/magic/animate{
+	pixel_x = 32
 	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/bronze{
+	name = "floor"
+	},
+/area/f13/brotherhood/rnd)
 "hBF" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -7941,12 +8007,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "hGF" = (
-/obj/machinery/light/floor{
-	critical_machine = 1;
-	flicker_chance = 0
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "hHc" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "stagestairs2"
@@ -7989,16 +8058,26 @@
 	},
 /area/f13/followers)
 "hIt" = (
-/obj/structure/destructible/clockwork/wall_gear{
-	pixel_x = 32
+/obj/structure/rack,
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = -7
 	},
-/obj/item/projectile/magic/animate{
-	pixel_x = 32
+/obj/item/reagent_containers/rag/towel{
+	pixel_y = -3
 	},
-/turf/open/floor/bronze{
-	name = "floor"
+/obj/item/reagent_containers/rag/towel,
+/obj/machinery/button/door{
+	id = "proctorbathroom";
+	name = "Bathroom Lock";
+	normaldoorcontrol = 1;
+	pixel_y = -32;
+	req_one_access_txt = "120";
+	specialfunctions = 4
 	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "hIy" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plastic/fifty,
@@ -8041,34 +8120,23 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "hKI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"hKS" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/rag/towel{
-	pixel_y = -7
-	},
-/obj/item/reagent_containers/rag/towel{
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/rag/towel,
-/obj/machinery/button/door{
-	id = "proctorbathroom";
-	name = "Bathroom Lock";
-	normaldoorcontrol = 1;
-	pixel_y = -32;
-	req_one_access_txt = "120";
-	specialfunctions = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whiterustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
+"hKS" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood/offices2nd)
 "hLd" = (
@@ -8133,6 +8201,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"hNm" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "hNq" = (
 /obj/item/defibrillator/loaded,
 /obj/item/storage/box/syringes,
@@ -8169,12 +8241,10 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "hOJ" = (
-/obj/structure/window/reinforced/tinted/frosted{
+/obj/structure/chair/stool/retro/backed{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "hOR" = (
 /obj/structure/girder,
@@ -8186,24 +8256,17 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"hOX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "hPn" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "hPD" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1
+/obj/structure/bookcase/random,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
 /turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
 "hPF" = (
@@ -8253,11 +8316,22 @@
 	},
 /area/f13/bunker)
 "hSU" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
+/obj/item/candle{
+	pixel_y = -7
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/circuit/red/anim{
+	light_range = 2.5
+	},
+/area/f13/brotherhood/rnd)
+"hTD" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
+	},
+/area/f13/caves)
 "hUn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -8300,14 +8374,11 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices1st)
 "hVy" = (
-/obj/structure/bookcase/random,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "hVV" = (
 /obj/machinery/light{
@@ -8343,18 +8414,26 @@
 	},
 /area/f13/bunker)
 "hXf" = (
-/obj/item/candle{
-	pixel_y = -7
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
 	},
-/area/f13/brotherhood/rnd)
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/item/pen/fountain{
+	pixel_x = 15;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "hXn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "hYh" = (
@@ -8369,19 +8448,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "hYI" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/door/airlock/grunge{
+	id_tag = "proctorbathroom";
+	req_access_txt = "120"
 	},
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/item/pen/fountain{
-	pixel_x = 15;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "hYS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8413,13 +8486,14 @@
 	},
 /area/f13/brotherhood/medical)
 "hZN" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowhorizontal"
 	},
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "ias" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/leather/twenty,
@@ -8556,13 +8630,14 @@
 /area/f13/tunnel)
 "ifX" = (
 /obj/machinery/door/airlock/grunge{
-	id_tag = "proctorbathroom";
+	name = "Proctor's Office";
 	req_access_txt = "120"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/rnd)
 "igo" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -8599,14 +8674,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "igV" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowhorizontal"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices2nd)
 "ihg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -8630,15 +8708,14 @@
 	},
 /area/f13/clinic)
 "iiE" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Proctor's Office";
-	req_access_txt = "120"
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "iiZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -8650,10 +8727,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
-"iki" = (
-/obj/structure/glowshroom/single,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "ikD" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -8706,16 +8779,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "ilw" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
+/obj/effect/landmark/start/f13/seniorscribe,
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "imc" = (
 /obj/effect/decal/cleanable/generic,
@@ -8862,12 +8930,14 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "isG" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Business"
 	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "isJ" = (
@@ -8898,11 +8968,14 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "itP" = (
-/obj/effect/landmark/start/f13/seniorscribe,
-/obj/structure/chair/office/dark{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	name = "Proctor's Office";
+	req_access_txt = "120"
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/offices2nd)
 "itV" = (
 /obj/machinery/vending/coffee,
@@ -8924,25 +8997,34 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "iuL" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Business"
+/obj/structure/table/wood,
+/obj/item/lighter{
+	color = "#3e4821";
+	desc = "That's one fancy Zippo!";
+	heat = 2500;
+	icon_state = "lighter_overlay_plain";
+	light_power = 2;
+	light_range = 1;
+	name = "Pre-War Military Lighter";
+	pixel_x = 7;
+	pixel_y = -6
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/storage/fancy/candle_box{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/item/storage/fancy/candle_box{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/open/floor/circuit/red/anim{
+	light_range = 2.5
+	},
+/area/f13/brotherhood/rnd)
 "iuX" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Proctor's Office";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/bed/pod,
+/obj/item/bedsheet/hos,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "ivj" = (
 /obj/structure/chair/wood{
@@ -8969,13 +9051,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "iwO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/item/clothing/accessory/bos/elder,
+/obj/item/clothing/suit/f13/elder,
+/obj/item/pda/heads/hop{
+	name = "Elder's PDA"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "ixT" = (
 /obj/structure/rack,
 /obj/item/book/granter/crafting_recipe/gunsmith_one,
@@ -8993,33 +9079,21 @@
 	},
 /area/f13/tunnel)
 "iyJ" = (
-/obj/structure/table/wood,
-/obj/item/lighter{
-	color = "#3e4821";
-	desc = "That's one fancy Zippo!";
-	heat = 2500;
-	icon_state = "lighter_overlay_plain";
-	light_power = 2;
-	light_range = 1;
-	name = "Pre-War Military Lighter";
-	pixel_x = 7;
-	pixel_y = -6
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
 	},
-/obj/item/storage/fancy/candle_box{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/item/pen/fountain/captain{
+	name = "elder's fountain pen"
 	},
-/obj/item/storage/fancy/candle_box{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "izo" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/hos,
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
+	},
+/obj/item/documents/syndicate/blue,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "izq" = (
@@ -9077,6 +9151,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"iAx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 8
+	},
+/area/f13/brotherhood/mining)
 "iAY" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9120,16 +9201,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "iEg" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/clothing/accessory/bos/elder,
-/obj/item/clothing/suit/f13/elder,
-/obj/item/pda/heads/hop{
-	name = "Elder's PDA"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "iER" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9185,14 +9262,14 @@
 	},
 /area/f13/clinic)
 "iJD" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	id_tag = null;
+	req_access_txt = "120"
 	},
-/obj/item/pen/fountain/captain{
-	name = "elder's fountain pen"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "iJK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9213,13 +9290,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "iKq" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
 	},
-/obj/item/documents/syndicate/blue,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "iKB" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/chemistry,
@@ -9234,12 +9311,13 @@
 	},
 /area/f13/brotherhood/offices1st)
 "iLO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
+/turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
 "iMc" = (
 /obj/structure/cable{
@@ -9321,15 +9399,9 @@
 /turf/closed/wall/f13/store,
 /area/f13/followers)
 "iQt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = null;
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
+/obj/structure/dresser,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/rnd)
 "iQC" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/f13{
@@ -9398,12 +9470,9 @@
 	},
 /area/f13/bunker)
 "iST" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/bedsheet/hos,
+/obj/structure/bed/pod,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "iTb" = (
 /obj/structure/mopbucket,
@@ -9444,14 +9513,22 @@
 	},
 /area/f13/bunker)
 "iVj" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/rnd)
 "iVx" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -9495,8 +9572,10 @@
 	},
 /area/f13/tunnel)
 "iWR" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
+/obj/structure/rack,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "iXC" = (
 /obj/machinery/conveyor/auto{
@@ -9533,9 +9612,10 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "iYI" = (
-/obj/item/bedsheet/hos,
-/obj/structure/bed/pod,
-/turf/open/floor/carpet/black,
+/obj/structure/bookcase/random,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "iYX" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -9571,29 +9651,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "iZQ" = (
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = 32
 	},
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"iZT" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "jak" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
@@ -9643,7 +9709,11 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "jdN" = (
-/obj/structure/rack,
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -9695,10 +9765,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "jfW" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "jga" = (
 /obj/structure/bed/mattress{
@@ -9727,14 +9797,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "jgL" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = 32
+/obj/item/kirbyplants/photosynthetic,
+/obj/structure/decoration/hatch{
+	desc = "That's pretty nifty.";
+	dir = 1;
+	name = "Plant Water Drain";
+	pixel_y = -13
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "jgP" = (
 /obj/structure/bed/roller,
@@ -9771,10 +9841,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"jim" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
 "jiL" = (
 /obj/effect/landmark/map_load_mark/dungeons/northsewer,
 /turf/closed/mineral/random/low_chance,
@@ -9835,13 +9901,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "jnO" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/item/card/id/dogtag{
+	desc = "Never thirsty is the grave of the fallen Brother, for their kin floods the ground with the blood of the blind.";
+	name = "The Fallen Brother's Holotags";
+	pixel_y = -2
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/item/clothing/glasses/sunglasses/blindfold{
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/blackred,
+/obj/item/candle{
+	pixel_x = 7;
+	pixel_y = 13
+	},
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
 	},
 /area/f13/brotherhood/rnd)
 "jpg" = (
@@ -9849,15 +9925,6 @@
 /obj/item/bedsheet/brown,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"jpM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 6
-	},
-/area/f13/brotherhood/mining)
 "jqx" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -9883,7 +9950,6 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "jrn" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -9926,11 +9992,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"jsL" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "jtx" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10045,21 +10106,21 @@
 	},
 /area/f13/followers)
 "jyc" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/vault{
+	name = "Elder'S Office";
+	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices2nd)
 "jyg" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/structure/decoration/hatch{
-	desc = "That's pretty nifty.";
-	dir = 1;
-	name = "Plant Water Drain";
-	pixel_y = -13
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices2nd)
 "jyZ" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/structure/window/spawner,
@@ -10085,26 +10146,33 @@
 	dir = 8
 	},
 /area/f13/brotherhood/reactor)
+"jzC" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "jzX" = (
-/obj/item/card/id/dogtag{
-	desc = "Never thirsty is the grave of the fallen Brother, for their kin floods the ground with the blood of the blind.";
-	name = "The Fallen Brother's Holotags";
-	pixel_y = -2
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/clothing/glasses/sunglasses/blindfold{
-	pixel_y = 2
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices2nd)
+"jAd" = (
+/obj/structure/debris/v3{
+	layer = 2
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/fancy/blackred,
-/obj/item/candle{
-	pixel_x = 7;
-	pixel_y = 13
+/turf/open/indestructible/ground/outside/water{
+	density = 1;
+	desc = "Deep lake water, filled with who knows what...";
+	name = "lake water"
 	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/rnd)
+/area/f13/caves)
 "jAZ" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
@@ -10112,14 +10180,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jBc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/vault{
-	name = "Elder'S Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/wood/fancy/black,
+/obj/item/construction/rcd/loaded,
+/obj/item/construction/rld,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "jBU" = (
 /obj/effect/decal/cleanable/oil,
@@ -10147,11 +10213,9 @@
 	},
 /area/f13/brotherhood/operations)
 "jEK" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "jEM" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/item/hand_labeler,
@@ -10247,19 +10311,17 @@
 	},
 /area/f13/brotherhood/rnd)
 "jJd" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
-"jJB" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/construction/rcd/loaded,
-/obj/item/construction/rld,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/clockwork/reebe{
+	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
+	name = "cool metal floor"
+	},
+/area/f13/brotherhood/rnd)
+"jJB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "jJM" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -10301,7 +10363,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jLX" = (
-/obj/machinery/vending/coffee,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "jMM" = (
@@ -10332,12 +10396,18 @@
 	},
 /area/f13/bunker)
 "jNr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
-/area/f13/brotherhood/rnd)
+/obj/item/kirbyplants/photosynthetic,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "jNA" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -10378,20 +10448,24 @@
 	},
 /area/f13/brotherhood/leisure)
 "jOL" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"jOU" = (
 /obj/structure/curtain{
 	color = "#5c131b";
 	pixel_y = -32
 	},
 /obj/item/kirbyplants/photosynthetic,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
+/area/f13/brotherhood/offices2nd)
+"jOU" = (
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
@@ -10535,11 +10609,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jTD" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
+/obj/machinery/button/door{
+	id = "headscribedorm";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = -24;
+	specialfunctions = 4
 	},
-/obj/item/kirbyplants/photosynthetic,
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
@@ -10596,19 +10677,24 @@
 /obj/effect/landmark/start/f13/detective,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"jXu" = (
+/obj/structure/sign/poster/contraband/hacking_guide,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "jYe" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/structure/chair/sofa/corp/right{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/structure/sign/poster/contraband/tools{
+	pixel_y = 31
 	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/rnd)
 "jYi" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -10660,35 +10746,11 @@
 	},
 /area/f13/followers)
 "jYP" = (
-/obj/machinery/button/door{
-	id = "headscribedorm";
-	normaldoorcontrol = 1;
-	pixel_x = -8;
-	pixel_y = -24;
-	specialfunctions = 4
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
-"jYS" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/mining)
-"jYV" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/rnd)
 "jZf" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -10701,13 +10763,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jZg" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/poster/contraband/tools{
+/obj/machinery/vending/tool,
+/obj/structure/sign/poster/contraband/rip_badger{
+	pixel_x = 14;
 	pixel_y = 31
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -10724,13 +10782,6 @@
 /obj/item/statuebust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"kap" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "kaY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains{
@@ -10761,20 +10812,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"kbt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 8
-	},
-/area/f13/brotherhood/mining)
+"kbH" = (
+/obj/structure/flora/junglebush,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kbZ" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "kcD" = (
-/obj/machinery/vending/robotics,
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/integrated_circuit_printer,
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_electronics/detailer,
+/obj/item/integrated_electronics/wirer,
+/obj/item/integrated_electronics/debugger,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -10814,11 +10871,12 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "keR" = (
-/obj/machinery/vending/tool,
-/obj/structure/sign/poster/contraband/rip_badger{
-	pixel_x = 14;
-	pixel_y = 31
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
 	},
+/obj/machinery/computer/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -10897,19 +10955,9 @@
 	},
 /area/f13/clinic)
 "kic" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/integrated_circuit_printer,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_electronics/debugger,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/clockwork/fulltile,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "kiu" = (
 /obj/structure/chair/wood{
@@ -10924,8 +10972,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "kiV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -10944,15 +10990,11 @@
 	},
 /area/f13/brotherhood/operations)
 "kiX" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/computer/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "kja" = (
 /obj/structure/table/wood/settler,
@@ -11002,9 +11044,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "klQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/clockwork/fulltile,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "klZ" = (
 /obj/machinery/chem_heater,
@@ -11022,17 +11063,6 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "koC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"kpd" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
-"kpo" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "headscribedorm";
 	name = "Head Scribe's Office";
@@ -11042,6 +11072,21 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
+/area/f13/brotherhood/rnd)
+"kpd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
+"kpo" = (
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "kqh" = (
 /obj/structure/chair/office{
@@ -11166,11 +11211,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "kxu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "kxL" = (
 /obj/structure/closet/cabinet,
@@ -11246,12 +11296,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "kBT" = (
-/obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
 "kCg" = (
 /obj/machinery/light/small{
@@ -11324,7 +11373,6 @@
 	},
 /area/f13/brotherhood/operations)
 "kFc" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -11362,11 +11410,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"kFP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "kGx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11399,6 +11442,10 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/sewer)
+"kJW" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/mining)
 "kKx" = (
 /obj/structure/window/reinforced/clockwork/fulltile,
 /obj/structure/grille,
@@ -11414,23 +11461,23 @@
 	},
 /area/f13/bunker)
 "kLA" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/kitchenspike_frame{
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
 	},
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "kLU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/kitchenspike_frame{
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/rnd)
 "kMF" = (
 /mob/living/simple_animal/hostile/radroach,
@@ -11493,10 +11540,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"kQI" = (
-/obj/structure/flora/junglebush/large,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "kQO" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13{
@@ -11551,6 +11594,18 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
+"kTP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "kUd" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/closed/wall/r_wall,
@@ -11595,7 +11650,9 @@
 	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
 	name = "Power Armor Frame"
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -11658,24 +11715,24 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "lbt" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
+/obj/structure/fluff/railing{
+	dir = 6;
+	pixel_x = 33
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "lbG" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
+/obj/structure/bookcase/manuals/research_and_development{
+	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Brotherhood Historical Archives"
 	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "lcn" = (
@@ -11810,12 +11867,19 @@
 	},
 /area/f13/tunnel)
 "lgv" = (
-/obj/structure/fluff/railing{
-	dir = 6;
-	pixel_x = 33
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/table/wood,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood/rnd)
+"lgA" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lhh" = (
 /obj/item/assembly/signaler{
 	code = 2;
@@ -11908,18 +11972,16 @@
 	},
 /area/f13/bunker)
 "lkT" = (
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
-	},
-/obj/machinery/light/small{
+/obj/structure/bookcase/random,
+/obj/machinery/light/fo13colored/Aqua{
 	brightness = 3;
-	dir = 8
+	critical_machine = 1;
+	dir = 1;
+	flicker_chance = 0;
+	icon_state = "bulb";
+	name = "Light Bulb"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "llp" = (
 /obj/structure/lattice{
@@ -12040,6 +12102,20 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"loJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/structure/sink/kitchen{
+	desc = "Strictly For filling Up mop buckets.";
+	dir = 8;
+	name = "Mop Sink";
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "lpd" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -12056,15 +12132,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"lpK" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "lqC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/table/wood,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "lre" = (
 /obj/structure/rack,
@@ -12108,15 +12187,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"lvn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "lvr" = (
 /obj/structure/table/optable/abductor,
 /obj/item/restraints/handcuffs,
@@ -12155,14 +12225,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
-"lwE" = (
-/obj/machinery/button/door{
-	id = "floor2elevatordoors";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "lyh" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12190,16 +12252,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"lzU" = (
-/obj/structure/table/reinforced,
-/obj/item/pda/engineering{
-	name = "Knight-Engineer Pip-Boy 3000"
-	},
-/obj/item/pda/engineering{
-	name = "Knight-Engineer Pip-Boy 3000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "lzW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
@@ -12259,6 +12311,10 @@
 /obj/item/lighter,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"lDx" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "lDD" = (
 /obj/item/paper_bin{
 	pixel_y = 6
@@ -12282,12 +12338,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
-"lFJ" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
-/area/f13/caves)
 "lGo" = (
 /obj/structure/sign/poster/prewar/poster88,
 /turf/closed/wall/r_wall,
@@ -12355,15 +12405,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lLy" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	dir = 1;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "lLA" = (
@@ -12475,22 +12521,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"lPw" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster82";
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/stool/f13stool,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "lPy" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/subway,
@@ -12523,9 +12553,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "lSl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "lSQ" = (
@@ -12615,12 +12643,11 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "lYu" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
 "lYx" = (
 /obj/machinery/light/small{
@@ -12651,8 +12678,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
 "lZF" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/floor,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 9
+	},
+/obj/structure/fluff/railing/corner,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "lZJ" = (
 /obj/item/clothing/suit/toggle/labcoat/scribecoat,
@@ -12691,10 +12725,9 @@
 /area/f13/caves)
 "mcC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
 	},
-/turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
 "mdv" = (
 /obj/machinery/light{
@@ -12780,15 +12813,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mjJ" = (
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_x = -32
 	},
-/obj/structure/fluff/railing{
-	dir = 9
-	},
-/obj/structure/fluff/railing/corner,
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "mjU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13025,10 +13056,13 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "mui" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "muA" = (
 /obj/structure/table,
@@ -13108,13 +13142,8 @@
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "mzX" = (
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/newscaster,
+/turf/closed/wall/mineral/iron,
 /area/f13/brotherhood/rnd)
 "mAa" = (
 /obj/structure/simple_door/metal/barred,
@@ -13145,13 +13174,12 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "mAX" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "mBn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13202,6 +13230,9 @@
 /obj/effect/turf_decal/stripes/box,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
 /obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -13220,6 +13251,9 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/clinic)
+"mEf" = (
+/turf/closed/mineral/random/high_chance,
+/area/f13/brotherhood/reactor)
 "mEm" = (
 /obj/structure/lattice{
 	density = 1
@@ -13329,14 +13363,15 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"mIo" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "mII" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/mineral/iron,
+/obj/machinery/door/poddoor/shutters{
+	id = "bosshop";
+	name = "brotherhood shutters"
+	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "vault"
+	},
 /area/f13/brotherhood/rnd)
 "mJG" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -13450,17 +13485,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/brotherhood/leisure)
-"mQQ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
 "mQX" = (
 /obj/effect/spawner/lootdrop/trash,
 /mob/living/simple_animal/hostile/gecko,
@@ -13472,26 +13496,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "mRK" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "mRT" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mSc" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
+/obj/structure/simple_door/bunker/glass{
+	name = "Archives";
+	req_access_txt = "120"
 	},
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "mSs" = (
 /obj/structure/table,
@@ -13509,12 +13533,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mTj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "mTq" = (
 /turf/closed/wall/f13/wood/house,
@@ -13523,12 +13548,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices2nd)
 "mTt" = (
-/obj/structure/simple_door/bunker/glass{
-	name = "Archives";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gps/computer{
+	desc = "A large, central database of currently-transmitting GPS signals.";
+	name = "GPS Ping Grabber."
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -13550,13 +13574,31 @@
 	},
 /area/f13/tunnel)
 "mUS" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
 	},
+/obj/structure/flora/junglebush{
+	pixel_x = -15
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/turf/open/water,
 /area/f13/brotherhood/rnd)
 "mVw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13564,13 +13606,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "mWp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gps/computer{
-	desc = "A large, central database of currently-transmitting GPS signals.";
-	name = "GPS Ping Grabber."
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = -9
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "mWD" = (
 /obj/structure/decoration/warning,
@@ -13606,6 +13654,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"mYI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "mYV" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
@@ -13644,31 +13703,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "nby" = (
-/obj/structure/flora/rock/jungle{
+/obj/structure/lattice{
 	density = 1
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
+/obj/structure/fence/handrail{
+	density = 0;
 	dir = 1;
-	layer = 3
+	pixel_y = -9
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/turf/open/water,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "nbz" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -13706,19 +13753,23 @@
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
 "neq" = (
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
 	},
-/obj/structure/fence/handrail{
-	density = 0;
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 1;
-	pixel_y = -9
+	layer = 3
 	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/brotherhood/rnd)
 "neu" = (
 /obj/structure/window/reinforced/spawner{
@@ -13782,6 +13833,11 @@
 	dir = 8
 	},
 /area/f13/tcoms)
+"ngP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "nha" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/box/white,
@@ -13828,10 +13884,6 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"nji" = (
-/obj/structure/sign/poster/contraband/hacking_guide,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "njZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash/crematorium,
@@ -13847,25 +13899,10 @@
 	},
 /area/f13/followers)
 "nkx" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"nkL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
 	color = "#3e3d42";
-	dir = 8
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	color = "#3e3d42";
@@ -13879,6 +13916,14 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
+/area/f13/brotherhood/rnd)
+"nkL" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 8;
+	name = "prewar lounge chair"
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "nlc" = (
 /obj/item/target,
@@ -13995,23 +14040,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nqE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/obj/structure/fence/handrail{
+	density = 0;
 	dir = 1;
-	layer = 3
+	pixel_y = 18
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "nqF" = (
 /obj/structure/lattice{
@@ -14125,12 +14168,13 @@
 	},
 /area/f13/clinic)
 "nwf" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 8;
-	name = "prewar lounge chair"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "nwA" = (
 /obj/structure/toilet{
@@ -14168,19 +14212,12 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "nzl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	layer = 2.9
+	},
 /obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = 18
+	layer = 3
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
@@ -14226,12 +14263,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nBh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/simple_door/bunker/glass{
+	name = "Archives";
+	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -14257,14 +14291,12 @@
 	},
 /area/f13/followers)
 "nDb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
 	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "nEl" = (
 /obj/structure/sign/departments/medbay,
@@ -14274,11 +14306,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "nEt" = (
-/obj/structure/simple_door/bunker/glass{
-	name = "Archives";
-	req_access_txt = "120"
+/obj/machinery/computer/secure_data{
+	dir = 4;
+	icon_state = "computer"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "nEz" = (
 /obj/structure/campfire/barrel,
@@ -14347,11 +14379,12 @@
 	},
 /area/f13/brotherhood/offices1st)
 "nIl" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "nIB" = (
@@ -14388,11 +14421,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "nKk" = (
-/obj/machinery/computer/secure_data{
-	dir = 4;
-	icon_state = "computer"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "nKZ" = (
 /obj/structure/barricade/bars,
@@ -14431,6 +14466,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"nMB" = (
+/obj/machinery/button/door{
+	id = "floor2elevatordoors";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "nMG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -14438,13 +14481,16 @@
 	},
 /area/f13/brotherhood/leisure)
 "nMN" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
+/obj/machinery/rnd/destructive_analyzer,
+/obj/machinery/light/fo13colored/Aqua{
+	brightness = 3;
+	critical_machine = 1;
+	dir = 4;
+	flicker_chance = 0;
+	icon_state = "bulb";
+	name = "Light Bulb"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "nMQ" = (
 /obj/structure/toilet{
@@ -14469,13 +14515,12 @@
 	},
 /area/f13/brotherhood/operations)
 "nNi" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
+/obj/structure/table/wood,
+/obj/machinery/bookbinder{
+	icon_state = "bigscanner";
+	pixel_y = 7
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "nNx" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
@@ -14491,11 +14536,6 @@
 /obj/item/circuitboard/machine/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"nNW" = (
-/obj/structure/flora/junglebush/large,
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "nOW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_t,
@@ -14619,16 +14659,13 @@
 	},
 /area/f13/clinic)
 "nWG" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	dir = 4;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
+/obj/machinery/libraryscanner{
+	desc = "This device scans books and other documents for entry into the Archives.";
+	name = "archive scanner";
+	pixel_y = 7
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "nWO" = (
 /obj/item/kitchen/knife/butcher,
@@ -14649,12 +14686,13 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "nXh" = (
-/obj/structure/table/wood,
-/obj/machinery/bookbinder{
-	icon_state = "bigscanner";
-	pixel_y = 7
+/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/spawner/lootdrop/keg,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "nXj" = (
 /turf/open/floor/f13{
@@ -14705,13 +14743,10 @@
 	},
 /area/f13/caves)
 "nYD" = (
-/obj/machinery/libraryscanner{
-	desc = "This device scans books and other documents for entry into the Archives.";
-	name = "archive scanner";
-	pixel_y = 7
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "nYR" = (
 /obj/structure/bed,
@@ -14776,22 +14811,31 @@
 	},
 /area/f13/tunnel)
 "odG" = (
-/obj/structure/closet/crate/large,
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/machinery/cell_charger{
+	pixel_y = 6
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "oeb" = (
 /turf/closed/wall,
 /area/f13/tunnel)
 "oei" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/blueprint/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/flashlight/lamp{
+	light_color = "#00FFFF";
+	pixel_x = -14;
+	pixel_y = 9
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "oeJ" = (
 /obj/structure/rack,
@@ -14808,13 +14852,6 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ofD" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "ofI" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/flora/rock/jungle,
@@ -14825,26 +14862,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ofQ" = (
-/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "ogl" = (
-/obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/blueprint/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/flashlight/lamp{
-	light_color = "#00FFFF";
-	pixel_x = -14;
-	pixel_y = 9
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -14878,11 +14906,28 @@
 	},
 /area/f13/tunnel)
 "oja" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail_corner{
+	density = 0;
+	dir = 1;
+	layer = 3.1;
+	pixel_x = -12;
+	pixel_y = -9
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = -9
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "ojR" = (
 /obj/machinery/light/small{
@@ -14892,14 +14937,28 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "okm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/obj/structure/window/reinforced/spawner{
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/window/reinforced/spawner{
+	color = "#777777";
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
+	},
+/obj/machinery/light/floor,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/fluff/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "okO" = (
 /obj/structure/table,
@@ -14911,12 +14970,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"okP" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
 "olw" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -15072,6 +15125,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"osk" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "otf" = (
 /turf/open/indestructible/ground/outside/water{
 	density = 1;
@@ -15109,28 +15169,10 @@
 	},
 /area/f13/brotherhood/leisure)
 "ovQ" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster70"
 	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 1;
-	layer = 3.1;
-	pixel_x = -12;
-	pixel_y = -9
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/turf/open/floor/plating/tunnel,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "ovY" = (
 /obj/structure/closet{
@@ -15163,28 +15205,12 @@
 	},
 /area/f13/tunnel)
 "owX" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
+/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/fluff/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "oxw" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -15287,36 +15313,38 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood/operations)
+"oCA" = (
+/obj/structure/flora/junglebush/large,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "oDf" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"oDg" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 1
-	},
-/area/f13/brotherhood/mining)
 "oDP" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/leisure)
 "oDV" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster70"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "A console used by the scribes of the Brotherhood of Steel.";
+	dir = 8;
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal";
+	name = "Archive Terminal"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "oEt" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster69"
 	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "oEC" = (
 /obj/structure/showcase/horrific_experiment,
@@ -15440,7 +15468,6 @@
 /area/f13/tunnel)
 "oLf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -15459,18 +15486,20 @@
 	},
 /area/f13/caves)
 "oNj" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
 	},
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "A console used by the scribes of the Brotherhood of Steel.";
-	dir = 8;
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal";
-	name = "Archive Terminal"
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_f,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "oNu" = (
 /obj/structure/debris/v1,
@@ -15524,6 +15553,17 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"oPU" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 1;
+	height = 4;
+	id = "bos_level_2";
+	name = "Level 2: Engineering";
+	width = 5
+	},
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/brotherhood/rnd)
 "oQa" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15702,10 +15742,12 @@
 	},
 /area/f13/tunnel)
 "oWc" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster69"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "oWl" = (
 /obj/machinery/computer/telecomms/monitor{
@@ -15717,19 +15759,17 @@
 	},
 /area/f13/tcoms)
 "oWr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
 	},
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "oWD" = (
@@ -15853,19 +15893,6 @@
 /obj/item/storage/box/cups,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"pdR" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
-	},
-/area/f13/brotherhood/reactor)
 "pez" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15892,11 +15919,9 @@
 	},
 /area/f13/tunnel)
 "pfC" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "pgi" = (
@@ -15913,14 +15938,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "pgS" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
+	icon_state = "generator_on";
+	name = "superheating forge"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkrustysolid"
@@ -15970,13 +15991,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"pja" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "pjj" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -16028,6 +16042,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"pmV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/f13stool,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "pnd" = (
 /obj/effect/landmark/start/f13/ncrmedofficer,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -16068,10 +16089,6 @@
 /obj/item/mining_scanner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"poJ" = (
-/obj/structure/grille,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
 "ppt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -16227,14 +16244,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/brotherhood/rnd)
 "pwa" = (
-/obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"pwF" = (
-/turf/closed/mineral/random/high_chance,
-/area/f13/brotherhood/reactor)
 "pwH" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -16243,11 +16256,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pwP" = (
-/obj/machinery/workbench/forge{
-	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
-	icon_state = "generator_on";
-	name = "superheating forge"
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkrustysolid"
 	},
@@ -16276,7 +16294,6 @@
 	},
 /area/f13/brotherhood/operations)
 "pxV" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -16303,6 +16320,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
+"pzw" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pzF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -16350,9 +16371,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pAE" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/fence/handrail_end/non_dense{
+	dir = 1;
+	pixel_x = -16
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "pAK" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -16520,19 +16547,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "pKf" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "pLl" = (
 /obj/structure/decoration/smokeold,
@@ -16565,15 +16584,14 @@
 	},
 /area/f13/clinic)
 "pNi" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
+/obj/structure/bookcase/random/religion{
+	desc = "A collection of scrolls, archives and relics.";
+	name = "Religious References"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "pNK" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -16604,6 +16622,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"pPS" = (
+/obj/structure/debris/v2,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "pQq" = (
 /obj/item/pickaxe,
@@ -16689,10 +16711,8 @@
 /area/f13/brotherhood/rnd)
 "pWr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small,
+/turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
 "pWX" = (
 /obj/structure/chair/wood/modern{
@@ -16704,27 +16724,11 @@
 /mob/living/simple_animal/hostile/giantant,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"pXf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "pXp" = (
-/obj/structure/bookcase/random/religion{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Religious References"
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster90"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "pXq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16823,7 +16827,10 @@
 /area/f13/tunnel)
 "qci" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/structure/simple_door/bunker{
+	name = "Ceremony Room";
+	req_access_txt = "120"
+	},
 /turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
 "qcm" = (
@@ -16838,13 +16845,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"qcL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "qdj" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -16909,10 +16909,11 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "qfB" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster90"
+/obj/structure/simple_door/bunker{
+	name = "Ceremony Room";
+	req_access_txt = "120"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/carpet,
 /area/f13/brotherhood/rnd)
 "qfK" = (
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -16928,12 +16929,21 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qgO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker{
-	name = "Ceremony Room";
-	req_access_txt = "120"
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
 	},
-/turf/open/floor/carpet,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -33
+	},
+/obj/structure/sign/warning/fire{
+	pixel_x = 23;
+	pixel_y = 30
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "qgP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16975,11 +16985,13 @@
 	},
 /area/f13/followers)
 "qid" = (
-/obj/structure/simple_door/bunker{
-	name = "Ceremony Room";
-	req_access_txt = "120"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "qii" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17016,13 +17028,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"qjv" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
-/area/f13/caves)
 "qjT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -17064,11 +17069,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "qnC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "qnM" = (
 /obj/structure/ladder/unbreakable{
@@ -17078,19 +17083,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qoi" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -33
-	},
-/obj/structure/sign/warning/fire{
-	pixel_x = 23;
-	pixel_y = 30
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
@@ -17152,9 +17148,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "qpY" = (
@@ -17202,6 +17201,9 @@
 "qsa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/simple_door/bunker{
+	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
@@ -17265,9 +17267,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "qtL" = (
 /obj/structure/cable{
@@ -17348,13 +17349,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "qyC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17431,12 +17427,6 @@
 /obj/item/clothing/suit/apron/surgical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
-"qEx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 6
-	},
-/area/f13/brotherhood/reactor)
 "qEO" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress1"
@@ -17468,14 +17458,12 @@
 /turf/closed/wall,
 /area/f13/tcoms)
 "qFQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/chair/sofa/corp/left,
+/obj/structure/window/reinforced/spawner/north{
+	dir = 4;
+	icon_state = "rwindow"
 	},
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "qFS" = (
 /obj/structure/sink{
@@ -17526,13 +17514,6 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
-"qHq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/f13stool,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "qHr" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood{
@@ -17547,12 +17528,21 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/tunnel)
-"qJc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"qIB" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Power Stores";
+	req_access_txt = "120"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
+"qJc" = (
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
+	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qJM" = (
 /obj/machinery/door/unpowered/wooddoor{
@@ -17571,17 +17561,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"qKt" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
 "qKP" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
@@ -17622,19 +17601,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "qMn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/carpet/purple,
+/obj/machinery/rnd/production/protolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qME" = (
-/obj/structure/chair/sofa/corp/left,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/turf/open/floor/carpet/purple,
+/obj/machinery/rnd/destructive_analyzer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qMO" = (
 /obj/structure/table/glass,
@@ -17698,13 +17672,8 @@
 	},
 /area/f13/tunnel)
 "qOJ" = (
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
-	},
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/flag/bos,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "qOT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17743,9 +17712,6 @@
 /area/f13/brotherhood/rnd)
 "qQF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/table{
 	layer = 2.9
 	},
@@ -17754,6 +17720,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"qQI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "qQS" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
 	icon_state = "casino"
@@ -17869,10 +17840,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qWa" = (
-/obj/machinery/rnd/production/protolathe,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "qWm" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -17888,31 +17864,29 @@
 /area/f13/brotherhood/rnd)
 "qWx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qXo" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "qXr" = (
 /obj/structure/barricade/wooden,
 /obj/structure/curtain,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"qXI" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "qXN" = (
 /obj/structure/sign/poster/prewar/poster90,
 /turf/closed/wall/r_wall,
@@ -17934,9 +17908,9 @@
 	},
 /area/f13/ncr)
 "qYS" = (
-/obj/item/flag/bos,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/reactor)
 "qZq" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -17955,21 +17929,29 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "qZA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/item/flag/bos,
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "qZY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/structure/window/reinforced/spawner/north{
+	dir = 8;
+	icon_state = "rwindow"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "raA" = (
 /obj/structure/table,
@@ -18082,18 +18064,21 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "rfD" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
 	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_x = -32;
+	pixel_y = 64
 	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-8"
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "rfH" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cloth/ten,
@@ -18145,9 +18130,13 @@
 	},
 /area/f13/tunnel)
 "riR" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
+/obj/structure/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood/rnd)
 "riT" = (
 /obj/structure/mirror{
 	pixel_x = 32
@@ -18254,23 +18243,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"roZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"rpa" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	icon_state = "conveyor_map"
-	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "rpI" = (
 /obj/structure/chair/right,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -18386,25 +18358,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "rsM" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table{
+	layer = 2.9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood/rnd)
 "rtf" = (
-/obj/item/flag/bos,
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/sign/poster/prewar/poster71,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "rtk" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -18453,18 +18418,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rvb" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "rvf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18494,21 +18452,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "rwk" = (
-/obj/structure/chair/office/dark{
-	dir = 1;
-	icon_state = "officechair_dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch{
+	name = "Backup Power";
+	req_access_txt = "120"
 	},
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -32;
-	pixel_y = 64
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "rwA" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
@@ -18539,12 +18492,8 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "ryL" = (
-/obj/structure/chair/office/dark{
-	dir = 1;
-	icon_state = "officechair_dark"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "ryV" = (
 /obj/structure/closet/crate/bin,
@@ -18590,13 +18539,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"rzM" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
 "rzQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/junglebush/b,
@@ -18671,16 +18613,6 @@
 	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
 /area/f13/caves)
-"rDB" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "rDS" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18716,6 +18648,10 @@
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"rFn" = (
+/obj/structure/grille,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/mining)
 "rFz" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/indestructible/ground/inside/subway,
@@ -18752,14 +18688,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "rIS" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "rJn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18771,24 +18704,15 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "rJv" = (
-/obj/structure/sign/poster/prewar/poster71,
-/turf/closed/wall/r_wall,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "rJA" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"rKa" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
 "rKd" = (
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
@@ -18816,11 +18740,15 @@
 	},
 /area/f13/clinic)
 "rKE" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "rKJ" = (
 /obj/structure/lattice{
@@ -18912,19 +18840,19 @@
 /area/f13/ncr)
 "rOb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Backup Power";
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
 	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "rOp" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "rOq" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -19181,10 +19109,6 @@
 	},
 /area/f13/brotherhood/operations)
 "rWh" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "rWY" = (
@@ -19209,10 +19133,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rXl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/carpet/purple,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood/rnd)
 "rXA" = (
 /obj/structure/timeddoor,
@@ -19220,16 +19146,12 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "rXR" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "rXS" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -19293,12 +19215,10 @@
 	},
 /area/f13/brotherhood/leisure)
 "saz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/reactor)
 "saC" = (
 /obj/structure/sink{
@@ -19323,6 +19243,15 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"sbj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "scG" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt,
@@ -19354,25 +19283,29 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sdJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/flashlight/lamp{
+	pixel_x = -3;
+	pixel_y = 15
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"sdQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/computer/terminal{
+	dir = 4;
+	pixel_x = -3;
+	pixel_y = -3;
+	termtag = "Business"
 	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
+/obj/structure/fluff/paper/stack{
+	pixel_x = 11;
+	pixel_y = 4
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/item/pen/fourcolor{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/f13/brotherhood/rnd)
 "sef" = (
 /obj/structure/curtain{
 	color = "#5c131b"
@@ -19388,6 +19321,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "seL" = (
+/obj/structure/window/reinforced/spawner/north{
+	dir = 4;
+	icon_state = "rwindow"
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_y = -32
+	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "seP" = (
@@ -19462,7 +19407,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/space/basic,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "sgn" = (
 /obj/structure/simple_door/bunker,
@@ -19476,12 +19421,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "sgI" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/fence/handrail_end/non_dense{
+	dir = 1;
+	pixel_x = -16
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "shl" = (
 /obj/machinery/telecomms/server/presets/service,
@@ -19492,12 +19439,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "shO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/window/reinforced/spawner/north{
+	dir = 8;
+	icon_state = "rwindow"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/rnd)
 "sic" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -19582,16 +19532,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
-"slo" = (
-/obj/effect/temp_visual/steam_release,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "slT" = (
 /obj/structure/falsewall/reinforced{
 	layer = 3
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "slX" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/rock/jungle,
@@ -19606,6 +19553,11 @@
 /obj/effect/light_emitter,
 /turf/open/water,
 /area/f13/brotherhood/operations)
+"smf" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "smm" = (
 /obj/structure/sink{
 	pixel_y = 19
@@ -19627,39 +19579,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"smT" = (
-/obj/structure/wreck/car{
-	layer = 2
-	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "snJ" = (
-/obj/item/flashlight/lamp{
-	pixel_x = -3;
-	pixel_y = 15
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 4;
-	pixel_x = -3;
-	pixel_y = -3;
-	termtag = "Business"
-	},
-/obj/structure/fluff/paper/stack{
-	pixel_x = 11;
-	pixel_y = 4
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "snL" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/decal/cleanable/robot_debris/down,
@@ -19678,14 +19604,6 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
-"soi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "sor" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -19714,6 +19632,13 @@
 /obj/effect/decal/cleanable/blood/innards,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"srb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "srD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -19759,6 +19684,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -19792,9 +19720,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "sxs" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/f13{
@@ -19919,19 +19844,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "sHk" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "sHo" = (
 /obj/machinery/chem_dispenser,
@@ -19953,13 +19869,10 @@
 	},
 /area/f13/tunnel)
 "sIK" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "casino"
 	},
 /area/f13/brotherhood/rnd)
 "sIN" = (
@@ -20026,6 +19939,15 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"sLF" = (
+/obj/structure/wreck/car{
+	layer = 2
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sLG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/mattress{
@@ -20036,14 +19958,9 @@
 	},
 /area/f13/tunnel)
 "sLI" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
+/obj/machinery/door/unpowered/wooddoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "sMc" = (
 /obj/machinery/door/unpowered/wooddoor{
@@ -20095,10 +20012,14 @@
 /area/f13/tunnel)
 "sOf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 10
 	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/rnd)
 "sOi" = (
 /obj/machinery/power/smes/engineering,
@@ -20129,11 +20050,9 @@
 	},
 /area/f13/tunnel)
 "sPa" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_right"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "sPl" = (
 /obj/structure/fluff/railing{
@@ -20198,18 +20117,26 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "sUy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/item/flag/bos,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "sUF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "engine"
 	},
 /area/f13/brotherhood/mining)
+"sUH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/brotherhood/rnd)
 "sWb" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "bosdorm7";
@@ -20228,11 +20155,15 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "sWu" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "sWB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -20251,12 +20182,18 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "sXi" = (
-/obj/machinery/light/small,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/machinery/power/am_control_unit{
+	anchored = 1;
+	dir = 8
 	},
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "sXC" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
@@ -20303,15 +20240,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"tba" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "tbg" = (
-/obj/machinery/door/unpowered/wooddoor,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/lattice{
+	density = 1
+	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "tbE" = (
@@ -20354,15 +20289,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "tcH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/obj/structure/fence/handrail{
+	density = 0;
 	dir = 4;
-	pixel_y = 10
+	layer = 3.1;
+	pixel_x = -16
 	},
-/obj/structure/toilet{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "tda" = (
 /obj/structure/toilet{
@@ -20475,6 +20414,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"tha" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "thr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -20500,10 +20443,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "thO" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_right"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "tiB" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/dirt,
@@ -20568,14 +20516,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "tkU" = (
-/obj/item/flag/bos,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/junglebush{
+	pixel_x = -15
 	},
+/turf/open/water,
 /area/f13/brotherhood/rnd)
 "tlc" = (
 /obj/structure/flora/grass/jungle/b,
@@ -20585,6 +20534,7 @@
 	dir = 1;
 	layer = 3.1
 	},
+/obj/machinery/light/small,
 /turf/open/water,
 /area/f13/brotherhood/offices1st)
 "tlr" = (
@@ -20631,15 +20581,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "tna" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/brotherhood/rnd)
 "tnh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/left{
@@ -20673,18 +20622,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "toO" = (
-/obj/machinery/power/am_control_unit{
-	anchored = 1;
-	dir = 8
+/obj/structure/flora/rock/jungle{
+	density = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
 	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
+/obj/structure/flora/junglebush{
+	pixel_x = -15
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/brotherhood/rnd)
 "toP" = (
 /obj/structure/target_stake{
 	anchored = 1
@@ -20730,6 +20681,10 @@
 /obj/structure/table/survival_pod,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"trJ" = (
+/obj/structure/bookcase/random,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood/mining)
 "tse" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -20739,7 +20694,6 @@
 	},
 /area/f13/tunnel)
 "tsm" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -20846,6 +20800,7 @@
 	color = "#3e3d42";
 	dir = 8
 	},
+/obj/machinery/light/small,
 /turf/open/water,
 /area/f13/brotherhood/offices1st)
 "tvZ" = (
@@ -20884,13 +20839,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "txU" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/chair/wood/normal{
+	dir = 1
 	},
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/light/small,
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "tyR" = (
 /obj/machinery/door/airlock/grunge{
@@ -20915,19 +20870,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "tzx" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
+/obj/structure/chair/wood/normal{
+	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "tzH" = (
 /obj/structure/table/reinforced,
@@ -20942,21 +20890,6 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/rust,
 /area/f13/tunnel)
-"tzO" = (
-/obj/structure/decoration/hatch{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 4
-	},
-/area/f13/brotherhood/mining)
 "tzZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -21138,14 +21071,6 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
-"tGt" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/atmos,
-/obj/item/twohanded/fireaxe,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
 "tHb" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -21170,25 +21095,15 @@
 /turf/closed/indestructible/opshuttle,
 /area/f13/brotherhood/leisure)
 "tHM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_right"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "tIz" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/item/flag/bos,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/turf/open/water,
 /area/f13/brotherhood/rnd)
 "tID" = (
 /obj/structure/table,
@@ -21224,13 +21139,9 @@
 	},
 /area/f13/tunnel)
 "tJH" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_left"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
 /area/f13/brotherhood/rnd)
 "tJL" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
@@ -21246,29 +21157,18 @@
 	},
 /area/f13/brotherhood/medical)
 "tJT" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/machinery/camera/autoname{
+	dir = 5;
+	name = "Reactor Camera";
+	network = list("BoS")
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "tJU" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "tJW" = (
 /obj/structure/rack,
 /obj/item/melee/classic_baton/telescopic{
@@ -21370,10 +21270,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
-"tLB" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
 "tLS" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/decal/cleanable/dirt,
@@ -21553,12 +21449,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "tTB" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
 "tUk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21604,9 +21496,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tXw" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_right"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/rnd)
 "tXJ" = (
 /obj/structure/table/reinforced,
@@ -21636,6 +21530,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"tYy" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/brotherhood/mining)
 "tYE" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -21685,17 +21587,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"uab" = (
-/obj/effect/decal/cleanable/robot_debris,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "uay" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase/manuals/engineering,
@@ -21719,11 +21610,18 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ucQ" = (
-/obj/item/flag/bos,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+"ucw" = (
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/mining)
+"ucQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/rnd)
 "ucS" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -21786,10 +21684,16 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "ufk" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_left"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "ufo" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "prospector2open"
@@ -21861,13 +21765,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uhT" = (
-/obj/machinery/camera/autoname{
-	dir = 5;
-	name = "Reactor Camera";
-	network = list("BoS")
+/obj/effect/decal/cleanable/oil/streak,
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "uhW" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -22035,10 +21938,11 @@
 	},
 /area/f13/brotherhood/leisure)
 "umw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "umG" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -22087,8 +21991,10 @@
 	},
 /area/f13/brotherhood/operations)
 "upu" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/decal/cleanable/robot_debris/limb,
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "upA" = (
 /obj/structure/flora/junglebush,
@@ -22257,11 +22163,14 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "uvd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/decoration/vent{
+	layer = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "uvB" = (
 /obj/machinery/jukebox,
@@ -22299,9 +22208,14 @@
 	},
 /area/f13/bunker)
 "uwV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/rnd)
+/obj/machinery/conveyor/auto{
+	dir = 8
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
+	},
+/area/f13/brotherhood/mining)
 "uxq" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/decal/cleanable/cobweb,
@@ -22416,23 +22330,38 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"uFn" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/brotherhood/mining)
 "uFO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
+/obj/machinery/conveyor/auto{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/mining)
 "uFQ" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"uGg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "uGL" = (
 /obj/machinery/light/floor,
 /obj/structure/lattice{
@@ -22498,12 +22427,10 @@
 	},
 /area/f13/brotherhood/operations)
 "uIq" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/item/multitool,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "uIE" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -22536,18 +22463,11 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "uJS" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
+	dir = 1
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/reactor)
 "uKn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -22803,6 +22723,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
+"uTL" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "uTT" = (
 /obj/machinery/reagentgrinder{
 	pixel_y = 9
@@ -22881,10 +22806,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "uXY" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "uYd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22998,10 +22925,11 @@
 	},
 /area/f13/clinic)
 "vdk" = (
-/obj/effect/decal/cleanable/robot_debris/limb,
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "ven" = (
 /obj/machinery/door/unpowered/wooddoor{
@@ -23191,14 +23119,23 @@
 	},
 /area/f13/brotherhood/operations)
 "vna" = (
-/obj/structure/decoration/vent{
-	layer = 2
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
+/obj/structure/flora/rock/jungle{
 	density = 1
 	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/turf/open/water,
 /area/f13/brotherhood/rnd)
 "vnJ" = (
 /obj/item/instrument/guitar,
@@ -23286,27 +23223,14 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"vqd" = (
-/obj/structure/simple_door/bunker/glass{
-	name = "Mining Storeroom";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
 "vqm" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "vqo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -23334,13 +23258,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "vqH" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "vra" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -23516,25 +23442,14 @@
 	},
 /area/f13/brotherhood/rnd)
 "vyb" = (
-/obj/item/multitool,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
-"vyc" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp{
-	pixel_x = 3;
-	pixel_y = 12
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_y = -32;
-	req_one_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/mining)
 "vyg" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -23582,6 +23497,12 @@
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"vAK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 6
+	},
+/area/f13/brotherhood/reactor)
 "vAM" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -23737,10 +23658,7 @@
 	},
 /area/f13/clinic)
 "vHQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "vIp" = (
 /obj/structure/showcase/horrific_experiment{
@@ -23760,47 +23678,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "vIL" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"vIO" = (
-/obj/item/am_containment{
-	pixel_x = 3
-	},
-/obj/structure/table/reinforced,
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/structure/window/plasma/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1
-	},
-/obj/item/am_containment,
-/obj/item/am_containment{
-	pixel_x = -3
-	},
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner,
-/area/f13/brotherhood/reactor)
 "vJC" = (
 /obj/structure/window/reinforced/tinted/frosted,
 /obj/effect/decal/cleanable/dirt,
@@ -23851,6 +23733,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"vLy" = (
+/obj/structure/flora/junglebush/large,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vLO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -23898,11 +23784,13 @@
 	},
 /area/f13/sewer)
 "vNU" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "vOf" = (
 /obj/structure/simple_door/bunker{
@@ -23961,8 +23849,8 @@
 /obj/item/stock_parts/cell/ammo/ecp,
 /obj/item/stock_parts/cell/ammo/ecp,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
 /obj/effect/turf_decal/bot_red,
+/obj/machinery/light,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -24006,23 +23894,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "vQZ" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/water,
 /area/f13/brotherhood/rnd)
 "vSd" = (
 /obj/effect/landmark/start/f13/settler,
@@ -24040,7 +23919,6 @@
 	pixel_x = -16;
 	pixel_y = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -24204,12 +24082,16 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "vYx" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "vYC" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -24272,6 +24154,7 @@
 /obj/item/storage/belt/utility/full,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -24429,16 +24312,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"wgN" = (
-/obj/structure/debris/v3{
-	layer = 2
-	},
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
-	},
-/area/f13/caves)
 "whp" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -24460,17 +24333,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"wiC" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_2";
-	name = "Level 2: Engineering";
-	width = 5
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/rnd)
 "wjW" = (
 /obj/structure/billboard/cola/pristine,
 /obj/effect/decal/cleanable/dirt,
@@ -24523,16 +24385,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "wmE" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/mining)
 "wmT" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -24556,10 +24417,6 @@
 "wox" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/brotherhood/mining)
-"wpH" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "wpJ" = (
 /obj/structure/barricade/bars,
 /obj/structure/curtain{
@@ -24575,6 +24432,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
+"wqL" = (
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wqW" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
@@ -24664,12 +24528,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "wuE" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
+	dir = 8
 	},
 /area/f13/brotherhood/mining)
 "wuM" = (
@@ -24691,8 +24552,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "wxb" = (
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 4;
+	output_dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
+	},
+/area/f13/brotherhood/mining)
 "wyl" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -24701,11 +24572,12 @@
 	},
 /area/f13/followers)
 "wyy" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "wAe" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	icon_state = "neutralrusty"
@@ -24777,14 +24649,15 @@
 	},
 /area/f13/tunnel)
 "wEX" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "wFj" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -24803,14 +24676,13 @@
 /area/f13/tunnel)
 "wFF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 8
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/reactor)
 "wFL" = (
 /obj/structure/chair{
 	dir = 8
@@ -24936,10 +24808,6 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"wLX" = (
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "wMr" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -24953,26 +24821,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wNi" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "wNs" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster70";
+	pixel_x = 31
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/mining)
 "wNJ" = (
 /obj/structure/table/wood/bar,
@@ -25018,11 +24882,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "wPV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 4
 	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/reactor)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -25046,18 +24909,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wQJ" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "wQS" = (
 /obj/machinery/button/door{
 	id = "boscheckpoint";
@@ -25078,6 +24932,17 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
+"wSC" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "wTd" = (
 /obj/structure/table,
 /obj/structure/window/spawner,
@@ -25140,12 +25005,16 @@
 	},
 /area/f13/clinic)
 "wVK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/machinery/light/small,
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "wVN" = (
 /obj/effect/decal/cleanable/flour,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -25165,15 +25034,15 @@
 	},
 /area/f13/tunnel)
 "wWM" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "wXG" = (
 /obj/structure/decoration/warning{
 	pixel_y = -2
@@ -25267,14 +25136,30 @@
 	},
 /area/f13/tunnel)
 "xdB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/decal/cleanable/insectguts,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = 13
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	density = 1
 	},
-/area/f13/brotherhood/reactor)
+/obj/structure/fence/handrail_corner{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = 13;
+	pixel_y = 16
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_x = -2;
+	pixel_y = 16
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "xdS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -25432,9 +25317,15 @@
 	},
 /area/f13/bunker)
 "xks" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_y = -32
 	},
+/obj/machinery/camera/autoname{
+	dir = 1;
+	name = "RnD Checkpoint Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "xkx" = (
 /obj/structure/showcase/horrific_experiment,
@@ -25505,18 +25396,16 @@
 	},
 /area/f13/tunnel)
 "xnb" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster70";
-	pixel_x = 31
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "xnk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -25538,10 +25427,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "xnV" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
+/obj/effect/decal/cleanable/insectguts,
+/obj/structure/fence/handrail{
+	density = 0;
+	pixel_y = 16
 	},
-/area/f13/brotherhood/reactor)
+/obj/structure/lattice{
+	density = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "xoo" = (
 /obj/structure/table{
 	layer = 2.9
@@ -25601,20 +25496,24 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "xsk" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side,
+/area/f13/brotherhood/mining)
 "xss" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/light/small,
-/obj/structure/lattice{
-	density = 1
+/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
+	dir = 1
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/mining)
 "xsL" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -25736,15 +25635,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xCf" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	icon_state = "conveyor_map"
 	},
-/obj/structure/lattice{
-	density = 1
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/mining)
 "xCv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/booth{
@@ -25855,30 +25754,39 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "xGu" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = 13
+/obj/item/am_containment{
+	pixel_x = 3
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
+/obj/structure/table/reinforced,
+/obj/structure/window/plasma/reinforced{
+	dir = 4
 	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = 13;
-	pixel_y = 16
+/obj/structure/window/plasma/reinforced{
+	dir = 8
 	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_x = -2;
-	pixel_y = 16
+/obj/structure/window/plasma/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/item/am_containment,
+/obj/item/am_containment{
+	pixel_x = -3
+	},
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/corner,
+/area/f13/brotherhood/reactor)
 "xGV" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
@@ -25911,16 +25819,15 @@
 	},
 /area/f13/clinic)
 "xIN" = (
-/obj/structure/sign/poster/contraband/smoke{
-	pixel_y = -32
+/obj/structure/table/reinforced,
+/obj/item/pda/engineering{
+	name = "Knight-Engineer Pip-Boy 3000"
 	},
-/obj/machinery/camera/autoname{
-	dir = 1;
-	name = "RnD Checkpoint Camera";
-	network = list("BoS")
+/obj/item/pda/engineering{
+	name = "Knight-Engineer Pip-Boy 3000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "xJE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -26083,6 +25990,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xQT" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
+	},
+/area/f13/caves)
 "xRm" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -26159,16 +26074,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xVV" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_x = 3;
+	pixel_y = 12
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_y = -32;
+	req_one_access_txt = "120"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "xVW" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/f13{
@@ -26311,16 +26230,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ydv" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "ydE" = (
 /obj/structure/window/spawner/north,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -26331,6 +26245,14 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"ydK" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 1
+	},
+/area/f13/brotherhood/mining)
 "ydV" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -26426,24 +26348,16 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"yjX" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "ykT" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side,
-/area/f13/brotherhood/mining)
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 
 (1,1,1) = {"
 eLE
@@ -79235,7 +79149,7 @@ uoO
 aoj
 uoO
 uoO
-jsL
+epe
 uoO
 uoO
 uoO
@@ -79954,7 +79868,7 @@ saF
 tKy
 nHR
 qfK
-euS
+epa
 vYw
 oeY
 uoO
@@ -80468,7 +80382,7 @@ tKy
 tKy
 vYw
 aHM
-eAw
+eub
 vYw
 oeY
 uoO
@@ -80982,7 +80896,7 @@ saF
 tKy
 nHR
 qfK
-euS
+epa
 vYw
 oeY
 uoO
@@ -81291,7 +81205,7 @@ uoO
 aoj
 xVz
 xVz
-wpH
+amf
 uoO
 uoO
 uoO
@@ -81496,7 +81410,7 @@ tKy
 tKy
 vYw
 aHM
-eAw
+eub
 vYw
 oeY
 uoO
@@ -81523,14 +81437,14 @@ vsI
 qmh
 qmh
 aZl
-rOb
+rwk
 xkQ
 uYd
 cqY
 wef
-tHM
+thO
 xkQ
-uFO
+ufk
 qta
 qta
 psA
@@ -81538,15 +81452,15 @@ qta
 qta
 qta
 psA
-kap
+gyp
 qmh
-kFP
+ngP
 vsI
 vsI
 uoO
 uoO
 uoO
-wpH
+amf
 xVz
 xVz
 uoO
@@ -81779,25 +81693,25 @@ kKy
 vsI
 bGU
 aRj
-qZA
+qWa
 vsI
 iPu
-shO
+rXR
 xkQ
-tna
+sWu
 xkQ
 xkQ
-uFO
+ufk
 qta
 qta
-wVK
+wyy
 qmh
 qmh
 qmh
 qmh
 rAt
 qmh
-hOX
+qQI
 vsI
 vsI
 uoO
@@ -82036,12 +81950,12 @@ xhA
 vsI
 sOi
 lea
-rfD
+qXo
 vsI
-saz
+rOb
 gWK
 gWK
-toO
+sXi
 gWK
 hpI
 pfv
@@ -82049,11 +81963,11 @@ faR
 nld
 rAt
 eGI
-vIO
+xGu
 vsI
 vsI
 oAp
-ofD
+qIB
 vsI
 vsI
 vsI
@@ -82273,11 +82187,11 @@ yhT
 gul
 xiI
 xNs
-hKS
+hIt
 gul
 iOt
 hlS
-iWR
+iQt
 xhA
 xhA
 xhA
@@ -82288,30 +82202,30 @@ jPB
 jPB
 jPB
 qpe
-odG
+nXh
 xhA
 vsI
 mWD
 pIg
-riR
+qYS
 vsI
 kYh
 kYh
 pis
 pis
 pis
-uhT
+tJT
 vsI
 vsI
 vsI
-wWM
+wEX
 vsI
 vsI
 vsI
 vch
 uRE
 vrC
-sdQ
+ble
 vsI
 uoO
 uoO
@@ -82527,48 +82441,48 @@ tKy
 cyA
 vYw
 yhT
-gfy
+gcD
 goi
 goi
 goi
-ifX
+hYI
 jrX
 jrX
-iYI
+iST
 xhA
 fxM
 yaO
-kWH
+kLA
 jPB
-mjJ
+lZF
 fFK
 fFK
 fFK
 fFK
 pDM
 vOo
-pgS
+oWr
 xhA
-qoi
+qgO
 vsI
 vsI
-sdJ
+rOp
 kYh
 pis
 pis
 pis
-umw
+tJU
 vsI
-vyb
+uIq
 qmh
 rAt
 qmh
-lzU
+xIN
 vsI
 vJX
 qRv
 tfd
-gZt
+mYI
 vsI
 vsI
 uoO
@@ -82785,15 +82699,15 @@ cCx
 vYw
 yhT
 gul
-gjB
+gfy
 goi
-hOJ
+hKI
 gul
 jrX
 jrX
-iZQ
+iVj
 xhA
-jZg
+jYe
 jPB
 jPB
 jPB
@@ -82804,9 +82718,9 @@ neP
 nxT
 wUT
 neu
-pwa
+pfC
 xhA
-qpX
+qid
 vsI
 vsI
 kYh
@@ -82817,15 +82731,15 @@ pis
 kYh
 vsI
 uay
-wxb
+vHQ
 rAt
 icI
-vyc
+xVV
 vsI
-uab
+wSC
 uRE
 vrC
-aYO
+daK
 vsI
 vsI
 uoO
@@ -83037,54 +82951,54 @@ tKy
 jgd
 tKy
 dvK
-emg
+dWN
 dtm
 vYw
 yhT
 gul
 uuQ
 fhk
-hPD
+hKS
 gul
-itP
+ilw
 jrX
-jdN
+iWR
 xhA
-kcD
+jYP
 jPB
-lbt
+kLU
 yaO
-mui
+mcC
 jPB
 efS
 xYS
-nMN
+nIl
 jPB
 hrv
-pwP
+pgS
 xhA
-qsa
+qnC
 vsI
 vsI
-sdJ
+rOp
 kYh
 pis
 pis
 pis
-umw
+tJU
 vsI
 wfH
 sZn
 ois
 fIV
-etu
+ydv
 vsI
 eaR
 ldA
 hcC
-aqR
+fai
 vsI
-pwF
+mEf
 uoO
 uoO
 uoO
@@ -83295,7 +83209,7 @@ vYw
 vYw
 vYw
 vYw
-eBP
+euS
 vYw
 yhT
 gul
@@ -83303,24 +83217,24 @@ gul
 vFa
 xjE
 sSP
-iuL
+isG
 jrX
-jfW
+iYI
 xhA
-keR
+jZg
 jPB
-lbG
+kWH
 jPB
-mui
+mcC
 jPB
-mUS
+mTj
 xYS
-nNi
+nKk
 jPB
 hrv
-pAE
+pwa
 xhA
-qsa
+qnC
 vsI
 vsI
 kYh
@@ -83334,11 +83248,11 @@ ggm
 qeh
 fuc
 dhM
-gJW
+ykT
 vsI
 vsI
-rDB
-ofD
+bdK
+qIB
 vsI
 vsI
 vsI
@@ -83552,19 +83466,19 @@ djs
 sJA
 dDE
 vYw
-epa
+eaz
 vYw
 yhT
 gul
-goG
+gim
 jrX
 iOt
 xjE
 jrX
 agI
-jgL
+iZQ
 xhA
-kic
+kcD
 jPB
 yaO
 jPB
@@ -83575,9 +83489,9 @@ nsN
 rEj
 tYE
 bFa
-pKf
+pwP
 xhA
-qtD
+qoi
 vsI
 vsI
 vsI
@@ -83589,14 +83503,14 @@ kYh
 vsI
 tJL
 eVi
-xdB
+wFF
 poa
 poa
 jzs
 mLN
 dSr
 spS
-eSS
+czn
 vsI
 vsI
 uoO
@@ -83809,51 +83723,51 @@ mZX
 mZX
 dGD
 vYw
-epa
+eaz
 vYw
 yhT
 gul
-gpl
+gjB
 jrX
-hSU
+hOJ
 gul
-iuX
+itP
 uAc
-jnO
+jdN
 xhA
-kiX
+keR
 yaO
-lbt
+kLU
 jPB
 myA
 glq
 xkB
-nzl
+nqE
 fFK
 fFK
-owX
-pAE
+okm
+pwa
 xhA
-qyv
+qpX
 xhA
 vsI
 vsI
 kYh
-sUy
+snJ
 kYh
-sUy
+snJ
 kYh
 vsI
-vHQ
+uJS
 fbP
 fbP
-xnV
+wPV
 stU
-pdR
+bKw
 stU
 stU
 qUR
-qEx
+vAK
 vsI
 vsI
 uoO
@@ -84066,17 +83980,17 @@ vYw
 vYw
 vYw
 vYw
-epa
+eaz
 vYw
 yhT
 gul
-gsw
+goG
 jrX
 rbu
-igV
+hZN
 iKl
 oBP
-jyc
+jfW
 xhA
 xhA
 xhA
@@ -84087,15 +84001,15 @@ lnF
 riY
 lnF
 sll
-oei
+nYD
 xhA
 xhA
 xhA
-qsa
+qnC
 xhA
 vsI
 vsI
-slT
+saz
 vsI
 vsI
 vsI
@@ -84104,7 +84018,7 @@ bMA
 vEe
 vXr
 fna
-xsk
+wQJ
 xhA
 xhA
 xhA
@@ -84323,32 +84237,32 @@ mZX
 mZX
 dGD
 vYw
-epa
+eaz
 vYw
 yhT
 gul
-gxj
+gpl
 jrX
-hVy
-igV
+hPD
+hZN
 xpu
 iKl
 iKl
-jLX
+jEK
 xhA
 xhA
 xhA
 xhA
 xhA
-mSc
+mII
 ppw
 ppw
 xhA
 xhA
-oDV
+ovQ
 xhA
 xhA
-qFQ
+qsa
 xhA
 xhA
 xhA
@@ -84358,14 +84272,14 @@ xhA
 xhA
 xhA
 pFn
-vIL
+uXY
 iKl
 iKl
-xss
+wVK
 xhA
 cus
 smy
-pXf
+kTP
 kdH
 xhA
 xhA
@@ -84578,21 +84492,21 @@ vYw
 uqU
 djs
 sJA
-dKk
+dHq
 vYw
-epa
+eaz
 iKQ
 yhT
 gul
 tmh
-hBC
+huh
 jrX
-iiE
+ifX
 iKl
-iST
+iKq
 iKl
 xpu
-klQ
+kic
 iKl
 seP
 seP
@@ -84605,25 +84519,25 @@ fnD
 bOf
 fkd
 xhA
-qJc
+qtD
 eHy
-rOp
+ryL
 rNi
 rNi
 xhA
 xhA
 xhA
 xhA
-uIq
-vIL
+uhT
+uXY
 iKl
 rFc
-xCf
+wWM
 xhA
 hUn
-qHq
+pmV
 kdH
-lvn
+sbj
 xhA
 xhA
 uoO
@@ -84837,7 +84751,7 @@ vYw
 vYw
 vYw
 vYw
-epa
+eaz
 iKQ
 gul
 gul
@@ -84849,7 +84763,7 @@ xhA
 xhA
 iKl
 iKl
-klQ
+kic
 iKl
 xpu
 qrl
@@ -84859,28 +84773,28 @@ iKl
 iKl
 iKl
 iKl
-oEt
+owX
 iKl
 wUr
-qMn
+qyv
 eHy
 eHy
-seL
-seL
+rWh
+rWh
 xhA
 xhA
 xGl
-upu
+tTB
 vBG
-vNU
+vdk
 iKl
 iKl
-xGu
+xdB
 xhA
 kdH
 kdH
 paO
-fJm
+loJ
 xhA
 xhA
 uoO
@@ -85094,13 +85008,13 @@ qoF
 qoF
 qoF
 ozI
-eCv
+eAw
 iKQ
 jUB
 jUB
 vxR
 qFm
-hXf
+hSU
 jUB
 jUB
 xhA
@@ -85109,33 +85023,33 @@ iKl
 xhA
 kOa
 sPl
-lLy
+lkT
 iKl
-ekP
-fFV
-nBh
-lSl
+rPG
 qjT
-fFV
+nwf
+lqC
+qjT
+qjT
 xoU
 tQe
 ybF
 teh
-rWh
+rIS
 eHy
-snJ
+sdJ
 xhA
 xhA
-tIz
-upu
+tkU
+tTB
 vBG
-vIL
+uXY
 iKl
 iKl
 xpu
-qcL
+srb
 kdH
-bGL
+cUC
 xhA
 xhA
 xhA
@@ -85355,42 +85269,42 @@ iKQ
 iKQ
 jUB
 xRW
-gNG
+gsw
 uSG
-gSN
+gxj
 xRW
 jUB
 xhA
 iKl
 iKl
 xhA
-kxu
+kpd
 xhA
 qrl
 mJJ
 qWx
-mWp
+mTt
 iKl
 hmP
-ofQ
-dHq
-fOQ
+odG
+iKl
+qWx
 mJJ
-qME
+qFQ
 eez
-rXl
+rJv
 eHy
-sHk
+seL
 mJJ
 xhA
 qVC
 uWA
 vBG
 jrA
-wyy
+vIL
 iKl
 xpu
-nji
+jXu
 xhA
 xhA
 xhA
@@ -85607,25 +85521,25 @@ dpR
 dpR
 dpR
 gEZ
-epa
+eaz
 iKQ
 iKQ
 xRW
-gim
+gcY
 jUB
 fUJ
 jUB
 xRW
 xRW
 xhA
-jyg
+jgL
 iKl
-koC
+kiX
 iKl
 fzR
 pIx
-mzX
-fOQ
+mjJ
+qWx
 fou
 cQR
 gnY
@@ -85639,16 +85553,16 @@ hNS
 kdH
 uGL
 leG
-txU
+tbg
 vBG
 qVC
 rfs
-vQZ
+vna
 kdH
 kdH
 kFc
 ydE
-pja
+clA
 bEK
 bEK
 bEK
@@ -85864,23 +85778,23 @@ dpR
 dpR
 dpR
 gEZ
-epa
+eaz
 iKQ
 iKQ
 xRW
 sfi
-gSN
+gxj
 fUJ
 cmE
 xRW
 fUJ
 qWq
 irr
-jNr
+jJd
 rPG
 qjT
 fSW
-lSl
+lqC
 qjT
 upI
 fDi
@@ -85888,24 +85802,24 @@ ulZ
 dGu
 vid
 xND
-pNi
+pAE
 sPC
 sPC
-rsM
+vTk
 hNS
 kdH
-sIK
+sgI
 bvC
 bvC
 bvC
 qPN
-uJS
+bvC
 bvC
 vTk
-xks
+wNi
 kdH
 cFj
-lwE
+nMB
 bEK
 bEK
 bEK
@@ -85926,7 +85840,7 @@ uoO
 uoO
 dkT
 xVz
-smT
+sLF
 aoj
 uoO
 uoO
@@ -86121,48 +86035,48 @@ dpR
 dpR
 dpR
 gEZ
-epa
+eaz
 iKQ
 iKQ
 pvX
 fDW
 uSG
-hGF
+hyR
 fUJ
 fUJ
 fUJ
 tuO
 cmE
 xgu
-fOQ
+qWx
 iKl
 kKx
 wCV
-mAX
-fOQ
+mui
+qWx
 iKl
 dGu
 xrA
-ogl
+oei
 xND
-pWr
+pKf
 deX
 deX
 rKX
-rXR
+rKE
 brt
 brt
 jGQ
 jGQ
 deX
-uvd
-jGQ
-jGQ
-wEX
+tXw
+deX
+deX
+vNU
 kFc
 kdH
 dRm
-roZ
+uGg
 bEK
 bEK
 bEK
@@ -86184,7 +86098,7 @@ uoO
 xVz
 xVz
 sXP
-iki
+fzT
 aoj
 aoj
 aoj
@@ -86383,24 +86297,24 @@ iKQ
 iKQ
 xRW
 sfi
-gTT
+gNG
 fUJ
 cmE
 xRW
 fUJ
 qWq
-jzX
+jnO
 cmE
-fOQ
-qnC
-kKx
-lYu
+qWx
 iKl
-mTj
+kKx
+lLy
+iKl
+mRK
 fDi
 xrA
 dGu
-oja
+ofQ
 xND
 iKl
 seP
@@ -86412,15 +86326,15 @@ kdH
 seP
 seP
 seP
-uwV
+ucQ
 seP
-sOf
-wFF
+seP
+vQZ
 kdH
-qZY
-soi
+kdH
+dcf
 xhA
-wiC
+oPU
 bEK
 bEK
 bEK
@@ -86635,11 +86549,11 @@ dpR
 dpR
 dpR
 gEZ
-epa
+eaz
 iKQ
 iKQ
 xRW
-gim
+gcY
 jUB
 fUJ
 jUB
@@ -86651,32 +86565,32 @@ rPG
 fME
 pWc
 bmK
-lZF
+lSl
 xpu
-fOQ
+qWx
 fou
-nDb
+nzl
 gnY
 seJ
 iKl
 baZ
 wKm
 xMa
-rtf
+qZA
 kdH
 kdH
 nTN
 bor
-tzx
+tcH
 xMa
 qVC
 dKo
 vsW
+vYx
 wNi
-xks
 kdH
 ydE
-pja
+clA
 bEK
 bEK
 bEK
@@ -86892,46 +86806,46 @@ gEZ
 gEZ
 gEZ
 gEZ
-eub
+emg
 iKQ
 iKQ
 jUB
 xRW
-hac
+gSN
 uSG
-gTT
+gNG
 xRW
-iyJ
+iuL
 xhA
 iKl
-fOQ
+qWx
 xhA
-kBT
+kpo
 xhA
 qrl
-mII
-fOQ
+mzX
+qWx
 oLf
 lZJ
 trr
-okm
-dHq
+ogl
+iKl
 iKl
 mJJ
 mEv
-rvb
+qZY
 iKl
 iKl
-sLI
+shO
 mJJ
 xhA
 qVC
 uWA
 bxX
-vYx
-fOQ
+vqm
+qWx
 iKl
-xIN
+xks
 xhA
 xhA
 xhA
@@ -87122,7 +87036,7 @@ geb
 eRI
 qii
 qii
-bxG
+ahx
 qii
 ojR
 eFS
@@ -87148,15 +87062,15 @@ oVJ
 oIP
 hPn
 guw
-dVj
+dKk
 mKE
-eER
+eBP
 iKQ
 jUB
 jUB
 vxR
-hIt
-hXf
+hBC
+hSU
 jUB
 jUB
 xhA
@@ -87164,36 +87078,36 @@ iKl
 mxa
 xhA
 kOa
-lgv
-lLy
+lbt
+lkT
 xpu
 qWx
-dHq
 iKl
 iKl
-dHq
-iwO
+iKl
+iKl
+iKl
 gnw
 xZI
 jVx
-rwk
+rfD
 iKl
 iKl
 reN
-sWu
+sHk
 xhA
-tJH
-upu
+tna
+tTB
 vBG
-vIL
-fOQ
+uXY
+qWx
 iKl
-jLX
+jEK
 xMi
-poJ
+rFn
 vOR
 vOR
-jim
+lDx
 xMi
 xMi
 uoO
@@ -87407,7 +87321,7 @@ sdz
 oVJ
 oVJ
 tJM
-eFE
+eCv
 jQs
 gul
 gul
@@ -87418,13 +87332,13 @@ gul
 gul
 xhA
 iKl
-fOQ
-klQ
+qWx
+kic
 iKl
 xpu
 qrl
-dHq
-fOQ
+iKl
+qWx
 xpu
 iKl
 xpu
@@ -87432,22 +87346,22 @@ xpu
 qwp
 mNL
 wUr
-qOJ
+qJc
 iKl
 iKl
 iKl
 reN
-sXi
+sIK
 xhA
-tJT
-upu
+toO
+tTB
 vBG
-vIL
-fOQ
+uXY
+qWx
 iKl
-xVV
+xnb
 xMi
-poJ
+rFn
 xMi
 xMi
 xMi
@@ -87662,21 +87576,21 @@ oOw
 oVJ
 sdz
 oVJ
-dWN
+dUW
 oVJ
-eLG
-fdN
-fwX
+eER
+eXJ
+fqM
 xjE
 xjE
 xjE
 eME
 xDy
-izo
+iuX
 xhA
 pxI
-jOL
-klQ
+jLX
+kic
 iKl
 tnF
 tnF
@@ -87684,35 +87598,35 @@ iKl
 mxa
 qrl
 xpu
-nWG
+nMN
 fnD
-oNj
+oDV
 fkd
-qfB
-qWa
+pXp
+qMn
 iKl
 iKl
 iKl
 reN
-sWu
+sHk
 xhA
 xhA
 xhA
 vBG
-vIL
-fOQ
+uXY
+qWx
 xpu
-xCf
+wWM
 xMi
-tLB
+hNm
 xMi
 dyR
 dyR
 xMi
 xMi
-wLX
+pzw
 uoO
-tba
+bCX
 uoO
 uoO
 uoO
@@ -87923,35 +87837,35 @@ hPn
 hPn
 hPn
 gul
-fxu
+ftt
 gul
-hhZ
+gTT
 gul
 pld
 pld
-iEg
+iwO
 gul
-jBc
+jyc
 gul
 xhA
 xhA
 xhA
 xhA
 xhA
-mTt
+mSc
 xhA
-nEt
-xhA
-xhA
-oWc
+nBh
 xhA
 xhA
-qXo
+oEt
+xhA
+xhA
+qME
 iKl
 iKl
-iKl
-reN
-sWu
+jJB
+slT
+xhA
 xhA
 xhA
 xhA
@@ -87959,17 +87873,17 @@ uZS
 quR
 mxa
 iKl
-xss
+wVK
 xMi
 vOR
-dIu
+kJW
 sAL
 sAL
 xMi
 xMi
 xVz
 uoO
-tba
+bCX
 xVz
 xVz
 xVz
@@ -88176,57 +88090,57 @@ oVJ
 oVJ
 oVJ
 oVJ
-eaz
-eaz
-eVA
+dVj
+dVj
+eFE
 gul
-fCf
+fwX
 kzn
-hrq
+hac
 sgm
 sUs
 sUs
 sUs
 ipv
-jEK
+jyg
 vQx
 xhA
 mnj
-lkT
+lbG
 mnj
 mnj
 ukT
 pNT
-nIl
+nDb
 omp
 omp
-lkT
+lbG
 mnj
 xhA
 wPy
 tsq
 tsq
-tsq
-sPa
-xhA
+sUH
+slT
 cZP
+cFi
 cZP
 peK
-uXY
+umw
 iKl
-fOQ
+qWx
 iKl
-xCf
+wWM
 xMi
-tLB
+hNm
 xMi
-tGt
+bTu
 dyR
 xMi
 xMi
 xVz
 uoO
-tba
+bCX
 xVz
 xVz
 xVz
@@ -88240,7 +88154,7 @@ uoO
 uoO
 uoO
 xVz
-wLX
+pzw
 uoO
 aoj
 uoO
@@ -88437,13 +88351,13 @@ oVJ
 oVJ
 jPi
 gul
-fDp
+fxu
 gul
-huh
+hhZ
 gul
 oYG
 pld
-iJD
+iyJ
 vQx
 vQx
 vQx
@@ -88453,37 +88367,37 @@ uMJ
 cEF
 uMJ
 ukT
-nby
-nIl
+mUS
+nDb
 uMJ
 cEF
 uMJ
 mnj
 tKr
 vMi
-ryL
+riR
 tsq
-tsq
+sUH
 gKJ
 cFi
 cFi
 cFi
 peK
-vdk
+upu
 xpu
-fOQ
+qWx
 iKl
-xCf
+wWM
 xMi
 vOR
 xMi
 xMi
-okP
+fze
 xMi
 xMi
 xVz
 uoO
-tba
+bCX
 xVz
 xVz
 xVz
@@ -88694,45 +88608,45 @@ oVJ
 oVJ
 jPi
 gul
-fxu
+ftt
 gul
 gul
 gul
 oYG
 dxx
 cCv
-iVj
+iLO
 vQx
 vQx
-kpd
+klQ
 mnj
 mnj
 omp
 omp
 ukT
-neq
-nIl
+mWp
+nDb
 mnj
 mnj
 mnj
 mnj
 xhA
 xRU
-rIS
-rIS
-sgI
+rsM
+rsM
+rXl
 xhA
-tbg
+sLI
 xhA
-tbg
+sLI
 xhA
 uKn
-wmE
+vqH
 mxa
 iKl
-xss
+wVK
 xMi
-qKt
+jzC
 xMi
 jFd
 paF
@@ -88740,7 +88654,7 @@ xMi
 xMi
 xVz
 uoO
-tba
+bCX
 xVz
 xVz
 xVz
@@ -88953,13 +88867,13 @@ khb
 jQs
 qOT
 oTk
-fwX
+fqM
 gul
 oYG
 vrD
-iKq
+izo
 vQx
-jJd
+jzX
 vQx
 xhA
 aSI
@@ -88967,29 +88881,29 @@ qQS
 cEF
 uMJ
 ukT
-nkx
-nIl
+nby
+nDb
 uMJ
 cEF
 qQS
-pXp
+pNi
 xhA
 tSH
-rJv
+rtf
 xhA
 xhA
 xhA
-tcH
+sOf
 xhA
-tcH
+sOf
 xhA
 bxX
-vIL
-fOQ
+uXY
+qWx
 iKl
-xCf
+wWM
 xMi
-dVv
+lpK
 xMi
 paF
 paF
@@ -88997,14 +88911,14 @@ xMi
 xMi
 xVz
 uoO
-tba
+bCX
 xVz
 xVz
 xVz
 xVz
 xVz
 xVz
-fDa
+lgA
 xVz
 xVz
 xVz
@@ -89180,7 +89094,7 @@ wOp
 wOp
 wOp
 sWB
-ahx
+jrn
 wOp
 kny
 bVY
@@ -89208,23 +89122,23 @@ jKo
 oVJ
 hYT
 jQs
-fxu
+ftt
 gul
-hyR
-gul
-gul
+hrq
 gul
 gul
 gul
 gul
 gul
-kpd
+gul
+gul
+klQ
 roa
 roa
 roa
 roa
 kXA
-nkL
+neq
 eeH
 mpY
 mpY
@@ -89240,13 +89154,13 @@ xhA
 xhA
 xhA
 xhA
-vna
-vNU
-fOQ
+uvd
+vdk
+qWx
 iKl
-ydv
+xnV
 xMi
-dVv
+lpK
 xMi
 paF
 paF
@@ -89254,14 +89168,14 @@ xMi
 xMi
 xVz
 uoO
-tba
+bCX
 xVz
 lIH
-bgZ
+vLy
 xVz
 xVz
 dWT
-qjv
+cHw
 xVz
 xVz
 xVz
@@ -89437,7 +89351,7 @@ wOp
 wOp
 wOp
 wOp
-ahx
+jrn
 wOp
 kny
 bVY
@@ -89465,18 +89379,18 @@ qbK
 cLp
 kAm
 pLl
-fKn
+fCf
 gul
 tls
-hKI
-hXn
+hGF
+hVy
 aBQ
 iAm
 aVV
-jJB
+jBc
 gul
 xhA
-kLA
+kxu
 rKJ
 rKJ
 nIB
@@ -89485,25 +89399,25 @@ rzQ
 fuQ
 dZE
 hhn
-oWr
+oNj
 eeH
-qgO
+qci
 xcC
-rKE
+rvb
 xcC
-rKE
+rvb
 xcC
 hHc
 uJx
-tJU
+txU
 xMi
 xMi
 xMi
-wNs
+wmE
 xMi
 xMi
 xMi
-rzM
+osk
 xMi
 jFd
 jFd
@@ -89511,16 +89425,16 @@ xMi
 xMi
 dkT
 uoO
-tba
+bCX
 xVz
-cAt
+xQT
 qUL
 qUL
 qGe
 ajJ
 upA
 rDr
-wpH
+amf
 xVz
 xVz
 xVz
@@ -89722,13 +89636,13 @@ hPn
 cXG
 dFh
 jQs
-fxu
+ftt
 gul
 xmQ
 fYf
-hYI
+hXf
 rJn
-iLO
+iEg
 tCe
 qfu
 eSC
@@ -89738,21 +89652,21 @@ jIm
 jIm
 nIB
 kXA
-nqE
+nkx
 xpu
 xpu
 xpu
 xpu
 fuQ
 xhA
-qYS
+qOJ
 cTh
 cTh
 cTh
 xcC
 wbM
 srH
-tTB
+tzx
 xMi
 qqJ
 mEm
@@ -89760,26 +89674,26 @@ oRZ
 qtL
 bKG
 fLF
-tzO
+ddQ
 xMi
 eOx
-gWU
+trJ
 xMi
 xMi
 xVz
 xVz
-iZT
+fkn
 xVz
 oMK
 iGY
-eXg
+hTD
 otf
 qxo
 suF
 eRg
 dWT
 uiV
-wpH
+amf
 xVz
 xVz
 xVz
@@ -89979,28 +89893,28 @@ hPn
 nWW
 liM
 nnN
-gcD
+fDp
 gul
 xmQ
 qKP
 vVg
-ilw
+igV
 oxw
 iIQ
 oxw
-jOU
+jNr
 mgt
 nIB
 nIB
-mcC
-kLU
+lYu
+kBT
 fOH
 eeH
 eeH
 kCz
-ovQ
+oja
 nIB
-qci
+pWr
 xhA
 xcC
 xYY
@@ -90009,20 +89923,20 @@ xYY
 xcC
 uJx
 tnl
-tXw
+tHM
 xMi
 oRM
 llp
 tAi
 mrx
-ykT
+xsk
 mTF
-oDg
+ydK
 xMi
 xMi
 xMi
 xMi
-jYS
+eIJ
 xVz
 xVz
 xVz
@@ -90030,10 +89944,10 @@ xVz
 nYw
 dur
 ofI
-eDN
+dlw
 qxo
 qxo
-fox
+pPS
 gTy
 gTy
 oaW
@@ -90240,25 +90154,25 @@ jQs
 gul
 xmQ
 vrD
-hZN
+hXn
 iIQ
 oxw
 iIQ
 iIQ
 rJn
-kpo
-kLU
-kLU
+koC
+kBT
+kBT
 fOH
 vDn
 sjR
 aCO
-nKk
+nEt
 vDn
 ukP
 nIB
 eeH
-qgO
+qci
 xcC
 xcC
 xcC
@@ -90266,7 +90180,7 @@ xcC
 xcC
 srH
 ksU
-ucQ
+tIz
 xMi
 rjQ
 mrV
@@ -90275,11 +90189,11 @@ lMT
 ldP
 hQt
 vCL
-jpM
+eeW
 gHi
 gHi
-rKa
-dzH
+haW
+tYy
 xVz
 xVz
 xVz
@@ -90287,17 +90201,17 @@ uoO
 qxo
 otf
 oaW
-slo
+fZB
 qxo
 qxo
 qxo
 qxo
 qxo
-gEy
+tha
 qxo
 qxo
 qxo
-wgN
+jAd
 aoj
 uoO
 aoj
@@ -90491,7 +90405,7 @@ ehz
 dtO
 vKT
 cuN
-eXJ
+eLG
 gul
 yhT
 gul
@@ -90499,44 +90413,44 @@ gul
 gul
 gul
 gul
-iQt
+iJD
 gul
 oxw
-jTD
+jOL
 mgt
 pEG
 pEG
 nIB
-mRK
+mAX
 xcC
-nwf
+nkL
 xcC
-nXh
+nNi
 ukP
 nIB
-qci
+pWr
 xhA
 xcC
 cTh
 cTh
 cTh
 xcC
-thO
+sPa
 tnl
-ufk
+tJH
 xMi
 mrV
 oRM
 mTF
 mTF
 thr
-kbt
+iAx
 aQg
 xYX
-dzH
+tYy
 gHi
 alw
-mQQ
+uFn
 xVz
 xVz
 xVz
@@ -90544,7 +90458,7 @@ uoO
 otf
 otf
 oaW
-slo
+fZB
 qxo
 qxo
 qxo
@@ -90553,7 +90467,7 @@ qxo
 qxo
 qxo
 qxo
-mIo
+smf
 uoO
 aoj
 uoO
@@ -90759,41 +90673,41 @@ xDy
 fYf
 gul
 bsF
-jYe
+jOU
 mgt
 bpH
-lqC
+lgv
 nIB
 xcC
 kGx
 umZ
 gsc
-nYD
+nWG
 ukP
-pfC
+oWc
 eeH
 xhA
-qYS
+qOJ
 xYY
 xYY
 xYY
 xcC
-tkU
+sUy
 srH
-tTB
+tzx
 xMi
 olK
 sUF
-wPV
+wuE
 mTF
-apA
+xss
 xMi
-vqd
-xMi
-xMi
+eDs
 xMi
 xMi
-jYS
+xMi
+xMi
+eIJ
 xVz
 xVz
 xVz
@@ -91009,14 +90923,14 @@ weF
 yhT
 yhT
 gul
-hhZ
+gTT
 mTr
 gul
-isG
-izo
+iiE
+iuX
 gul
 cLJ
-jYP
+jTD
 xhA
 xhA
 xhA
@@ -91029,40 +90943,40 @@ xhA
 xhA
 xhA
 eeH
-qid
+qfB
 xcC
 gsc
 xcC
 gsc
 xcC
 hHc
-thO
-tJU
+sPa
+txU
 xMi
 scG
-wuE
+vyb
 sUF
-xnb
+wNs
 sUF
 cej
 qVt
 aQg
 aQg
-jYV
+bum
 xMi
 xMi
 xVz
 xVz
 xVz
 xVz
-yjX
+wqL
 otf
 oaW
 qxo
-dFw
+eQL
 qxo
 suF
-qjv
+cHw
 oaW
 oaW
 oaW
@@ -91262,7 +91176,7 @@ bKi
 xly
 oHT
 weF
-fcn
+eVA
 gul
 gul
 gul
@@ -91296,35 +91210,35 @@ xhA
 xhA
 xhA
 xMi
-vqm
+uwV
 xMi
-wQJ
+wxb
 xMi
-rpa
+xCf
 xMi
 dTR
-lPw
+acv
 qVt
-qXI
+ucw
 xMi
 xMi
 xVz
-tba
+bCX
 xVz
-nNW
+uTL
 xVz
 dur
-eXg
-eDN
+hTD
+dlw
 qxo
 oNu
 suF
 upA
-lFJ
+hnU
 oaW
 xVz
 xVz
-iki
+fzT
 uoO
 uoO
 uoO
@@ -91483,7 +91397,7 @@ uoO
 uoO
 gEZ
 fpv
-dUW
+bTG
 xxn
 gEZ
 lHS
@@ -91519,9 +91433,9 @@ huv
 eQh
 weF
 weF
-eXJ
-fqM
-gcY
+eLG
+fcn
+fKn
 yhT
 yhT
 yhT
@@ -91553,7 +91467,7 @@ kKy
 kKy
 kKy
 wox
-vqH
+uFO
 iXC
 iXC
 iXC
@@ -91565,18 +91479,18 @@ xMi
 xMi
 xMi
 wox
-tba
+bCX
 uoO
 vxo
 isU
-kQI
+oCA
 uoO
-frL
+fEs
 xVz
 gbA
 dkT
 kqS
-eHg
+kbH
 uoO
 uoO
 uoO
@@ -91777,7 +91691,7 @@ dFh
 dFh
 dFh
 dFh
-ftt
+fdN
 eLE
 eLE
 eLE


### PR DESCRIPTION
## About The Pull Request
Bunch of bunker remapping to fix things that have been bugging me for weeks, and to better manifest the new bunkers surface goal.

## Why It's Good For The Game
BoS are supposed to do a lot of trading with compliant outsiders and potential recruits now, so I've better emphasised that aspect by giving them a dedicated trading point and made the second gatehouse inhavitable and usable. Bunch of other QoL patches.

## Changelog
:cl:
del: Removed a few pieces of clutter from the surface compound
tweak: Remapped Hydro; added a few more trays and deleted the spare tray boards, added a workshop/workbench for stim crafting to cut down on needless hauling, and added a ready-to-use manipulator
add/tweak: Remapped one of the surface camp buildings to function as a BoS trading point with fillable vendors
add/tweak: Remapped the main gatehouse and opened up the second gatehouse, with the two differing in function; one is geared towards storage of visitor guns and controlling the gate, while the other gatehouse has access to the trading point and a bigger exterior window to emphasise its purpose as the trading window for those who can't or don't want to enter the camp properly
add: Also the gate has a second button on the inside now
tweak: Remapped Star Knight Office, adding desk space and terminals for Knights
tweak: Remapped Paladin Hall
tweak: Remapped Star Paladin Offices
tweak: Remapped the back of the armory to have a locker/changing room, instead of pointless storage
add/tweak: Slightly modified the power cabling that crosses the first and second floor between the Codex and Surgery, and used otherwise pointless maintenance areas behind the SK/Paladin Offices to carry redundant cabling
tweak: Increased security of the Elders Office by upgrading the entrance airlock and removing the maintenance access into the back of their office; instead they get a personal bathroom
tweak: Removed the mop closet in the medical area, making room for a second surgery area
tweak: There's a small, dedicated janitorial closet installed at the fore of the maintenance by the armory instead
fix: Devoted more space to the cryotube, and maybe it will actually work with an attached thermocontroller and proper facing
tweak: Rotated the lower bathroms to slot them into the same area and take up less space; intention was to put in an airlock for faster passage through the area but then decided against it for security reasons
del: Got rid of the rack in the toilet wall
tweak: Swapped the bookshelves in one of the RnD zones to racks instead, now that we have a full library area
del: Removed the 'No ERP' poster from the sauna
:cl:

