### PR TITLE
Fixes the legion armor to fit blacksmith weaponry

### DIFF
--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -197,7 +197,7 @@
 	lefthand_file = 'icons/mob/inhands/clothing_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/clothing_righthand.dmi'
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola, /obj/item/twohanded)
+	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola, /obj/item/twohanded, /obj/item/melee/smith, /obj/item/melee/smith/twohand)
 	armor = list("tier" = 3, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 20, "fire" = 50, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/legion/recruit


### PR DESCRIPTION
## About The Pull Request
This pull requests fixes the legion armors to fit blacksmith weaponry which is basically means that the legion can carry the weapons on there armor if they would like too. This is **legion loremaster approved** and I would like to see legion carry more of an melee feel myself.

## Why It's Good For The Game
This in game would allow the legionaries to be more adventurous with there gear if you would say that as it fits on there armor and would make a good sense for an legionaries to be more adventurous as some could be doing weapon if it fits in the backpack and a strong melee weapon attached to there armor.

## Changelog
:cl:
tweak: Fixed Legion armors to fit blacksmith weaponry.
/:cl: