### PR TITLE
Mourning Poultice fixes

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -513,7 +513,7 @@
 	singular_name = "mourning poultice"
 	desc = "A type of primitive herbal poultice.\nWhile traditionally used to prepare corpses for the mourning feast, it can also treat scrapes and burns on the living, however, it is liable to cause shortness of breath when employed in this manner.\nIt is imbued with ancient wisdom."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bandid_mourningpoultice"
+	icon_state = "bandaid_mourningpoultice"
 	amount = 15
 	max_amount = 15
 	heal_brute = 10
@@ -524,6 +524,12 @@
 	merge_type = /obj/item/stack/medical/poultice
 	novariants = TRUE
 
+/obj/item/stack/medical/poultice/one
+	amount = 1
+
+/obj/item/stack/medical/poultice/five
+	amount = 5
+
 /obj/item/stack/medical/poultice/heal(mob/living/M, mob/user)
 	if(iscarbon(M))
 		return heal_carbon(M, user, heal_brute, heal_burn)
@@ -533,3 +539,13 @@
 	. = ..()
 	healed_mob.adjustOxyLoss(amount_healed)
 
+/datum/chemical_reaction/mourningpoultice
+	name = "mourning poultice"
+	id = "mournpoultice"
+	required_reagents = list(/datum/reagent/consumable/tea/coyotetea = 10, /datum/reagent/cellulose = 20, /datum/reagent/consumable/tea/feratea = 10)
+	mob_react = FALSE
+
+/datum/chemical_reaction/mourningpoultice/on_reaction(datum/reagents/holder, multiplier)
+	var/location = get_turf(holder.my_atom)
+	for(var/i = 1, i <= multiplier, i++)
+		new /obj/item/stack/medical/poultice/one(location)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Mourning Poultice now has the proper icon state. Previous spelling made it so Mourning Poultice had no icon.
- Mourning Poultice now comes in stacks of 15, 5 or 1.
- Mourning Poultice is now craftable by combining 20u Cellulose (from wooden planks), 10u Coyote Tea (Coyote Tobacco) and 10u Feracactus Tea (from Barrel Cactus, the yellow one). This is meant to act as a substitute of Synthflesh for the Tribals.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is to add more viability to the Healers of the Wayfarer Tribe, as if their teammates are too wounded, they'll have to run to someone with tech to bandage up. This is meant to provide an alternative to that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Recipe for Mourning Poultice, will produce 1 per reaction.
fix: Mourning Poultice now has it's proper icon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
