### PR TITLE
PA training for restored helmet, smelling salts buff

### DIFF
--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -269,7 +269,7 @@
 	var/mob/living/carbon/human/H = user
 	if(src == H.head) //Suit is already equipped
 		return ..()
-	if (!HAS_TRAIT(H, TRAIT_PA_WEAR) && !istype(src, /obj/item/clothing/head/helmet/f13/power_armor/t45b) && slot == SLOT_HEAD && requires_training)
+	if (!HAS_TRAIT(H, TRAIT_PA_WEAR) && slot == SLOT_HEAD && requires_training)
 		to_chat(user, "<span class='warning'>You don't have the proper training to operate the power armor!</span>")
 		return 0
 	if(slot == SLOT_HEAD)

--- a/code/modules/fallout/obj/smelling_salts.dm
+++ b/code/modules/fallout/obj/smelling_salts.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/fallout/smelling_salts.dmi'
 	icon_state = "smelling_salts_legion"
 	var/time_limit = DEFIB_TIME_LIMIT * 5 // half compared to an actual defib
-	var/charges = 8 // a bit lower than a normal defib's 10
+	var/charges = 50 // a bit lower than a normal defib's 10
 	var/in_use = FALSE
 	var/time_to_use = 10 SECONDS // a defib is 5 seconds
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes restored PA helmet not requiring PA training.
Buffed smelling salt charged to 50, until we come up with a way to recharge/craft them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Restored PA having same requirements as normal PA, salt change was requested until we come up with something permanent.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
