### PR TITLE
Tinkering quickfixes

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -564,7 +564,7 @@
 	name = "Invent"
 	result = /obj/item/invention
 	time = 30
-	reqs = list(/obj/item/crafting = 15)
+	reqs = list(/obj/item/crafting = 5)
 	tools = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL, TOOL_WORKBENCH)
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -11,7 +11,7 @@
 	var/datum/beepsky_fashion/beepsky_fashion //the associated datum for applying this to a secbot
 	var/list/speechspan = null
 	armor = list("tier" = 1)
-	var/tinkered = 0
+	//var/tinkered = 0
 
 /obj/item/clothing/head/Initialize()
 	. = ..()

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -16,7 +16,7 @@
 	var/mutable_appearance/accessory_overlay
 	var/dummy_thick = FALSE // is able to hold accessories on its item
 
-	var/tinkered = 0
+	//var/tinkered = 0
 
 /obj/item/clothing/suit/Initialize()
 	. = ..()

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -1022,6 +1022,9 @@
 	to_chat(user,"You destroy the item in the process.")
 
 /obj/item/experimental/proc/gun(obj/item/W, mob/user)
+	if(istype(W,/obj/item/gun/ballistic/automatic/shotgun))
+		to_chat(usr, "You can't improve [W.name]...")
+		return
 	var/obj/item/gun/ballistic/B = W 
 
 	var/dmgmod = rand(-10,10)
