### PR TITLE
Alchemy Table fix and Datura fix

### DIFF
--- a/code/modules/fallout/obj/food_and_drinks/wastefood.dm
+++ b/code/modules/fallout/obj/food_and_drinks/wastefood.dm
@@ -341,7 +341,7 @@
 	icon_grow = "datura-grow"
 	icon_dead = "datura-dead"
 	icon_harvest = "datura-harvest"
-	reagents_add = list(/datum/reagent/medicine/morphine = 0.2, /datum/reagent/drug/mushroomhallucinogen = 0.1, /datum/reagent/toxin = 0.1,  /datum/reagent/consumable/nutriment = 0.1)
+	reagents_add = list(/datum/reagent/medicine/morphine = 0.2, /datum/reagent/drug/mushroomhallucinogen = 0.1, /datum/reagent/toxin = 0.05,  /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/datura
 	seed = /obj/item/seeds/datura

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -304,6 +304,8 @@
 			vol_each_max = min(20, vol_each_max)
 		else if (item_type == "bottle_primitive")
 			vol_each_max = min(60, vol_each_max)
+		else if (item_type == "bag")
+			vol_each_max = min (40, vol_each_max)
 		else
 			return FALSE
 		if(vol_each_text == "auto")
@@ -430,7 +432,7 @@
 			var/obj/item/reagent_containers/pill/patch/P
 			for(var/i = 0; i < amount; i++)
 				P = new/obj/item/reagent_containers/pill/patch/healingpowder/custom(drop_location())
-				P.name = trim("[name] patch")
+				P.name = trim("[name] powder")
 				adjust_item_drop_location(P)
 				reagents.trans_to(P, vol_each)//, transfered_by = usr)
 			return TRUE
@@ -533,9 +535,6 @@
 		icon_state = "alchemy_table"
 	else
 		icon_state = "alchemy_table"
-
-/obj/machinery/chem_master/primitive/attackby(obj/item/I, mob/user, params)
-		return
 
 /obj/machinery/chem_master/primitive/ui_interact(mob/living/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Alchemy Table now accepts reagent_containers once more. This was caused by an excessive line of code that made you return the value, no matter what item you held in your hand. This code was removed.
- Alchemy Table can now also be used to produce custom powders. Before the code lacked a few critical lines that's needed to make more of them.
- Datura now contains 5% Toxin instead of 10%. The reason is that the rest of the items are somewhat required for Datura to have it's 'trippy' effect and KO sleep, while now finally allowing maximum tea production as it was originally intended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes it so that the Tribals can use their Alchemy table again at last, the powders can now be produced, and that they can get the maximum amount of datura tea as was originally desired.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Datura now contains less toxins to allow for maximum tea production without impacting the icon of Datura as a KO mushroom trip.
fix: Alchemy table now accepts reagent containers again, now also allows for the production of custom powders.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
