### PR TITLE
Waster loadouts and stuff

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -89,10 +89,10 @@
 		return
 
 	if (force >= 5 && HAS_TRAIT(user, TRAIT_BIG_LEAGUES))
-		force = force + 5
+		force = force*1.15 + 5
 	
 	if (force >= 5 && HAS_TRAIT(user, TRAIT_BUFFOUT_BUFF))
-		force = force + 15
+		force = force*1.25 + 15
 
 	if(!force)
 		playsound(loc, 'sound/weapons/tap.ogg', get_clamped_volume(), 1, -1)

--- a/code/datums/components/crafting/recipes/recipes_assemblies.dm
+++ b/code/datums/components/crafting/recipes/recipes_assemblies.dm
@@ -46,7 +46,7 @@
 				/obj/item/stack/crafting/electronicparts = 5,
 				/obj/item/stack/crafting/goodparts = 10,
 				/obj/item/stack/cable_coil = 10)
-	tools = list(TOOL_WELDER, TOOL_WORKBENCH, TOOL_SCREWDRIVER)
+	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER)
 	time = 80
 	category = CAT_MISC
 	subcategory = CAT_TOOL

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -761,7 +761,7 @@
 	name = "varmint rifle and ammo spawner"
 	items = list(
 				/obj/item/gun/ballistic/automatic/varmint,
-				/obj/item/ammo_box/magazine/m556/rifle/small
+				/obj/item/ammo_box/magazine/m556/rifle
 				)
 
 /obj/effect/spawner/bundle/f13/pistol22

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -320,6 +320,9 @@
 /obj/item/stack/medical/ointment/five
 	amount = 5
 
+/obj/item/stack/medical/ointment/twelve
+	amount = 12
+
 /obj/item/stack/medical/ointment/heal(mob/living/M, mob/user)
 	if(M.stat == DEAD)
 		to_chat(user, "<span class='warning'>[M] is dead! You can not help [M.p_them()].</span>")

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -387,6 +387,16 @@
 	item_state = "duffel"
 	slowdown = 1
 
+/obj/item/storage/backpack/duffelbag/scavengers
+	name = "scavenger's duffel bag"
+	desc = "An extra large duffel bag for holding extra things."
+	slowdown = 1.2
+
+/obj/item/storage/backpack/duffelbag/scavengers/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_combined_w_class = 40
+
 /obj/item/storage/backpack/duffelbag/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1429,3 +1429,26 @@ obj/item/storage/box/stingbangs
 /obj/item/storage/box/citizenship_permits/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/card/id/dogtag/town(src)
+
+/obj/item/storage/box/vendingmachine
+	name = "Vending Machine Kit"
+	desc = "A box containing all the necessary items to construct a vending machine."
+/*
+list(/obj/item/stack/sheet/metal = 20,
+				/obj/item/stack/crafting/metalparts = 10,
+				/obj/item/stack/crafting/electronicparts = 5,
+				/obj/item/stack/crafting/goodparts = 10,
+				/obj/item/stack/cable_coil = 10)
+*/
+
+/obj/item/storage/box/vendingmachine/PopulateContents()
+	. = ..()
+	new /obj/item/stack/sheet/metal/twenty(src)
+	new /obj/item/stack/crafting/metalparts/five(src)
+	new /obj/item/stack/crafting/metalparts/five(src)
+	new /obj/item/stack/crafting/electronicparts/five(src)
+	new /obj/item/stack/crafting/goodparts/five(src)
+	new /obj/item/stack/crafting/goodparts/five(src)
+	new /obj/item/stack/cable_coil/ten(src)
+	new /obj/item/screwdriver(src)
+	new /obj/item/weldingtool(src)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -343,6 +343,7 @@
 	desc = "An upgraded welder based of the industrial welder."
 	icon_state = "upindwelder"
 	item_state = "upindwelder"
+	toolspeed = 0.6
 	max_fuel = 80
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=120)
 

--- a/code/modules/fallout/obj/stack/f13Cash.dm
+++ b/code/modules/fallout/obj/stack/f13Cash.dm
@@ -70,6 +70,10 @@
 	amount = 500
 	merge_type = /obj/item/stack/f13Cash
 
+/obj/item/stack/f13Cash/threefivezero
+	amount = 350
+	merge_type = /obj/item/stack/f13Cash
+
 /obj/item/stack/f13Cash/Initialize()
 	. = ..()
 	update_desc()

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -383,12 +383,12 @@ Raider
 	access = list()		//we can expand on this and make alterations as people suggest different loadouts
 	minimal_access = list()
 	loadout_options = list(
-	/datum/outfit/loadout/vault_refugee,
-	/datum/outfit/loadout/petro,
-	//datum/outfit/loadout/follower,
-	/datum/outfit/loadout/merchant,
-	/datum/outfit/loadout/gambler,
-	/datum/outfit/loadout/citizen,
+	/datum/outfit/loadout/vault_refugee, 
+	/datum/outfit/loadout/salvager, 
+	/datum/outfit/loadout/medic, 
+	/datum/outfit/loadout/merchant, 
+	/datum/outfit/loadout/scavenger, 
+	/datum/outfit/loadout/citizen, 
 	/datum/outfit/loadout/slave)
 
 /datum/outfit/job/wasteland/f13wastelander
@@ -429,37 +429,42 @@ Raider
 	/obj/item/gun/ballistic/revolver/zipgun, \
 	/obj/item/gun/ballistic/revolver/pipe_rifle)
 
-/datum/outfit/loadout/vault_refugee
-	name = "Vaultie"
-	uniform = /obj/item/clothing/under/f13/vault
-	gloves = /obj/item/pda
-	shoes = /obj/item/clothing/shoes/jackboots
-	gloves = /obj/item/clothing/gloves/fingerless
-	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/pistol/n99=1,
-		/obj/item/ammo_box/magazine/m10mm_adv/simple=2)
+/datum/outfit/loadout/salvager
+	name = "Salvager"
+	suit = /obj/item/clothing/suit/apron
+	shoes = /obj/item/clothing/shoes/f13/explorer
+	gloves = /obj/item/clothing/gloves/f13/blacksmith
+	head = /obj/item/clothing/head/welding
+	r_hand = /obj/item/weldingtool/hugetank
+	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1)
+	
+/datum/outfit/loadout/scavenger
+	name = "Scavenger"
+	shoes = /obj/item/clothing/shoes/f13/explorer
+	r_hand = /obj/item/storage/backpack/duffelbag/scavengers
+	l_hand = /obj/item/pickaxe/drill
+	belt = /obj/item/storage/belt/utility
+	backpack_contents = list(/obj/item/mining_scanner=1,
+							/obj/item/metaldetector=1,
+							/obj/item/shovel=1,
+							/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1)
 
 
-/datum/outfit/loadout/petro
-	name = "Petro"
-	suit = /obj/item/clothing/suit/armor/f13/vaquero
-	head = /obj/item/clothing/head/helmet/f13/vaquerohat
-	uniform = /obj/item/clothing/under/f13/petrochico
-	shoes = /obj/item/clothing/shoes/f13/fancy
-	gloves = /obj/item/clothing/gloves/rifleman
-	backpack_contents = list(
-		/obj/item/gun/ballistic/revolver/colt357=2,
-		/obj/item/ammo_box/a357=2)
-
-/datum/outfit/loadout/follower
-	name = "Follower"
+/datum/outfit/loadout/medic
+	name = "Wasteland Doctor"
 	uniform = /obj/item/clothing/under/f13/follower
 	suit = /obj/item/clothing/suit/toggle/labcoat/f13/followers
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	gloves = /obj/item/clothing/gloves/color/latex
-	l_hand = /obj/item/storage/firstaid/ancient
-	backpack_contents =  list(
-		/obj/item/gun/ballistic/automatic/pistol/m1911=1)
+	l_hand = /obj/item/storage/backpack/duffelbag/med/surgery
+	backpack_contents =  list(/obj/item/reagent_containers/medspray/synthflesh=2,
+							/obj/item/reagent_containers/medspray/silver_sulf=1,
+							/obj/item/reagent_containers/medspray/styptic=1,
+							/obj/item/smelling_salts/crafted=1,
+							/obj/item/healthanalyzer=1,
+							/obj/item/stack/sheet/mineral/silver=1,
+							/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1
+		)
 
 /datum/outfit/loadout/merchant
 	name = "Roving Trader"
@@ -470,23 +475,21 @@ Raider
 	gloves = /obj/item/clothing/gloves/color/brown
 	glasses = /obj/item/clothing/glasses/f13/biker
 	l_hand = /obj/item/gun/ballistic/revolver/caravan_shotgun
-	backpack_contents =  list(
-		/obj/item/storage/fancy/ammobox/lethalshot=1)
+	backpack_contents =  list(/obj/item/storage/box/vendingmachine=1,
+							/obj/item/stack/f13Cash/threefivezero=1,
+							/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1)
 
+//end new
 
-
-/datum/outfit/loadout/gambler
-	name = "Gambler"
-	uniform = list(/obj/item/clothing/under/f13/cowboyg,
-	/obj/item/clothing/under/f13/bennys,
-	/obj/item/clothing/under/f13/formal)
-	suit = /obj/item/clothing/suit/f13/cowboygvest
-	shoes = /obj/item/clothing/shoes/f13/fancy
-	head = list(/obj/item/clothing/head/fedora,
-	/obj/item/clothing/head/f13/gambler)
-	l_hand = /obj/item/gun/ballistic/automatic/pistol/ninemil
-	backpack_contents =  list(
-		/obj/item/ammo_box/magazine/m9mm=2)
+/datum/outfit/loadout/vault_refugee
+	name = "Vaultie"
+	uniform = /obj/item/clothing/under/f13/vault
+	gloves = /obj/item/pda
+	shoes = /obj/item/clothing/shoes/jackboots
+	gloves = /obj/item/clothing/gloves/fingerless
+	backpack_contents = list(
+		/obj/item/gun/ballistic/automatic/pistol/n99=1,
+		/obj/item/ammo_box/magazine/m10mm_adv/simple=2)
 
 
 /datum/outfit/loadout/citizen
