### PR TITLE
Fixes the Fire ants from attacking the Queen

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
@@ -279,7 +279,7 @@
 	attack_sound = 'sound/creatures/radroach_attack.ogg'
 	speak_emote = list("skitters")
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
-	faction = list("gecko")
+	faction = list("ant")
 	gold_core_spawnable = HOSTILE_SPAWN
 	a_intent = INTENT_HARM
 	decompose = TRUE
@@ -321,7 +321,7 @@
 	attack_sound = 'sound/creatures/radroach_attack.ogg'
 	speak_emote = list("skitters")
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
-	faction = list("gecko")
+	faction = list("ant")
 	gold_core_spawnable = HOSTILE_SPAWN
 	decompose = TRUE
 	a_intent = INTENT_HARM


### PR DESCRIPTION
**## About The Pull Request**
The fire ants were apart of the Gecko faction, in this pull request the fire ants betray the gecko faction. Which before this the Ant mother was being attacked by her little babies. Which was an simple fix, as someone must of messed it up before. This was tested on my own before hand, Should have no errors besides the Queen going backwards walking left or right. Which would be most likely seen from an player playing this mob, then AI operating it. This I believe was like that before. (Sorry for doing two of these, I dont understand fully yet, but I know this works tested it on my own)

**## Why It's Good For The Game**
Fixes the ants so they don't attack the Ant Mother. So whenever this does get readded into the ant maze. It wont go crazy and kill the maze for players who are searching for treasure. 

**## Changelog**
:cl:
Tweaks: The fireants joining the Ant family betraying the gecko family.
/:cl: