### PR TITLE
North bunkee fixes, tier updates for forgotten areas, oasis tier update

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -417,6 +417,10 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"anA" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "anC" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1809,6 +1813,7 @@
 "bmu" = (
 /obj/structure/rack,
 /obj/item/stack/f13Cash/random/ncr/high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "bmx" = (
@@ -2229,7 +2234,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
 "bzr" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/carpet/black,
 /area/f13/city)
 "bzB" = (
@@ -2448,8 +2453,8 @@
 "bFV" = (
 /obj/structure/rack,
 /obj/item/bikehorn,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -3516,7 +3521,7 @@
 	},
 /area/f13/wasteland)
 "cAM" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cAW" = (
@@ -6035,6 +6040,9 @@
 /area/f13/brotherhood)
 "esE" = (
 /obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "esP" = (
@@ -7210,6 +7218,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"ffy" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "ffI" = (
 /obj/structure/chair/stool/retro,
 /obj/machinery/light/small{
@@ -7731,6 +7743,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"fwu" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/water,
+/area/f13/caves)
 "fwG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
@@ -7801,6 +7817,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"fzl" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/water,
+/area/f13/caves)
 "fzo" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -10416,6 +10436,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
+"hjw" = (
+/obj/structure/chair/stool{
+	icon_state = "bench"
+	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "hjA" = (
 /obj/structure/table/snooker{
 	dir = 10
@@ -15199,8 +15228,9 @@
 /area/f13/ncr)
 "kiP" = (
 /obj/structure/rack,
-/obj/item/stack/f13Cash/random/ncr/high,
-/obj/item/stack/f13Cash/random/ncr/high,
+/obj/effect/spawner/lootdrop/f13/cash_legion_high,
+/obj/effect/spawner/lootdrop/f13/cash_legion_high,
+/obj/item/stack/f13Cash/random/aureus/low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "kiW" = (
@@ -15436,7 +15466,7 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "kqk" = (
@@ -23158,6 +23188,16 @@
 /obj/machinery/trading_machine/ammo,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"pHx" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "pHy" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13/wood{
@@ -28512,7 +28552,7 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "tnu" = (
@@ -31372,6 +31412,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
+"uZp" = (
+/obj/effect/spawner/lootdrop/f13/cash_ncr_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "uZy" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood,
@@ -35669,6 +35713,10 @@
 /area/f13/wasteland)
 "xQo" = (
 /obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"xQu" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xQz" = (
@@ -65815,7 +65863,7 @@ koD
 bFJ
 ijg
 uRJ
-uRJ
+anA
 uRJ
 fbo
 gjP
@@ -69513,7 +69561,7 @@ fyf
 gts
 kqc
 dtq
-gsu
+pHx
 vYv
 vYv
 gts
@@ -70283,7 +70331,7 @@ fyf
 fyf
 gts
 vYv
-dtq
+hjw
 gsu
 vYv
 vYv
@@ -71164,7 +71212,7 @@ pcG
 uRJ
 uRJ
 cnX
-uRJ
+anA
 uRJ
 pcG
 bAT
@@ -76941,7 +76989,7 @@ ccF
 rpu
 rkZ
 uCO
-rpu
+xQu
 rpu
 cuv
 fyf
@@ -77469,7 +77517,7 @@ qij
 qij
 qij
 qij
-qij
+ffy
 qij
 bIh
 yhv
@@ -78737,7 +78785,7 @@ gcK
 gcK
 eXw
 eXw
-rpu
+xQu
 xVZ
 uCO
 rpu
@@ -83169,7 +83217,7 @@ gcK
 mTd
 csk
 csk
-csk
+fwu
 ggK
 gcK
 gcK
@@ -89863,7 +89911,7 @@ ufP
 csk
 csk
 csk
-csk
+fzl
 csk
 csk
 csk
@@ -91394,7 +91442,7 @@ sjX
 csk
 csk
 ggK
-ggK
+uZp
 gcK
 gcK
 gcK

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1262,6 +1262,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
+"bnM" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "bnW" = (
 /obj/structure/simple_door/bunker,
 /turf/open/indestructible/ground/inside/subway,
@@ -1324,10 +1328,10 @@
 /area/f13/brotherhood/rnd)
 "bqs" = (
 /obj/structure/guncase,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bqO" = (
@@ -3802,13 +3806,13 @@
 /area/f13/clinic)
 "dJx" = (
 /obj/structure/guncase,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "dJD" = (
@@ -3992,7 +3996,7 @@
 /area/f13/brotherhood/leisure)
 "dML" = (
 /obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dMQ" = (
@@ -8286,8 +8290,7 @@
 /area/f13/tunnel)
 "hKm" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/trench,
-/obj/item/storage/fancy/ammobox/slugshot,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
@@ -8498,6 +8501,10 @@
 /area/f13/caves)
 "hQG" = (
 /mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"hQR" = (
+/mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "hRy" = (
@@ -10334,6 +10341,10 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"jwA" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "jxG" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -11124,7 +11135,7 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kfV" = (
@@ -13087,7 +13098,7 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/item/storage/fancy/candle_box,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "miy" = (
@@ -14608,7 +14619,7 @@
 /area/f13/tunnel)
 "nBL" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nCi" = (
@@ -14680,6 +14691,13 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
+/area/f13/tunnel)
+"nFJ" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "nGN" = (
 /obj/machinery/light/small{
@@ -14942,13 +14960,13 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/stack/f13Cash/random/med,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /obj/machinery/light/fo13colored/Aqua{
 	bulb_colour = "#800080";
 	dir = 4;
 	light_color = "#800080";
 	name = "light fixture"
 	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nTN" = (
@@ -15215,11 +15233,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "ohv" = (
-/obj/item/gun/ballistic/automatic/marksman/sniper/gold,
 /obj/structure/rack,
 /obj/item/ammo_box/a308,
 /obj/item/ammo_box/a308,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/gun/ballistic/automatic/marksman/sniper,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ohO" = (
@@ -19714,6 +19732,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"sek" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "seJ" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -24035,6 +24057,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"vCe" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "vCi" = (
 /obj/effect/spawner/lootdrop/f13/cash_ncr_med,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25855,6 +25881,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"xop" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xoU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Aqua{
@@ -26475,7 +26506,7 @@
 	dir = 8
 	},
 /obj/item/stack/f13Cash/random/med,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "xYS" = (
@@ -32505,7 +32536,7 @@ lnr
 rKx
 lnr
 uoO
-uoO
+hQf
 uoO
 uoO
 uoO
@@ -32762,7 +32793,7 @@ lnr
 bAD
 uoO
 uoO
-uoO
+hQf
 uoO
 uoO
 uoO
@@ -54582,7 +54613,7 @@ mDq
 rkH
 mDq
 mDq
-jbA
+xop
 hkn
 oHE
 mDq
@@ -66260,7 +66291,7 @@ lnr
 lnr
 lnr
 lnr
-lnr
+hQR
 lnr
 lnr
 lnr
@@ -66775,7 +66806,7 @@ aBb
 aBb
 aBb
 wMr
-pNK
+jwA
 aBb
 aBb
 aBb
@@ -67028,7 +67059,7 @@ lnr
 lnr
 aBb
 aBb
-uzO
+bnM
 aBb
 aBb
 aBb
@@ -68844,8 +68875,8 @@ lnr
 aBb
 pXa
 lnr
+vCe
 lnr
-uzO
 aBb
 aBb
 uoO
@@ -71153,7 +71184,7 @@ aBb
 vZR
 lnr
 lnr
-onY
+nFJ
 aBb
 aBb
 aBb
@@ -72163,7 +72194,7 @@ lnr
 lnr
 lnr
 lnr
-uzO
+sek
 aBb
 lnr
 aBb

--- a/_maps/map_files/templates/dungeons/north_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_2.dmm
@@ -181,6 +181,11 @@
 /obj/item/seeds/ambrosia/gaia,
 /turf/open/floor/grass,
 /area/f13/bunker)
+"ee" = (
+/mob/living/simple_animal/hostile/alien,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "eq" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/tarantula,
 /obj/structure/spider/stickyweb,
@@ -266,6 +271,12 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/fireant,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
+/turf/open/floor/grass,
+/area/f13/bunker)
+"fC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
 /turf/open/floor/grass,
 /area/f13/bunker)
 "fI" = (
@@ -417,6 +428,7 @@
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -658,6 +670,12 @@
 /obj/item/seeds/sunflower/novaflower,
 /turf/open/floor/grass,
 /area/f13/bunker)
+"nU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "nW" = (
 /mob/living/simple_animal/opossum{
 	name = "Fudge"
@@ -685,6 +703,7 @@
 "of" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -737,6 +756,10 @@
 /area/f13/bunker)
 "pP" = (
 /obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"pQ" = (
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "pR" = (
@@ -907,8 +930,8 @@
 /area/f13/bunker)
 "tD" = (
 /obj/structure/toilet/secret/high_loot,
-/obj/item/grenade,
 /obj/item/grenade/flashbang,
+/obj/item/grenade/frag,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -1119,7 +1142,8 @@
 	},
 /area/f13/bunker)
 "yV" = (
-/obj/item/storage/box/hug,
+/obj/item/storage/box/hug/medical,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "zq" = (
@@ -1501,6 +1525,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"FD" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/bunker)
 "FK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1541,6 +1572,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/bunker)
+"Hi" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "Hm" = (
 /obj/machinery/door/poddoor{
 	id = 806
@@ -1552,6 +1587,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/giantant,
+/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/grass,
 /area/f13/bunker)
 "HB" = (
@@ -1700,6 +1736,10 @@
 /mob/living/simple_animal/hostile/alien,
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"KR" = (
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/grass,
 /area/f13/bunker)
 "KY" = (
 /obj/item/reagent_containers/food/snacks/grown/pungafruit,
@@ -1901,10 +1941,10 @@
 	},
 /area/f13/bunker)
 "OG" = (
-/mob/living/simple_animal/hostile/handy/sentrybot/playable{
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/sentrybot{
 	faction = list("ant")
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -2365,6 +2405,10 @@
 	id = 806
 	},
 /turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"XS" = (
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/plasteel/showroomfloor,
 /area/f13/bunker)
 "XY" = (
 /turf/closed/indestructible/rock,
@@ -2997,7 +3041,7 @@ Rl
 xG
 eG
 sJ
-qV
+XS
 Eg
 xG
 Rl
@@ -3227,7 +3271,7 @@ Om
 DY
 DY
 nu
-nu
+KR
 nu
 ZP
 nu
@@ -3434,7 +3478,7 @@ go
 zR
 iq
 lc
-oj
+Hi
 xG
 Rl
 Rl
@@ -3611,7 +3655,7 @@ xG
 XM
 XM
 XM
-XM
+FD
 yS
 XM
 XM
@@ -3673,7 +3717,7 @@ Rl
 Rl
 xG
 IY
-oj
+pQ
 DM
 oj
 Pp
@@ -4019,7 +4063,7 @@ kj
 vp
 Cp
 xG
-sl
+nU
 Pp
 XM
 jX
@@ -4029,7 +4073,7 @@ xG
 xG
 xG
 xG
-Od
+Pl
 PW
 PW
 PW
@@ -4052,7 +4096,7 @@ xG
 nr
 XM
 XM
-XM
+FD
 XM
 mX
 XM
@@ -4411,7 +4455,7 @@ nu
 dj
 nu
 Vx
-nu
+KR
 nu
 nu
 nu
@@ -4550,7 +4594,7 @@ wb
 ZP
 pR
 ZP
-ts
+fC
 QF
 Lk
 jX
@@ -4967,7 +5011,7 @@ PF
 oj
 hI
 go
-RB
+ee
 oj
 YR
 gu


### PR DESCRIPTION
## About The Pull Request

Fixes the hole in the wall at the start of north bunker. Other north bunker changes are the addition of more blueprints and HEALING SUPPLIES because I completely forgot to add any when I made it. 
Gives some love to forgotten areas, specifically the ant caves that I have added the weapons to since it was not updated since tier changes.
Also not updated since tier changes, the oasis. The store was changed but everywhere else was messed up. I changed the tiers of guns spawning and changed a bit of the money so they hopefully get a bit more of that too. We give the Oasis a little love before its gone. 
The sheriff's armoury is now fixed up because it had 3 tier 3s and 3 tier 2s, that sucked. Also removed the golden sniper because custom item and replaced it for a regular upon mod request. 

## Why It's Good For The Game

People can heal and it will encourage people to actually go back to ant caves. 

## Changelog
:cl:
add: Blueprints and healing supplies to north bunker. 
add: Ant queen back to ant caves.
tweak: Tiers of guns in oasis.
fix: Missing wall and wrong grenade in north bunker. 
/:cl:
