### PR TITLE
Uncomments Big Leagues from Headhunter

### DIFF
--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -162,7 +162,7 @@ Tribal Head Hunter
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
-	//ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src) //Disabled until Big Leagues can be changed to armour penetration instead of bonus damage, as having +5 damage per attack on a role that gets a melee weapon with a superfast attack speed is kind of broken.
+	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
 
 /datum/outfit/job/tribal/f13Hhunter
 	name = "Hunter"
@@ -348,7 +348,7 @@ Hunter
 		/obj/item/reagent_containers/pill/patch/healingpowder=2,
 		/obj/item/stack/medical/gauze=1,
 		/obj/item/flashlight/flare/torch=1)
-	
+
 /datum/outfit/loadout/ranged
 	name = "Ranged"
 	backpack_contents = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the Head Hunter Big Leagues as they used to, as every Decanus and head of the Legion has it, plus the Tribal Chief already has it. Not really any reason to keep it commented for Head Hunter

## Why It's Good For The Game

Makes it so the Head Hunter is, no surprise, stronger than regular hunters with a melee weapon.

## Changelog
:cl:
balance: Uncomments Big Leagues from the Headhunter role. They now get the same perk as the Tribal Chief and Legionnaires.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