@@ -499,9 +502,7 @@ Raider
 	glasses = /obj/item/clothing/glasses/welding
 	l_hand = /obj/item/shield/legion/buckler
 	backpack_contents = list(
-		/obj/item/claymore/machete/reinforced=1)
-
-
+		/obj/item/claymore/machete/spatha=1)
 
 /datum/outfit/loadout/slave
 	name = "NCR Citizen"
@@ -512,5 +513,5 @@ Raider
 	glasses = /obj/item/clothing/glasses/orange
 	l_hand = /obj/item/gun/ballistic/automatic/varmint
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m556/rifle/small=2)
+		/obj/item/ammo_box/magazine/m556/rifle=2)
 

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -437,7 +437,7 @@ Raider
 	head = /obj/item/clothing/head/welding
 	r_hand = /obj/item/weldingtool/hugetank
 	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1)
-	
+
 /datum/outfit/loadout/scavenger
 	name = "Scavenger"
 	shoes = /obj/item/clothing/shoes/f13/explorer
@@ -456,14 +456,18 @@ Raider
 	suit = /obj/item/clothing/suit/toggle/labcoat/f13/followers
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	gloves = /obj/item/clothing/gloves/color/latex
-	l_hand = /obj/item/storage/backpack/duffelbag/med/surgery
+	neck = /obj/item/bedsheet/medical
 	backpack_contents =  list(/obj/item/reagent_containers/medspray/synthflesh=2,
-							/obj/item/reagent_containers/medspray/silver_sulf=1,
-							/obj/item/reagent_containers/medspray/styptic=1,
+							/obj/item/stack/medical/suture/emergency/fifteen=1,
+							/obj/item/stack/medical/ointment/twelve=1,
 							/obj/item/smelling_salts/crafted=1,
 							/obj/item/healthanalyzer=1,
 							/obj/item/stack/sheet/mineral/silver=1,
-							/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1
+							/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1,
+							/obj/item/lighter=1,
+							/obj/item/screwdriver=1,
+							/obj/item/wirecutters=1,
+							/obj/item/hatchet=1
 		)
 
 /datum/outfit/loadout/merchant

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -514,6 +514,9 @@ By design, d1 is the smallest direction and d2 is the highest
 	usesound = 'sound/items/deconstruct.ogg'
 	used_skills = list(/datum/skill/level/job/wiring)
 
+/obj/item/stack/cable_coil/ten
+	amount = 10
+
 /obj/item/stack/cable_coil/cyborg
 	is_cyborg = 1
 	custom_materials = null

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -736,7 +736,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	extra_damage = 0
 	extra_penetration = 0
-	fire_delay = 5
+	fire_delay = 6
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	spawnwithmagazine = FALSE

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -18,8 +18,7 @@
 	contraband = list(/obj/item/weldingtool/largetank = 4,
 					/obj/item/clothing/gloves/color/fyellow = 4,
 					/obj/item/multitool = 2)
-	premium = list(/obj/item/clothing/gloves/color/yellow = 2,
-					/obj/item/weldingtool/hugetank = 2)
+	premium = list(/obj/item/clothing/gloves/color/yellow = 2)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	refill_canister = /obj/item/vending_refill/tool
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Introduces 3 new loadouts for wasters to encourage different playstyles.
Salvager: 
![image](https://user-images.githubusercontent.com/67761424/116108346-d33e4e80-a681-11eb-9e56-003b437957c8.png)
Scavenger:
![image](https://user-images.githubusercontent.com/67761424/116108400-ddf8e380-a681-11eb-803f-9a2c7d53eb7b.png)
Wasteland Doctor:
![image](https://user-images.githubusercontent.com/67761424/116120006-13ef9500-a68d-11eb-9565-e38be9f2d4cf.png)
![image](https://user-images.githubusercontent.com/67761424/116120038-1eaa2a00-a68d-11eb-85b9-cc1e55421373.png)
On second thought they all start with a compact m1911 as to not die to a single ghoul or cazador.
![image](https://user-images.githubusercontent.com/67761424/116111999-26fe6700-a685-11eb-87d1-cc5bee607cea.png)
Updates the following loadouts:
NCR Citizen: Replaces the 10rd mags with 20rd mags. Nerfs the varmint rifle.
Legion Citizen: Replaces the reinforced machete with a Spatha.

Also "fixes" gaia I guess.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less focus on combat, more focus on different game mechanics, minor changes for balance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
