### PR TITLE
Removes useless (literally) ammo subtype

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -190,7 +190,7 @@ GLOBAL_LIST_INIT(trash_ammo, list(
 	/obj/item/ammo_box/a308box = 3,
 	/obj/item/ammo_box/a556/sport = 3,
 	/obj/item/ammo_box/magazine/m45 = 3,
-	/obj/item/ammo_box/magazine/m10mm_adv/simple = 3,
+	/obj/item/ammo_box/magazine/m10mm_adv = 3,
 	/obj/item/ammo_box/magazine/m9mm = 3,
 	/obj/item/ammo_casing/shotgun/buckshot = 3,
 	/obj/item/ammo_box/c45rev = 3,
@@ -521,13 +521,13 @@ GLOBAL_LIST_INIT(loot_t1_range, list(
 	/obj/item/gun/ballistic/shotgun/remington,
 	/obj/item/ammo_box/a308,
 	/obj/item/gun/ballistic/automatic/pistol/n99,
-	/obj/item/ammo_box/magazine/m10mm_adv/simple,
+	/obj/item/ammo_box/magazine/m10mm_adv,
 	/obj/item/gun/ballistic/automatic/pistol/m1911,
 	/obj/item/ammo_box/magazine/m45,
 	/obj/item/gun/ballistic/automatic/pistol/ninemil,
 	/obj/item/ammo_box/magazine/m9mm,
 	/obj/item/gun/ballistic/revolver/colt6520,
-	/obj/item/ammo_box/magazine/m10mm_adv/simple,
+	/obj/item/ammo_box/magazine/m10mm_adv,
 	/obj/item/gun/ballistic/automatic/varmint,
 	/obj/item/ammo_box/magazine/m556/rifle/small
 ))
@@ -551,7 +551,7 @@ GLOBAL_LIST_INIT(loot_t2_range, list(
 	/obj/item/gun/energy/laser/pistol,
 	/obj/item/stock_parts/cell/ammo/ec,
 	/obj/item/gun/ballistic/automatic/m1carbine,
-	/obj/item/ammo_box/magazine/m10mm_adv/simple,
+	/obj/item/ammo_box/magazine/m10mm_adv,
 	/obj/item/gun/ballistic/automatic/commando,
 	/obj/item/ammo_box/magazine/m45
 ))
@@ -631,7 +631,7 @@ GLOBAL_LIST_INIT(loot_t1_ammo, list(
 	/obj/item/storage/fancy/ammobox,
 	/obj/item/storage/fancy/ammobox/beanbag,
 	/obj/item/ammo_box/c38,
-	/obj/item/ammo_box/magazine/m10mm_adv/simple,
+	/obj/item/ammo_box/magazine/m10mm_adv,
 	/obj/item/ammo_box/magazine/m556/rifle/small
 ))
 
@@ -639,7 +639,7 @@ GLOBAL_LIST_INIT(loot_t2_ammo, list(
 	/obj/item/ammo_box/magazine/m45,
 	/obj/item/ammo_box/a762,
 	/obj/item/ammo_box/a308,
-	/obj/item/ammo_box/magazine/m10mm_adv/simple,
+	/obj/item/ammo_box/magazine/m10mm_adv,
 	/obj/item/ammo_box/magazine/m556/rifle,
 	/obj/item/ammo_box/c38,
 	/obj/item/ammo_box/magazine/m9mm,
@@ -652,7 +652,7 @@ GLOBAL_LIST_INIT(loot_t2_ammo, list(
 GLOBAL_LIST_INIT(loot_t3_ammo, list(
 	/obj/item/storage/fancy/ammobox/lethalshot,
 	/obj/item/ammo_box/magazine/uzim9mm,
-	/obj/item/ammo_box/magazine/m10mm_adv/simple,
+	/obj/item/ammo_box/magazine/m10mm_adv,
 	/obj/item/ammo_box/magazine/greasegun,
 	/obj/item/ammo_box/needle,
 	/obj/item/ammo_box/magazine/tommygunm45,

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -856,7 +856,7 @@
 	name = "m1 carbine and ammo spawner"
 	items = list(
 				/obj/item/gun/ballistic/automatic/m1carbine,
-				/obj/item/ammo_box/magazine/m10mm_adv/simple
+				/obj/item/ammo_box/magazine/m10mm_adv
 	)
 
 /obj/effect/spawner/bundle/f13/commando
@@ -1297,7 +1297,7 @@
 				/obj/item/storage/fancy/ammobox,
 				/obj/item/storage/fancy/ammobox/beanbag,
 				/obj/item/ammo_box/c38,
-				/obj/item/ammo_box/magazine/m10mm_adv/simple,
+				/obj/item/ammo_box/magazine/m10mm_adv,
 				/obj/item/ammo_box/magazine/m556/rifle/small
 				)
 
@@ -1309,7 +1309,7 @@
 				/obj/item/ammo_box/magazine/m45,
 				/obj/item/ammo_box/a762,
 				/obj/item/ammo_box/a308,
-				/obj/item/ammo_box/magazine/m10mm_adv/simple,
+				/obj/item/ammo_box/magazine/m10mm_adv,
 				/obj/item/ammo_box/magazine/m556/rifle,
 				/obj/item/ammo_box/c38,
 				/obj/item/ammo_box/magazine/m9mm,
@@ -1330,7 +1330,7 @@
 	loot = list(
 				/obj/item/storage/fancy/ammobox/lethalshot,
 				/obj/item/ammo_box/magazine/uzim9mm,
-				/obj/item/ammo_box/magazine/m10mm_adv/simple,
+				/obj/item/ammo_box/magazine/m10mm_adv,
 				/obj/item/ammo_box/magazine/greasegun,
 				/obj/item/ammo_box/needle,
 				/obj/item/ammo_box/magazine/tommygunm45,

--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -555,7 +555,7 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 	prize_list = list(
 		new /datum/data/wasteland_equipment("Handgun magazine (.45)",		/obj/item/ammo_box/magazine/m45,									50),
 		new /datum/data/wasteland_equipment("9mm pistol magazine (9mm)",	/obj/item/ammo_box/magazine/m9mm,									50),
-		new /datum/data/wasteland_equipment("10mm pistol magazine (10mm)",	/obj/item/ammo_box/magazine/m10mm_adv/simple,								60),
+		new /datum/data/wasteland_equipment("10mm pistol magazine (10mm)",	/obj/item/ammo_box/magazine/m10mm_adv,								60),
 		new /datum/data/wasteland_equipment("Speed strip (.357)",			/obj/item/ammo_box/a357,											70),
 		new /datum/data/wasteland_equipment("Speed loader (.44)",			/obj/item/ammo_box/m44,												70),
 		new /datum/data/wasteland_equipment("Speed loader (.38)",			/obj/item/ammo_box/c38,												70),

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -145,14 +145,14 @@ Head Paladin
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/mfc=3,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2)
+		/obj/item/ammo_box/magazine/m10mm_adv=2)
 
 /datum/outfit/loadout/sentvet
 	name = "Veteran Head Paladin"
 	backpack_contents = list(
 		/obj/item/gun/energy/ionrifle=1,
 		/obj/item/stock_parts/cell/ammo/mfc=3,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2,
+		/obj/item/ammo_box/magazine/m10mm_adv=2,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
 		)
 
@@ -294,7 +294,7 @@ Head Knight
 		/obj/item/gun/energy/laser/aer14=1,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
 		/obj/item/stock_parts/cell/ammo/mfc=2,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2
+		/obj/item/ammo_box/magazine/m10mm_adv=2
 		)
 
 /datum/outfit/loadout/capsap
@@ -382,7 +382,7 @@ Star Paladin
 		/obj/item/gun/energy/laser/aer14=1,
 		/obj/item/stock_parts/cell/ammo/mfc=2,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2
+		/obj/item/ammo_box/magazine/m10mm_adv=2
 		)
 
 /*
@@ -454,7 +454,7 @@ Paladin
 		/obj/item/gun/energy/laser/rcw=1,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
 		/obj/item/stock_parts/cell/ammo/ecp=2,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2,
+		/obj/item/ammo_box/magazine/m10mm_adv=2,
 		/obj/item/clothing/accessory/bos/juniorpaladin=1
 		)
 
@@ -474,7 +474,7 @@ Paladin
 		/obj/item/gun/energy/laser/rcw=1,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
 		/obj/item/stock_parts/cell/ammo/ecp=2,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2,
+		/obj/item/ammo_box/magazine/m10mm_adv=2,
 		/obj/item/clothing/accessory/bos/paladin=1
 		)
 
@@ -643,7 +643,7 @@ datum/job/bos/f13seniorknight
 		/obj/item/gun/energy/laser/rcw=1,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
 		/obj/item/stock_parts/cell/ammo/ecp=2,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2,
+		/obj/item/ammo_box/magazine/m10mm_adv=2,
 		)
 
 /datum/outfit/loadout/sknightb

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -196,7 +196,7 @@ Mayor
 		/obj/item/hatchet=1,
 		/obj/item/shovel/spade=1, \
 		/obj/item/gun/ballistic/automatic/pistol/n99, \
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2)
+		/obj/item/ammo_box/magazine/m10mm_adv=2)
 	shoes = 		/obj/item/clothing/shoes/workboots
 
 /datum/outfit/job/den/f13settler/pre_equip(mob/living/carbon/human/H)
@@ -248,7 +248,7 @@ Mayor
 		/obj/item/shovel=1, \
 		/obj/item/kitchen/knife/combat, \
 		/obj/item/gun/ballistic/automatic/pistol/n99, \
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2)
+		/obj/item/ammo_box/magazine/m10mm_adv=2)
 
 /datum/outfit/job/den/f13settler/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -630,7 +630,7 @@ Mayor
 			/obj/item/storage/bag/money/small/settler = 1, \
 			/obj/item/kitchen/knife/combat = 1, \
 			/obj/item/gun/ballistic/automatic/pistol/n99 = 1, \
-			/obj/item/ammo_box/magazine/m10mm_adv/simple=2)
+			/obj/item/ammo_box/magazine/m10mm_adv=2)
 /*----------------------------------------------------------------
 --							Detective							--
 ----------------------------------------------------------------*/

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -359,7 +359,7 @@ Follower Guard
 	name = "Followers Ranged Guard"
 	suit_store = /obj/item/gun/ballistic/automatic/m1carbine
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2
+		/obj/item/ammo_box/magazine/m10mm_adv=2
 	)
 
 /datum/outfit/loadout/guard_close

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -570,7 +570,7 @@ Rear Echelon
 	belt = /obj/item/storage/belt/military/NCR_Bandolier
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/m1carbine=1, \
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=3)
+		/obj/item/ammo_box/magazine/m10mm_adv=3)
 
 /*
 Trooper
@@ -778,7 +778,7 @@ Veteran Ranger
 	belt =	/obj/item/storage/belt/military/assault/ncr
 	suit_store = /obj/item/gun/ballistic/automatic/m1carbine/compact
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m10mm_adv/simple = 3,
+		/obj/item/ammo_box/magazine/m10mm_adv = 3,
 		/obj/item/storage/firstaid/ancient = 1,
 		/obj/item/clothing/accessory/armband/med/ncr = 1,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,

--- a/code/modules/jobs/job_types/vault.dm
+++ b/code/modules/jobs/job_types/vault.dm
@@ -68,7 +68,7 @@ Overseer
 		/obj/item/storage/box/ids = 1,
 		/obj/item/melee/classic_baton/telescopic = 1,
 		/obj/item/gun/ballistic/automatic/pistol/n99/executive = 1,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple = 3,
+		/obj/item/ammo_box/magazine/m10mm_adv = 3,
 		/obj/item/crowbar = 1)
 
 /*
@@ -123,7 +123,7 @@ Head of Security
 	backpack_contents = list(
 		/obj/item/melee/classic_baton/telescopic = 1,
 		/obj/item/restraints/handcuffs = 2,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple = 2,
+		/obj/item/ammo_box/magazine/m10mm_adv = 2,
 		/obj/item/crowbar = 1)
 
 	implants = list(/obj/item/implant/mindshield)
@@ -266,7 +266,7 @@ Security Officer
 	backpack_contents = list(
 		/obj/item/melee/classic_baton/telescopic = 1,
 		/obj/item/restraints/handcuffs = 1,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple = 2,
+		/obj/item/ammo_box/magazine/m10mm_adv = 2,
 		/obj/item/crowbar = 1)
 
 	implants = list(/obj/item/implant/mindshield)

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -273,7 +273,7 @@ Raider
 		/obj/item/twohanded/fireaxe=1,
 		/obj/item/gun/ballistic/revolver/colt6520=1,
 		/obj/item/grenade/iedcasing=2,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2)
+		/obj/item/ammo_box/magazine/m10mm_adv=2)
 
 /datum/outfit/loadout/raider_sadist
 	name = "Sadist"
@@ -366,7 +366,7 @@ Raider
 	id = /obj/item/card/id/rusted/fadedvaultid
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2)
+		/obj/item/ammo_box/magazine/m10mm_adv=2)
 
 /datum/job/wasteland/f13wastelander
 	title = "Wastelander"
@@ -437,7 +437,7 @@ Raider
 	gloves = /obj/item/clothing/gloves/fingerless
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2)
+		/obj/item/ammo_box/magazine/m10mm_adv=2)
 
 
 /datum/outfit/loadout/petro

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -92,11 +92,6 @@
 /obj/item/ammo_box/magazine/m10mm_adv/empty
 	start_empty = 1
 
-/obj/item/ammo_box/magazine/m10mm_adv/simple
-
-/obj/item/ammo_box/magazine/m10mm_adv/simple/empty
-	start_empty = 1
-
 /obj/item/ammo_box/magazine/m10mm_adv/ext
 	name = "10mm pistol extended magazine (10mm)"
 	icon_state = "smg10mm"

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -184,7 +184,7 @@
 	name = "10mm pistol"
 	desc = "A pre-war large-framed, gas-operated advanced 10mm pistol."
 	icon_state = "n99"
-	mag_type = /obj/item/ammo_box/magazine/m10mm_adv/simple
+	mag_type = /obj/item/ammo_box/magazine/m10mm_adv
 	fire_sound = 'sound/f13weapons/10mm_fire_02.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
 	can_attachments = TRUE

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -45,7 +45,7 @@
 	name = "empty 10mm pistol magazine (10mm)"
 	id = "m10mm_adv"
 	materials = list(/datum/material/iron = 2000)
-	build_path = /obj/item/ammo_box/magazine/m10mm_adv/simple/empty
+	build_path = /obj/item/ammo_box/magazine/m10mm_adv/empty
 	category = list("initial", "Simple Magazines")
 
 /datum/design/ammolathe/m9mm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes `/obj/item/ammo_box/magazine/m10mm_adv/simple`, which had literally no var changes, not even the name. It was literally the exact same as /obj/item/ammo_box/magazine/m10mm_adv`.

## Why It's Good For The Game

Prevents issues like #434 until Corvo speedmerges one of Nokele's broken PRs at Reece's behest again.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Bak
tweak: Removes useless ammo subtype, no effect on gameplay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