@@ -1272,8 +1275,8 @@
 	var/list/vhigh = list(/obj/item/melee/powerfist, /obj/item/nullrod/claymore/chainsaw_sword)
 
 	var/list/high = list(/obj/item/shishkebabpack, /obj/item/gun/energy/gammagun, /obj/item/clothing/suit/armor/f13/sulphitearmor,
-	/obj/item/clothing/head/helmet/f13/sulphitehelm, /obj/item/melee/powerfist/moleminer, /obj/machinery/chem_master, 
-	/obj/machinery/cell_charger)
+	/obj/item/clothing/head/helmet/f13/sulphitehelm, /obj/item/melee/powerfist/moleminer, /obj/item/circuitboard/machine/chem_master, 
+	/obj/item/circuitboard/machine/cell_charger)
 
 	var/list/mid = list(/obj/item/twohanded/fireaxe/bmprsword, /obj/item/twohanded/sledgehammer, /obj/item/shield/makeshift,/obj/item/gun/ballistic/automatic/autopipe,
 	/obj/item/gun/ballistic/shotgun/lasmusket, /obj/item/gun/ballistic/shotgun/plasmacaster, /obj/item/clothing/suit/armor/f13/metalarmor,

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -1010,6 +1010,16 @@
 		hat(W, user)
 		return
 	
+/obj/item
+	var/tinkered = 0
+
+/obj/item/experimental/proc/reroll(obj/item/W, mob/user)
+	var/obj/item/item = W.type
+	qdel(W)
+	if(prob(70))
+		new item(user.loc)
+		return
+	to_chat(user,"You destroy the item in the process.")
 
 /obj/item/experimental/proc/gun(obj/item/W, mob/user)
 	var/obj/item/gun/ballistic/B = W 
@@ -1029,7 +1039,9 @@
 	if(B.tinkered > 0 && !HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
 		to_chat(usr, "You have already tinkered with this item.")
 		return
-
+	if(B.tinkered == 1)
+		reroll(B,user)
+		return
 	if(B.tinkered > 1 && HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
 		to_chat(usr, "You have already tinkered with this item too much.")
 		return
@@ -1051,7 +1063,7 @@
 	B.fire_delay += (spdmod/5)
 	B.name = prefix + B.name
 	B.tinkered += 1
-	B.desc += " Attempt[B.tinkered] - Extra damage: [B.extra_damage]; Extra penetration: [B.extra_penetration]; Fire delay: [B.fire_delay]"
+	B.desc += " Extra damage: [B.extra_damage]; Extra penetration: [B.extra_penetration]; Fire delay: [B.fire_delay]"
 
 	to_chat(usr, "You tinker with the gun making [W.name]...")
 	qdel(src)
@@ -1075,7 +1087,9 @@
 	if(E.tinkered > 0 && !HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
 		to_chat(usr, "You have already tinkered with this item.")
 		return
-
+	if(E.tinkered == 1)
+		reroll(E,user)
+		return
 	if(E.tinkered > 1 && HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
 		to_chat(usr, "You have already tinkered with this item too much.")
 		return
@@ -1098,7 +1112,7 @@
 	//E.ammo_type[1].delay += spdmod
 	E.name = prefix + E.name
 	E.tinkered += 1
-	E.desc += " Attempt[E.tinkered] - Extra damage: [E.extra_damage]; Extra penetration: [E.extra_penetration]; Fire delay: [E.fire_delay]"
+	E.desc += " Extra damage: [E.extra_damage]; Extra penetration: [E.extra_penetration]; Fire delay: [E.fire_delay]"
 
 	to_chat(usr, "You tinker with the energy gun making [W.name]...")
 	qdel(src)
@@ -1118,7 +1132,9 @@
 	if(A.tinkered > 0 && !HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
 		to_chat(usr, "You have already tinkered with this item.")
 		return
-
+	if(A.tinkered == 1)
+		reroll(A,user)
+		return
 	if(A.tinkered > 1 && HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
 		to_chat(usr, "You have already tinkered with this item too much.")
 		return
@@ -1141,7 +1157,7 @@
 	A.slowdown += (spdmod/50)
 	A.name = prefix + A.name
 	A.tinkered += 1
-	A.desc += " Attempt[A.tinkered] - Armor: Melee: [A.armor.linemelee], Bullet: [A.armor.linebullet], Laser: [A.armor.linelaser]; Speed: [A.slowdown]"
+	A.desc += " Armor: Melee: [A.armor.linemelee], Bullet: [A.armor.linebullet], Laser: [A.armor.linelaser]; Speed: [A.slowdown]"
 
 	to_chat(usr, "You tinker with the armor making [W.name]...")
 	qdel(src)
@@ -1161,7 +1177,9 @@
 	if(H.tinkered > 0 && !HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
 		to_chat(usr, "You have already tinkered with this item.")
 		return
-
+	if(H.tinkered == 1)
+		reroll(H,user)
+		return
 	if(H.tinkered > 1 && HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
 		to_chat(usr, "You have already tinkered with this item too much.")
 		return
@@ -1184,7 +1202,7 @@
 	H.slowdown += (spdmod/50)
 	H.name = prefix + H.name
 	H.tinkered += 1
-	H.desc += " Attempt[H.tinkered] - Armor: Melee: [H.armor.linemelee], Bullet: [H.armor.linebullet], Laser: [H.armor.linelaser]; Speed: [H.slowdown]"
+	H.desc += " Armor: Melee: [H.armor.linemelee], Bullet: [H.armor.linebullet], Laser: [H.armor.linelaser]; Speed: [H.slowdown]"
 
 	to_chat(usr, "You tinker with the armor making [W.name]...")
 	qdel(src)
@@ -1192,7 +1210,7 @@
 /obj/item/experimental/proc/parmor(obj/item/W, mob/user)
 	var/obj/item/clothing/suit/armor/f13/power_armor/A = W
 	//chance to upgrade all t45b versions to salvaged t45b, chance to upgrade salvaged t45b to t45b (new sprotes, t8 armor with no slowdown)
-	if(prob(15))
+	if(prob(20))
 		if(istype(A,/obj/item/clothing/suit/armor/f13/power_armor/raiderpa))//ups raider to salvaged
 			new /obj/item/clothing/suit/armor/f13/power_armor/t45b(user.loc)
 			qdel(A)
@@ -1205,14 +1223,17 @@
 			new /obj/item/clothing/suit/armor/f13/power_armor/t45b/restored(user.loc)
 			qdel(A)
 			return
-	if(prob(10))
+	if(prob(10)&&!HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
+		qdel(A)
+		to_chat(user,"You ruin the armor completely, destroying it in the process...")
+	if(prob(5)&&HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
 		qdel(A)
 		to_chat(user,"You ruin the armor completely, destroying it in the process...")
 	qdel(src)
 
 /obj/item/experimental/proc/pahat(obj/item/W, mob/user)
 	var/obj/item/clothing/head/helmet/f13/power_armor/H = W
-	if(prob(15))
+	if(prob(20))
 		if(istype(H,/obj/item/clothing/head/helmet/f13/power_armor/raiderpa_helm))//ups raider to salvaged
 			new /obj/item/clothing/head/helmet/f13/power_armor/t45b(user.loc)
 			qdel(H)
@@ -1225,7 +1246,10 @@
 			new /obj/item/clothing/head/helmet/f13/power_armor/t45b/restored(user.loc)
 			qdel(H)
 			return
-	if(prob(10))
+	if(prob(10)&&!HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
+		qdel(H)
+		to_chat(user,"You ruin the helmet completely, destroying it in the process...")
+	if(prob(5)&&HAS_TRAIT(user,TRAIT_MASTER_GUNSMITH))
 		qdel(H)
 		to_chat(user,"You ruin the helmet completely, destroying it in the process...")
 	qdel(src)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -114,7 +114,7 @@
 
 	var/dualwield_spread_mult = 1		//dualwield spread multiplier
 
-	var/tinkered = 0
+	//var/tinkered = 0
 	/// Just 'slightly' snowflakey way to modify projectile damage for projectiles fired from this gun.
 //	var/projectile_damage_multiplier = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes some stuff about tinkering to make it more balanced.
No more stacking, instead master tinkerer gives you the ability to restore the item to its original state with a 30% chance of destroying the item. After that the item can be tinkered with again.
Power armor restoration given higher chance to occur (20%) and lower chance of complete failure (5%) with the master tinkerer trait.
Invention changed to 5 from 15 components required in order to make it a viable alternative to tinkering.
Replaces machines with boards.

## Why It's Good For The Game

Balance and stuff.
