### PR TITLE
BoS Bunker Underground v2

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -2715,19 +2715,7 @@
 	},
 /area/f13/building)
 "bQI" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "SW";
-	move_me = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5;
-	icon_state = "warningline_red"
-	},
+/obj/item/flag/bos,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "bQL" = (
@@ -5019,10 +5007,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"dBy" = (
-/obj/machinery/trading_machine/ammo,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/brotherhood)
 "dBM" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13{
@@ -5176,10 +5160,17 @@
 	},
 /area/f13/wasteland)
 "dIW" = (
-/obj/structure/chair/bench,
-/obj/item/trash/f13/porknbeans,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "SW";
+	move_me = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "dJg" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/wood/interior,
@@ -12309,10 +12300,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "irQ" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ish" = (
 /obj/structure/spirit_board{
 	anchored = 1
@@ -13577,11 +13568,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jcp" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/obj/structure/flora/grass/wasteland,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "jcB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -14583,14 +14572,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jQH" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "NW";
-	move_me = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
-	icon_state = "warningline_red"
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
@@ -18932,7 +18916,10 @@
 	},
 /area/f13/tunnel)
 "mKm" = (
-/obj/structure/wreck/trash/halftire,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
+/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
+/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mKp" = (
@@ -19046,7 +19033,9 @@
 	},
 /area/f13/building)
 "mNU" = (
-/obj/structure/flora/grass/wasteland,
+/obj/structure/chair/wood{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mOx" = (
@@ -19492,8 +19481,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "neo" = (
-/obj/machinery/trading_machine,
-/turf/open/indestructible/ground/outside/wood,
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/brotherhood)
 "neN" = (
 /obj/structure/destructible/tribal_torch{
@@ -23333,9 +23323,8 @@
 	},
 /area/f13/wasteland)
 "pLJ" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/sunset,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pMf" = (
@@ -24178,11 +24167,12 @@
 	},
 /area/f13/wasteland)
 "qod" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/sunset{
-	pixel_y = 17
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	layer = 6;
+	pixel_x = -6;
+	pixel_y = 13
 	},
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "qoj" = (
@@ -24844,9 +24834,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "qLa" = (
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/obj/structure/wreck/trash/halftire,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "qLr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24972,8 +24962,14 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "qOR" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "NW";
+	move_me = 1
+	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+	dir = 6;
+	icon_state = "warningline_red"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
@@ -30833,12 +30829,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "uJr" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	layer = 6;
-	pixel_x = -6;
-	pixel_y = 13
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/sunset{
+	pixel_y = 17
 	},
+/obj/item/reagent_containers/food/drinks/bottle/sunset,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "uJB" = (
@@ -32649,10 +32644,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vQS" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
-/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
-/obj/item/reagent_containers/food/snacks/meat/slab/gecko,
+/obj/structure/chair/bench,
+/obj/item/trash/f13/porknbeans,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "vQU" = (
@@ -33633,10 +33626,6 @@
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"wEv" = (
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
 "wEO" = (
 /obj/machinery/shower{
 	dir = 4
@@ -33742,7 +33731,7 @@
 "wIO" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/wood,
+/turf/open/floor/f13/wood,
 /area/f13/brotherhood)
 "wIP" = (
 /obj/structure/sink{
@@ -33807,11 +33796,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"wLy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "wLB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67293,7 +67277,7 @@ gcK
 gcK
 gcK
 iFI
-fMu
+bQI
 jQH
 fMu
 bQI
@@ -67550,10 +67534,10 @@ gcK
 gcK
 gcK
 iFI
-qLa
-qOR
 fMu
-wEv
+qOR
+dIW
+fMu
 iFI
 gcK
 gcK
@@ -67807,10 +67791,10 @@ gcK
 gcK
 gcK
 iFI
-jcp
-pnh
 fMu
+pnh
 gPK
+fMu
 iFI
 gcK
 gcK
@@ -68321,8 +68305,8 @@ gcK
 gcK
 gcK
 iFI
-cXU
 iFI
+cXU
 cXU
 iFI
 iFI
@@ -76051,8 +76035,8 @@ jWO
 fyf
 fyf
 fyf
-uJr
-cTp
+fyf
+fyf
 gCh
 gCh
 xhh
@@ -76307,9 +76291,9 @@ jtc
 fyf
 fyf
 fyf
-wrg
 fyf
-cTp
+fyf
+fyf
 gCh
 kGe
 sYV
@@ -76563,10 +76547,10 @@ ktB
 gcK
 gcK
 fyf
-mNU
 fyf
-mKm
-dIW
+fyf
+fyf
+fyf
 oFP
 jVq
 sYV
@@ -76820,9 +76804,9 @@ ktB
 gcK
 gcK
 gcK
-vQS
-pLJ
-pLJ
+fyf
+fyf
+sqA
 fyf
 oFP
 xGg
@@ -77078,8 +77062,8 @@ gcK
 gcK
 gcK
 gcK
-irQ
-qod
+fyf
+fyf
 fyf
 oFP
 oFP
@@ -80157,7 +80141,7 @@ lCc
 hbm
 jUn
 jeO
-dBy
+neo
 wIO
 neo
 hbm
@@ -80421,21 +80405,21 @@ hbm
 ovO
 tka
 qzM
-rRT
+irQ
 tGx
 rem
 xwl
 fyf
 fyf
 fyf
+qod
+cTp
+fyf
+fyf
+fyf
+fyf
 fyf
 sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 tBN
 mvv
@@ -80678,20 +80662,20 @@ hbm
 tka
 tka
 qPG
-rRT
+irQ
 rRT
 rem
 xwl
 fyf
 fyf
+wrg
+fyf
+cTp
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-sqA
 fyf
 fyf
 tBN
@@ -80937,13 +80921,13 @@ tka
 rrC
 rRT
 rRT
-wLy
+rRT
 jem
 xSV
+jcp
 fyf
-fyf
-fyf
-fyf
+qLa
+vQS
 fyf
 fyf
 fyf
@@ -81194,14 +81178,14 @@ tka
 rrC
 rRT
 rRT
-wLy
+rRT
 jem
 xZK
+mKm
+mNU
+mNU
 fyf
 fyf
-fyf
-fyf
-sqA
 fyf
 fyf
 fyf
@@ -81454,9 +81438,9 @@ tSA
 jem
 jem
 gcK
-fyf
-fyf
-fyf
+hwC
+pLJ
+uJr
 fyf
 fyf
 fyf
@@ -81718,7 +81702,7 @@ gcK
 fyf
 fyf
 fyf
-fyf
+sqA
 fyf
 fyf
 fyf

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -46,11 +46,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "abY" = (
-/obj/structure/simple_door/bunker{
-	name = "Changing Room"
-	},
+/obj/structure/chair/stool/retro/black,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
 "acc" = (
@@ -71,25 +69,9 @@
 	},
 /area/f13/tunnel)
 "acv" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster82";
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/stool/f13stool,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
-"acJ" = (
-/obj/structure/sign/poster/prewar/poster74,
+/obj/structure/sign/poster/prewar/poster65,
 /turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/leisure)
 "acT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
@@ -121,16 +103,9 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/tunnel)
 "aej" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
+/obj/structure/sign/poster/prewar/poster61,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/leisure)
 "aeN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -168,12 +143,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"afZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/frame/machine,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
 "agm" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -183,17 +152,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"agI" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
 "ahe" = (
 /obj/machinery/vending/medical{
 	req_access = null
@@ -202,32 +160,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"ahx" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "ahB" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aiq" = (
-/obj/structure/closet/fridge/standard,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/structure/sign/poster/prewar/poster60,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "ajc" = (
-/obj/machinery/shower{
-	pixel_y = 24
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/obj/structure/decoration/vent,
-/obj/structure/window/reinforced/tinted/frosted,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
@@ -243,13 +188,9 @@
 	},
 /area/f13/bunker)
 "ajJ" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
-	},
-/area/f13/caves)
+/obj/structure/sign/poster/prewar/poster71,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/leisure)
 "ajM" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -269,8 +210,15 @@
 	},
 /area/f13/tunnel)
 "ajZ" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/survival_pod{
+	dir = 4
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "akd" = (
 /obj/structure/table,
@@ -293,28 +241,28 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "alw" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror{
+	pixel_x = 27
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/leisure)
 "alO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "amf" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/dresser,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/leisure)
 "aoj" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
@@ -324,23 +272,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"apt" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/button/door{
-	id = "bosdoors";
-	name = "Bunker Lockdown Button"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "aqn" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
-"aqB" = (
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
 "aqP" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/structure/table/wood/poker,
@@ -349,17 +284,20 @@
 	},
 /area/f13/tunnel)
 "aqX" = (
-/obj/structure/chair/f13foldupchair,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"arg" = (
+/obj/structure/closet/wardrobe/pjs,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
+"arg" = (
+/obj/effect/decal/cleanable/shreds,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker{
+	name = "Washroom/Dorms"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
 "ask" = (
@@ -384,24 +322,23 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
 "atO" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/generic,
-/obj/structure/sign/poster/prewar/poster89{
-	pixel_x = 32
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/floor/wood/f13/stage_t,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
-"aue" = (
-/obj/structure/fluff/railing{
-	dir = 4;
-	pixel_x = -29
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "auO" = (
-/obj/structure/sign/poster/prewar/poster68,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
+/obj/structure/target_stake,
+/obj/item/target/alien,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "auQ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -417,22 +354,6 @@
 /obj/structure/bed/mattress,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"axk" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/leisure)
-"axQ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "ayH" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -456,39 +377,23 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"azv" = (
-/obj/structure/table{
-	pixel_y = 6
-	},
-/obj/structure/fluff/paper/stack,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/brotherhood/offices1st)
 "azD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "aBb" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
 "aBq" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/structure/toilet{
+	pixel_y = 10
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices1st)
 "aBr" = (
 /obj/structure/simple_door/metal/fence{
@@ -503,14 +408,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "aBQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
+/mob/living/simple_animal/hostile/deathclaw{
+	name = "Rock Claw"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "aCf" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/caves)
@@ -537,46 +439,19 @@
 	icon_state = "floordirty"
 	},
 /area/f13/tunnel)
-"aCO" = (
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Secret"
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
 "aCS" = (
-/obj/structure/janitorialcart,
-/obj/item/mop,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"aDN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/turf_decal/trimline/blue/line{
+	pixel_y = -6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8;
+	pixel_x = -6
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, filtered pool water.";
+	name = "pool water"
+	},
 /area/f13/brotherhood/leisure)
-"aEq" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
-"aER" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "aGv" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -609,63 +484,31 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aHj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/survival_pod{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"aHn" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm2";
-	req_access_txt = "120"
+/obj/structure/toilet{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "aHH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	anchored = 1
+/obj/structure/decoration/vent{
+	pixel_x = 15;
+	pixel_y = -17
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
-"aHM" = (
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
 "aIn" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"aIS" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = -32
-	},
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
 "aIU" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/f13/combat,
@@ -678,29 +521,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "aJR" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosarmoryacc";
+	name = "Armory";
+	req_access_txt = "120"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/operations)
-"aKH" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/grass/wasteland,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
 "aLn" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
@@ -719,10 +548,6 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"aLN" = (
-/obj/machinery/defibrillator_mount/loaded,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "aMg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -731,34 +556,26 @@
 "aNI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"aOT" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/cane,
-/obj/item/cane,
-/obj/item/roller,
-/obj/item/roller,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "aQg" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
-"aRj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/button/door{
+	id = "bosdorm6";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/leisure)
+"aRj" = (
+/obj/machinery/button/door{
+	id = "bosdorm7";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/leisure)
 "aRn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -774,72 +591,41 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"aSI" = (
-/obj/structure/bookcase/random/reference{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Archival References"
+"aSJ" = (
+/obj/machinery/button/door{
+	id = "bosdorm8";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
 	},
-/obj/machinery/light/small{
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/leisure)
+"aSW" = (
+/obj/structure/chair/wood{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "floordirtysolid"
 	},
-/area/f13/brotherhood/rnd)
-"aSJ" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"aSW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"aTP" = (
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
 "aUo" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
 /area/f13/tunnel)
-"aVV" = (
-/obj/item/ship_in_a_bottle{
-	pixel_x = -5;
-	pixel_y = 5
+"aWq" = (
+/obj/machinery/button/door{
+	id = "bosdorm9";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
 	},
-/obj/structure/table/wood/fancy/black,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"aWq" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 1;
-	pixel_x = 16;
-	pixel_y = 8;
-	termtag = "Business"
-	},
-/obj/item/pen{
-	pixel_x = -16;
-	pixel_y = 6
-	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/leisure)
 "aWx" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -856,89 +642,207 @@
 /area/f13/tcoms)
 "aXP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"aXW" = (
-/obj/structure/chair/stool/retro/backed{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	pixel_y = -6
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "aYI" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Head Paladin on duty.";
-	name = "Head Paladin's Office"
-	},
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "aYS" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/simple_door/bunker{
+	name = "Star Paladin Office";
+	req_access = 120;
+	req_access_txt = "120"
 	},
-/obj/effect/landmark/start/f13/Knight,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"aYY" = (
-/obj/machinery/hydroponics/constructable{
-	anchored = 0
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating/f13/inside,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/offices1st)
-"aZl" = (
+"aYY" = (
+/obj/structure/rack,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
-"baP" = (
-/obj/machinery/door/airlock/wood{
-	name = "Sauna"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/leisure)
-"baZ" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"bbq" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"aZl" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosdorm6";
+	req_access_txt = "120"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/leisure)
+"bbq" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices1st)
 "bbs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug/coco{
-	pixel_x = 4;
-	pixel_y = 9
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "bbw" = (
-/obj/machinery/workbench/advanced,
-/obj/effect/turf_decal/stripes/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "Brig Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -952,14 +856,22 @@
 /turf/open/water,
 /area/f13/tunnel)
 "bbO" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "bbV" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -970,15 +882,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/caves)
-"bcf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "bcr" = (
 /obj/item/trash/f13/tin{
 	dir = 4;
@@ -1040,49 +943,30 @@
 	},
 /area/f13/tunnel)
 "bdK" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosdorm7";
 	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"bdP" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"bdV" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
-"ber" = (
-/obj/structure/sign/poster/prewar/poster72,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
-"beN" = (
-/obj/structure/table/wood/fancy/black{
-	desc = "A set of thin pipes that no longer function.";
-	icon_state = "latticefull";
-	layer = 2.4;
-	name = "pipes"
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/leisure)
+"bdP" = (
+/obj/effect/landmark/start/f13/seniorpaladin,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/offices1st)
+"ber" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "beY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1092,17 +976,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "bfh" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "bfL" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosdorm8";
+	req_access_txt = "120"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/leisure)
 "bgg" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight,
@@ -1130,8 +1015,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bhq" = (
-/obj/structure/closet/wardrobe/pjs,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "bis" = (
 /obj/structure/chair/office/dark{
@@ -1143,23 +1030,14 @@
 /area/f13/followers)
 "biy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/sustenance,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"biW" = (
-/obj/structure/table{
-	layer = 2.9
+/mob/living/simple_animal/mouse/white{
+	desc = "It's a strangely clean little white rodent.";
+	name = "Algernon"
 	},
-/obj/machinery/light/small,
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = -8;
-	pixel_y = 4
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/item/paper_bin{
-	pixel_x = 7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices1st)
 "bje" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -1191,12 +1069,12 @@
 	},
 /area/f13/followers)
 "bjz" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "bjF" = (
 /obj/structure/barricade/bars{
 	layer = 5
@@ -1209,18 +1087,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "ble" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosdorm9";
+	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/leisure)
 "blH" = (
 /obj/structure/table,
 /obj/item/multitool,
@@ -1241,27 +1113,34 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/f13/tunnel)
-"bmv" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Star Knight's that walk these halls and may make use of this office.";
-	name = "Star Knight's Office"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
 "bmx" = (
 /obj/docking_port/stationary/bosaway,
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
 "bmF" = (
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
-"bmK" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster81"
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
+"bmK" = (
+/obj/item/bedsheet/red,
+/obj/structure/bed/pod,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "bnM" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1288,21 +1167,19 @@
 	},
 /area/f13/followers)
 "bor" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "boG" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -1310,22 +1187,30 @@
 	},
 /area/f13/tunnel)
 "boI" = (
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/pdapainter,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "bpj" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bpH" = (
+/obj/structure/target_stake,
+/obj/item/target,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "bqs" = (
 /obj/structure/guncase,
 /obj/effect/decal/cleanable/dirt,
@@ -1340,13 +1225,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"bqU" = (
-/obj/effect/landmark/start/f13/initiate,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "bqY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wrench/crude,
@@ -1354,17 +1232,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"bqZ" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "bri" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "brp" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -1377,13 +1253,11 @@
 /area/f13/tunnel)
 "brt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/leisure)
 "brM" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old"
@@ -1401,14 +1275,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "bsF" = (
-/obj/structure/table{
-	layer = 2.9
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Dorms Camera";
+	network = list("BoS");
+	pixel_x = -1
 	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "bsG" = (
 /obj/item/crowbar/red,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -1416,9 +1293,22 @@
 	},
 /area/f13/tunnel)
 "bta" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/rack,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "btB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -1430,18 +1320,6 @@
 "btM" = (
 /turf/closed/wall/rust,
 /area/space)
-"btW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "bud" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -1451,14 +1329,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "bum" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1;
+	icon_state = "warningline_red"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/operations)
 "buo" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -1489,8 +1370,8 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "buZ" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "bvr" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -1503,36 +1384,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bvC" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1;
+	icon_state = "warningline_red"
 	},
-/area/f13/brotherhood/rnd)
-"bvP" = (
-/obj/structure/filingcabinet/employment,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"bwd" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"bxq" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "bxz" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -1545,13 +1410,11 @@
 /area/f13/tunnel)
 "bxG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/chair/f13foldupchair,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "bxU" = (
 /obj/effect/decal/cleanable/dirt{
@@ -1561,19 +1424,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "bxX" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/leisure)
 "byA" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/flora/grass/wasteland,
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bzt" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
@@ -1636,21 +1499,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "bCf" = (
-/obj/structure/toilet{
-	dir = 4;
-	icon_state = "toilet00";
-	pixel_x = 0;
-	pixel_y = 0
+/obj/structure/bed/pod,
+/obj/machinery/button/door{
+	id = "sentdorm";
+	normaldoorcontrol = 1;
+	pixel_y = 26;
+	specialfunctions = 4
 	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
+/obj/item/bedsheet/hos,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
-"bCh" = (
-/obj/structure/sign/poster/prewar/poster92,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "bCn" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -1659,21 +1517,39 @@
 	},
 /area/f13/tunnel)
 "bCX" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
-"bDi" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
+"bDi" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/item/flag/bos,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/rnd)
 "bDG" = (
-/obj/structure/sign/poster/prewar/poster76,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
 /area/f13/brotherhood/operations)
 "bEp" = (
 /obj/structure/window/fulltile/house{
@@ -1696,42 +1572,33 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bEz" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/pda/engineering{
+	name = "Knight-Engineer Pip-Boy 3000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/item/pda/engineering{
+	name = "Knight-Engineer Pip-Boy 3000"
+	},
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/reactor)
 "bEK" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/rnd)
-"bFa" = (
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/lattice{
-	density = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -12
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"bFi" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Star Paladin's that walk these halls and may make use of this office.";
-	name = "Star Paladin's Office"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/leisure)
 "bGf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1757,20 +1624,14 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "bGU" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
 /obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "bHd" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -1790,33 +1651,24 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"bIN" = (
-/obj/structure/simple_door/bunker{
-	name = "Firing Range";
-	req_one_access_txt = "120"
+"bIS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"bIS" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 4;
-	name = "light fixture"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
 "bJa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "bJn" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -1825,18 +1677,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"bJv" = (
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "bJG" = (
 /obj/item/paper_bin/bundlenatural,
 /obj/structure/rack,
@@ -1846,45 +1686,38 @@
 "bKi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices2nd)
 "bKw" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
-	},
-/area/f13/brotherhood/reactor)
-"bKG" = (
-/obj/machinery/light/small{
+/obj/machinery/autolathe/ammo,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/effect/turf_decal/stripes/box,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/machinery/light{
 	dir = 8
 	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
+"bKG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
-"bKT" = (
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
+/obj/structure/rack,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/item/kitchen/knife/combat,
+/obj/item/twohanded/sledgehammer/supersledge,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/operations)
 "bKX" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -1894,14 +1727,17 @@
 	},
 /area/f13/tunnel)
 "bMe" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	pixel_y = -6
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/wood/wood_tiled,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Mess Hall Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/leisure)
 "bMq" = (
 /obj/structure/bed/mattress{
@@ -1917,46 +1753,66 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "bMA" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
-"bMC" = (
-/obj/machinery/button/door{
-	id = "bosdorm9";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
+"bMC" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/washing_machine,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/leisure)
 "bNv" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
 "bNA" = (
-/obj/structure/simple_door/blast{
-	max_integrity = 10000;
-	name = "bunker entry";
-	req_access_txt = "120"
+/obj/structure/rack,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/book/granter/trait/pa_wear,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9;
+	icon_state = "warningline_red"
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Armory Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_x = 33
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
 "bOf" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "A console used by the scribes of the Brotherhood of Steel.";
-	dir = 4;
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal";
-	name = "Archive Terminal"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "bPh" = (
 /obj/structure/simple_door/metal/dirtystore,
 /obj/structure/decoration/rag{
@@ -1975,21 +1831,23 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"bPW" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	name = "Armoury"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "bRf" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bRN" = (
-/obj/structure/sign/poster/prewar/poster90,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/obj/structure/curtain{
+	open = 0
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/leisure)
 "bSs" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
@@ -2004,22 +1862,25 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "bTu" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/atmos,
-/obj/item/twohanded/fireaxe,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
-"bTG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
+/obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
-/area/f13/brotherhood/operations)
+/obj/structure/closet{
+	storage_capacity = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/leisure)
+"bTG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/leisure)
 "bTH" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -2027,10 +1888,13 @@
 	},
 /area/f13/tunnel)
 "bTN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
+	name = "Armoury"
+	},
+/turf/closed/indestructible/opshuttle{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
 	},
 /area/f13/brotherhood/operations)
 "bUh" = (
@@ -2041,10 +1905,6 @@
 /obj/structure/wreck/trash/halftire,
 /turf/open/water,
 /area/f13/tunnel)
-"bUR" = (
-/obj/structure/decoration/vent,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
 "bUX" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -2057,28 +1917,30 @@
 	},
 /area/f13/tunnel)
 "bVb" = (
-/obj/structure/simple_door/bunker{
-	name = "Paladin Halls";
-	req_access = 120;
-	req_access_txt = "120"
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"bVO" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/obj/effect/landmark/start/f13/Knight,
 /turf/open/floor/f13{
-	icon_state = "redmark"
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
+"bVO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "bVY" = (
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/sign/poster/prewar/poster91,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "bWk" = (
 /obj/structure/barricade/bars,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -2127,24 +1989,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"bZQ" = (
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
-"cah" = (
-/obj/structure/table/wood/bar,
-/obj/machinery/chem_dispenser/drinks{
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
 "caQ" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -2153,8 +1997,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "cbs" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/fluff/railing{
+	dir = 9
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "cbG" = (
 /obj/item/storage/fancy/donut_box,
@@ -2168,17 +2017,14 @@
 	},
 /area/f13/tunnel)
 "ccb" = (
-/obj/structure/simple_door/bunker{
-	name = "Paladin Halls";
-	req_access = 120;
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "ccq" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -2190,13 +2036,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "cej" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
 	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/leisure)
 "cek" = (
 /obj/item/organ/liver,
 /obj/effect/decal/cleanable/dirt,
@@ -2211,16 +2056,22 @@
 	},
 /area/f13/clinic)
 "cfk" = (
-/obj/machinery/processor,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "cfA" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "cfJ" = (
 /obj/item/storage/trash_stack,
@@ -2245,20 +2096,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
-"cgy" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/fancy/candle_box,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"chf" = (
-/obj/item/papercutter,
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
 "chW" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
@@ -2288,19 +2125,22 @@
 	},
 /area/f13/tunnel)
 "ckm" = (
-/obj/structure/rack,
-/obj/item/pda/warden{
-	desc = "The RobCo PipBoy. This one is only issued to the acting Armory Warden.";
-	name = "Armory Warden PDA"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
 	},
-/obj/item/pda/warden{
-	desc = "The RobCo PipBoy. This one is only issued to the acting Armory Warden.";
-	name = "Armory Warden PDA"
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/fireaxecabinet{
+	pixel_y = 39
 	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices1st)
 "ckx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -2311,13 +2151,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"cly" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "clz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
@@ -2326,49 +2159,36 @@
 	},
 /area/f13/bunker)
 "clA" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"clT" = (
-/obj/structure/sign/poster/prewar/poster83,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
-"cmy" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Paladin's that walk these halls and may make use of this office.";
-	name = "Paladins Offices"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
-"cmE" = (
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/rnd)
-"cna" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
-"cnm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/operations)
-"cnq" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+"clT" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
+"cna" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "cnF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -2383,12 +2203,14 @@
 	},
 /area/f13/bunker)
 "coe" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "cof" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
@@ -2396,20 +2218,18 @@
 	},
 /area/f13/tunnel)
 "coQ" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/fluff/railing,
-/obj/structure/fluff/railing{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -12
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "coX" = (
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/inside/subway,
@@ -2445,34 +2265,30 @@
 	},
 /area/f13/tunnel)
 "cqO" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "twindowold"
-	},
-/turf/open/floor/wood,
+/obj/machinery/computer/auxillary_base,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "cqT" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cqY" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/effect/turf_decal/caution/stand_clear/white,
+/obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "crg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"crH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "crL" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2511,16 +2327,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"ctL" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/f13/Knight,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
 "cuj" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -2535,20 +2341,15 @@
 	},
 /area/f13/tunnel)
 "cus" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/curtain{
+	open = 0
 	},
-/area/f13/brotherhood/rnd)
-"cuN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/shower{
+	dir = 4
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/leisure)
 "cvb" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
@@ -2577,15 +2378,6 @@
 /obj/structure/wreck/car/bike,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"cxq" = (
-/obj/machinery/button/door{
-	id = "bosdorm8";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
 "cxu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/small{
@@ -2611,15 +2403,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "cyA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/reactor)
 "cyG" = (
 /obj/structure/table/glass,
 /obj/item/pen,
@@ -2631,15 +2422,21 @@
 /area/f13/followers)
 "cyO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/closet{
+	storage_capacity = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "czn" = (
+/obj/structure/closet/secure_closet/personal,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 10
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/leisure)
 "czF" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13{
@@ -2652,17 +2449,8 @@
 	},
 /area/f13/sewer)
 "cAB" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
-"cAQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/prewar/poster90,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "cBH" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2683,44 +2471,36 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"cCv" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "cCx" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
 	},
-/obj/item/paper_bin{
-	pixel_y = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/flashlight/lamp{
-	pixel_x = 2;
-	pixel_y = 12
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
-"cCQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/pool/ladder{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, filtered pool water.";
-	name = "pool water"
+/area/f13/brotherhood/reactor)
+"cCQ" = (
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
 "cDp" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cola/space_up,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/leisure)
 "cDY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -2730,34 +2510,65 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "cEF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/rnd)
-"cFd" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"cFi" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = 7
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
+"cFd" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Secret"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/offices1st)
+"cFi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/offices1st)
 "cFj" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
 	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "cFE" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/human,
@@ -2789,32 +2600,44 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "cGq" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/structure/sign/poster/prewar/poster93,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "cHw" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
-/area/f13/caves)
-"cHA" = (
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
+"cHA" = (
+/obj/machinery/vending/wallmed{
+	pixel_y = 30;
+	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 10, /obj/item/reagent_containers/pill/patch/silver_sulf = 10, /obj/item/reagent_containers/medspray/styptic = 4, /obj/item/reagent_containers/medspray/silver_sulf = 4, /obj/item/reagent_containers/pill/charcoal = 2, /obj/item/reagent_containers/medspray/sterilizine = 2)
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "cIi" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -2834,10 +2657,12 @@
 	},
 /area/f13/sewer)
 "cIS" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
+/obj/structure/dresser,
+/obj/machinery/light{
+	dir = 4
 	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "cJp" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /mob/living/simple_animal/hostile/ghoul,
@@ -2861,33 +2686,35 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"cKQ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/crate/large,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"cLp" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
 "cLJ" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9;
+	icon_state = "warningline_red"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/operations)
 "cLN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -2934,17 +2761,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
-"cOC" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/walk{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/leisure)
 "cPA" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -2962,14 +2778,28 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "cQR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/item/ammo_casing/spent{
+	pixel_x = -12;
+	pixel_y = -9
 	},
-/obj/structure/lattice{
-	layer = 3
+/obj/item/ammo_casing/spent{
+	pixel_x = 6;
+	pixel_y = 9
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/item/ammo_casing/spent{
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "cQW" = (
 /obj/item/clothing/under/f13/rag,
 /turf/open/floor/f13/wood{
@@ -3016,21 +2846,63 @@
 	},
 /area/f13/bunker)
 "cSG" = (
-/turf/closed/indestructible/opshuttle,
-/area/f13/brotherhood/reactor)
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cSH" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/ammo_casing/spent{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/ammo_casing/spent{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/ammo_casing/spent{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/operations)
 "cSY" = (
 /turf/open/water,
 /area/f13/caves)
 "cTh" = (
-/obj/structure/chair/bench{
-	icon_state = "dropshipleft"
+/obj/item/ammo_casing/spent{
+	pixel_x = 16;
+	pixel_y = -36
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/obj/item/ammo_casing/spent{
+	pixel_x = 9;
+	pixel_y = -12
+	},
+/obj/item/ammo_casing/spent{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/ammo_casing/spent{
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "cTp" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3061,15 +2933,28 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "cUC" = (
+/obj/item/ammo_casing/spent{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/ammo_casing/spent{
+	pixel_x = -10;
+	pixel_y = 7
+	},
+/obj/item/ammo_casing/spent{
+	pixel_x = 6
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "AUX"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "cWd" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/indestructible/ground/inside/subway,
@@ -3086,10 +2971,6 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"cXG" = (
-/obj/structure/sign/poster/prewar/poster89,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "cYr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/hatch,
@@ -3104,58 +2985,31 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "cZm" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/reactor)
 "cZA" = (
 /obj/machinery/telecomms/server/presets/vault,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "cZP" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/obj/structure/mirror{
-	pixel_x = -27
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "daK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"dbk" = (
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/dog/pug{
-	name = "Paladin Ramos"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"dbT" = (
-/obj/structure/sign/departments/medbay,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/leisure)
 "dbZ" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -3164,22 +3018,12 @@
 	},
 /area/f13/tunnel)
 "dcf" = (
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/snack/green,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/rnd)
-"dcg" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 30;
-	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 10, /obj/item/reagent_containers/pill/patch/silver_sulf = 10, /obj/item/reagent_containers/medspray/styptic = 4, /obj/item/reagent_containers/medspray/silver_sulf = 4, /obj/item/reagent_containers/pill/charcoal = 2, /obj/item/reagent_containers/medspray/sterilizine = 2)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "dcB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3201,29 +3045,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ddJ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "ddQ" = (
-/obj/structure/decoration/hatch{
-	dir = 8
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 4
-	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/offices1st)
 "dek" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -3238,14 +3065,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "deX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/f13foldupchair{
+	dir = 1
 	},
 /turf/open/floor/f13{
-	icon_state = "rampdowntop"
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
 "dfO" = (
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3258,11 +3084,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"dgH" = (
-/obj/structure/chair/bench,
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "dgL" = (
 /obj/structure/table/wood/settler,
 /obj/item/gun/ballistic/revolver/caravan_shotgun,
@@ -3275,18 +3096,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "dhM" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -11
 	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "dhN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -3311,16 +3131,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "djs" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/storage/belt/holster,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/senior,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/senior,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/storage/belt/military,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/reactor)
 "djR" = (
 /obj/structure/toilet{
 	dir = 4
@@ -3335,16 +3153,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "dkT" = (
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"dlw" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/simple_door/bunker{
+	name = "Firing Range"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
+"dlw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker{
+	name = "Washroom/Gym"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "dlz" = (
 /obj/structure/toilet{
 	pixel_y = 10
@@ -3357,16 +3182,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"dlT" = (
-/obj/effect/landmark/start/f13/seniorpaladin,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
 "dmH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -3379,31 +3194,17 @@
 /area/f13/caves)
 "dnM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/structure/filingcabinet/employment,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/area/f13/brotherhood/offices1st)
-"dod" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Kitchen";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/reactor)
 "doi" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dok" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "doL" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -3422,26 +3223,17 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"dpR" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/operations)
 "dpV" = (
 /turf/open/floor/plating/f13,
 /area/f13/followers)
-"dqh" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "dqp" = (
-/obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "sentdorm";
+	req_access_txt = "120"
 	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/offices1st)
 "dqs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3494,20 +3286,12 @@
 "dtm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/area/f13/brotherhood/offices1st)
-"dtO" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/reactor)
 "duf" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt{
@@ -3516,14 +3300,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "dur" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
-/area/f13/caves)
+/area/f13/brotherhood/leisure)
 "duI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3531,26 +3313,16 @@
 /obj/structure/table,
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"dvK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+"dvP" = (
+/obj/structure/displaycase/trophy,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"dvP" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
 "dxi" = (
 /obj/structure/bookcase/manuals,
 /obj/effect/decal/cleanable/dirt{
@@ -3566,14 +3338,15 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dxx" = (
-/obj/effect/landmark/start/f13/elder,
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	layer = 2.7;
-	name = "prewar lounge chair"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/highsecurity{
+	name = "The Codex";
+	req_access_txt = "120"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "dxL" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -3618,11 +3391,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dyR" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/offices1st)
 "dzJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -3634,29 +3411,28 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dBy" = (
-/obj/structure/table/wood/poker,
-/obj/item/dice/d20,
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "NW"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1;
+	icon_state = "warningline_red"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "dCf" = (
 /obj/structure/campfire/barrel,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"dDE" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Secret"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "dEa" = (
 /obj/machinery/telecomms/server/presets/den,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -3670,34 +3446,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dEm" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
+/obj/effect/landmark/start/f13/seniorknight,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/chair/office/dark,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/machinery/camera/autoname{
-	dir = 5;
-	name = "Foyer Camera";
-	network = list("BoS");
-	pixel_x = -1
+/area/f13/brotherhood/offices1st)
+"dEq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/operations)
-"dEq" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/offices1st)
 "dEy" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -3716,11 +3480,11 @@
 	},
 /area/f13/followers)
 "dFh" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/offices2nd)
 "dFz" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/f13/wood{
@@ -3733,31 +3497,33 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "dGe" = (
-/obj/structure/fluff/railing{
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
 	dir = 4;
-	pixel_x = 6
+	pixel_y = 10
 	},
-/obj/structure/chair/f13chair1,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/machinery/computer/terminal{
+	dir = 4;
+	pixel_y = -6;
+	termtag = "Secret"
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
-"dGu" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood/rnd)
-"dGD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/ce,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/operations)
+"dGu" = (
+/obj/effect/landmark/start/f13/Knight,
+/obj/structure/chair/office/dark,
+/obj/machinery/button/door{
+	id = "bosarmoryacc";
+	normaldoorcontrol = 1;
+	pixel_x = -23;
+	specialfunctions = 4
+	},
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/operations)
 "dGR" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/xeno/larva,
@@ -3765,23 +3531,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"dHn" = (
-/obj/structure/sign/poster/prewar/poster85,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
-"dHq" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Secret"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "dID" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
@@ -3816,20 +3565,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "dJD" = (
-/obj/structure/rack,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
-	icon_state = "warningline_red"
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -3852,19 +3593,21 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dKk" = (
-/obj/structure/closet/crate/medical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
-"dKm" = (
-/obj/effect/landmark/start/f13/seniorknight,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/operations)
 "dKn" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -3873,18 +3616,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dKo" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
+/obj/structure/simple_door/bunker,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "dKx" = (
 /obj/item/chair,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -3913,26 +3653,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLF" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dLJ" = (
 /obj/structure/handrail/g_central{
@@ -3964,22 +3689,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"dMg" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "dMj" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
@@ -3992,8 +3701,21 @@
 /area/f13/ncr)
 "dMm" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "SE"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "dML" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
@@ -4003,9 +3725,12 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/tunnel)
 "dMW" = (
-/obj/structure/decoration/smokeold,
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Star Knight's that walk these halls and may make use of this office.";
+	name = "Star Knight's Office"
+	},
 /turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices1st)
 "dNu" = (
 /obj/structure/sink{
 	dir = 8;
@@ -4068,32 +3793,25 @@
 	},
 /area/f13/clinic)
 "dRc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/machinery/vending/wallmed,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "dRm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/computer/shuttle/boselevator{
-	dir = 1
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "dRA" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = null;
-	req_access_txt = "120"
+/obj/machinery/shower{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices2nd)
 "dRM" = (
 /turf/open/floor/f13{
@@ -4101,48 +3819,57 @@
 	},
 /area/f13/bunker)
 "dRZ" = (
-/obj/item/flag/bos{
-	pixel_x = 16
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"dSd" = (
-/obj/structure/chair/right{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4;
-	pixel_x = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
+/obj/machinery/power/apc{
 	dir = 1;
-	pixel_y = 6
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
+"dSd" = (
+/obj/item/radio/intercom{
+	desc = "Is there anyone on the other end? Who's in there?";
+	frequency = 1291;
+	name = "Mysterious Intercom";
+	pixel_y = null
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operations)
 "dSf" = (
-/obj/item/toy/poolnoodle/yellow,
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, filtered pool water.";
-	name = "pool water"
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
 "dSr" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "NE"
 	},
-/area/f13/brotherhood/reactor)
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "dSv" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -4165,14 +3892,15 @@
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Secret"
 	},
-/obj/item/paper_bin{
-	pixel_x = 7
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices1st)
 "dTE" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -4183,43 +3911,17 @@
 	},
 /area/f13/tunnel)
 "dTR" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/item/t_scanner/adv_mining_scanner{
-	pixel_x = 9
-	},
-/obj/item/t_scanner/adv_mining_scanner{
-	pixel_x = -9
-	},
-/obj/item/gps/mining{
-	gpstag = "BOSMINE1";
-	pixel_x = -10;
-	pixel_y = 22
-	},
-/obj/item/gps/mining{
-	gpstag = "BOSMINE2";
-	pixel_x = 1;
-	pixel_y = 22
-	},
-/obj/item/pickaxe/drill/diamonddrill{
-	pixel_x = 32;
-	pixel_y = -9
-	},
-/obj/item/pickaxe/drill/diamonddrill{
-	pixel_x = 32
-	},
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/operations)
 "dUk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -4239,49 +3941,38 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"dUF" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Dorms";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"dUL" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "sentdorm";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "dUW" = (
-/obj/machinery/button/crematorium{
-	pixel_x = 22
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
-"dVj" = (
-/obj/machinery/sleeper{
-	density = 1;
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
+"dVj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
+"dVs" = (
+/obj/machinery/button/crematorium{
+	pixel_x = 22
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/medical)
-"dVs" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/window/fulltile/store,
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
 "dVB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4302,41 +3993,26 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dWN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/paladin,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = 33
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/mining)
 "dWT" = (
-/obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/obj/structure/bed/mattress/pregame,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/area/f13/caves)
+/area/f13/brotherhood/operations)
 "dWV" = (
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dXe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "dXp" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight/lamp,
@@ -4376,109 +4052,71 @@
 /area/f13/tunnel)
 "dZE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 16
 	},
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "dZF" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "dZR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/statuebust,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "dZW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/blue/line{
+/obj/structure/toilet{
 	dir = 4;
-	pixel_x = 6
-	},
-/obj/machinery/light/fo13colored/Aqua{
-	critical_machine = 1;
-	dir = 8;
-	flicker_chance = 0;
-	name = "light fixture"
+	icon_state = "toilet00";
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "darkrusty"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "eag" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"eaz" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/offices1st)
 "eaR" = (
-/obj/structure/frame/machine,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operations)
 "ecp" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/surgical_drapes,
+/obj/item/stack/sticky_tape/surgical{
+	pixel_x = -11;
+	pixel_y = 8
+	},
+/obj/machinery/light,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "ede" = (
 /obj/machinery/shower{
@@ -4503,12 +4141,17 @@
 	},
 /area/f13/followers)
 "edO" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood/rnd)
 "eew" = (
 /obj/structure/decoration/vent/rusty,
 /obj/machinery/shower{
@@ -4521,12 +4164,11 @@
 /area/f13/ncr)
 "eez" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "eeG" = (
 /obj/structure/noticeboard{
 	pixel_x = 32
@@ -4534,10 +4176,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"eeH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
 "eeT" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -4547,14 +4185,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "eeW" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/kirbyplants{
+	pixel_y = 14
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 6
-	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/leisure)
 "eeX" = (
 /obj/effect/decal/fakelattice{
 	density = 0;
@@ -4570,15 +4211,6 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
-"efS" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "efX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4587,13 +4219,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"egd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "egg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe/ammo,
@@ -4608,21 +4233,37 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ehz" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/camera/autoname{
+	dir = 5;
+	name = "Foyer Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "ehT" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "SW"
+	},
+/obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
+	dir = 5;
 	icon_state = "warningline_red"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
 "ehY" = (
@@ -4637,8 +4278,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "eiN" = (
-/obj/structure/chair/stool/retro,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -4656,13 +4301,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "ejQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
 	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
 "ekK" = (
@@ -4690,14 +4333,17 @@
 	},
 /area/f13/bunker)
 "emg" = (
-/obj/structure/simple_door/metal/ventilation,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/rnd)
 "emX" = (
 /obj/structure/table/glass,
 /obj/item/pda,
@@ -4706,16 +4352,18 @@
 	},
 /area/f13/followers)
 "enl" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_x = 32;
-	start_charge = 500
+/obj/structure/mirror{
+	pixel_x = -32
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/brotherhood/operations)
 "eom" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/effect/decal/cleanable/dirt,
@@ -4735,23 +4383,18 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"epa" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
 "epe" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "epH" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4790,12 +4433,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "eqD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "eqU" = (
 /obj/item/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
@@ -4804,14 +4452,12 @@
 	},
 /area/f13/tunnel)
 "erF" = (
-/obj/item/toy/plush/nukeplushie{
-	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
-	name = "Knight-Captain Aryom";
-	pixel_x = 9
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
+	dir = 4
+	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
 "esG" = (
@@ -4821,9 +4467,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "esP" = (
-/obj/structure/sign/poster/prewar/poster60,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "etN" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -4833,12 +4486,8 @@
 	},
 /area/f13/tunnel)
 "eub" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/ce,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plating,
+/area/f13/brotherhood/reactor)
 "eug" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -4847,13 +4496,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "euS" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "euY" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
@@ -4872,20 +4527,16 @@
 	},
 /area/f13/bunker)
 "exH" = (
-/obj/structure/chair/left{
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4;
-	pixel_x = 6
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "exK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -4964,23 +4615,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "eAw" = (
-/obj/structure/lattice{
-	layer = 3
-	},
+/obj/structure/table,
+/obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/offices1st)
-"eAO" = (
-/obj/item/flag/bos,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "eAQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -5015,28 +4656,10 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
-"eBP" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/offices1st)
 "eCr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"eCv" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/ash/large,
-/obj/effect/decal/cleanable/ash/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
 "eCE" = (
 /obj/structure/barricade/bars{
 	layer = 5
@@ -5062,46 +4685,65 @@
 	},
 /area/f13/clinic)
 "eDd" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
-"eDs" = (
-/obj/structure/simple_door/bunker/glass{
-	name = "Mining Storeroom";
-	req_access_txt = "120"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = -8;
+	pixel_y = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
-"eDu" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/item/paper_bin{
+	pixel_x = 7
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
+"eDs" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/light/small,
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper_bin{
+	pixel_x = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
+"eDu" = (
+/obj/structure/closet,
+/obj/item/storage/box/gloves,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/wrench/medical,
+/obj/item/toy/figure/cmo{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	layer = 2;
+	name = "Head Scribe Action Figure";
+	toysay = "Ad astra per aspera."
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "eDy" = (
-/obj/structure/closet/crate/bin,
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = 24
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
-"eDA" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "eDV" = (
@@ -5111,55 +4753,9 @@
 	},
 /area/f13/bunker)
 "eEL" = (
-/obj/structure/sink/kitchen{
-	desc = "Strictly for filling up mop buckets.";
-	dir = 1;
-	name = "Mop Sink";
-	pixel_y = 13
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"eER" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/box/lights/tubes,
-/obj/item/storage/box/lights/bulbs,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/lipstick/black,
-/obj/item/storage/box/bodybags{
-	pixel_x = -9;
-	pixel_y = 12
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/item/pda/medical{
-	name = "Scribe-Medic Pip-Boy 3000"
-	},
-/obj/item/pda/medical{
-	name = "Scribe-Medic Pip-Boy 3000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
-"eFE" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/kirbyplants{
-	pixel_y = 14
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
-"eFS" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "eGn" = (
 /turf/open/floor/f13/wood{
@@ -5167,20 +4763,39 @@
 	},
 /area/f13/sewer)
 "eGI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
-"eGW" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/light/small,
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper_bin{
+	pixel_x = 7
+	},
+/obj/item/toy/figure/warden{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	name = "Knight Action Figure";
+	toysay = "Steel be with you."
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
+"eGW" = (
+/obj/machinery/chem_heater,
+/obj/item/toy/figure/chemist{
+	layer = 2.8;
+	name = "Scribe action figure";
+	toysay = "Ad meliora."
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "eGX" = (
 /obj/structure/sink{
 	dir = 8;
@@ -5196,18 +4811,26 @@
 	},
 /area/f13/followers)
 "eHh" = (
-/obj/structure/decoration/smokeold{
-	pixel_y = -31
+/turf/closed/indestructible/opshuttle{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
 "eHl" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/sewer)
 "eHy" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
+/obj/structure/barricade/bars,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/security/cell/westleft{
+	name = "Brotherhood cell door";
+	req_access = null;
+	req_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/brotherhood/operations)
 "eHN" = (
 /obj/structure/showcase/horrific_experiment{
 	icon_state = "pod_0"
@@ -5224,17 +4847,23 @@
 	},
 /area/f13/bunker)
 "eIJ" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/deepfryer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "eIU" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "eJh" = (
-/obj/structure/table/wood,
+/obj/structure/chair/right{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_tiled,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/leisure)
 "eJi" = (
 /obj/structure/chair/office/dark,
@@ -5255,11 +4884,6 @@
 "eLE" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
-"eLG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
 "eLI" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -5273,9 +4897,12 @@
 	},
 /area/f13/tunnel)
 "eME" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/bookcase/random,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "eMM" = (
 /obj/structure/table/wood,
 /obj/item/documents{
@@ -5290,34 +4917,49 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "eMO" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
+/obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"eNq" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "eNt" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "eOh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/offices1st)
-"eOx" = (
-/obj/item/toy/figure/miner{
-	desc = "A strangely dressed Knight figure, holding a pickaxe in one hand, sword in the other!";
-	name = "The Lonesome Knight";
-	toysay = "In case anyone's wondering, i'm still alive out here..."
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
+"eOx" = (
+/obj/structure/simple_door/blast{
+	max_integrity = 10000;
+	name = "bunker entry";
+	req_access_txt = "120"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "bosdoors";
+	name = "brotherhood shutters"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "eOW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -5341,56 +4983,33 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"eQh" = (
-/obj/item/circuitboard/machine/smes,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
 "eQC" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"eQF" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "eQL" = (
-/obj/structure/glowshroom/single,
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/item/radio/intercom{
+	desc = "Is there anyone on the other end? Who's in there?";
+	frequency = 1291;
+	name = "Mysterious Intercom";
+	pixel_y = null
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices1st)
 "eRg" = (
-/obj/structure/flora/junglebush,
-/obj/structure/bus_door,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood/offices1st)
 "eRs" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "eRw" = (
-/obj/machinery/vending/wallmed,
+/obj/structure/decoration/smokeold,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
-"eRI" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"eSC" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
 "eSD" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -5442,20 +5061,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "eVi" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices1st)
 "eVA" = (
-/obj/structure/frame/machine,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
-"eWj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/f13{
-	icon_state = "redmark"
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
 "eWN" = (
@@ -5479,15 +5094,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "eXJ" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/bed,
+/obj/item/bedsheet/hos,
+/obj/item/toy/figure/warden{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	name = "Head Knight Action Figure";
+	toysay = "Victory is our tradition!"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "eXS" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -5495,63 +5110,57 @@
 	},
 /area/f13/tunnel)
 "eZh" = (
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced{
-	req_access_txt = "120"
-	},
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"eZX" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/hemostat,
-/obj/item/retractor,
-/obj/item/scalpel,
-/obj/item/circular_saw,
-/obj/item/surgicaldrill,
-/obj/item/cautery,
-/obj/item/bonesetter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
-"faa" = (
-/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/chair/office{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"fai" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/power/smes/engineering,
 /obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
+"faa" = (
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/pda/heads/hos{
+	name = "Head Knight's PDA"
+	},
+/obj/item/storage/briefcase,
+/obj/item/clothing/suit/armor/vest/capcarapace/syndicate{
+	desc = "A sinister looking vest of advanced armor worn over a black and red fireproof jacket. The gold collar and shoulders denote that this belongs to a high ranking officer of some lost prewar army.";
+	name = "old officer's vest"
+	},
+/obj/item/clothing/head/HoS/beret/syndicate{
+	name = "officer's beret"
+	},
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/machinery/button/door{
+	id = "kcdorm";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
+"fai" = (
+/obj/structure/safe/floor,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices1st)
 "faR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation{
-	anchored = 1
+/obj/machinery/vending/wallmed{
+	pixel_y = 30;
+	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 10, /obj/item/reagent_containers/pill/patch/silver_sulf = 10, /obj/item/reagent_containers/medspray/styptic = 4, /obj/item/reagent_containers/medspray/silver_sulf = 4, /obj/item/reagent_containers/pill/charcoal = 2, /obj/item/reagent_containers/medspray/sterilizine = 2)
 	},
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "fbC" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -5564,34 +5173,86 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"fbK" = (
-/obj/structure/sign/poster/ripped,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "fbP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
+/obj/machinery/computer/security/wooden_tv{
+	network = list("BoS")
 	},
-/area/f13/brotherhood/reactor)
-"fcn" = (
-/turf/closed/wall/r_wall,
-/area/f13/caves)
+/obj/structure/fireaxecabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "fdN" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
+/obj/structure/rack,
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -10;
+	pixel_y = -10
 	},
-/area/f13/caves)
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 13;
+	pixel_y = -8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "feo" = (
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "feu" = (
-/obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/surface)
 "feB" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal"
@@ -5602,10 +5263,10 @@
 /area/f13/followers)
 "feM" = (
 /obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "feP" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -5620,19 +5281,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"ffA" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "ffE" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -5649,10 +5297,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "fhk" = (
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/offices2nd)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "fhn" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -5670,9 +5322,15 @@
 	},
 /area/f13/tunnel)
 "fkd" = (
-/obj/machinery/rnd/production/protolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/closet/fridge/standard,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "fkf" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -5681,19 +5339,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"fkh" = (
-/obj/machinery/light/sign{
-	icon_state = "board_text6"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "fkn" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/area/f13/brotherhood/leisure)
 "fkv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -5736,13 +5394,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "flW" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8;
-	pixel_x = -6
+/obj/structure/simple_door/bunker{
+	name = "Gym/Kitchen"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
 "flY" = (
@@ -5776,11 +5433,12 @@
 	},
 /area/f13/tunnel)
 "fna" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Power"
+/obj/machinery/vending/dinnerware,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "fnv" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -5788,9 +5446,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fnD" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood/operations)
 "fnZ" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden,
@@ -5799,15 +5462,15 @@
 	},
 /area/f13/bunker)
 "fou" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/junglebush/c,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fpv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
 "fpJ" = (
@@ -5815,40 +5478,30 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "fqz" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/surgical_drapes,
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/item/stack/sticky_tape/surgical{
-	pixel_x = -11;
-	pixel_y = 8
-	},
+/area/f13/brotherhood/operations)
+"fqK" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
-"fqK" = (
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/suit_storage_unit/radsuit,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "fqM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/bookcase/random/religion,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
-"fqU" = (
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "frf" = (
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
@@ -5864,25 +5517,35 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "frn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
+/obj/machinery/door/airlock/grunge{
+	id_tag = "kcdorm";
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "frS" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "ftt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/rnd)
 "ftF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "ftO" = (
 /obj/structure/barricade/bars,
@@ -5900,23 +5563,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fuc" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operations)
 "fuE" = (
 /obj/structure/simple_door/metal/barred,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -5928,31 +5583,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "fuQ" = (
-/turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
+/mob/living/simple_animal/hostile/mirelurk,
+/turf/open/water,
+/area/f13/caves)
 "fvp" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
 "fwX" = (
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
+	},
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/rnd)
 "fwZ" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
@@ -5975,66 +5624,82 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fxu" = (
+/obj/machinery/bookbinder{
+	icon_state = "bigscanner";
+	pixel_y = 7
+	},
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
-"fxA" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4;
-	pixel_x = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/fo13colored/Aqua{
-	critical_machine = 1;
-	dir = 8;
-	flicker_chance = 0;
-	name = "light fixture"
-	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/leisure)
-"fxM" = (
-/obj/structure/table/survival_pod,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
-	},
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
 /area/f13/brotherhood/rnd)
+"fxA" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
+"fxM" = (
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/cigbutt,
+/obj/structure/table{
+	pixel_y = 6
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "fxN" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fze" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	name = "bitter black coffee";
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/machinery/computer/terminal{
+	dir = 1;
+	pixel_x = 16;
+	pixel_y = 8;
+	termtag = "Business"
+	},
+/obj/structure/table{
+	pixel_y = 6
+	},
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = -3;
+	pixel_y = 15
+	},
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "fzR" = (
-/obj/structure/sign/poster/prewar/poster93,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/obj/structure/table{
+	pixel_y = 6
+	},
+/obj/item/holosign_creator/security{
+	layer = 3.1;
+	name = "Knight Captain's holobarrier projector";
+	pixel_y = 7
+	},
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "fzT" = (
-/obj/structure/glowshroom/single,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood/offices1st)
 "fAs" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -6044,44 +5709,36 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "fAJ" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/obj/structure/fluff/railing,
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fBi" = (
 /obj/structure/closet/crate/large,
 /obj/structure/closet/crate/large,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "fBQ" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	layer = 2.7;
-	name = "prewar lounge chair"
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
+	name = "Brig"
 	},
-/obj/effect/landmark/start/f13/sentinel,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/offices1st)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operations)
 "fCf" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/kirbyplants{
+	pixel_y = 14
 	},
-/turf/open/floor/plating/f13/inside,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
+	},
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "fCi" = (
 /obj/structure/table/wood,
@@ -6091,23 +5748,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"fDi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	icon = 'icons/obj/machines/particle_accelerator.dmi';
-	icon_keyboard = "generic_key";
-	icon_screen = "generic";
-	icon_state = "control_boxp"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "fDp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/libraryscanner{
+	desc = "This device scans books and other documents for entry into the Archives.";
+	name = "archive scanner";
+	pixel_y = 7
 	},
-/obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/plating/f13/inside,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "fDw" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
@@ -6115,44 +5765,17 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"fDW" = (
-/obj/machinery/computer/terminal{
-	density = 0;
-	desc = "A pre-war high security terminal. There's virtually no way to hack into this thing; it holds the most secure information the Brotherhood has to offer.";
-	doc_content_1 = "The preservation of technology is our primary goal, all others are secondary. <br> <br>  Shield yourself from those not bound to you by steel, for they are the blind. Aid them when you can, but lose not sight of yourself.";
-	doc_content_2 = "Give way your suspicions to the wisdom of thine Elder. Where he shows trust, so shall you. <br> <br> Fear those who do not pledge to the Brotherhood for though their eyes may be opened through service, they are now blind. ";
-	doc_content_3 = "Through discourse, we gain the strength of our Brothers' minds. Deceit and lies of all ilk serve only to harm that strength. <br> <br> Your caste and duties mean everything, you will follow your leader and your leader will lead you. <br> <br> You may only follow the orders of another if it will save the life of a brother. ";
-	doc_content_4 = "Theft is for lesser men, the Brotherhood provides for you and you provide for the Brotherhood. <br> <br>  What lesser men see as fashionable shall be shunned. Foreign garment and practice will do nothing but shame your fellow brothers.  ";
-	doc_content_5 = "The Blind can not read, only those who have taken the Oath of Fraternity may read this text.";
-	doc_title_1 = "Doctrine pt. 1";
-	doc_title_2 = "Doctrine pt. 2";
-	doc_title_3 = "Doctrine pt. 3";
-	doc_title_4 = "Doctrine pt. 4";
-	doc_title_5 = "Doctrine pt. 5";
-	icon_screen = null;
-	icon_state = "ratvarcomputer1";
-	idle_power_usage = 1;
-	light_color = "#6e1722";
-	light_power = 2;
-	light_range = 3;
-	max_integrity = 1000;
-	name = "The Codex";
-	note = "Scribe Note of the Week:";
-	pixel_y = 16;
-	termtag = "Codex"
-	},
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood/rnd)
 "fEs" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/structure/glowshroom/single,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/brotherhood/operations)
 "fEB" = (
 /obj/machinery/light{
 	dir = 1
@@ -6185,18 +5808,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"fFK" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "fGA" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -6224,30 +5835,24 @@
 	},
 /area/f13/clinic)
 "fIN" = (
-/obj/structure/chair/middle{
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "bosdoors";
+	name = "brotherhood shutters"
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
+"fIV" = (
+/obj/effect/landmark/start/f13/Knight,
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4;
-	pixel_x = 6
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
-"fIV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 8;
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operations)
 "fJw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
@@ -6284,9 +5889,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"fKn" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood/offices2nd)
 "fKq" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -6302,17 +5904,18 @@
 	},
 /area/f13/tunnel)
 "fLF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 5
+/obj/structure/mirror{
+	pixel_x = -32
 	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices1st)
 "fLK" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -6327,24 +5930,17 @@
 "fLU" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"fMz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "fME" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/fluff/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "fNk" = (
 /obj/machinery/autolathe,
@@ -6362,36 +5958,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
-"fNB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/structure/decoration/hatch{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "fNX" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "fOH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
+/obj/machinery/door/window/northright,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices1st)
 "fOZ" = (
 /obj/machinery/door/airlock/abandoned,
 /turf/open/indestructible/ground/inside/subway,
@@ -6429,22 +6003,12 @@
 /area/f13/tunnel)
 "fQF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/leisure)
-"fRN" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "fSe" = (
 /obj/structure/filingcabinet,
@@ -6453,12 +6017,14 @@
 	},
 /area/f13/clinic)
 "fSI" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "fSK" = (
 /obj/item/trash/f13/dog,
 /obj/structure/spider/stickyweb,
@@ -6470,54 +6036,77 @@
 	},
 /area/f13/bunker)
 "fSW" = (
-/obj/structure/window/reinforced/clockwork/fulltile,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
 "fTt" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
-"fUJ" = (
-/turf/open/floor/wood,
-/area/f13/brotherhood/rnd)
 "fUZ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fVx" = (
-/obj/machinery/iv_drip,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "fXm" = (
 /obj/structure/bookcase,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "fXr" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "fXs" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/obj/effect/landmark/start/f13/Knight,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"fYf" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
+"fYf" = (
+/obj/effect/landmark/start/f13/headscribe,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "fYq" = (
 /obj/structure/curtain{
@@ -6538,9 +6127,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "fZB" = (
-/obj/effect/temp_visual/steam_release,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/structure/simple_door/bunker{
+	name = "Head Knight's Office";
+	req_access = 120;
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/brotherhood/offices1st)
 "fZG" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -6560,9 +6156,14 @@
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "gbA" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/door/airlock/hatch{
+	name = "Brig";
+	req_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "gbG" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -6596,28 +6197,13 @@
 	},
 /area/f13/followers)
 "gcD" = (
-/obj/structure/rack,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/under/misc/bathrobe,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
-"gcK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/circuitboard/machine/pacman/mrs,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
-"gcY" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/animate,
-/turf/closed/wall/f13/wood,
-/area/f13/brotherhood/rnd)
-"geb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowbottom"
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "gev" = (
 /obj/structure/decoration/hatch{
 	dir = 4
@@ -6627,39 +6213,40 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"gfy" = (
-/obj/structure/chair/bench,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
 "gfz" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/rd{
-	desc = "A fine quilted blanket, made with purple and yellow fabric.";
-	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
-	name = "fine bedsheet"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper_bin{
+	pixel_x = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "ggm" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "bosdoors";
+	name = "brotherhood shutters"
 	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-2"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operations)
 "ggq" = (
-/obj/structure/sign/poster/prewar/poster94,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker{
+	name = "bunks"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/leisure)
 "ggx" = (
 /obj/machinery/light{
@@ -6712,21 +6299,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"gim" = (
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "giA" = (
 /obj/structure/table/snooker{
 	dir = 10
@@ -6734,20 +6306,45 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"gjb" = (
-/obj/machinery/computer/security/wooden_tv{
-	network = list("BoS")
-	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
 "gjB" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/hos,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/item/t_scanner/adv_mining_scanner{
+	pixel_x = 9
+	},
+/obj/item/t_scanner/adv_mining_scanner{
+	pixel_x = -9
+	},
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/pickaxe/drill/diamonddrill,
+/obj/item/pickaxe/drill/diamonddrill,
+/obj/item/gps/mining{
+	gpstag = "BOSMINE1"
+	},
+/obj/item/gps/mining{
+	gpstag = "BOSMINE2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Mining Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "gjQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -6768,25 +6365,20 @@
 /area/f13/tunnel)
 "gkZ" = (
 /turf/closed/indestructible/f13/matrix,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "glq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "bosdoors";
+	name = "brotherhood shutters"
 	},
-/obj/structure/lattice{
-	density = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/fluff/railing{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "gly" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -6800,10 +6392,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"glQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/leisure)
 "gmv" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -6822,57 +6410,52 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"gnw" = (
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "gnY" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/toilet{
+	dir = 4
 	},
-/obj/machinery/light/floor{
-	critical_machine = 1;
-	flicker_chance = 0
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices1st)
 "goi" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 8;
+	output_dir = 4
 	},
-/area/f13/brotherhood/offices2nd)
-"goG" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"goQ" = (
-/obj/structure/sign/poster/prewar/poster77,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "goR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/closet/secure_closet/personal,
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
 "gpl" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "A console used by the scribes of the Brotherhood of Steel.";
+	dir = 4;
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal";
+	name = "Archive Terminal"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "gpM" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6884,34 +6467,19 @@
 	},
 /area/f13/tunnel)
 "gqR" = (
-/obj/structure/closet/wardrobe/pjs,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
-"gsc" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
-"gse" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
-"gsw" = (
-/obj/item/candle{
-	pixel_x = 7
+"gse" = (
+/obj/machinery/shower{
+	dir = 8
 	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices1st)
 "gsQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice{
@@ -6934,11 +6502,15 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
 "guw" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/item/kirbyplants{
+	pixel_y = 14
 	},
-/area/f13/brotherhood/medical)
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "guL" = (
 /obj/structure/bodycontainer/crematorium,
 /turf/open/floor/f13{
@@ -6969,16 +6541,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"gxj" = (
-/obj/item/candle{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/rnd)
 "gyf" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/closed/wall/r_wall/rust,
@@ -6988,12 +6550,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gyp" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/brotherhood/offices1st)
 "gyB" = (
 /obj/effect/landmark/start/f13/dendoc,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -7019,47 +6584,23 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"gzy" = (
-/obj/effect/landmark/start/f13/initiate,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "gzD" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/machinery/computer/terminal{
+	dir = 4
 	},
-/area/f13/brotherhood/rnd)
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "gzK" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"gAu" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/junglebush/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/operations)
 "gAz" = (
 /obj/structure/chair/f13chair1,
 /turf/open/floor/f13{
@@ -7092,21 +6633,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"gEp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "gED" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/supermart,
@@ -7121,9 +6647,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "gFv" = (
-/obj/structure/noticeboard,
+/obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "gFP" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
@@ -7150,22 +6676,14 @@
 	},
 /area/f13/tunnel)
 "gHh" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gHi" = (
+/obj/item/flag/bos,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "gId" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
@@ -7191,15 +6709,12 @@
 	},
 /area/f13/tunnel)
 "gKJ" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/effect/turf_decal/caution/stand_clear/white,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster74"
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "gLS" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mre,
@@ -7214,26 +6729,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "gMX" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/turf_decal/caution/stand_clear/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
 /area/f13/brotherhood/operations)
 "gNj" = (
 /obj/machinery/light/small{
@@ -7245,16 +6748,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"gNG" = (
-/obj/item/candle{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/rnd)
 "gNP" = (
 /obj/item/clothing/head/helmet/roman/fake,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7276,14 +6769,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"gPq" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
 "gPJ" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden,
@@ -7346,12 +6831,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "gSN" = (
-/obj/item/candle{
-	pixel_x = -7
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_x = 33
 	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "A console used by the scribes of the Brotherhood of Steel.";
+	dir = 8;
+	icon_keyboard = "terminal_key";
+	icon_screen = "terminal_on_alt";
+	icon_state = "terminal";
+	name = "Archive Terminal"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "gTv" = (
@@ -7363,25 +6860,19 @@
 	},
 /area/f13/bunker)
 "gTy" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Head Knight on duty.";
+	name = "Head Knight's Office"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices1st)
 "gTT" = (
-/obj/machinery/shower{
-	pixel_y = 27
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/open/space/basic,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/shoes/laceup,
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/carpet/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/rnd)
 "gUf" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
@@ -7426,36 +6917,20 @@
 /turf/open/water,
 /area/f13/tunnel)
 "gWK" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/grille,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood/operations)
 "gXb" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"gXH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"gYI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/leisure)
 "gYV" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -7465,10 +6940,11 @@
 	},
 /area/f13/tunnel)
 "gZx" = (
-/obj/structure/table/wood,
-/obj/item/toy/crayon/spraycan,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/remains/robot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "gZF" = (
@@ -7476,11 +6952,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "hac" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/offices2nd)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "han" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light/small/broken{
@@ -7491,24 +6972,29 @@
 	},
 /area/f13/tunnel)
 "haB" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/structure/decoration/vent,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/leisure)
-"haW" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/area/f13/brotherhood/operations)
+"haW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/operations)
 "hbQ" = (
 /obj/structure/table/booth,
 /obj/item/flashlight,
@@ -7524,29 +7010,22 @@
 	},
 /area/f13/tunnel)
 "hcx" = (
-/obj/effect/decal/cleanable/greenglow,
+/obj/structure/chair/right{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "hcC" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/power/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operations)
 "hdd" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/metal/five,
@@ -7603,9 +7082,12 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "heI" = (
-/obj/structure/displaycase/trophy,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "hfb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -7655,26 +7137,11 @@
 /area/f13/tunnel)
 "hhn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "hhC" = (
 /obj/item/trash/f13/dog,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7685,14 +7152,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "hhZ" = (
-/obj/structure/toilet{
-	pixel_y = 10
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/rnd)
 "hil" = (
 /obj/structure/table/wood/settler,
 /obj/structure/reagent_dispensers/beerkeg,
@@ -7708,18 +7175,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"hji" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "hkh" = (
-/obj/structure/chair/comfy/black{
-	dir = 8;
-	icon_state = "comfychair"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
 "hkn" = (
@@ -7728,23 +7188,13 @@
 "hkD" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel)
-"hlH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
-	icon_state = "warningline_red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "hlS" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 1
-	},
-/obj/machinery/light/small{
+/obj/structure/chair/left{
 	dir = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "hmk" = (
 /mob/living/simple_animal/hostile/alien,
 /turf/open/floor/f13{
@@ -7768,78 +7218,49 @@
 	},
 /area/f13/sewer)
 "hmP" = (
+/obj/structure/bookcase/manuals/engineering,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/camera_advanced/abductor{
-	desc = "One day, we'll get that dish working. Not today.";
-	name = "Inactive Radar Console";
-	pixel_y = 17
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/item/wrench/advanced{
-	pixel_x = 2
-	},
-/obj/effect/decal/cleanable/robot_debris/down,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
 "hmZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "hng" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/bookcase/random/religion,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"hnU" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/caves)
-"hog" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"hoh" = (
-/obj/item/chair/stool/retro/black{
-	anchored = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"hoj" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
-"hox" = (
+"hnU" = (
+/obj/structure/bookcase/random,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 16
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"hoz" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "1-2"
+/area/f13/brotherhood/offices1st)
+"hog" = (
+/obj/item/bedsheet/red,
+/obj/structure/bed/pod,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 16
 	},
-/turf/open/floor/plating/f13/inside,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
+"hoj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13foldupchair,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "hoH" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -7878,31 +7299,25 @@
 /area/f13/tunnel)
 "hpI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/grille,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
+/obj/structure/chair/f13foldupchair,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "hpM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/chair/f13foldupchair,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"hpT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
+"hpT" = (
+/obj/structure/sign/departments/medbay,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "hqg" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -7923,40 +7338,40 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"hqO" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 8
-	},
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "hri" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "hro" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/statuebust{
+	pixel_y = 15
+	},
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/machinery/computer/terminal{
-	termtag = "Secret"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "hrq" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/window/fulltile/store,
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
+	layer = 3.3;
+	name = "Medical Lab"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "hrv" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/rnd)
+/obj/structure/grille,
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "hsv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -8000,24 +7415,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"huh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
-"huv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	dir = 4
-	},
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
 "huS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -8026,26 +7423,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"huV" = (
-/obj/structure/table,
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "hxB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/area/f13/brotherhood/operations)
+/obj/item/newspaper{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "hyj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/booth{
@@ -8058,13 +7450,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"hyR" = (
-/obj/machinery/light/floor{
-	critical_machine = 1;
-	flicker_chance = 0
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/rnd)
 "hzg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -8094,31 +7479,28 @@
 	},
 /area/f13/sewer)
 "hBz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/simple_door/bunker,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "hBC" = (
-/obj/structure/destructible/clockwork/wall_gear{
-	pixel_x = 32
-	},
-/obj/item/projectile/magic/animate{
-	pixel_x = 32
-	},
-/turf/open/floor/bronze{
-	name = "floor"
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "hBF" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "hBN" = (
 /obj/machinery/door/airlock/wood{
 	req_access_txt = "121"
@@ -8156,30 +7538,13 @@
 	},
 /area/f13/building)
 "hDX" = (
-/obj/structure/sign/poster/prewar/poster73,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/obj/machinery/computer/secure_data,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "hEp" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"hFb" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"hFc" = (
-/obj/item/storage/firstaid/regular{
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/regular,
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "hFm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -8198,20 +7563,27 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "hGF" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/pda/heads/cmo{
+	name = "Head Scribe PipBoy"
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "hHc" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "hHw" = (
 /obj/item/trash/f13/cram_large,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8248,27 +7620,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"hIt" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/rag/towel{
-	pixel_y = -7
-	},
-/obj/item/reagent_containers/rag/towel{
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/rag/towel,
-/obj/machinery/button/door{
-	id = "proctorbathroom";
-	name = "Bathroom Lock";
-	normaldoorcontrol = 1;
-	pixel_y = -32;
-	req_one_access_txt = "120";
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
 "hIy" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plastic/fifty,
@@ -8278,12 +7629,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "hJk" = (
-/obj/effect/decal/remains/robot,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "hJV" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8296,39 +7649,33 @@
 	},
 /area/f13/tunnel)
 "hKx" = (
-/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/roller,
+/obj/item/roller,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/medical)
 "hKG" = (
 /obj/structure/falsewall,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "hKI" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/effect/turf_decal/bot_white,
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/offices2nd)
-"hKS" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/mining)
 "hLd" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8344,13 +7691,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"hLL" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "hLS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/sign{
@@ -8392,9 +7732,12 @@
 	},
 /area/f13/clinic)
 "hNm" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "hNq" = (
 /obj/item/defibrillator/loaded,
 /obj/item/storage/box/syringes,
@@ -8410,32 +7753,22 @@
 /obj/item/storage/box/gloves,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"hNy" = (
-/obj/structure/toilet{
-	pixel_y = 13
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "hNS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
+	},
+/obj/structure/table{
+	layer = 2.9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/medical)
 "hOz" = (
 /obj/structure/sign/poster/prewar/poster91,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
-"hOJ" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "hOR" = (
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -8450,22 +7783,22 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "hPD" = (
-/obj/structure/bookcase/random,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
+/obj/machinery/chem_master/advanced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/medical)
 "hPF" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "hPG" = (
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/hostile/wolf/alpha{
@@ -8488,14 +7821,18 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "hQt" = (
+/obj/structure/sink/kitchen{
+	desc = "Strictly for filling up mop buckets.";
+	dir = 1;
+	name = "Mop Sink";
+	pixel_y = 13
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "hQE" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
@@ -8518,69 +7855,103 @@
 	},
 /area/f13/bunker)
 "hSU" = (
-/obj/item/candle{
-	pixel_y = -7
+/obj/structure/decoration/vent{
+	layer = 2
 	},
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
-	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "hTD" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
 	},
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
 	},
-/area/f13/caves)
-"hUn" = (
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/box/lights/tubes{
-	pixel_x = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/item/storage/box/lights/bulbs{
-	pixel_x = -8
+/area/f13/brotherhood/medical)
+"hUn" = (
+/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/structure/sign/poster/official/hydro_ad{
-	pixel_y = 31
+/area/f13/brotherhood/medical)
+"hUV" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/rnd)
-"hUV" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosarmoryacc";
-	name = "Armory";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/medical)
 "hVk" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/ash/snappop_phoenix,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_x = -32;
-	start_charge = 500
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices1st)
-"hVy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
+"hVy" = (
+/obj/item/ship_in_a_bottle{
+	pixel_x = -5;
+	pixel_y = 5
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/table/wood/fancy/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "hVV" = (
 /obj/structure/table/wood,
@@ -8592,25 +7963,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "hWJ" = (
-/obj/structure/rack,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/book/granter/trait/pa_wear,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9;
-	icon_state = "warningline_red"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "hWZ" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -8618,29 +7975,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"hXf" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
-	},
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/item/pen/fountain{
-	pixel_x = 15;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"hXn" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "hYh" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/decal/cleanable/dirt{
@@ -8655,50 +7989,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"hYI" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "proctorbathroom";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
 "hYS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
-"hYT" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/surgical_drapes,
-/obj/item/stack/sticky_tape/surgical{
-	pixel_x = -11;
-	pixel_y = 8
-	},
-/obj/machinery/light,
-/obj/structure/sign/poster/prewar/poster87{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
-"hZN" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowhorizontal"
-	},
 /turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
+"hYT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
+"hZN" = (
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
@@ -8718,25 +8024,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iav" = (
-/obj/item/flag/bos,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"iaI" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/item/kirbyplants{
+	pixel_y = 14
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/medical)
 "iaO" = (
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8768,18 +8067,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "icI" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/machinery/button/door{
-	id = "bosengineaccess";
-	name = "Engineering Lockdown";
-	pixel_x = 34;
-	pixel_y = -4
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
 	},
+/obj/item/book/granter/trait/pa_wear,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/wood/f13/carpet,
+/area/f13/brotherhood/offices1st)
 "ide" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/effect/decal/cleanable/dirt{
@@ -8799,13 +8097,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"idU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
 "ife" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_high,
@@ -8821,13 +8112,16 @@
 	},
 /area/f13/followers)
 "ifR" = (
-/obj/structure/table/wood,
-/obj/item/toy/figure/hos{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Head Paladin Action Figure";
-	toysay = "SEMPER INVICTA!"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/wood,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	name = "bitter black coffee";
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
 "ifW" = (
 /obj/structure/rack,
@@ -8838,25 +8132,45 @@
 	},
 /area/f13/tunnel)
 "ifX" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Proctor's Office";
-	req_access_txt = "120"
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/item/integrated_electronics/debugger,
+/obj/item/integrated_electronics/wirer,
+/obj/item/integrated_electronics/detailer,
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_circuit_printer,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "igo" = (
-/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "igr" = (
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "igC" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8883,31 +8197,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "igV" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/machinery/camera/autoname{
+	dir = 5;
+	name = "Briefing Camera";
+	network = list("BoS");
+	pixel_x = -1
 	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "ihg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"ihz" = (
-/obj/structure/simple_door/metal/barred{
-	req_one_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "iiu" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -8917,14 +8223,14 @@
 	},
 /area/f13/clinic)
 "iiE" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13foldupchair,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
 	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
+/obj/machinery/light/floor,
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/operations)
 "iiZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -8932,10 +8238,6 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"ijT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
 "ikD" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -8949,13 +8251,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ikI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/grenades{
-	pixel_x = 5;
-	pixel_y = 9
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "ilb" = (
 /obj/structure/decoration/vent{
@@ -8982,22 +8283,26 @@
 /turf/open/floor/plating/f13,
 /area/f13/followers)
 "ill" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
+/obj/structure/sign/poster/prewar/poster92,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
+"ilw" = (
+/obj/structure/decoration/hatch{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"ilw" = (
-/obj/effect/landmark/start/f13/seniorscribe,
-/obj/structure/chair/office/dark{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"imc" = (
-/obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
+"imc" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
+	},
 /area/f13/brotherhood/medical)
 "imd" = (
 /obj/item/circular_saw,
@@ -9042,19 +8347,26 @@
 /area/f13/tunnel)
 "ioQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Reactor Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
+"ipv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike_frame{
+	anchored = 1;
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"ipv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
 "ipw" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -9069,24 +8381,32 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "iqE" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/storage/box/medsprays,
+/obj/item/pda/chemist{
+	name = "Scribe-Chemist Pip-Boy 3000"
+	},
+/obj/item/pda/chemist{
+	name = "Scribe-Chemist Pip-Boy 3000"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "iqN" = (
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -32
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/item/storage/bag/chemistry{
+	pixel_x = -18
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/medical)
 "iqS" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider,
@@ -9094,28 +8414,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"irr" = (
-/obj/item/reagent_containers/food/snacks/grown/poppy{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/snacks/grown/poppy/geranium{
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/food/snacks/grown/poppy/lily{
-	pixel_y = -5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/fancy/blackred,
-/obj/item/candle{
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/rnd)
 "irB" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
@@ -9128,27 +8426,28 @@
 	},
 /area/f13/clinic)
 "isj" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
 	},
-/obj/structure/mirror{
-	pixel_x = -30
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "isG" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Business"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "isJ" = (
 /obj/machinery/shower{
 	layer = 2.8;
@@ -9161,31 +8460,37 @@
 	},
 /area/f13/tunnel)
 "isU" = (
-/obj/structure/flora/junglebush/large,
-/obj/structure/flora/junglebush/b,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
-"itI" = (
-/obj/effect/decal/cleanable/ash/snappop_phoenix,
-/obj/item/cigbutt/cigarbutt,
-/obj/machinery/button/door{
-	id = "kcdorm";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
-"itP" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Proctor's Office";
-	req_access_txt = "120"
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/operations)
+"itI" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/terminal{
+	dir = 1;
+	pixel_x = 16;
+	pixel_y = 8;
+	termtag = "Business"
+	},
+/obj/item/pen{
+	pixel_x = -16;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/brotherhood/offices1st)
+"itP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/mining)
 "itV" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13{
@@ -9206,35 +8511,32 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "iuL" = (
-/obj/structure/table/wood,
-/obj/item/lighter{
-	color = "#3e4821";
-	desc = "That's one fancy Zippo!";
-	heat = 2500;
-	icon_state = "lighter_overlay_plain";
-	light_power = 2;
-	light_range = 1;
-	name = "Pre-War Military Lighter";
-	pixel_x = 7;
-	pixel_y = -6
-	},
-/obj/item/storage/fancy/candle_box{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/candle_box{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
 "iuX" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/hos,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/item/book/granter/crafting_recipe/blueprint/aep7,
+/obj/item/book/granter/crafting_recipe/blueprint/aep7,
+/obj/item/book/granter/crafting_recipe/blueprint/aer9,
+/obj/item/book/granter/crafting_recipe/blueprint/aer9,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/rnd)
 "ivj" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -9259,27 +8561,11 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"iwO" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/accessory/bos/elder,
-/obj/item/clothing/suit/f13/elder,
-/obj/item/pda/heads/hop{
-	name = "Elder's PDA"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "ixT" = (
 /obj/structure/rack,
 /obj/item/book/granter/crafting_recipe/gunsmith_one,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"ixU" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "ixX" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /obj/effect/decal/cleanable/dirt,
@@ -9288,23 +8574,9 @@
 	},
 /area/f13/tunnel)
 "iyJ" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
-	},
-/obj/item/pen/fountain/captain{
-	name = "elder's fountain pen"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"izo" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
-	},
-/obj/item/documents/syndicate/blue,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/table/wood/fancy/blackred,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/f13/brotherhood/rnd)
 "izq" = (
 /obj/machinery/light{
 	dir = 4
@@ -9326,31 +8598,15 @@
 	},
 /area/f13/tunnel)
 "iAm" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/pda/heads/cmo{
-	name = "Head Scribe PipBoy"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/mineral/plastitanium/airless,
+/area/f13/brotherhood/rnd)
 "iAs" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/storage/box/lights/tubes,
+/obj/item/storage/box/lights/bulbs,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/toy/figure/warden{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Knight Action Figure";
-	toysay = "Steel be with you."
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "iAv" = (
@@ -9361,26 +8617,19 @@
 	},
 /area/f13/tunnel)
 "iAx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 8
+/obj/structure/simple_door/bunker,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "iAY" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"iBR" = (
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/washing_machine,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "iCS" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -9398,25 +8647,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iDP" = (
-/obj/structure/mopbucket{
-	pixel_x = 6;
-	pixel_y = 10
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
-"iDS" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
-"iEg" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/medical)
 "iER" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -9432,61 +8670,59 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "iGY" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/glowshroom/single,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/obj/item/storage/firstaid/regular{
+	pixel_y = 5
 	},
-/area/f13/caves)
-"iHs" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/item/storage/firstaid/regular,
+/obj/structure/table{
+	layer = 2.9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
+"iHs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13foldupchair,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "iHB" = (
 /obj/structure/barricade/wooden,
 /turf/open/water,
 /area/f13/tunnel)
-"iIs" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "iIu" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
 /area/f13/sewer)
 "iIQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/item/card/id/dogtag{
+	desc = "Never thirsty is the grave of the fallen Brother, for their kin floods the ground with the blood of the blind.";
+	name = "The Fallen Brother's Holotags";
+	pixel_y = -2
 	},
-/area/f13/brotherhood/offices2nd)
+/obj/item/clothing/glasses/sunglasses/blindfold{
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/blackred,
+/obj/item/candle{
+	pixel_x = 7;
+	pixel_y = 13
+	},
+/turf/open/floor/mineral/plastitanium/airless,
+/area/f13/brotherhood/rnd)
 "iJc" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"iJD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = null;
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
-"iJK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/right{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "iKd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bodypart/l_arm,
@@ -9496,15 +8732,12 @@
 /area/f13/tunnel)
 "iKl" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"iKq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "iKB" = (
 /obj/structure/table,
@@ -9514,27 +8747,35 @@
 	},
 /area/f13/bunker)
 "iKQ" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
+/obj/structure/lattice{
+	layer = 3
 	},
-/area/f13/brotherhood/offices1st)
-"iLO" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = -16
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
-"iMc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	icon_state = "hologram_ship";
+	name = "old hologram";
+	pixel_x = 14;
+	pixel_y = 9
 	},
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	icon_state = "hologram_on";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 9
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "iMs" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/outside/ruins,
@@ -9546,12 +8787,18 @@
 	},
 /area/f13/building)
 "iMP" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood/offices2nd)
 "iNY" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -9562,9 +8809,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "iOt" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "iOJ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9588,12 +8838,9 @@
 	},
 /area/f13/followers)
 "iPu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/machinery/defibrillator_mount/loaded,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "iPH" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/f13{
@@ -9604,9 +8851,14 @@
 /turf/closed/wall/f13/store,
 /area/f13/followers)
 "iQt" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "iQC" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/f13{
@@ -9677,11 +8929,6 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"iST" = (
-/obj/item/bedsheet/hos,
-/obj/structure/bed/pod,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
 "iTb" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -9692,60 +8939,19 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"iTW" = (
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/offices1st)
 "iUq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/fo13colored/Pink{
-	critical_machine = 1;
-	dir = 8;
-	flicker_chance = 0
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/obj/structure/decoration/vent,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "iVi" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"iVj" = (
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
 "iVx" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/carpet/black,
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "iVD" = (
 /obj/structure/bed/mattress{
@@ -9817,19 +9023,28 @@
 	},
 /area/f13/tunnel)
 "iWR" = (
-/obj/structure/rack,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/rnd)
-"iXC" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/mining)
+"iXC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/simple_door/bunker,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "iXF" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 8
@@ -9857,29 +9072,32 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "iYI" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/f13{
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/mining)
 "iYX" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "iZB" = (
-/obj/machinery/camera/autoname{
-	dir = 8;
-	name = "Armory Camera";
-	network = list("BoS");
-	pixel_x = -1
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "iZD" = (
 /obj/structure/chair/wood{
@@ -9891,15 +9109,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "iZQ" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/destructible/clockwork/wall_gear,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/mining)
 "jak" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
@@ -9916,15 +9128,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jbP" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/simple_door/bunker{
+	name = "Star Knight Office";
+	req_access = 120;
+	req_access_txt = "120"
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/offices1st)
 "jcf" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/toy/figure/detective{
@@ -9934,30 +9150,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jcl" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
+/obj/structure/fluff/railing{
+	dir = 9
 	},
-/obj/item/book/granter/trait/pa_wear,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
-"jdI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
-"jdN" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "jdP" = (
 /obj/structure/chair/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -10005,11 +9208,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "jfW" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices1st)
 "jga" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -10021,30 +9231,27 @@
 /area/f13/tunnel)
 "jgd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/paladin,
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/closet/radiation{
+	anchored = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
-"jge" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/reactor)
+"jge" = (
+/obj/machinery/door/window/westleft,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "jgL" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/structure/decoration/hatch{
-	desc = "That's pretty nifty.";
-	dir = 1;
-	name = "Plant Water Drain";
-	pixel_y = -13
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "jgP" = (
 /obj/structure/bed/roller,
@@ -10073,13 +9280,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "jii" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "jiL" = (
 /obj/effect/landmark/map_load_mark/dungeons/northsewer,
@@ -10133,33 +9336,16 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "jnI" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/fulltile/store,
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"jnO" = (
-/obj/item/card/id/dogtag{
-	desc = "Never thirsty is the grave of the fallen Brother, for their kin floods the ground with the blood of the blind.";
-	name = "The Fallen Brother's Holotags";
-	pixel_y = -2
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/item/clothing/glasses/sunglasses/blindfold{
-	pixel_y = 2
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/fancy/blackred,
-/obj/item/candle{
-	pixel_x = 7;
-	pixel_y = 13
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
-	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/medical)
 "jpg" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -10174,14 +9360,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"jqX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "jrk" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -10196,10 +9374,9 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "jrn" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "jro" = (
 /obj/structure/barricade/wooden,
@@ -10210,37 +9387,40 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jrA" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/oil/streak,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/machinery/door/window/eastright,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "jrV" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"jrX" = (
+"jsD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "bluedirtychess2"
 	},
-/area/f13/brotherhood/offices2nd)
-"jsD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor1elevatordoors";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "jtx" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "boscheckpointmedical";
+	name = "brotherhood shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "jug" = (
 /obj/structure/chair/stool/retro,
@@ -10248,19 +9428,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "juq" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4;
-	pixel_x = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	pixel_y = -6
+/obj/structure/chair/office{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/medical)
 "juP" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -10271,26 +9446,14 @@
 	},
 /area/f13/bunker)
 "juU" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/turf/open/water,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/medical)
 "jvg" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -10356,21 +9519,24 @@
 	},
 /area/f13/followers)
 "jyc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/machinery/door/airlock/vault{
-	name = "Elder'S Office";
-	req_access_txt = "120"
+/obj/structure/fluff/railing{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "jyg" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "jyZ" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -10384,59 +9550,45 @@
 	},
 /area/f13/tunnel)
 "jzs" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/medical)
 "jzC" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
+"jAd" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
-"jzX" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
-"jAd" = (
-/obj/structure/debris/v3{
-	layer = 2
-	},
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
-	},
-/area/f13/caves)
+/area/f13/brotherhood/medical)
 "jAZ" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jBc" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/construction/rcd/loaded,
-/obj/item/construction/rld,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "jBU" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -10444,51 +9596,38 @@
 	},
 /area/f13/tunnel)
 "jCU" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
+"jFd" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"jDt" = (
-/obj/structure/target_stake{
-	anchored = 1
-	},
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/operations)
-"jEK" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"jEM" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/item/hand_labeler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
-"jFd" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood/mining)
 "jFm" = (
-/obj/structure/closet/crate/bin{
-	anchorable = 0;
-	storage_capacity = 30
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/processor/chopping_block{
+	pixel_x = -4;
+	pixel_y = 16
 	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1;
-	pixel_y = 6
+/obj/machinery/reagentgrinder{
+	pixel_x = 5;
+	pixel_y = 21
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_tiled,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "jFx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10512,11 +9651,9 @@
 	},
 /area/f13/tunnel)
 "jFC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13foldupchair{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "jFU" = (
 /obj/machinery/chem_master,
@@ -10526,58 +9663,52 @@
 /area/f13/followers)
 "jGQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/medical)
 "jGX" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/reactor)
 "jHN" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"jHR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "jIm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy/black{
-	dir = 8;
-	icon_state = "comfychair"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 16
 	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/medical)
 "jJd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/clockwork/reebe{
-	desc = "Cool coloured plating. You can feel it gently vibrating, as if machinery is on the other side.";
-	name = "cool metal floor"
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "jJB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/machinery/light,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "jJM" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/light_emitter,
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood/operations)
 "jJT" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -10591,15 +9722,19 @@
 	},
 /area/f13/bunker)
 "jKo" = (
-/obj/structure/table/optable,
-/obj/machinery/iv_drip{
-	pixel_x = 15;
-	pixel_y = -2
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "jKM" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -10613,20 +9748,35 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jLX" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stack/sheet/prewar/five,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stack/sheet/prewar/five,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "jMM" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/machinery/sleeper{
+	density = 1;
+	dir = 4
 	},
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "jMR" = (
 /obj/structure/chair/stool,
@@ -10646,18 +9796,9 @@
 	},
 /area/f13/bunker)
 "jNr" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
-	},
-/obj/item/kirbyplants/photosynthetic,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
+/obj/item/flag/bos,
+/turf/open/floor/circuit/f13_red,
+/area/f13/brotherhood/rnd)
 "jNA" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -10691,68 +9832,23 @@
 	},
 /area/f13/tunnel)
 "jOE" = (
-/obj/item/toy/beach_ball,
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, filtered pool water.";
-	name = "pool water"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/punching_bag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
-"jOL" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
-	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
 "jOU" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
+/obj/machinery/door/window/eastright{
+	dir = 8
 	},
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices1st)
 "jPi" = (
-/obj/structure/closet,
-/obj/item/storage/box/gloves,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/wrench/medical,
-/obj/item/toy/figure/cmo{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	layer = 2;
-	name = "Head Scribe Action Figure";
-	toysay = "Ad astra per aspera."
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
-"jPz" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
-"jPB" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
 "jPC" = (
@@ -10784,20 +9880,23 @@
 	},
 /area/f13/tcoms)
 "jQs" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
+/obj/structure/simple_door/bunker/glass{
+	name = "Archives";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/offices2nd)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "jQD" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/structure/filingcabinet/employment,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "jQN" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood{
@@ -10826,16 +9925,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
-"jRI" = (
-/obj/machinery/button/door{
-	id = "bosdorm7";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
 "jSf" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -10847,34 +9936,17 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"jSx" = (
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, filtered pool water.";
-	name = "pool water"
-	},
-/area/f13/brotherhood/leisure)
 "jSJ" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jTD" = (
-/obj/machinery/button/door{
-	id = "headscribedorm";
-	normaldoorcontrol = 1;
-	pixel_x = -8;
-	pixel_y = -24;
-	specialfunctions = 4
-	},
-/obj/structure/chair/sofa/corp/corner{
+/obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices1st)
 "jUe" = (
 /obj/item/reagent_containers/glass/bucket{
 	desc = "It smells awful.";
@@ -10884,11 +9956,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"jUB" = (
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
-	},
-/area/f13/brotherhood/rnd)
 "jUX" = (
 /obj/effect/decal/fakelattice{
 	density = 0;
@@ -10897,19 +9964,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "jVx" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/chair/f13foldupchair{
+	dir = 1
 	},
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "A console used by the scribes of the Brotherhood of Steel.";
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal";
-	name = "Archive Terminal"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/window/reinforced,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "jWa" = (
 /obj/structure/chair{
 	dir = 1
@@ -10928,55 +9991,27 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "jXu" = (
-/obj/structure/sign/poster/contraband/hacking_guide,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
-"jYe" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/light/small{
+/obj/structure/chair/f13foldupchair{
 	dir = 1
 	},
-/obj/structure/sign/poster/contraband/tools{
-	pixel_y = 31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
-"jYi" = (
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/pda/heads/hos{
-	name = "Head Knight's PDA"
-	},
-/obj/item/storage/briefcase,
-/obj/item/clothing/suit/armor/vest/capcarapace/syndicate{
-	desc = "A sinister looking vest of advanced armor worn over a black and red fireproof jacket. The gold collar and shoulders denote that this belongs to a high ranking officer of some lost prewar army.";
-	name = "old officer's vest"
-	},
-/obj/item/clothing/head/HoS/beret/syndicate{
-	name = "officer's beret"
-	},
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
+/obj/structure/window/reinforced,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
+"jYe" = (
+/obj/machinery/door/window/southleft,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "jYj" = (
-/obj/machinery/door/window/northleft,
-/obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
+/obj/structure/chair/f13foldupchair{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "jYt" = (
 /obj/structure/chair/stool/retro,
 /obj/item/instrument/guitar{
@@ -10996,11 +10031,10 @@
 	},
 /area/f13/followers)
 "jYP" = (
-/obj/machinery/vending/robotics,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/simple_door/bunker,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/medical)
 "jZf" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -11013,15 +10047,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "jZg" = (
-/obj/machinery/vending/tool,
-/obj/structure/sign/poster/contraband/rip_badger{
-	pixel_x = 14;
-	pixel_y = 31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/medical)
 "jZH" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
@@ -11042,18 +10069,17 @@
 	},
 /area/f13/tunnel)
 "kbf" = (
-/obj/machinery/button/door{
-	id = "sentdorm";
-	normaldoorcontrol = 1;
-	pixel_y = 26;
-	specialfunctions = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "kbm" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Control Room";
@@ -11063,37 +10089,17 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "kbH" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"kbZ" = (
-/obj/structure/closet/secure_closet/freezer/meat,
+/obj/structure/curtain,
+/obj/effect/turf_decal/loading_area/white,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "kcD" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/integrated_circuit_printer,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_electronics/debugger,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
-"kcF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/structure/bookcase/manuals/medical,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/medical)
 "kdh" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -11106,31 +10112,36 @@
 	},
 /area/f13/clinic)
 "kdH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"keH" = (
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	dir = 8
-	},
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/medical)
-"keR" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
+"keH" = (
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
-/obj/machinery/computer/terminal,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
+"keR" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/paper_bin{
+	pixel_x = 6
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "kfQ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -11142,25 +10153,6 @@
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"kgs" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
-"kgv" = (
-/obj/machinery/jukebox,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/leisure)
 "kgP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -11168,24 +10160,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"khb" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/hemostat,
-/obj/item/retractor,
-/obj/item/scalpel,
-/obj/item/circular_saw,
-/obj/item/surgicaldrill,
-/obj/item/cautery,
-/obj/item/bonesetter,
-/obj/structure/sign/poster/prewar/poster88{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
 "khz" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -11204,11 +10178,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"kic" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/clockwork/fulltile,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "kiu" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -11222,47 +10191,36 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "kiV" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 31
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
-"kiX" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "kja" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/microwave,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "kjU" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "kjW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/handrail/g_central{
@@ -11278,11 +10236,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "kkB" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/machinery/light,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/medical)
 "kkU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
@@ -11298,9 +10255,11 @@
 	},
 /area/f13/ncr)
 "klQ" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "klZ" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/f13{
@@ -11308,49 +10267,48 @@
 	},
 /area/f13/followers)
 "kny" = (
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/sign/poster/prewar/poster74,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "kot" = (
 /obj/structure/sign/poster/prewar/poster89,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "koC" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "headscribedorm";
-	name = "Head Scribe's Office";
-	req_access_txt = "120"
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/fluff/railing{
+	dir = 9
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "kpd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/fluff/railing{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "kpo" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "kqh" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "kqS" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/bus_door,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/turf_decal/arrows/white,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "krt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/unpowered/wooddoor{
@@ -11375,16 +10333,35 @@
 	},
 /area/f13/followers)
 "ksU" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/rnd)
+/obj/item/clothing/under/rank/medical/green,
+/obj/item/clothing/under/rank/medical/purple,
+/obj/item/clothing/under/rank/medical/blue,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "ktE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/bodybags{
+	pixel_x = -9;
+	pixel_y = 12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "ktQ" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -11396,11 +10373,15 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "kur" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "kve" = (
 /obj/item/storage/trash_stack,
@@ -11427,10 +10408,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kvO" = (
-/obj/structure/barricade/bars,
-/obj/structure/sign/poster/prewar/poster76,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "kvS" = (
@@ -11462,31 +10445,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"kxu" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "kxL" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "kxR" = (
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
-"kzn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
 "kzO" = (
 /obj/machinery/vending/nukacolavend,
 /obj/machinery/light/small{
@@ -11496,25 +10463,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"kAm" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/under/rank/medical/green,
-/obj/item/clothing/under/rank/medical/purple,
-/obj/item/clothing/under/rank/medical/blue,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
 "kAp" = (
 /obj/structure/table/wood,
 /obj/item/chair/stool,
@@ -11530,14 +10478,13 @@
 /area/f13/tunnel)
 "kAW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = 33
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
 "kBo" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -11557,20 +10504,20 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"kBT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
 "kCg" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/item/hemostat,
+/obj/item/retractor,
+/obj/item/scalpel,
+/obj/item/circular_saw,
+/obj/item/surgicaldrill,
+/obj/item/cautery,
+/obj/item/bonesetter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "kCo" = (
 /obj/structure/table/wood,
@@ -11603,28 +10550,12 @@
 	},
 /area/f13/followers)
 "kCz" = (
-/obj/structure/lattice{
-	density = 1
+/mob/living/simple_animal/hostile/mirelurk/baby,
+/obj/structure/mirelurkegg{
+	anchored = 1
 	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 8;
-	layer = 3.1;
-	pixel_x = -12;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -12
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_x = 3;
-	pixel_y = 16
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/turf/open/water,
+/area/f13/caves)
 "kCG" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
@@ -11643,19 +10574,21 @@
 	},
 /area/f13/bunker)
 "kEP" = (
-/obj/item/paper/crumpled/ruins,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/lattice{
+	layer = 3
 	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "kFc" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/sign/poster/prewar/poster83,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "kFg" = (
 /obj/effect/decal/waste,
 /obj/structure/closet/cabinet,
@@ -11687,21 +10620,9 @@
 	},
 /area/f13/tunnel)
 "kGx" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
-"kHh" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	pixel_y = -6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/leisure)
+/obj/structure/sign/poster/prewar/poster89,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "kHD" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -11719,17 +10640,11 @@
 	},
 /area/f13/sewer)
 "kJW" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
-"kKx" = (
-/obj/structure/window/reinforced/clockwork/fulltile,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"kKy" = (
-/turf/closed/indestructible/opshuttle,
-/area/f13/brotherhood/rnd)
+/obj/structure/toilet{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices2nd)
 "kKB" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/floor/f13{
@@ -11737,36 +10652,26 @@
 	},
 /area/f13/bunker)
 "kLA" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
+/obj/structure/bed/pod,
+/obj/item/bedsheet/blue,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
-"kLU" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "kMF" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kNb" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "kNK" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11778,9 +10683,14 @@
 	},
 /area/f13/clinic)
 "kOa" = (
-/obj/structure/simple_door/bunker/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
+	icon_state = "generator_on";
+	name = "superheating forge"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "kOc" = (
 /obj/effect/decal/cleanable/blood/bubblegum,
@@ -11793,29 +10703,30 @@
 /turf/open/water,
 /area/f13/tunnel)
 "kPE" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "NW"
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
-	icon_state = "warningline_red"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/storage/belt/holster,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/senior,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/senior,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/storage/belt/military,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "kQy" = (
-/obj/structure/curtain,
-/obj/effect/turf_decal/loading_area/white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/area/f13/brotherhood/medical)
+/obj/item/clothing/accessory/bos/elder,
+/obj/item/clothing/suit/f13/elder,
+/obj/item/pda/heads/hop{
+	name = "Elder's PDA"
+	},
+/obj/item/documents/syndicate/blue,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "kQO" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13{
@@ -11852,13 +10763,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"kSz" = (
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = 33
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "kTF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -11884,20 +10788,18 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "kTP" = (
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"kUd" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/closed/wall/r_wall,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "kUN" = (
 /obj/structure/window/fulltile/ruins{
@@ -11914,17 +10816,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kVP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12
+	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
 "kWl" = (
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/pug{
+	name = "Paladin Ramos"
 	},
-/turf/open/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/offices1st)
 "kWr" = (
 /obj/structure/bed/mattress{
@@ -11935,17 +10845,17 @@
 	},
 /area/f13/tunnel)
 "kWH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/kitchenspike_frame{
+	anchored = 1;
 	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
 	name = "Power Armor Frame"
-	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
 "kWK" = (
 /obj/structure/barricade/bars,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -11954,40 +10864,31 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kXA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = 2;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "kYh" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"kZq" = (
-/obj/structure/sign/poster/prewar/poster69,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
-"kZQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/glass/rag/towel{
-	pixel_x = -19;
-	pixel_y = -3
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_x = 33
 	},
-/obj/item/reagent_containers/glass/rag/towel{
-	pixel_x = -19
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/item/reagent_containers/glass/rag/towel{
-	pixel_x = -19;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/rag/towel{
-	pixel_x = -19;
-	pixel_y = 7
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/offices1st)
 "kZR" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -12004,26 +10905,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "lbt" = (
-/obj/structure/fluff/railing{
-	dir = 6;
-	pixel_x = 33
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
-"lbG" = (
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
+/obj/item/flag/bos,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "lcn" = (
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
@@ -12038,12 +10931,9 @@
 	},
 /area/f13/tunnel)
 "ldi" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/papercutter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/sign/poster/prewar/poster84,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "ldn" = (
 /obj/machinery/light{
 	dir = 8
@@ -12053,26 +10943,24 @@
 	},
 /area/f13/ncr)
 "ldA" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/closet/crate/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/medical)
 "ldK" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ldP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 6
+/obj/machinery/light{
+	dir = 8
 	},
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices1st)
 "ldY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12091,18 +10979,12 @@
 	},
 /area/f13/tunnel)
 "lea" = (
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate listing the many Paladin's that walk these halls and may make use of this office.";
+	name = "Paladins Offices"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices1st)
 "lec" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/f13{
@@ -12126,31 +11008,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "leG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/computer/terminal{
+	dir = 4
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "lfw" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"lfJ" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "lfW" = (
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood{
@@ -12159,18 +11031,18 @@
 /area/f13/tunnel)
 "lgv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/landmark/start/f13/paladin,
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/structure/table/wood,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
 "lgA" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/sign/poster/prewar/poster85,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "lhh" = (
 /obj/item/assembly/signaler{
 	code = 2;
@@ -12190,10 +11062,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
-"lia" = (
-/obj/structure/decoration/hatch,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
 "liq" = (
 /obj/machinery/shower{
 	dir = 8
@@ -12205,21 +11073,24 @@
 	},
 /area/f13/ncr)
 "liD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_y = 19
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"liM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/medical)
+"liM" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "liS" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -12266,30 +11137,14 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"lkT" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	dir = 1;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "llp" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/curtain{
+	color = "#363636"
 	},
-/obj/structure/fluff/railing{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/medical)
 "llv" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -12299,13 +11154,10 @@
 /area/f13/followers)
 "llQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "llV" = (
 /obj/machinery/workbench/advanced,
@@ -12325,39 +11177,15 @@
 	},
 /area/f13/tunnel)
 "llZ" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/medical)
 "lmd" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"lmf" = (
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	name = "bitter black coffee";
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/machinery/computer/terminal{
-	dir = 1;
-	pixel_x = 16;
-	pixel_y = 8;
-	termtag = "Business"
-	},
-/obj/structure/table{
-	pixel_y = 6
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/brotherhood/offices1st)
 "lmG" = (
 /obj/structure/chair/wood/modern,
 /turf/open/floor/f13/wood,
@@ -12365,15 +11193,6 @@
 "lnr" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"lnF" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
 "lnL" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
@@ -12392,26 +11211,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "lok" = (
-/obj/structure/table/wood,
-/obj/item/pda/captain{
-	name = "Head Paladin PipBoy"
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
-"loJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/structure/sink/kitchen{
-	desc = "Strictly For filling Up mop buckets.";
-	dir = 8;
-	name = "Mop Sink";
-	pixel_x = 11
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+/area/f13/brotherhood/offices2nd)
+"loJ" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Proctor's Office";
+	req_access_txt = "120"
+	},
+/turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices2nd)
 "lpd" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -12422,25 +11235,26 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"lpe" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "lpK" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker{
+	name = "Paladin Halls";
+	req_access = 120;
+	req_access_txt = "120"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "lqC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "lre" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/welding,
@@ -12448,24 +11262,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "lrP" = (
-/obj/machinery/chem_master/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
-"lsr" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = -32
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/leisure)
-"lsy" = (
-/mob/living/simple_animal/hostile/deathclaw{
-	name = "Rock Claw"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/area/f13/brotherhood/medical)
+"lsy" = (
+/obj/structure/sign/poster/prewar/poster88,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "lsW" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -12491,14 +11299,16 @@
 	},
 /area/f13/clinic)
 "lvt" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 30;
-	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 10, /obj/item/reagent_containers/pill/patch/silver_sulf = 10, /obj/item/reagent_containers/medspray/styptic = 4, /obj/item/reagent_containers/medspray/silver_sulf = 4, /obj/item/reagent_containers/pill/charcoal = 2, /obj/item/reagent_containers/medspray/sterilizine = 2)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "lvT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -12517,10 +11327,13 @@
 	},
 /area/f13/followers)
 "lwz" = (
-/obj/structure/filingcabinet/employment,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13foldupchair,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "lyh" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12562,7 +11375,11 @@
 	},
 /area/f13/tunnel)
 "lAw" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "lAR" = (
 /obj/structure/table/glass,
@@ -12589,25 +11406,45 @@
 	},
 /area/f13/tunnel)
 "lBX" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm6";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#363636"
 	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/medical)
 "lCK" = (
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/item/lighter,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/item/kirbyplants{
+	pixel_y = 14
+	},
+/obj/item/pda/medical{
+	name = "Scribe-Medic Pip-Boy 3000"
+	},
+/obj/item/pda/medical{
+	name = "Scribe-Medic Pip-Boy 3000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "lDx" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/paladin,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/offices1st)
 "lDD" = (
 /obj/item/paper_bin{
 	pixel_y = 6
@@ -12620,44 +11457,22 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"lDH" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/machinery/button/door{
-	id = "bosdorm4";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
 "lEl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = -33
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lGo" = (
-/obj/structure/sign/poster/prewar/poster88,
-/turf/closed/wall/r_wall,
+/obj/structure/table/optable,
+/obj/machinery/iv_drip{
+	pixel_x = 15;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
-"lHS" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/bomb_suit/security,
-/obj/item/clothing/head/bomb_hood/security,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10;
-	icon_state = "warningline_red"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "lIx" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -12671,24 +11486,13 @@
 	},
 /area/f13/tunnel)
 "lIH" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/sign/poster/prewar/poster86,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "lKh" = (
-/obj/structure/toilet{
-	dir = 1
-	},
+/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	pixel_x = -10
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "lKk" = (
 /obj/item/flashlight/flare,
@@ -12707,24 +11511,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"lLy" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
-	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "lLA" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/medical)
 "lLP" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
@@ -12765,20 +11557,16 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"lMC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "lMT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/medical)
 "lOt" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -12861,22 +11649,11 @@
 /obj/machinery/light,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
-"lSl" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "lSQ" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/cannabis,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"lSZ" = (
-/obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
 "lUq" = (
 /obj/structure/table/wood,
 /obj/item/restraints/legcuffs/bola,
@@ -12916,29 +11693,27 @@
 	},
 /area/f13/followers)
 "lXw" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "SE"
-	},
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9;
-	icon_state = "warningline_red"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench/advanced,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
 "lXy" = (
-/obj/structure/simple_door/bunker,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "lXF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -12950,23 +11725,19 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "lXT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
+/turf/closed/indestructible/opshuttle{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/offices2nd)
 "lYu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
 /area/f13/brotherhood/rnd)
 "lYx" = (
 /obj/machinery/light/small{
@@ -12988,33 +11759,34 @@
 	},
 /area/f13/followers)
 "lZb" = (
-/obj/machinery/button/door{
-	id = "bosdorm6";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
+/obj/structure/bed/pod,
+/obj/item/bedsheet/brown,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
 "lZF" = (
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 9
-	},
-/obj/structure/fluff/railing/corner,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lZJ" = (
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/toggle/labcoat/scribecoat,
-/obj/structure/table/survival_pod,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/hemostat,
+/obj/item/retractor,
+/obj/item/scalpel,
+/obj/item/circular_saw,
+/obj/item/surgicaldrill,
+/obj/item/cautery,
+/obj/item/bonesetter,
+/obj/structure/sign/poster/prewar/poster88{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "mba" = (
 /obj/structure/rack,
 /obj/item/twohanded/sledgehammer,
@@ -13027,27 +11799,19 @@
 /obj/item/trash/f13/porknbeans,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"mbV" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/leisure)
 "mbX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "mcC" = (
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/lipstick/black,
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/medical)
 "mdv" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -13066,10 +11830,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"mgt" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/wood,
-/area/f13/brotherhood/rnd)
 "mgx" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
@@ -13079,12 +11839,11 @@
 	},
 /area/f13/bunker)
 "mhc" = (
-/obj/machinery/computer/shuttle/boselevator{
-	dir = 1;
-	pixel_y = -2
+/turf/closed/indestructible/opshuttle{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "mhD" = (
 /obj/structure/toilet{
 	dir = 8
@@ -13123,44 +11882,18 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"miX" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "mjz" = (
 /obj/item/clothing/under/f13/brahmin,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mjJ" = (
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -32
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"mjU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/vent{
-	pixel_x = 15;
-	pixel_y = -17
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/leisure)
-"mkc" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/machinery/button/door{
-	id = "bosdorm2";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/medical)
 "mko" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -13169,9 +11902,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "mkC" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/bodycontainer/crematorium{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "mkR" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -13197,8 +11935,26 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "mlC" = (
-/obj/structure/sign/poster/prewar/poster84,
-/turf/closed/wall/r_wall,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/surgical_drapes,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/stack/sticky_tape/surgical{
+	pixel_x = -11;
+	pixel_y = 8
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "mmv" = (
 /obj/machinery/door/airlock/abandoned,
@@ -13223,46 +11979,27 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/followers)
-"mnj" = (
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "mnk" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
 /area/f13/clinic)
-"mnH" = (
-/obj/structure/table/reinforced{
-	req_access_txt = "120"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "mot" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mpn" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/item/flag/bos,
-/obj/machinery/light/small{
-	brightness = 3;
+/obj/machinery/computer/terminal{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "mpE" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -13270,25 +12007,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"mpX" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen{
-	pixel_y = -1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"mpY" = (
-/obj/structure/bookcase/random/religion{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Religious References"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "mql" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -13300,92 +12018,54 @@
 	},
 /area/f13/clinic)
 "mqJ" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
+/obj/effect/landmark/start/f13/seniorscribe,
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/carpet/blue,
+/area/f13/brotherhood/offices2nd)
 "mrp" = (
 /mob/living/simple_animal/hostile/alien,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"mrq" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	name = "Brig"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "mrx" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
-"mrV" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
-"mrX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = 33
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Business"
 	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices2nd)
+"mrV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "boscheckpoint";
+	name = "brotherhood shutters"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood/rnd)
 "msK" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old"
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"msV" = (
-/turf/closed/indestructible/opshuttle,
-/area/f13/brotherhood/operations)
-"mtG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
 "mui" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	icon_state = "shuttle_chair";
-	name = "prewar lounge chair"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "boscheckpoint";
+	name = "brotherhood shutters"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/brotherhood/rnd)
 "muA" = (
 /obj/structure/table,
@@ -13396,38 +12076,44 @@
 	},
 /area/f13/tunnel)
 "muD" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "NE"
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10;
-	icon_state = "warningline_red"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bookcase/random,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices2nd)
 "mvH" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mxa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "mxh" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
 "mxI" = (
@@ -13437,18 +12123,20 @@
 	},
 /area/f13/clinic)
 "myA" = (
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/fluff/railing{
-	dir = 5
+/obj/item/paper_bin{
+	pixel_x = 7
 	},
-/obj/structure/fluff/railing/corner{
-	dir = 8
+/obj/item/pen/fountain{
+	pixel_x = -8
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "myP" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -13468,9 +12156,17 @@
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "mzX" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/mineral/iron,
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "mAa" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/simple_door/metal/barred,
@@ -13484,10 +12180,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"mAm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "mAn" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -13496,17 +12188,40 @@
 	},
 /area/f13/clinic)
 "mAQ" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
-"mAX" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
+"mAX" = (
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "mBn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight/lamp,
@@ -13534,40 +12249,22 @@
 "mCL" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/tunnel)
-"mDe" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/operations)
 "mDq" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "mDt" = (
-/obj/machinery/autolathe/ammo,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/effect/turf_decal/stripes/box,
-/obj/item/book/granter/crafting_recipe/gunsmith_two,
-/obj/item/book/granter/crafting_recipe/gunsmith_one,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "yellowdirtyfull"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/reactor)
 "mDK" = (
 /obj/machinery/light{
 	dir = 4
@@ -13583,35 +12280,37 @@
 	},
 /area/f13/clinic)
 "mEf" = (
-/turf/closed/mineral/random/high_chance,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/brotherhood/reactor)
 "mEm" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
-"mEv" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen/fourcolor,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
+"mEv" = (
+/obj/structure/sign/poster/prewar/poster94{
+	icon_state = "poster70"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/reactor)
 "mEQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -13660,23 +12359,19 @@
 	},
 /area/f13/tunnel)
 "mHj" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bookcase/manuals/engineering,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/structure/flora/ausbushes,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/water,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/reactor)
 "mHs" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/f13/ruins,
@@ -13698,35 +12393,27 @@
 	},
 /area/f13/tunnel)
 "mII" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
-	},
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/junglebush/c,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "mJG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"mJJ" = (
-/turf/closed/wall/mineral/iron,
-/area/f13/brotherhood/rnd)
 "mJZ" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mKE" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "rampdowntop"
 	},
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/rnd)
 "mKY" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -13746,20 +12433,25 @@
 /area/f13/followers)
 "mLN" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/reactor)
 "mLP" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/space_cube{
-	pixel_x = -32
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fireaxecabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/reactor)
 "mLW" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -13783,11 +12475,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
-"mNL" = (
-/obj/structure/lattice,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "mNM" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -13811,12 +12498,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "mPa" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm9";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/generic,
+/obj/structure/table/wood,
+/obj/item/toy/crayon/spraycan,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
 	},
 /turf/open/floor/f13{
-	icon_state = "purplefull"
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
 "mQX" = (
@@ -13830,26 +12519,35 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "mRK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"mRT" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
-"mSc" = (
-/obj/structure/simple_door/bunker/glass{
-	name = "Archives";
+/obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "boscheckpointreactor";
+	name = "brotherhood shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/reactor)
+"mRT" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
+"mSc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/brotherhood/rnd)
 "mSs" = (
 /obj/structure/table,
@@ -13867,35 +12565,31 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mTj" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/obj/effect/temp_visual/steam_release,
+/turf/open/water,
+/area/f13/caves)
 "mTq" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/tunnel)
 "mTr" = (
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/door/window/northright,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/brotherhood/offices2nd)
-"mTt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gps/computer{
-	desc = "A large, central database of currently-transmitting GPS signals.";
-	name = "GPS Ping Grabber."
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "mTF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_y = 21;
+	req_one_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood/rnd)
 "mUb" = (
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
@@ -13907,70 +12601,19 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"mUS" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/turf/open/water,
-/area/f13/brotherhood/rnd)
-"mVw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"mWp" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "mWD" = (
-/obj/structure/decoration/warning,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
-"mWM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/deepfryer,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"mXi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood/rnd)
+"mWM" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "mXW" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/f13{
@@ -13978,27 +12621,31 @@
 	},
 /area/f13/tunnel)
 "mYt" = (
-/obj/structure/toilet{
-	dir = 4;
-	icon_state = "toilet00";
-	pixel_x = 0;
-	pixel_y = 0
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
 	},
-/area/f13/brotherhood/operations)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "mYI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/libraryscanner{
+	desc = "This device scans books and other documents for entry into the Archives.";
+	name = "archive scanner";
+	pixel_y = 7
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
 	},
-/obj/machinery/power/smes/engineering,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "mYV" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
@@ -14025,9 +12672,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"mZX" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "naY" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -14036,21 +12680,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"nby" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "nbz" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -14087,60 +12716,24 @@
 "ndp" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
-"neq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood/rnd)
 "neu" = (
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "neP" = (
-/obj/effect/turf_decal/stripes/white/line{
+/obj/machinery/bookbinder{
+	icon_state = "bigscanner";
+	pixel_y = 7
+	},
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "nfz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -14169,10 +12762,10 @@
 	},
 /area/f13/tcoms)
 "ngP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/structure/bed/pod,
+/obj/item/bedsheet/hos,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "nha" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/box/white,
@@ -14233,59 +12826,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"nkx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood/rnd)
-"nkL" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 8;
-	name = "prewar lounge chair"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
-"nlc" = (
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/structure/closet/crate{
-	anchored = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "nld" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation{
-	anchored = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/reactor)
 "nlw" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -14318,21 +12866,18 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"nnH" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "nnN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/offices2nd)
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "boscheckpointreactor";
+	name = "brotherhood shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/reactor)
 "noe" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -14340,20 +12885,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "noI" = (
-/obj/effect/decal/remains/robot,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluedirtychess2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/rnd)
 "noQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -14368,7 +12907,15 @@
 	},
 /area/f13/clinic)
 "npR" = (
-/obj/item/kirbyplants/photosynthetic,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/fluff/railing{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "nqA" = (
@@ -14380,31 +12927,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nqE" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = 18
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/structure/glowshroom/single,
+/obj/structure/campfire/barrel,
+/turf/open/water,
+/area/f13/caves)
 "nqF" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/obj/machinery/light/small{
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/landmark/start/f13/Knight,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "nqO" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -14435,29 +12970,30 @@
 	},
 /area/f13/clinic)
 "nsN" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/item/stack/sheet/prewar/five,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/area/f13/brotherhood/rnd)
-"ntS" = (
-/obj/structure/rack,
-/obj/item/shield/riot/bullet_proof,
-/obj/item/shield/riot/bullet_proof,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "yellowdirtyfull"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/reactor)
+"ntS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "nue" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/water,
@@ -14508,58 +13044,57 @@
 	},
 /area/f13/clinic)
 "nwf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/reactor)
+"nwA" = (
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -12
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"nwA" = (
-/obj/structure/toilet{
-	dir = 4;
-	icon_state = "toilet00";
-	pixel_x = 0;
-	pixel_y = 0
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "boscheckpointreactor";
+	name = "Research Checkpoint Button";
+	pixel_x = -25;
+	req_one_access_txt = "120"
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood/rnd)
 "nxH" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "nxT" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = 12
 	},
-/obj/structure/rack,
-/obj/item/book/granter/crafting_recipe/blueprint/aep7,
-/obj/item/book/granter/crafting_recipe/blueprint/aer9,
-/obj/item/book/granter/crafting_recipe/blueprint/aer9,
-/obj/item/book/granter/crafting_recipe/blueprint/aep7,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/brotherhood/rnd)
-"nyK" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	layer = 2.7;
-	name = "prewar lounge chair"
-	},
-/obj/effect/landmark/start/f13/knightcap,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
 "nzl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/structure/fence/handrail{
+	density = 0;
 	dir = 4;
-	layer = 2.9
+	pixel_x = -12
 	},
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "nzm" = (
 /obj/structure/closet,
@@ -14568,19 +13103,23 @@
 	},
 /area/f13/clinic)
 "nzw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/power/apc,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/medical)
 "nzI" = (
-/obj/machinery/flasher/portable,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = 12
 	},
-/area/f13/brotherhood/operations)
-"nzX" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood/rnd)
 "nAC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14608,12 +13147,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nBh" = (
-/obj/structure/simple_door/bunker/glass{
-	name = "Archives";
-	req_access_txt = "120"
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Secret"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "nBk" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
@@ -14623,11 +13166,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nCi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4;
+	pixel_x = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1;
+	pixel_y = 6
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, filtered pool water.";
+	name = "pool water"
+	},
 /area/f13/brotherhood/leisure)
 "nCD" = (
 /obj/structure/simple_door/bunker,
@@ -14636,13 +13186,12 @@
 	},
 /area/f13/followers)
 "nDb" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
 	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "nEl" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt{
@@ -14654,12 +13203,9 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "nEt" = (
-/obj/machinery/computer/secure_data{
-	dir = 4;
-	icon_state = "computer"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/reactor)
 "nEz" = (
 /obj/structure/campfire/barrel,
 /turf/open/floor/f13{
@@ -14668,12 +13214,12 @@
 /area/f13/bunker)
 "nEC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/machinery/processor/chopping_block{
-	pixel_x = -4;
-	pixel_y = 16
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "nFr" = (
 /obj/structure/toilet{
@@ -14708,46 +13254,35 @@
 	},
 /area/f13/clinic)
 "nHN" = (
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
-	color = "#3e3d42";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
-"nHR" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
 "nIl" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/machinery/computer/terminal{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = -4
 	},
-/area/f13/brotherhood/rnd)
-"nIB" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/reactor)
 "nIL" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -14776,12 +13311,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "nKk" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
 "nKZ" = (
@@ -14794,14 +13334,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nLM" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "rampdowntop"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "nMh" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -14822,30 +13364,29 @@
 	},
 /area/f13/tunnel)
 "nMB" = (
-/obj/machinery/button/door{
-	id = "floor2elevatordoors";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gps/computer{
+	desc = "A large, central database of currently-transmitting GPS signals.";
+	name = "GPS Ping Grabber."
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
-"nMG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/rnd)
 "nMN" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	dir = 4;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
+	name = "Head Scribe's Archive Terminal"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "nMQ" = (
 /obj/structure/toilet{
@@ -14861,21 +13402,15 @@
 	},
 /area/f13/tunnel)
 "nMR" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
 	},
+/obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/operations)
-"nNi" = (
-/obj/structure/table/wood,
-/obj/machinery/bookbinder{
-	icon_state = "bigscanner";
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "nNx" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
@@ -14884,7 +13419,11 @@
 	},
 /area/f13/tunnel)
 "nNF" = (
-/turf/closed/wall/f13/wood,
+/obj/structure/simple_door/bunker,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "nNR" = (
 /obj/structure/rack,
@@ -14892,25 +13431,31 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nOW" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_x = 33
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/stage_t,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/offices1st)
 "nPp" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "twindowold"
+/obj/machinery/rnd/server/bos,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/rnd)
 "nPH" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13foldupchair,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "nQe" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -14945,16 +13490,30 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "nSI" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood/rnd)
 "nTr" = (
-/obj/structure/sign/poster/prewar/poster61,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood/rnd)
 "nTt" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
@@ -14970,39 +13529,44 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "nTN" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices2nd)
 "nUF" = (
-/obj/structure/bookcase/manuals/engineering,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "nVP" = (
 /obj/structure/rack,
 /obj/item/mining_scanner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "nWb" = (
-/obj/effect/decal/remains/robot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "nWg" = (
+/obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "nWh" = (
 /obj/structure/table,
@@ -15014,63 +13578,48 @@
 	},
 /area/f13/clinic)
 "nWG" = (
-/obj/machinery/libraryscanner{
-	desc = "This device scans books and other documents for entry into the Archives.";
-	name = "archive scanner";
-	pixel_y = 7
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "nWO" = (
-/obj/item/kitchen/knife/butcher,
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -11;
-	pixel_y = 13
-	},
-/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "nWW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/door/airlock/grunge{
+	name = "Proctor's Office";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
-"nXh" = (
-/obj/structure/closet/crate/large,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices2nd)
 "nXj" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/sewer)
 "nXm" = (
-/obj/structure/bed{
-	pixel_y = 7
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
 	},
-/obj/item/bedsheet{
-	icon_state = "sheetcmo";
-	pixel_y = 7
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/machinery/iv_drip{
-	pixel_x = 13;
-	pixel_y = 2
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "nXN" = (
 /obj/structure/simple_door/bunker,
@@ -15080,39 +13629,39 @@
 	},
 /area/f13/clinic)
 "nXS" = (
-/obj/structure/table{
-	pixel_y = 6
+/obj/structure/simple_door/bunker{
+	name = "Head Paladin's Office";
+	req_access = 120;
+	req_access_txt = "120"
 	},
-/obj/item/holosign_creator/security{
-	layer = 3.1;
-	name = "Knight Captain's holobarrier projector";
-	pixel_y = 7
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/brotherhood/offices1st)
-"nYw" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/debris/v4,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
-/area/f13/caves)
-"nYD" = (
-/obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/rnd)
-"nYR" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hos,
-/obj/effect/decal/cleanable/generic,
-/obj/item/toy/figure/warden{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Head Knight Action Figure";
-	toysay = "Victory is our tradition!"
+/area/f13/brotherhood/offices1st)
+"nYw" = (
+/obj/machinery/button/door{
+	id = "bosengine";
+	name = "Radiation Shutters";
+	pixel_x = 27
 	},
-/turf/open/floor/wood/f13/stage_t,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
+"nYD" = (
+/obj/structure/flora/junglebush,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
+"nYR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/offices1st)
 "nZI" = (
 /obj/structure/girder,
@@ -15121,24 +13670,27 @@
 	},
 /area/f13/tunnel)
 "oaW" = (
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
-/area/f13/caves)
-"obS" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"obV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/toy/poolnoodle/blue,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/reactor)
+"obV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/reactor)
 "odj" = (
 /obj/structure/ore_box,
 /turf/open/floor/f13/wood,
@@ -15167,71 +13719,62 @@
 	},
 /area/f13/tunnel)
 "odG" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/obj/machinery/button/door{
+	id = "boscheckpoint";
+	name = "Research Checkpoint Button";
+	pixel_y = 21;
+	req_one_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "oeb" = (
 /turf/closed/wall,
 /area/f13/tunnel)
 "oei" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/blueprint/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/flashlight/lamp{
-	light_color = "#00FFFF";
-	pixel_x = -14;
-	pixel_y = 9
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"oeJ" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"oeY" = (
-/turf/closed/indestructible/opshuttle,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "ofm" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ofI" = (
-/obj/structure/flora/grass/wasteland,
-/obj/structure/flora/rock/jungle,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
 	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "ofQ" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"ogl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/obj/item/statuebust{
+	pixel_y = 15
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
+"ogl" = (
+/obj/item/am_shielding_container,
+/turf/open/floor/plating,
+/area/f13/brotherhood/reactor)
 "ohv" = (
 /obj/structure/rack,
 /obj/item/ammo_box/a308,
@@ -15250,11 +13793,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "ois" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/brotherhood/reactor)
 "oiy" = (
 /obj/item/storage/trash_stack,
@@ -15266,61 +13812,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"oja" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 1;
-	layer = 3.1;
-	pixel_x = -12;
-	pixel_y = -9
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"ojR" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "okm" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/fluff/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/b,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "okO" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -15340,16 +13836,17 @@
 	},
 /area/f13/followers)
 "olK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/turf_decal/bot_white,
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/rnd)
 "olU" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -15358,20 +13855,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "omk" = (
-/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/machinery/light,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
 "omp" = (
-/obj/structure/bookcase/manuals/engineering{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Archives"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -15383,12 +13875,6 @@
 /obj/item/book/manual/wiki/circuitry,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"omE" = (
-/obj/structure/window/fulltile/wood,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/leisure)
 "omL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -15396,27 +13882,14 @@
 	},
 /area/f13/tunnel)
 "onL" = (
-/obj/machinery/light,
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
-"onU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/kitchen/knife/combat,
-/obj/item/twohanded/sledgehammer/supersledge,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "onY" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -15439,10 +13912,15 @@
 	},
 /area/f13/tunnel)
 "ooV" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/eightball,
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "opt" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -15500,19 +13978,31 @@
 	},
 /area/f13/tunnel)
 "osk" = (
-/obj/structure/simple_door/metal/ventilation,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "otf" = (
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
+/obj/machinery/door/airlock/vault{
+	name = "Elder'S Office";
+	req_access_txt = "120"
 	},
-/area/f13/caves)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "otF" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -15534,20 +14024,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "ovL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/simple_door/bunker{
+	name = "Washroom/Dorms"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/leisure)
 "ovQ" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster70"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/junglebush,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "ovY" = (
 /obj/structure/closet{
 	name = "implants locker"
@@ -15565,7 +14052,10 @@
 	},
 /area/f13/followers)
 "owa" = (
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood/leisure)
 "owm" = (
 /obj/structure/sink{
@@ -15579,28 +14069,45 @@
 	},
 /area/f13/tunnel)
 "owX" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/am_control_unit{
+	anchored = 1;
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+	icon_state = "yellowdirtyfull"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/reactor)
 "oxw" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/structure/table/wood/fancy/blackred,
+/obj/item/candle{
+	pixel_x = 7;
+	pixel_y = 13
 	},
-/area/f13/brotherhood/offices2nd)
+/obj/item/clothing/head/helmet/f13/power_armor/t51b{
+	armor = list("tier" = 3, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0);
+	armor_block_chance = 0;
+	desc = "A ruined T-51b power helmet. Its circuitry has been stripped out and the outer plating still bears the markings of a Deathclaw attack. Useless as armor. Honors the Fallen.";
+	name = "helm of a fallen Brother"
+	},
+/turf/open/floor/mineral/plastitanium/airless,
+/area/f13/brotherhood/rnd)
 "oyk" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "oyr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
@@ -15629,19 +14136,6 @@
 /obj/item/flashlight/pen,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"ozI" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/offices1st)
 "ozN" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "prospector3open"
@@ -15650,15 +14144,14 @@
 /turf/open/water,
 /area/f13/tunnel)
 "oAp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/brotherhood/reactor)
 "oAt" = (
 /obj/structure/bed/mattress,
@@ -15675,52 +14168,41 @@
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
 "oBP" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "oCn" = (
-/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "oCA" = (
-/obj/structure/flora/junglebush/large,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "oDf" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"oDP" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/leisure)
-"oDV" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "A console used by the scribes of the Brotherhood of Steel.";
-	dir = 8;
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal";
-	name = "Archive Terminal"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "oEt" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster69"
+/obj/structure/flora/junglebush/b,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oEC" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
@@ -15774,14 +14256,19 @@
 	},
 /area/f13/bunker)
 "oGc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "oGA" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -15800,10 +14287,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oHT" = (
-/obj/item/circuitboard/machine/smes,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "boscheckpointmines";
+	name = "brotherhood shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "oIo" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -15821,13 +14318,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "oIP" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/abductor{
+	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
+	name = "Table 3"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/item/paper_bin{
+	pixel_x = 6
 	},
-/area/f13/brotherhood/medical)
+/obj/item/pen/fountain/captain{
+	name = "elder's fountain pen"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "oJc" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15837,11 +14339,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"oLf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "oMb" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibleg"
@@ -15851,46 +14348,35 @@
 	},
 /area/f13/tunnel)
 "oMK" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/area/f13/caves)
-"oNj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "oNu" = (
-/obj/structure/debris/v1,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
-"oNM" = (
-/obj/structure/wreck/trash/machinepiletwo,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices1st)
-"oOw" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/offices2nd)
+"oNM" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "oOE" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -15925,16 +14411,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "oPU" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_2";
-	name = "Level 2: Engineering";
-	width = 5
+/obj/effect/landmark/start/f13/seniorscribe,
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "oQa" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15982,48 +14464,33 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "oRM" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
-"oRZ" = (
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = 16;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
+/obj/machinery/power/smes/engineering,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
+"oRZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "oSc" = (
 /obj/effect/spawner/lootdrop/f13/cash_legion_med,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "oSq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/medical)
 "oSx" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -16037,22 +14504,16 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"oTk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
 "oUK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "oUO" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -16091,17 +14552,14 @@
 	},
 /area/f13/tunnel)
 "oVE" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/pod,
+/obj/item/bedsheet/brown,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
-"oVJ" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
 "oVS" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood{
@@ -16109,13 +14567,36 @@
 	},
 /area/f13/tunnel)
 "oWc" = (
-/obj/machinery/light/small{
+/obj/item/am_containment{
+	pixel_x = 3
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/plasma/reinforced{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/window/plasma/reinforced{
+	dir = 8
 	},
-/area/f13/brotherhood/rnd)
+/obj/structure/window/plasma/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1
+	},
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/item/am_containment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Reactor Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/brotherhood/reactor)
 "oWl" = (
 /obj/machinery/computer/telecomms/monitor{
 	dir = 4;
@@ -16126,19 +14607,19 @@
 	},
 /area/f13/tcoms)
 "oWr" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "oWD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16162,34 +14643,33 @@
 	},
 /area/f13/followers)
 "oXD" = (
-/obj/structure/falsewall/reinforced,
-/obj/structure/sign/poster/prewar/poster78,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wallmed{
+	pixel_x = 25;
+	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 10, /obj/item/reagent_containers/pill/patch/silver_sulf = 10, /obj/item/reagent_containers/medspray/styptic = 4, /obj/item/reagent_containers/medspray/silver_sulf = 4, /obj/item/reagent_containers/pill/charcoal = 2, /obj/item/reagent_containers/medspray/sterilizine = 2)
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"oXG" = (
-/obj/structure/sign/poster/prewar/poster86,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "oYG" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"oZd" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"oZm" = (
 /obj/structure/chair/office/dark{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
+"oZd" = (
+/obj/structure/toilet{
+	pixel_y = 13
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
 "oZF" = (
@@ -16224,15 +14704,30 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "paF" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood/mining)
-"paO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "boscheckpointmines";
+	name = "brotherhood shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
+"paO" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "pbr" = (
@@ -16284,14 +14779,24 @@
 	},
 /area/f13/clinic)
 "peK" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "pfv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
+/obj/structure/fluff/railing{
+	dir = 5
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "pfy" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
@@ -16299,21 +14804,15 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
-"pfC" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+"pgt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/structure/table/survival_pod,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"pgi" = (
-/obj/structure/simple_door/bunker,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"pgt" = (
-/obj/machinery/computer/auxillary_base,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
 "pgw" = (
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -16321,19 +14820,9 @@
 	},
 /area/f13/ncr)
 "pgS" = (
-/obj/machinery/workbench/forge{
-	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
-	icon_state = "generator_on";
-	name = "superheating forge"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"phh" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/reactor)
 "phA" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/timeddoor,
@@ -16361,22 +14850,30 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pis" = (
-/obj/item/am_shielding_container,
-/turf/open/floor/plating,
-/area/f13/brotherhood/reactor)
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "piT" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = 33
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/mining)
 "pjj" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -16384,13 +14881,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"pjX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "pkL" = (
 /obj/effect/decal/cleanable/blood/old,
 /mob/living/simple_animal/hostile/raider/ranged,
@@ -16399,17 +14889,29 @@
 	},
 /area/f13/bunker)
 "pkW" = (
-/obj/machinery/shower{
-	dir = 1;
-	pixel_y = -2
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8;
+	pixel_x = -6
 	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, filtered pool water.";
+	name = "pool water"
+	},
 /area/f13/brotherhood/leisure)
 "pld" = (
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "plQ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16430,9 +14932,14 @@
 /area/f13/tunnel)
 "pmV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/f13stool,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/machinery/button/door{
+	id = "boscheckpointmines";
+	name = "Research Checkpoint Button";
+	pixel_x = -25;
+	req_one_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "pnd" = (
@@ -16455,22 +14962,17 @@
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"pnX" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "poa" = (
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/cell_charger{
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "poG" = (
 /obj/structure/window/fulltile/store,
 /obj/structure/barricade/wooden/planks,
@@ -16481,12 +14983,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ppt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/obj/structure/fluff/railing{
+	dir = 10
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/bronze{
+	name = "floor"
+	},
+/area/f13/brotherhood/rnd)
 "ppv" = (
 /obj/machinery/light{
 	dir = 8
@@ -16495,23 +15002,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"ppw" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood/rnd)
 "pqi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/fluff/railing,
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "pqw" = (
 /obj/structure/chair{
 	dir = 8
@@ -16530,29 +15027,18 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"psg" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm3";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood/leisure)
-"psv" = (
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "psA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/fluff/railing{
+	dir = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/machinery/light/floor,
+/turf/open/floor/bronze{
+	name = "floor"
+	},
+/area/f13/brotherhood/rnd)
 "psD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16595,20 +15081,28 @@
 	},
 /area/f13/bunker)
 "pud" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
 	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/medical)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices2nd)
 "puJ" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "puL" = (
-/obj/structure/weightlifter,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/bookcase/random/nonfiction,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices1st)
 "pvH" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -16634,19 +15128,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
-"pvX" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/animate{
-	layer = 2.5;
-	name = "weird light"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/brotherhood/rnd)
-"pwa" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "pwH" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -16654,57 +15135,25 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"pwP" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "pwY" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pxy" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/survival_pod,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/item/lighter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"pxI" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"pxS" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+"pxI" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/operations)
-"pxV" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
-"pyl" = (
-/obj/structure/decoration/rads,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/rnd)
 "pym" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16721,9 +15170,16 @@
 	},
 /area/f13/followers)
 "pzw" = (
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/kirbyplants{
+	pixel_y = 14
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "pzF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -16732,14 +15188,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"pzO" = (
-/obj/structure/decoration/smokeold,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
-"pzS" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood/medical)
 "pzW" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13{
@@ -16753,34 +15201,24 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "pAn" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/machinery/door/airlock/grunge{
+	id_tag = "headscribedorm";
+	name = "Head Scribe's Office";
+	req_access_txt = "120"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "pAB" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"pAE" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "pAK" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /mob/living/simple_animal/hostile/raider/ranged/boss,
@@ -16788,14 +15226,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"pBa" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
 "pBe" = (
 /obj/machinery/light/small,
 /mob/living/simple_animal/hostile/deathclaw,
@@ -16827,53 +15257,44 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "pDM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/junglebush,
+/obj/structure/bus_door,
+/turf/open/water,
+/area/f13/caves)
 "pDU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	icon_state = "conveyor_map"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/mining)
 "pEF" = (
 /obj/item/instrument/piano_synth,
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "pEG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	icon_state = "conveyor_map"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/mining)
 "pFn" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/lattice{
-	density = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/mining)
 "pGw" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -16885,37 +15306,30 @@
 /obj/machinery/telecomms/server/presets/enclave,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"pHQ" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/table/reinforced,
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "pIg" = (
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 16;
-	pixel_y = 35
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/reactor)
-"pIp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
+"pIp" = (
+/obj/effect/landmark/start/f13/scribe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "pIw" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
@@ -16923,43 +15337,27 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "pIx" = (
-/obj/machinery/rnd/server/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"pIX" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	name = "bitter black coffee";
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/mining)
 "pJO" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"pKf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "pLl" = (
-/obj/structure/decoration/smokeold,
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
+/obj/machinery/ore_silo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/mining)
 "pLC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16988,11 +15386,10 @@
 	},
 /area/f13/clinic)
 "pNi" = (
-/obj/structure/bookcase/random/religion{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Religious References"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/light/small,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -17002,35 +15399,26 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pNT" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/water,
-/area/f13/brotherhood/rnd)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pOB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pPS" = (
-/obj/structure/debris/v2,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "pQq" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17065,27 +15453,19 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"pRD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "pRM" = (
 /obj/machinery/telecomms/message_server,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "pRW" = (
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
+/obj/item/kirbyplants{
+	pixel_y = 14
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/medical)
 "pSr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/raider,
@@ -17100,26 +15480,44 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"pSY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "pVA" = (
-/obj/effect/spawner/lootdrop/trash,
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = -4
 	},
-/area/f13/brotherhood/operations)
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = -4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "pWc" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "pWr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/carpet,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "pWX" = (
 /obj/structure/chair/wood/modern{
@@ -17132,30 +15530,30 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "pXp" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster90"
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "pXq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Dorms";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices1st)
 "pXB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices1st)
 "pXC" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/f13,
@@ -17195,12 +15593,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/followers)
-"qaR" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "qaX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -17209,14 +15601,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"qbK" = (
-/obj/machinery/computer/operating/bos{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
 "qbZ" = (
 /obj/structure/rack,
 /obj/item/electropack/shockcollar{
@@ -17233,13 +15617,15 @@
 	},
 /area/f13/tunnel)
 "qci" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker{
-	name = "Ceremony Room";
-	req_access_txt = "120"
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "qcm" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/centaur,
@@ -17253,11 +15639,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qdj" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
+	name = "archive database"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "qdZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden{
@@ -17266,20 +15656,38 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qeh" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/item/t_scanner/adv_mining_scanner{
+	pixel_x = 9
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/t_scanner/adv_mining_scanner{
+	pixel_x = -9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/pickaxe/drill/diamonddrill,
+/obj/item/pickaxe/drill/diamonddrill,
+/obj/item/gps/mining{
+	gpstag = "BOSMINE3"
+	},
+/obj/item/gps/mining{
+	gpstag = "BOSMINE4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "qez" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard/fifty,
@@ -17304,29 +15712,16 @@
 	},
 /area/f13/tunnel)
 "qfu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
-"qfB" = (
-/obj/structure/simple_door/bunker{
-	name = "Ceremony Room";
-	req_access_txt = "120"
-	},
-/turf/open/floor/carpet,
+/obj/item/candle,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/f13/brotherhood/rnd)
-"qfK" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+"qfB" = (
+/obj/machinery/rnd/production/protolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/rnd)
 "qgC" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -17336,22 +15731,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qgO" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -33
-	},
-/obj/structure/sign/warning/fire{
-	pixel_x = 23;
-	pixel_y = 30
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/rnd)
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "qgP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
@@ -17371,9 +15759,15 @@
 	},
 /area/f13/tunnel)
 "qhw" = (
-/obj/structure/decoration/smokeold,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "qhB" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -17391,21 +15785,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"qid" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/rnd)
-"qii" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "qiH" = (
 /obj/item/trash/f13/fancylads,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17436,28 +15815,24 @@
 	},
 /area/f13/bunker)
 "qjT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/junglebush/large,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qmh" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/machinery/door/airlock/grunge{
+	id_tag = null;
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "qmL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/bed/pod,
+/obj/item/bedsheet/rd,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "qmV" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -17466,21 +15841,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qmZ" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/firelock_frame,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
-"qno" = (
-/obj/structure/sign/poster/prewar/poster65,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
-"qnC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/bookcase/random/reference,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
+"qno" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "qnM" = (
 /obj/structure/ladder/unbreakable{
@@ -17490,13 +15863,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qoi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qoB" = (
 /obj/effect/landmark/start/f13/followersdoctor,
 /obj/structure/chair/stool/f13stool,
@@ -17505,39 +15874,50 @@
 	},
 /area/f13/followers)
 "qoF" = (
-/obj/structure/lattice{
-	layer = 3
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/computer/camera_advanced/abductor{
+	desc = "One day, we'll get that dish working. Not today.";
+	name = "Inactive Radar Console"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/offices1st)
-"qpc" = (
-/obj/structure/sign/poster/prewar/poster73,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
-"qpd" = (
-/obj/machinery/button/door{
-	id = "bosarmoryacc";
-	normaldoorcontrol = 1;
-	pixel_x = -23;
-	specialfunctions = 4
+/obj/item/wrench/advanced{
+	pixel_x = 11;
+	pixel_y = -18
 	},
+/obj/effect/decal/cleanable/robot_debris/down,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"qpe" = (
-/obj/structure/closet/crate/large,
-/obj/item/trash/f13/electronic/toaster/atomics,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"qpc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
+"qpd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 23;
+	start_charge = 500
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
+"qpe" = (
+/obj/structure/flora/junglebush,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qpG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/wasteland{
@@ -17552,17 +15932,9 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "qpX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/rock/jungle,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "qpY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17577,44 +15949,39 @@
 	},
 /area/f13/tunnel)
 "qqJ" = (
-/obj/machinery/ore_silo,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/structure/table/wood/fancy/black,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/item/pen/fountain{
+	pixel_x = -8
+	},
+/obj/item/paper_bin{
+	pixel_x = 6
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+	icon_state = "casino"
 	},
-/area/f13/brotherhood/mining)
-"qqN" = (
-/obj/machinery/button/door{
-	id = "floor1elevatordoors";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
-"qrl" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices2nd)
 "qrJ" = (
-/obj/structure/simple_door/bunker{
-	name = "Head Paladin's Office";
-	req_access = 120;
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"qsa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
+/obj/machinery/light/small{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/kitchenspike_frame{
+	anchored = 1;
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
+"qsa" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "qsm" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibup1"
@@ -17631,22 +15998,17 @@
 	},
 /area/f13/followers)
 "qsM" = (
-/obj/structure/toilet{
-	pixel_y = 10
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_x = -10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "qta" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "qtb" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -17670,34 +16032,31 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"qtD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
 "qtL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/dresser,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/brotherhood/mining)
+/turf/open/space/basic,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "quB" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/obj/item/statuebust{
+	pixel_y = 15
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/medical)
 "quR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fence/handrail{
-	density = 0;
-	layer = 3;
-	pixel_y = 16
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/mining)
 "qvI" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -17717,13 +16076,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"qwp" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/rnd)
 "qwP" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17738,8 +16090,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "qxo" = (
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "qxO" = (
 /obj/machinery/telecomms/server/presets/ncr,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -17750,15 +16106,17 @@
 	},
 /area/f13/tunnel)
 "qys" = (
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
-"qyv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
 	},
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
+/obj/effect/landmark/start/f13/sentinel,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/offices1st)
 "qyC" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul,
@@ -17791,13 +16149,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qBQ" = (
-/obj/machinery/button/crematorium{
-	pixel_y = 19
+/obj/effect/landmark/start/f13/elder,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "qCu" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -17840,14 +16199,10 @@
 	},
 /area/f13/tunnel)
 "qFm" = (
-/obj/structure/destructible/clockwork/wall_gear{
-	pixel_x = -32
-	},
-/obj/item/projectile/magic/animate{
-	pixel_x = -32
-	},
-/turf/open/floor/bronze{
-	name = "floor"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "qFn" = (
@@ -17862,16 +16217,11 @@
 /turf/closed/wall,
 /area/f13/tcoms)
 "qFQ" = (
-/obj/structure/chair/sofa/corp/left,
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = 24
-	},
-/turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "qFS" = (
 /obj/structure/sink{
@@ -17881,13 +16231,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "qGe" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
+/obj/machinery/rnd/destructive_analyzer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/area/f13/caves)
+/area/f13/brotherhood/rnd)
 "qGf" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/electropack/shockcollar{
@@ -17906,12 +16255,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "qGz" = (
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	density = 1
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/auto{
+	dir = 8
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "qHc" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17921,10 +16272,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "qHi" = (
-/obj/item/stack/cable_coil,
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/obj/structure/dresser,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "qHr" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood{
@@ -17940,20 +16290,25 @@
 	},
 /area/f13/tunnel)
 "qIB" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"qJc" = (
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
-	},
-/obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
+"qJc" = (
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
+	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "qJM" = (
 /obj/machinery/door/unpowered/wooddoor{
@@ -17972,21 +16327,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"qKP" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	layer = 2.7;
-	name = "prewar lounge chair"
-	},
-/obj/effect/landmark/start/f13/headscribe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"qLb" = (
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "qLf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/revolver{
@@ -18009,42 +16349,39 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "qMm" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/reagent_containers/food/drinks/mug/coco{
-	pixel_y = 5
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "qMn" = (
-/obj/machinery/rnd/production/protolathe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "qME" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = 24
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qMO" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/storage/box/medsprays,
-/obj/item/pda/chemist{
-	name = "Scribe-Chemist Pip-Boy 3000"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 12
 	},
-/obj/item/pda/chemist{
-	name = "Scribe-Chemist Pip-Boy 3000"
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "qNn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -18094,19 +16431,17 @@
 	},
 /area/f13/tunnel)
 "qOJ" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/flag/bos,
-/turf/open/floor/carpet/black,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 10
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"qOT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices2nd)
 "qPh" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
@@ -18114,44 +16449,59 @@
 	},
 /area/f13/tunnel)
 "qPC" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
 /area/f13/brotherhood/operations)
 "qPN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "boscheckpoint";
-	name = "Checkpoint";
-	req_one_access = "120";
-	req_one_access_txt = "120"
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
 /area/f13/brotherhood/rnd)
 "qQF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/recharger,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"qQI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
-"qQS" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"qQI" = (
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
+	},
+/obj/item/flag/bos,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/railing,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
+"qQS" = (
+/obj/structure/flora/junglebush/c,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qRc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -18166,18 +16516,14 @@
 /turf/open/water,
 /area/f13/tunnel)
 "qRv" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/lattice{
+	density = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/fluff/railing/corner{
+	dir = 8
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "qTb" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18194,13 +16540,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qUL" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/indestructible/ground/outside/water{
-	density = 1;
-	desc = "Deep lake water, filled with who knows what...";
-	name = "lake water"
+/obj/structure/lattice{
+	density = 1
 	},
-/area/f13/caves)
+/obj/structure/fluff/railing/corner,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "qUO" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters{
@@ -18212,14 +16557,12 @@
 	},
 /area/f13/followers)
 "qUR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
-	},
-/area/f13/brotherhood/reactor)
+/obj/structure/railing,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "qUS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -18243,36 +16586,33 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "qVt" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
-"qVC" = (
-/obj/structure/decoration/vent{
-	layer = 2
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
+"qVC" = (
+/obj/structure/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "qVG" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qWa" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "qWm" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -18281,40 +16621,31 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"qWq" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/item/projectile/magic/change,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "qWx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qXo" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "qXr" = (
 /obj/structure/barricade/wooden,
 /obj/structure/curtain,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qXN" = (
-/obj/structure/sign/poster/prewar/poster90,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices1st)
 "qYq" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -18335,9 +16666,14 @@
 	},
 /area/f13/ncr)
 "qYS" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
+/obj/structure/fence/handrail_end/non_dense{
+	pixel_x = -16;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "qZq" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -18348,37 +16684,32 @@
 	},
 /area/f13/followers)
 "qZt" = (
-/mob/living/simple_animal/mouse/gray,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
-"qZA" = (
-/obj/item/flag/bos,
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
 /obj/structure/lattice{
 	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
+"qZA" = (
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 4
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "qZY" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/autolathe/ammo,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 16
 	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "raA" = (
 /obj/structure/table,
@@ -18404,16 +16735,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"rbu" = (
-/obj/structure/rack,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
 "rbE" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -18466,46 +16787,35 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
-"rcX" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
 "rex" = (
 /turf/closed/indestructible/rock,
 /area/f13/bunker)
 "reN" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
 "rfs" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/flag/bos,
-/obj/structure/lattice{
-	density = 1
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/f13/brotherhood/rnd)
 "rfD" = (
-/obj/structure/chair/office/dark{
-	dir = 1;
-	icon_state = "officechair_dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -32;
-	pixel_y = 64
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/mining)
 "rfH" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cloth/ten,
@@ -18561,13 +16871,19 @@
 	},
 /area/f13/tunnel)
 "riR" = (
-/obj/structure/chair/office/dark{
-	dir = 1;
-	icon_state = "officechair_dark"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "riT" = (
 /obj/structure/mirror{
 	pixel_x = 32
@@ -18576,17 +16892,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/tunnel)
-"riY" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
 "rjq" = (
 /obj/structure/toilet{
 	dir = 1
@@ -18606,13 +16911,10 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/sign/poster/prewar/poster73{
-	pixel_y = 31
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/rnd)
 "rkH" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -18644,18 +16946,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "rmv" = (
-/obj/effect/turf_decal/stripes/red/line{
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
 	dir = 1;
-	icon_state = "warningline_red"
+	pixel_y = 18
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/rnd)
 "rmR" = (
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
@@ -18665,15 +16966,6 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"roa" = (
-/obj/structure/bookcase/random/reference{
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Archival References"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "roc" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/wood/settler,
@@ -18695,13 +16987,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "rrh" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Brig";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "rrm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18732,54 +17022,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rsj" = (
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
 /obj/structure/table{
 	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/clothing/under/rank/medical/green,
+/obj/item/clothing/under/rank/medical/purple,
+/obj/item/clothing/under/rank/medical/blue,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/structure/sign/poster/prewar/poster87{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "rsB" = (
 /obj/machinery/light{
@@ -18789,23 +17051,30 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"rsD" = (
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "rsM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/table{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
 	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = 18
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
 "rtf" = (
-/obj/structure/sign/poster/prewar/poster71,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "rtk" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -18827,14 +17096,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ruc" = (
-/obj/structure/simple_door/bunker{
-	name = "Head Knight's Office";
-	req_access = 120;
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "run" = (
 /obj/machinery/light/fo13colored/Aqua{
 	name = "light fixture"
@@ -18854,11 +17115,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rvb" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "rvf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18866,13 +17133,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"rvG" = (
-/obj/machinery/vending/snack/orange,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "rvI" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -18895,16 +17155,14 @@
 	},
 /area/f13/ncr)
 "rwk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Backup Power";
-	req_access_txt = "120"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/rnd)
 "rwA" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
@@ -18932,17 +17190,27 @@
 	},
 /area/f13/tunnel)
 "ryy" = (
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
-"ryL" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet/purple,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Workshop Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"ryV" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+"ryL" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "ryY" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -18954,16 +17222,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rzi" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8;
-	pixel_x = -6
-	},
+/obj/machinery/smartfridge/food,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Pink{
-	critical_machine = 1;
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "rzz" = (
 /obj/machinery/light/fo13colored/Red,
@@ -18982,24 +17245,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"rzQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/junglebush/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/rnd)
 "rAb" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/tunnel)
@@ -19011,17 +17256,15 @@
 	},
 /area/f13/tunnel)
 "rAo" = (
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "rAt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/circuit/f13_red,
+/area/f13/brotherhood/rnd)
 "rAx" = (
 /obj/machinery/light{
 	dir = 8
@@ -19051,56 +17294,62 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rDr" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
+/obj/machinery/light{
+	dir = 1
 	},
+/obj/machinery/camera/autoname{
+	name = "Mine Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rDS" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rEj" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/item/stack/sheet/prewar/five,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rEl" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rFc" = (
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = 18
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "rFn" = (
-/obj/structure/grille,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "rFz" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "rFJ" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/operations)
 "rFQ" = (
 /obj/structure/rack,
@@ -19122,38 +17371,82 @@
 	},
 /area/f13/followers)
 "rHV" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
-"rIl" = (
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/item/paper_bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"rIS" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/item/pen/fountain,
+/obj/machinery/button/door{
+	id = "bosdoors";
+	name = "Bunker Lockdown Button";
+	pixel_x = -22;
+	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
+"rIl" = (
+/obj/machinery/newscaster,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/reactor)
+"rIS" = (
+/obj/item/candle{
+	pixel_x = 7;
+	pixel_y = 13
+	},
+/obj/item/candle{
+	pixel_x = 7
+	},
+/obj/item/candle{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/candle{
+	pixel_x = -7
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "rJn" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "The Codex";
+	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
 "rJv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/computer/terminal{
+	density = 0;
+	desc = "A pre-war high security terminal. There's virtually no way to hack into this thing; it holds the most secure information the Brotherhood has to offer.";
+	doc_content_1 = "The preservation of technology is our primary goal, all others are secondary. <br> <br>  Shield yourself from those not bound to you by steel, for they are the blind. Aid them when you can, but lose not sight of yourself.";
+	doc_content_2 = "Give way your suspicions to the wisdom of thine Elder. Where he shows trust, so shall you. <br> <br> Fear those who do not pledge to the Brotherhood for though their eyes may be opened through service, they are now blind. ";
+	doc_content_3 = "Through discourse, we gain the strength of our Brothers' minds. Deceit and lies of all ilk serve only to harm that strength. <br> <br> Your caste and duties mean everything, you will follow your leader and your leader will lead you. <br> <br> You may only follow the orders of another if it will save the life of a brother. ";
+	doc_content_4 = "Theft is for lesser men, the Brotherhood provides for you and you provide for the Brotherhood. <br> <br>  What lesser men see as fashionable shall be shunned. Foreign garment and practice will do nothing but shame your fellow brothers.  ";
+	doc_content_5 = "The Blind can not read, only those who have taken the Oath of Fraternity may read this text.";
+	doc_title_1 = "Doctrine pt. 1";
+	doc_title_2 = "Doctrine pt. 2";
+	doc_title_3 = "Doctrine pt. 3";
+	doc_title_4 = "Doctrine pt. 4";
+	doc_title_5 = "Doctrine pt. 5";
+	icon = 'icons/obj/machines/particle_accelerator.dmi';
+	icon_keyboard = "generic_key";
+	icon_screen = generic;
+	icon_state = "control_boxp";
+	idle_power_usage = 1;
+	light_color = "#6e1722";
+	light_power = 2;
+	light_range = 3;
+	max_integrity = 1000;
+	name = "The Codex";
+	note = "Scribe Note of the Week:";
+	termtag = "Codex"
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "rJA" = (
 /obj/item/pickaxe,
@@ -19186,25 +17479,37 @@
 	},
 /area/f13/clinic)
 "rKE" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/item/candle{
+	pixel_x = -6;
+	pixel_y = 13
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/item/candle{
+	pixel_x = 7;
+	pixel_y = 7
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/item/candle{
+	pixel_y = -7
 	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/rnd)
 "rKJ" = (
+/obj/structure/window/reinforced/spawner{
+	color = "#777777";
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
+	},
 /obj/structure/lattice{
 	density = 1
 	},
-/obj/structure/table/wood,
-/obj/structure/lattice{
-	density = 1
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = 12
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "rKW" = (
@@ -19216,29 +17521,33 @@
 	},
 /area/f13/tunnel)
 "rKX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
 "rLq" = (
 /obj/item/stack/sheet/bone,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rLI" = (
-/obj/machinery/microwave/stove,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/obj/structure/window/reinforced/spawner{
+	color = "#777777";
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
+	},
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/rnd)
 "rMk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -19249,8 +17558,19 @@
 	},
 /area/f13/clinic)
 "rNi" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/carpet/purple,
+/obj/structure/window/reinforced/spawner{
+	color = "#777777";
+	dir = 0;
+	max_integrity = 5000;
+	name = "ultra-reinforced window"
+	},
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/structure/fluff/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "rNj" = (
 /obj/structure/table/wood/poker,
@@ -19261,20 +17581,15 @@
 	},
 /area/f13/tunnel)
 "rOb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/flora/junglebush/b,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "rOp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/debris/v3{
+	layer = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/water,
+/area/f13/caves)
 "rOq" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -19306,11 +17621,18 @@
 	},
 /area/f13/tcoms)
 "rPG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/lattice{
+	density = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 1;
+	pixel_y = 18
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "rQA" = (
 /mob/living/simple_animal/hostile/handy,
@@ -19327,14 +17649,21 @@
 	},
 /area/f13/sewer)
 "rRQ" = (
-/obj/structure/sign/poster/prewar/poster91,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "boscheckpointmedical";
+	name = "brotherhood shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "rSw" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "rSM" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
@@ -19367,170 +17696,28 @@
 	},
 /area/f13/tunnel)
 "rUF" = (
-/obj/structure/rack,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "rVd" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"rVE" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/restraints/legcuffs,
-/obj/item/restraints/legcuffs,
-/obj/item/storage/box/handcuffs,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/operations)
 "rWh" = (
-/turf/open/floor/carpet/purple,
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "rWY" = (
 /obj/structure/table,
@@ -19554,25 +17741,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rXl" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rXA" = (
 /obj/structure/timeddoor,
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "rXR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rXS" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -19585,17 +17767,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rZw" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	dir = 8;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rZF" = (
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19613,30 +17787,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "sam" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "saw" = (
-/obj/structure/simple_door/house{
-	icon_state = "room"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "saz" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "saC" = (
 /obj/structure/sink{
 	dir = 4;
@@ -19646,53 +17814,19 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
-"saF" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin{
-	pixel_x = 6
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
 "sbj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/junglebush/large,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "scG" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sdw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
-"sdz" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/blue,
+/area/f13/brotherhood/offices2nd)
 "sdI" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
@@ -19700,72 +17834,37 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sdJ" = (
-/obj/item/flashlight/lamp{
-	pixel_x = -3;
-	pixel_y = 15
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	dir = 4;
-	pixel_x = -3;
-	pixel_y = -3;
-	termtag = "Business"
-	},
-/obj/structure/fluff/paper/stack{
-	pixel_x = 11;
-	pixel_y = 4
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/water,
+/area/f13/caves)
 "sef" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sek" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "seJ" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/junglebush,
+/obj/structure/flora/rock/jungle,
+/turf/open/water,
+/area/f13/caves)
 "seL" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "seP" = (
+/mob/living/simple_animal/hostile/mirelurk/baby,
+/turf/open/water,
+/area/f13/caves)
+"sfi" = (
+/obj/effect/landmark/start/f13/scribe,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/rnd)
-"sfi" = (
-/obj/item/flag/bos,
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
 "sfj" = (
@@ -19820,16 +17919,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"sgm" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = null;
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "sgn" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -19842,21 +17931,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "sgI" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"shc" = (
+/obj/structure/simple_door/bunker{
+	name = "Star Paladin Office";
+	req_access = 120;
+	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/rnd)
-"shc" = (
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = -33
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "shl" = (
 /obj/machinery/telecomms/server/presets/service,
@@ -19867,15 +17954,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "shO" = (
-/obj/structure/window/reinforced/spawner/north{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sic" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -19913,19 +17995,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "sjA" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/leisure)
+/obj/structure/flora/junglebush,
+/turf/open/water,
+/area/f13/caves)
 "sjR" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/bus_door,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "ska" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -19935,11 +18012,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "skL" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
 "skN" = (
@@ -19947,44 +18023,37 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "slg" = (
-/obj/structure/decoration/vent,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood/offices1st)
 "sll" = (
-/obj/machinery/button/door{
-	id = "bosshop";
-	pixel_x = 32
+/obj/structure/glowshroom/single,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
+/area/f13/caves)
 "slT" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"slX" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/rock/jungle,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
+/obj/structure/flora/junglebush/b,
 /turf/open/water,
+/area/f13/caves)
+"slX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosaccesscontrol";
+	req_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/operations)
 "smf" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/outside/water,
+/obj/structure/wreck/car{
+	layer = 2
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "smm" = (
 /obj/structure/sink{
@@ -19996,42 +18065,28 @@
 	},
 /area/f13/tunnel)
 "smq" = (
-/obj/structure/rack,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"smy" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/kirbyplants{
+	pixel_y = 14
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
+"smy" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
+"snP" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/rnd)
-"snJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"snL" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/effect/decal/cleanable/robot_debris/down,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"snP" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/offices2nd)
 "sor" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -20051,22 +18106,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"spS" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
-/area/f13/brotherhood/reactor)
 "sqr" = (
 /obj/effect/decal/cleanable/blood/innards,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"srb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "srD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -20076,9 +18119,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"srH" = (
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/rnd)
 "srZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -20105,36 +18145,16 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"stJ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
+"suk" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/prewar/poster89{
+	pixel_x = 32
+	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"stU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
-	},
-/area/f13/brotherhood/reactor)
-"suk" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
-"suF" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "suZ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/cups,
@@ -20143,17 +18163,14 @@
 	},
 /area/f13/ncr)
 "swY" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"sxs" = (
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood/rnd)
 "sxA" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
@@ -20173,21 +18190,26 @@
 	},
 /area/f13/bunker)
 "szW" = (
-/obj/structure/chair/f13chair1,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/cell_charger{
+	pixel_y = 6
 	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
+/obj/machinery/recharger,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "sAa" = (
 /obj/structure/campfire,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sAL" = (
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/mining)
 "sBm" = (
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
@@ -20205,7 +18227,12 @@
 /area/f13/clinic)
 "sCB" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "sCZ" = (
 /obj/structure/barricade/bars,
@@ -20222,36 +18249,14 @@
 	},
 /area/f13/tunnel)
 "sDK" = (
-/obj/structure/bed,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"sEK" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8;
-	pixel_x = -6
+/obj/structure/chair/f13foldupchair{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
-"sFl" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bossecgear";
-	name = "Internal Security Gear";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "sGx" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -20265,18 +18270,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"sGY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"sHk" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/rnd)
 "sHo" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/f13{
@@ -20296,70 +18289,45 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"sIK" = (
-/obj/machinery/light/small,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/rnd)
 "sIN" = (
 /obj/effect/decal/cleanable/cobweb,
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sJm" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "SW"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5;
-	icon_state = "warningline_red"
+/obj/item/paper_bin,
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_x = 33
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/offices1st)
+"sJA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "bosengineaccess";
+	name = "Engineering Lockdown";
+	pixel_x = 34;
+	pixel_y = -4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/operations)
-"sJA" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"sKf" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/store,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/reactor)
 "sKg" = (
 /obj/structure/curtain,
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sKB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
-"sKW" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/revolver{
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
 "sLx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -20367,15 +18335,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"sLF" = (
-/obj/structure/wreck/car{
-	layer = 2
-	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "sLG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/mattress{
@@ -20385,11 +18344,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"sLI" = (
-/obj/machinery/door/unpowered/wooddoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "sMc" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -20410,13 +18364,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
-"sNg" = (
-/obj/machinery/button/door{
-	id = "bosshop";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "sNu" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -20426,11 +18373,14 @@
 	},
 /area/f13/followers)
 "sNB" = (
-/obj/machinery/door/airlock/grunge,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
 	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "sNF" = (
 /obj/structure/closet/fridge,
 /obj/item/storage/fancy/egg_box,
@@ -20444,25 +18394,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sOf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 10
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/rnd)
-"sOi" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "sOq" = (
 /obj/structure/sink{
 	dir = 8;
@@ -20483,29 +18414,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"sPa" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_right"
-	},
-/area/f13/brotherhood/rnd)
-"sPl" = (
-/obj/structure/fluff/railing{
-	dir = 10;
-	pixel_x = -33
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
-"sPC" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/rnd)
 "sPK" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/f13/battlecoat,
@@ -20519,18 +18427,20 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sSF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
 "sSP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "sSS" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/remains{
@@ -20545,68 +18455,28 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "sUs" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
-"sUy" = (
-/obj/item/flag/bos,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 4
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"sUF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
-"sUH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/rnd)
-"sWb" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm7";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood/leisure)
 "sWp" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
-"sWu" = (
+/obj/item/flashlight/lamp{
+	pixel_x = 3;
+	pixel_y = 12
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"sWB" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices1st)
 "sWT" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/fountain{
@@ -20627,22 +18497,18 @@
 	},
 /area/f13/ncr)
 "sWX" = (
-/obj/structure/sign/poster/prewar/poster75,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
-"sXi" = (
-/obj/machinery/power/am_control_unit{
-	anchored = 1;
-	dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/item/paper_bin,
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_x = -33
 	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/offices1st)
 "sXC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -20656,33 +18522,10 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"sXP" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "sXV" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
-"sZn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/mug/coco{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "sZJ" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -20695,15 +18538,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"tbg" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "tbE" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -20712,29 +18546,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"tco" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
-"tcv" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "AUX"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "tcC" = (
 /obj/structure/chair/stool/retro,
 /obj/effect/decal/cleanable/dirt,
@@ -20743,21 +18554,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"tcH" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "tda" = (
 /obj/structure/toilet{
 	dir = 8
@@ -20768,22 +18564,20 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"teh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+"tem" = (
 /obj/structure/table{
 	layer = 2.9
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
-"tem" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = -8;
+	pixel_y = 4
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/obj/item/paper_bin{
+	pixel_x = 7
+	},
+/obj/item/pen/fountain,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/medical)
 "tep" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -20815,16 +18609,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"tfd" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "tfw" = (
 /obj/effect/decal/cleanable/blood/innards,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -20838,52 +18622,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
-"tfI" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "tgC" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"tgU" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"tgY" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"tha" = (
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
-"thr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/sign/poster/contraband/free_tonto{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 9
-	},
-/area/f13/brotherhood/mining)
 "tht" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -20904,26 +18648,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"thO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"tiB" = (
-/obj/effect/decal/cleanable/shreds,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker{
-	name = "Locker Room"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "tiS" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20958,19 +18682,6 @@
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"tkD" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"tkO" = (
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "tkS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "NCR War Room";
@@ -20978,39 +18689,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"tkU" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/turf/open/water,
-/area/f13/brotherhood/rnd)
-"tlc" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
-"tlr" = (
-/obj/structure/decoration/vent,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "tls" = (
-/obj/item/kirbyplants/photosynthetic,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/item/statuebust{
+	pixel_y = 15
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "tlS" = (
 /obj/structure/table/wood/settler,
@@ -21020,13 +18707,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "tmh" = (
-/obj/effect/landmark/start/f13/seniorscribe,
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/rnd)
 "tmM" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -21043,40 +18729,18 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"tna" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood/rnd)
 "tnh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/left{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
-"tnk" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
-"tnl" = (
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/brotherhood/rnd)
 "tnp" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
-"tnF" = (
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/rnd)
 "toA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark{
@@ -21084,28 +18748,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"toO" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = -6
-	},
-/obj/structure/flora/junglebush{
-	pixel_x = -15
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood/rnd)
 "toP" = (
-/obj/structure/target_stake{
-	anchored = 1
-	},
+/obj/structure/rack,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
 "tpf" = (
@@ -21120,14 +18776,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"tqS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosaccesscontrol";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "tqZ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -21138,16 +18786,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"trr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/survival_pod,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"trJ" = (
-/obj/structure/bookcase/random,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood/mining)
 "tse" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -21157,18 +18795,11 @@
 	},
 /area/f13/tunnel)
 "tsm" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"tsq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/rnd)
 "tsK" = (
 /obj/structure/table,
 /obj/item/pen,
@@ -21195,29 +18826,21 @@
 	},
 /area/f13/tunnel)
 "ttW" = (
-/obj/structure/simple_door/blast{
-	max_integrity = 10000;
-	name = "bunker entry";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices1st)
 "tur" = (
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "tuO" = (
-/obj/machinery/door/airlock/vault{
-	desc = "A massive gear set into two heavy slabs of brass.";
-	icon = 'icons/obj/doors/airlocks/clockwork/pinion_airlock.dmi';
-	name = "Codex";
-	req_access_txt = "120"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/wood,
 /area/f13/brotherhood/rnd)
 "tvc" = (
 /obj/structure/rack,
@@ -21228,15 +18851,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"tvj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
 "tvl" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood{
@@ -21249,23 +18863,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"tvN" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/machinery/light/small,
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
 "tvZ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -21283,40 +18880,15 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"twR" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/obj/machinery/button/door{
-	id = "bosdorm3";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
 "txg" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
-"txU" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
-/area/f13/brotherhood/rnd)
 "tyR" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm4";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tzi" = (
 /obj/machinery/door/airlock/hatch{
@@ -21325,14 +18897,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"tzx" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
-/area/f13/brotherhood/rnd)
 "tzH" = (
 /obj/structure/table/reinforced,
 /obj/item/folder{
@@ -21352,33 +18916,6 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/tunnel)
-"tAi" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
-"tAD" = (
-/obj/machinery/vending/dinnerware,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/structure/sign/poster/contraband/eat{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"tBw" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "tBZ" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -21386,14 +18923,8 @@
 	},
 /area/f13/tunnel)
 "tCe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/f13/brotherhood/rnd)
 "tCt" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -21403,42 +18934,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"tCw" = (
-/obj/structure/table/wood/bar,
-/obj/machinery/chem_dispenser/drinks/beer{
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -8;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
 "tDl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
@@ -21467,13 +18962,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "tEG" = (
-/obj/structure/simple_door/bunker{
-	name = "Star Knight Office";
-	req_access = 120;
-	req_access_txt = "120"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/offices1st)
 "tEH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21493,10 +18985,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
-"tFl" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "tFF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -21520,13 +19008,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"tGm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
 "tHb" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -21538,33 +19019,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"tHq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/mirror{
-	pixel_x = 27
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
-"tHG" = (
-/turf/closed/indestructible/opshuttle,
-/area/f13/brotherhood/leisure)
-"tHM" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_right"
-	},
-/area/f13/brotherhood/rnd)
-"tIz" = (
-/obj/item/flag/bos,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "tID" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -21598,89 +19052,15 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
-"tJH" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_left"
-	},
-/area/f13/brotherhood/rnd)
-"tJL" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 9
-	},
-/area/f13/brotherhood/reactor)
 "tJM" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
-"tJT" = (
-/obj/machinery/camera/autoname{
-	dir = 5;
-	name = "Reactor Camera";
-	network = list("BoS")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"tJU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"tJW" = (
-/obj/structure/rack,
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 11
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -6;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -2;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = 2;
-	pixel_y = -10
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 13;
-	pixel_y = -8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "bluerustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "tKe" = (
 /obj/structure/chair/wood/fancy,
 /obj/effect/decal/cleanable/dirt{
@@ -21688,27 +19068,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"tKr" = (
-/obj/structure/sign/poster/prewar/poster68,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
-"tKy" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
-"tKJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/leisure)
 "tKU" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -21722,66 +19081,43 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"tLz" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
-"tLS" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "tMw" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/storage/bag/chemistry{
-	pixel_x = -18
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
-"tMD" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
-"tML" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/offices2nd)
+"tMD" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
+"tML" = (
+/obj/structure/closet/secure_closet/contraband/armory{
+	req_access_txt = "120"
+	},
+/obj/item/clothing/head/helmet/f13/power_armor/t45d,
+/obj/item/clothing/suit/armor/f13/power_armor/t45d/knightcaptain,
+/obj/item/radio/intercom{
+	frequency = 1891;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "tNq" = (
 /obj/machinery/telecomms/server/presets/bos,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "tOi" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/table/reinforced,
-/obj/structure/window/fulltile/store,
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	layer = 3.3;
-	name = "Medical Lab"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "tOn" = (
 /obj/machinery/light/small{
@@ -21795,20 +19131,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tOD" = (
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "tOY" = (
 /obj/structure/rack,
@@ -21822,32 +19149,6 @@
 /obj/structure/curtain,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"tQe" = (
-/obj/structure/table/wood/fancy/black{
-	desc = "A set of thin pipes that no longer function.";
-	icon_state = "latticefull";
-	layer = 2.4;
-	name = "pipes"
-	},
-/obj/item/statuebust,
-/obj/structure/table{
-	icon_state = "1-f"
-	},
-/obj/structure/table{
-	icon_state = "2-f"
-	},
-/obj/structure/table{
-	icon_state = "3-f"
-	},
-/obj/structure/table{
-	icon_state = "4-f"
-	},
-/obj/structure/window/reinforced/clockwork/fulltile,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/rnd)
 "tQw" = (
 /obj/structure/table,
 /obj/item/storage/fancy/ammobox/slugshot,
@@ -21873,18 +19174,13 @@
 /obj/item/gun/ballistic/revolver/caravan_shotgun,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"tSH" = (
-/obj/structure/sign/poster/official/safety_eye_protection,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "tSI" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 8;
-	name = "light fixture"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
 "tSK" = (
@@ -21911,10 +19207,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
-"tTB" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/rnd)
 "tUk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/chips,
@@ -21933,23 +19225,6 @@
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"tVL" = (
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_y = -33
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -21968,21 +19243,6 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tXw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/rnd)
-"tXJ" = (
-/obj/structure/table/reinforced,
-/obj/item/trash/f13/electronic/toaster{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "tYd" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -22004,27 +19264,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"tYy" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
-"tYE" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
-"tZc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "tZf" = (
 /obj/structure/sink{
 	pixel_y = 19
@@ -22061,14 +19300,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"uay" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase/manuals/engineering,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "uaL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
@@ -22084,62 +19315,10 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ucw" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/mining)
-"ucQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/rnd)
 "ucS" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ucV" = (
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"ucY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/structure/mirror{
-	pixel_x = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
-"udU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/leisure)
 "uel" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/terminal{
@@ -22150,24 +19329,12 @@
 	},
 /area/f13/followers)
 "ueZ" = (
-/obj/structure/simple_door/metal/ventilation,
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
-"ufk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/offices2nd)
 "ufo" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "prospector2open"
@@ -22198,30 +19365,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"ufZ" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"ugR" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "ugU" = (
 /obj/structure/bookcase/random/adult,
 /obj/machinery/light{
@@ -22237,13 +19380,6 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"uhT" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "uhW" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -22263,12 +19399,6 @@
 /obj/structure/nest/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ujt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "ujx" = (
 /obj/structure/decoration/vent,
 /obj/machinery/shower{
@@ -22277,14 +19407,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/followers)
 "ukv" = (
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "kcdorm";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "ukI" = (
 /obj/structure/dresser,
@@ -22292,48 +19422,18 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"ukN" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
-"ukP" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 1;
-	pixel_y = -9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"ukT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
-	},
-/area/f13/brotherhood/rnd)
 "ulr" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/computer/terminal{
+	icon = 'icons/obj/machines/particle_accelerator.dmi';
+	icon_keyboard = "generic_key";
+	icon_screen = "generic";
+	icon_state = "control_boxp"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "uls" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/pa_wear,
@@ -22351,71 +19451,12 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/tunnel)
-"ulA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/statuebust{
-	pixel_y = 15
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
 "ulE" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/followers)
-"ulS" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/bedsheetbin,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"ulZ" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/shuttle_manipulator{
-	desc = "You have no idea what this shows.";
-	name = "old hologram";
-	pixel_x = 16;
-	pixel_y = -16
-	},
-/obj/machinery/shuttle_manipulator{
-	desc = "You have no idea what this shows.";
-	icon_state = "hologram_ship";
-	name = "old hologram";
-	pixel_x = 14;
-	pixel_y = 9
-	},
-/obj/machinery/shuttle_manipulator{
-	desc = "You have no idea what this shows.";
-	icon_state = "hologram_on";
-	name = "old hologram";
-	pixel_x = 16;
-	pixel_y = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"uml" = (
-/obj/structure/pool/ladder,
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, filtered pool water.";
-	name = "pool water"
-	},
-/area/f13/brotherhood/leisure)
-"umw" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "umG" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -22423,10 +19464,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"umZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
 "unV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/wasteplant/wild_fungus,
@@ -22444,53 +19481,21 @@
 	},
 /area/f13/tunnel)
 "uoI" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
-"uoO" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
-"ups" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/f13{
-	icon_state = "rampdowntop"
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"upu" = (
-/obj/effect/decal/cleanable/robot_debris/limb,
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"upA" = (
-/obj/structure/flora/junglebush,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
+"uoO" = (
+/turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "upC" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"upI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "uqk" = (
 /obj/item/flashlight,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -22509,44 +19514,39 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "uqO" = (
-/obj/structure/table/wood,
-/obj/item/lighter{
-	pixel_x = 4;
-	pixel_y = 6
+/obj/item/flashlight/lamp,
+/obj/item/toy/figure/hos{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	name = "Head Paladin Action Figure";
+	toysay = "SEMPER INVICTA!"
 	},
-/turf/open/floor/wood/f13/stage_t,
+/obj/item/pda/captain{
+	name = "Head Paladin PipBoy"
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/offices1st)
 "uqU" = (
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"urc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/reactor)
+"urc" = (
+/obj/structure/chair/left{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/leisure)
-"uri" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = 30
-	},
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Head Knight on duty.";
-	dir = 4;
-	name = "Head Knight's Office"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
 "urM" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -22561,28 +19561,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "usN" = (
-/obj/docking_port/stationary{
-	area_type = /area/f13;
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	id = "bos_level_1";
-	name = "Level 1: Operations";
-	roundstart_template = /datum/map_template/shuttle/bos/elevator;
-	width = 5
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "utr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "utP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood/operations)
 "uub" = (
@@ -22603,18 +19597,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "uuN" = (
-/obj/structure/table{
-	layer = 2.9
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/rxglasses,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/gloves,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "uuP" = (
 /obj/structure/simple_door/metal/dirtystore,
@@ -22622,39 +19607,16 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"uuQ" = (
-/obj/structure/chair/bench,
-/obj/machinery/button/door{
-	id = "proctorbathroom";
-	name = "Bathroom Lock";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_one_access_txt = "120";
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
-"uvd" = (
-/obj/structure/decoration/vent{
-	layer = 2
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"uvB" = (
-/obj/machinery/jukebox,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "uwd" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/structure/decoration/vent{
+	pixel_x = 15;
+	pixel_y = -17
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "uwt" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
@@ -22662,10 +19624,10 @@
 /area/f13/caves)
 "uwA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "uwC" = (
 /obj/machinery/light/small{
@@ -22681,15 +19643,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"uwV" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "uxq" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/decal/cleanable/cobweb,
@@ -22698,12 +19651,12 @@
 	},
 /area/f13/tunnel)
 "uyl" = (
-/obj/machinery/sleeper{
-	density = 1;
-	dir = 4;
-	icon_state = "sleeper_clockwork"
+/obj/machinery/computer/operating/bos{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "uyz" = (
 /obj/structure/flora/grass/wasteland{
@@ -22734,15 +19687,8 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "uAc" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/mining)
 "uBO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -22831,60 +19777,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"uFn" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/brotherhood/mining)
-"uFO" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "uFQ" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"uGg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"uGL" = (
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"uGO" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "uGR" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -22909,38 +19807,23 @@
 /obj/item/reagent_containers/glass/beaker/plastic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uHP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "uHU" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"uIm" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"uIq" = (
-/obj/item/multitool,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "uIE" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "uIZ" = (
-/obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood/offices2nd)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /obj/effect/decal/waste{
@@ -22948,64 +19831,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"uJx" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_left"
-	},
-/area/f13/brotherhood/rnd)
 "uJD" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/tunnel)
-"uJG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
-"uJS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
-	dir = 1
-	},
-/area/f13/brotherhood/reactor)
-"uKn" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 1;
-	layer = 3.1;
-	pixel_x = -12;
-	pixel_y = -16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = -12
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "uKB" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/warning,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uKD" = (
-/obj/machinery/hydroponics/constructable{
-	anchored = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "uKP" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8";
@@ -23045,13 +19878,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
-"uLP" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "uMi" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -23096,20 +19922,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uMD" = (
-/obj/structure/simple_door/bunker{
-	name = "Head Knight's Office";
-	req_access = 120;
-	req_access_txt = "120"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"uMJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/operations)
 "uMO" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -23117,23 +19932,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"uMR" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
-"uNG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "uNS" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -23172,15 +19970,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uRE" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "uRG" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -23200,12 +19989,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uSG" = (
-/obj/structure/lattice/catwalk/clockwork,
-/turf/open/floor/bronze{
-	name = "floor"
-	},
-/area/f13/brotherhood/rnd)
 "uSI" = (
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -23213,36 +19996,28 @@
 	},
 /area/f13/tunnel)
 "uTy" = (
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 16
 	},
-/obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
-	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/leisure)
-"uTL" = (
-/obj/structure/flora/junglebush/large,
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"uTT" = (
-/obj/machinery/reagentgrinder{
-	pixel_y = 9
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/leisure)
 "uUk" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/item/trash/cheesie,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 4;
+	name = "Medical Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "uVp" = (
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/floor/f13{
@@ -23279,22 +20054,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"uWn" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
-"uWA" = (
-/obj/structure/destructible/clockwork/wall_gear,
-/obj/machinery/light/floor,
-/obj/effect/temp_visual/impact_effect/blue_laser,
-/obj/effect/decal/cleanable/glitter/blue,
-/turf/closed/wall/mineral/iron,
-/area/f13/brotherhood/rnd)
 "uWC" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/hos,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/medical)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "uXs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/mattress{
@@ -23302,67 +20070,31 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"uXT" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"uXY" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"uYd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"uZa" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 30;
-	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 10, /obj/item/reagent_containers/pill/patch/silver_sulf = 10, /obj/item/reagent_containers/medspray/styptic = 4, /obj/item/reagent_containers/medspray/silver_sulf = 4, /obj/item/reagent_containers/pill/charcoal = 2, /obj/item/reagent_containers/medspray/sterilizine = 2)
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
 "uZy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/workbench/forge,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uZG" = (
-/obj/structure/simple_door/bunker{
-	name = "Locker Room"
+/obj/structure/rack,
+/obj/item/shield/riot/bullet_proof,
+/obj/item/shield/riot/bullet_proof,
+/obj/item/pda/warden{
+	desc = "The RobCo PipBoy. This one is only issued to the acting Armory Warden.";
+	name = "Armory Warden PDA"
 	},
+/obj/item/pda/warden{
+	desc = "The RobCo PipBoy. This one is only issued to the acting Armory Warden.";
+	name = "Armory Warden PDA"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/operations)
-"uZS" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	layer = 3.1;
-	pixel_x = 12;
-	pixel_y = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 12
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "vaf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -23399,19 +20131,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"vch" = (
-/obj/structure/frame/machine,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "vcL" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -23425,13 +20144,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"vdk" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "ven" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -23490,33 +20202,16 @@
 	},
 /area/f13/tunnel)
 "vfx" = (
-/obj/effect/landmark/start/f13/scribe,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10
+/obj/structure/toilet{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices2nd)
 "vfL" = (
 /obj/machinery/mineral/ore_redemption,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"vfQ" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm8";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood/leisure)
-"vfU" = (
-/obj/structure/sign/poster/prewar/poster71,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
 "vgo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/tools{
@@ -23526,11 +20221,11 @@
 /area/f13/tunnel)
 "vgW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "vhO" = (
@@ -23543,31 +20238,11 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/tunnel)
-"vid" = (
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"viv" = (
-/obj/structure/decoration/rag,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
-"vjx" = (
-/obj/structure/grille,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "vkb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
 "vkc" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -23602,53 +20277,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"vlo" = (
-/obj/structure/filingcabinet/employment,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "vmm" = (
 /turf/closed/wall{
 	icon_state = "fwall_opening"
 	},
 /area/f13/tunnel)
-"vmx" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/closet/radiation,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"vna" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/water,
-/area/f13/brotherhood/rnd)
-"vng" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = 33
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "vnJ" = (
 /obj/item/instrument/guitar,
 /obj/structure/rack,
@@ -23693,18 +20326,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"vnZ" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "vof" = (
-/obj/item/paper_bin,
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/fulltile/store,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/item/pen/fountain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/medical)
 "vov" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13{
@@ -23715,17 +20344,6 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"voZ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "vpz" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs"
@@ -23735,50 +20353,17 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"vqm" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "vqo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/simple_door/bunker{
+	name = "Star Knight Office";
+	req_access = 120;
+	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "rampdowntop"
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/operations)
-"vqD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/item/statuebust{
-	pixel_y = 15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"vqH" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
 "vra" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -23786,34 +20371,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"vrv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/leisure)
-"vrC" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "vrD" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"vrH" = (
-/obj/structure/bed,
-/obj/item/bedsheet/rd{
-	desc = "A fine quilted blanket, made with purple and yellow fabric.";
-	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
-	name = "fine bedsheet"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
 "vsC" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood{
@@ -23821,8 +20384,9 @@
 	},
 /area/f13/tunnel)
 "vsI" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/water,
+/area/f13/caves)
 "vsJ" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13{
@@ -23830,43 +20394,14 @@
 	},
 /area/f13/clinic)
 "vsT" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
-"vsW" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/turf/open/water,
-/area/f13/brotherhood/rnd)
+/obj/effect/landmark/start/f13/knightcap,
+/turf/open/floor/wood,
+/area/f13/brotherhood/offices1st)
 "vtz" = (
 /obj/machinery/door/airlock/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -23908,11 +20443,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"vvR" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/leisure)
 "vwa" = (
 /obj/structure/chair/wood/modern{
 	dir = 8;
@@ -23926,12 +20456,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"vwp" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
 "vxm" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -23945,63 +20469,16 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"vxo" = (
-/obj/structure/flora/junglebush/b,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "vxs" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"vxR" = (
-/obj/item/candle{
-	pixel_y = 7
-	},
-/turf/open/floor/circuit/red/anim{
-	light_range = 2.5
-	},
-/area/f13/brotherhood/rnd)
-"vyb" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
-"vyg" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
 "vyN" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"vyQ" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
-/area/f13/brotherhood/operations)
 "vzL" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -24019,12 +20496,6 @@
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"vAK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 6
-	},
-/area/f13/brotherhood/reactor)
 "vAM" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -24036,12 +20507,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"vBG" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "vBO" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24076,14 +20541,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"vCL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 5
-	},
-/area/f13/brotherhood/mining)
 "vCM" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -24097,15 +20554,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vDn" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
 "vDC" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "vEd" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -24113,13 +20572,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"vEe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance{
-	name = "Power"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
 "vEA" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -24143,15 +20595,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "vFa" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "proctorbathroom";
-	req_access_txt = "120"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/mining)
 "vFl" = (
 /obj/machinery/light{
 	dir = 1
@@ -24184,9 +20633,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
-"vHQ" = (
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "vIp" = (
 /obj/structure/showcase/horrific_experiment{
 	icon_state = "pod_0"
@@ -24195,39 +20641,17 @@
 	icon_state = "grass2"
 	},
 /area/f13/clinic)
-"vIu" = (
-/obj/structure/chair/right{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"vIL" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "vJC" = (
-/obj/structure/window/reinforced/tinted/frosted,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/structure/mirror{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/leisure)
-"vJX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "vKh" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -24235,24 +20659,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "vKm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
 "vKF" = (
-/obj/machinery/door/window/eastright,
-/obj/machinery/light,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "vKT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "vLg" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/landmark/start/f13/followersadministrator,
@@ -24260,10 +20678,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"vLy" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "vLO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -24273,28 +20687,26 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"vMi" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/rnd)
 "vMm" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
+/obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/medical)
 "vMx" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/decoration/vent,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4;
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	pixel_y = -6
+	},
+/turf/open/indestructible/ground/outside/water{
+	desc = "Deep, filtered pool water.";
+	name = "pool water"
+	},
 /area/f13/brotherhood/leisure)
 "vMO" = (
 /obj/machinery/light{
@@ -24311,87 +20723,18 @@
 	},
 /area/f13/sewer)
 "vNF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = 33
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
-"vNU" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"vOf" = (
-/obj/structure/simple_door/bunker{
-	name = "Star Paladin Office";
-	req_access = 120;
-	req_access_txt = "120"
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
-"vOo" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/obj/structure/window/reinforced/spawner{
-	color = "#777777";
-	dir = 0;
-	max_integrity = 5000;
-	name = "ultra-reinforced window"
-	},
-/obj/machinery/light/floor,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"vOR" = (
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/mining)
-"vPd" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/light,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/reactor)
+"vOo" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vPw" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -24399,13 +20742,22 @@
 	},
 /area/f13/tunnel)
 "vPB" = (
-/obj/machinery/chem_heater,
-/obj/item/toy/figure/chemist{
-	layer = 2.8;
-	name = "Scribe action figure";
-	toysay = "Ad meliora."
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "boscheckpointmedical";
+	name = "Research Checkpoint Button";
+	pixel_x = -25;
+	req_one_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "vQn" = (
 /obj/effect/decal/waste{
@@ -24418,28 +20770,38 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQx" = (
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices2nd)
-"vQJ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/item/reagent_containers/food/snacks/grown/poppy{
+	pixel_x = 4;
+	pixel_y = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/item/reagent_containers/food/snacks/grown/poppy/geranium{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/snacks/grown/poppy/lily{
+	pixel_y = -5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/blackred,
+/obj/item/candle{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/turf/open/floor/mineral/plastitanium/airless,
+/area/f13/brotherhood/rnd)
 "vQU" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
-"vQZ" = (
+/obj/machinery/iv_drip{
+	pixel_x = 13;
+	pixel_y = 2
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/medical)
 "vSd" = (
 /obj/effect/landmark/start/f13/settler,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24451,23 +20813,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/followers)
-"vTk" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"vTF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	dir = 4
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "vTH" = (
 /obj/structure/barricade/wooden{
 	layer = 2.5
@@ -24483,34 +20828,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"vUF" = (
-/obj/item/instrument/guitar,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
 "vUM" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"vUY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "vVg" = (
-/obj/structure/table{
-	layer = 2.9
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/obj/machinery/computer/terminal{
-	dir = 1;
-	pixel_x = 16;
-	pixel_y = 8;
-	termtag = "Business"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "vVz" = (
 /obj/structure/bookcase,
@@ -24574,22 +20899,6 @@
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/tunnel)
-"vXo" = (
-/turf/closed/indestructible/opshuttle,
-/area/f13/brotherhood/medical)
-"vXr" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Power"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/reactor)
-"vXx" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/f13/brotherhood/operations)
 "vXF" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/reagent_dispensers/fueltank,
@@ -24618,38 +20927,26 @@
 "vYw" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
-"vYx" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "vYC" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "vZj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "vZr" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
+/turf/open/water,
+/area/f13/caves)
 "vZI" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/trash,
@@ -24675,33 +20972,19 @@
 /turf/closed/wall/r_wall,
 /area/f13/tunnel)
 "wac" = (
-/obj/structure/safe/floor,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
 /area/f13/brotherhood/offices1st)
-"wao" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "waU" = (
-/obj/structure/falsewall/wood{
-	layer = 3;
-	name = "steam generator shutter"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/smoke_machine{
-	desc = "An old world machine with a centrifuge installed into it. It produces steam with any reagents you put into the machine.";
-	name = "Steam Generator"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/closed/wall/f13/wood,
 /area/f13/brotherhood/leisure)
 "wbh" = (
 /obj/item/reagent_containers/pill/patch/turbo,
@@ -24713,15 +20996,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"wbM" = (
-/obj/item/flag/bos,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "wcm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -24740,51 +21014,21 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/tunnel)
-"wdL" = (
-/obj/structure/dresser,
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
-"wdW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/leisure)
-"wef" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "bosengine";
-	name = "Radiation Shutters";
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"weu" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/offices1st)
 "weF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
-"weR" = (
-/obj/structure/closet/secure_closet/contraband/armory{
-	req_access_txt = "120"
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/syndicate/brotherhood,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/obj/item/clothing/head/helmet/f13/power_armor/t45d,
-/obj/item/clothing/suit/armor/f13/power_armor/t45d/knightcaptain,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/offices1st)
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "weW" = (
 /turf/open/water,
 /area/f13/tunnel)
@@ -24818,10 +21062,6 @@
 /obj/effect/landmark/start/f13/settler,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
-"wfH" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "wgg" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -24867,29 +21107,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"wkR" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/clock/active{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
-"wmE" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
 "wmT" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -24907,9 +21124,6 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"wox" = (
-/turf/closed/indestructible/opshuttle,
-/area/f13/brotherhood/mining)
 "wpJ" = (
 /obj/structure/barricade/bars,
 /obj/structure/curtain{
@@ -24925,13 +21139,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
-"wqL" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "wqW" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
@@ -24968,46 +21175,10 @@
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"wtB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
-"wtT" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
-"wue" = (
-/obj/structure/simple_door/bunker{
-	name = "Locker Room"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "wuf" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wug" = (
-/obj/machinery/vending/coffee,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "wus" = (
 /obj/structure/curtain,
 /turf/open/floor/f13{
@@ -25020,12 +21191,6 @@
 /obj/item/flashlight,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"wuE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 8
-	},
-/area/f13/brotherhood/mining)
 "wuM" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -25040,31 +21205,10 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"wwp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	frequency = 1891;
-	pixel_x = 33
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "wwU" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"wxb" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "wyl" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -25072,13 +21216,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"wyy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "wAe" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	icon_state = "neutralrusty"
@@ -25089,28 +21226,14 @@
 /obj/structure/wreck/trash/engine,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"wCV" = (
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
-	name = "Head Scribe's Archive Terminal"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "wDm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/photosynthetic,
-/obj/structure/decoration/hatch{
-	desc = "That's pretty nifty.";
-	dir = 1;
-	name = "Plant Water Drain";
-	pixel_y = -13
+/obj/structure/lattice{
+	layer = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"wDq" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
-/area/f13/brotherhood/mining)
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/rnd)
 "wDz" = (
 /obj/structure/closet/fridge/standard,
 /obj/item/reagent_containers/food/condiment/yeast,
@@ -25142,37 +21265,19 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"wEX" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "wFu" = (
-/obj/effect/landmark/start/f13/initiate,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/medical)
 "wFx" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/supermart,
 /area/f13/tunnel)
-"wFF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
-/area/f13/brotherhood/reactor)
 "wFL" = (
 /obj/structure/chair{
 	dir = 8
@@ -25198,51 +21303,18 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"wJl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker{
-	name = "Pool"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "wJQ" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
 	},
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/operations)
-"wKm" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices1st)
 "wKF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -25255,14 +21327,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wKL" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "wLM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -25292,48 +21359,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wNi" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"wNs" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster70";
-	pixel_x = 31
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
-"wNJ" = (
-/obj/structure/table/wood/bar,
-/obj/machinery/reagentgrinder{
-	pixel_x = -7;
-	pixel_y = 16
-	},
-/obj/item/crafting/coffee_pot{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/storage/box/drinkingglasses{
-	pixel_x = -16;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/shamblers_juice{
-	pixel_y = 31
-	},
-/turf/open/floor/wood/wood_tiled,
-/area/f13/brotherhood/leisure)
 "wOg" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -25341,19 +21366,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wOp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"wPy" = (
-/obj/structure/filingcabinet/filingcabinet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/rnd)
-"wPV" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -25376,47 +21396,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wQJ" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "wQS" = (
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -10;
-	pixel_y = 22
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "bosaccesscontrol";
-	normaldoorcontrol = 1;
-	pixel_x = 12;
-	pixel_y = 22;
-	specialfunctions = 4
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
-"wSC" = (
-/obj/effect/decal/cleanable/robot_debris,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"wTF" = (
-/obj/effect/turf_decal/arrows/white,
+/obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/medical)
+"wTF" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = null;
+	req_access_txt = "120"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "wUi" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -25425,10 +21420,6 @@
 /obj/item/mining_scanner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wUr" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "wUv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25442,12 +21433,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"wUT" = (
-/obj/machinery/autolathe/ammo,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/rnd)
 "wVl" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -25459,21 +21444,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"wVK" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/machinery/light/small,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"wVN" = (
-/obj/effect/decal/cleanable/flour,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "wWc" = (
 /obj/machinery/button/crematorium{
 	pixel_y = 19
@@ -25488,16 +21458,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"wWM" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "wXG" = (
 /obj/structure/decoration/warning{
 	pixel_y = -2
@@ -25522,22 +21482,24 @@
 	},
 /area/f13/tunnel)
 "wZZ" = (
-/obj/item/paper_bin{
-	pixel_y = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/item/flag/bos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/item/cigbutt,
-/obj/structure/table{
-	pixel_y = 6
-	},
-/obj/item/pen/fourcolor{
-	pixel_y = 8
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/operations)
 "xak" = (
-/obj/structure/grille,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/kirbyplants{
+	pixel_y = 14
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "xas" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -25564,18 +21526,10 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
-"xcx" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "xcC" = (
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
+/obj/structure/nest/mirelurk,
+/turf/open/water,
+/area/f13/caves)
 "xcH" = (
 /obj/structure/noticeboard{
 	pixel_x = 32
@@ -25590,31 +21544,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"xdB" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	pixel_x = 13
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fence/handrail_corner{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = 13;
-	pixel_y = 16
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_x = -2;
-	pixel_y = 16
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "xdS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -25632,12 +21561,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"xeO" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/broken_bottle,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "xfb" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
@@ -25655,11 +21578,8 @@
 	},
 /area/f13/tunnel)
 "xfh" = (
-/obj/structure/bodycontainer/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "xfu" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -25680,10 +21600,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"xgu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/bronze,
-/area/f13/brotherhood/rnd)
 "xgY" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibtorso"
@@ -25717,18 +21633,16 @@
 	},
 /area/f13/tunnel)
 "xiI" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	pixel_y = 27
+/obj/machinery/conveyor/auto{
+	dir = 1
 	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/curtain{
-	color = "#5c131b"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/mining)
 "xjk" = (
 /obj/structure/chair/bench,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -25740,8 +21654,10 @@
 /area/f13/tunnel)
 "xjE" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "xkd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -25761,76 +21677,35 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"xks" = (
-/obj/structure/sign/poster/contraband/smoke{
-	pixel_y = -32
-	},
-/obj/machinery/camera/autoname{
-	dir = 1;
-	name = "RnD Checkpoint Camera";
-	network = list("BoS")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "xkx" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"xkB" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice{
-	layer = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "xkH" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xkQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"xly" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/cable_coil/cut/red,
-/obj/structure/grille,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/medical)
 "xlL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/medical)
+/obj/machinery/door/window/eastright,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/brotherhood/offices2nd)
 "xmk" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/terminal{
-	termtag = "Secret"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/offices1st)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/reactor)
 "xmQ" = (
-/obj/structure/bookcase/random,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/computer/terminal{
+	pixel_x = -3;
+	pixel_y = -3;
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "xmX" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -25840,17 +21715,6 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/tunnel)
-"xnb" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "xnk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -25861,60 +21725,29 @@
 	icon_state = "dark"
 	},
 /area/f13/bunker)
-"xnV" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"xoo" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "xop" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xoU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"xpo" = (
-/obj/structure/closet/crate/large,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xpu" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "xqa" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "xqd" = (
 /obj/effect/decal/remains,
@@ -25926,34 +21759,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "xrz" = (
-/obj/machinery/smartfridge/food,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"xrA" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"xsk" = (
-/obj/structure/fence/handrail_end/non_dense{
-	pixel_x = -16;
-	pixel_y = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side,
-/area/f13/brotherhood/mining)
-"xss" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/corner{
-	dir = 1
-	},
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/leisure)
 "xsL" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -25981,12 +21791,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"xwI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
 "xxn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -26045,10 +21849,19 @@
 	},
 /area/f13/tunnel)
 "xAn" = (
-/obj/structure/chair/f13chair1,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/f13/brotherhood/leisure)
+/obj/structure/simple_door/blast{
+	max_integrity = 10000;
+	name = "bunker entry";
+	req_access_txt = "120"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "bosdoors";
+	name = "brotherhood shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "xAw" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -26059,16 +21872,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xCf" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	icon_state = "conveyor_map"
-	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "engine"
-	},
-/area/f13/brotherhood/mining)
 "xCv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/booth{
@@ -26077,11 +21880,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xCN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/medical)
 "xDr" = (
 /obj/machinery/light{
 	dir = 4;
@@ -26091,12 +21894,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
-"xDy" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "xEd" = (
 /obj/structure/closet/crate/freezer{
 	storage_capacity = 30
@@ -26156,62 +21953,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"xGl" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/brotherhood/rnd)
 "xGp" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1;
-	pixel_y = 6
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Pink{
-	critical_machine = 1;
-	dir = 1;
-	flicker_chance = 0
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
-"xGu" = (
-/obj/item/am_containment{
-	pixel_x = 3
-	},
-/obj/structure/table/reinforced,
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/structure/window/plasma/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1
-	},
-/obj/item/am_containment,
-/obj/item/am_containment{
-	pixel_x = -3
-	},
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner,
-/area/f13/brotherhood/reactor)
 "xGV" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
@@ -26243,16 +21993,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"xIN" = (
-/obj/structure/table/reinforced,
-/obj/item/pda/engineering{
-	name = "Knight-Engineer Pip-Boy 3000"
-	},
-/obj/item/pda/engineering{
-	name = "Knight-Engineer Pip-Boy 3000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "xJE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -26260,31 +22000,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"xJR" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "xLd" = (
 /obj/structure/table/snooker{
 	dir = 10
@@ -26295,37 +22010,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"xLA" = (
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"xMa" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	dir = 4;
-	layer = 3.1;
-	pixel_x = -16
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"xMi" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/mining)
 "xMx" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "xNs" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/conveyor/auto{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/mining)
 "xNu" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -26333,19 +22029,14 @@
 	},
 /area/f13/tunnel)
 "xNC" = (
-/obj/item/radio/intercom{
-	desc = "Is there anyone on the other end? Who's in there?";
-	frequency = 1291;
-	name = "Mysterious Intercom";
-	pixel_y = null
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
-"xND" = (
-/obj/effect/landmark/start/f13/scribe,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/offices1st)
 "xOj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/sunglasses{
@@ -26373,36 +22064,42 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xQT" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/floor/plating/ashplanet/wateryrock{
-	baseturfs = /turf/open/floor/plating/f13/outside/desert
-	},
-/area/f13/caves)
 "xRm" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"xRU" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/integrated_electronics/debugger,
-/obj/item/integrated_electronics/wirer,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_circuit_printer,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/fence/handrail{
+	density = 0;
+	dir = 4;
+	layer = 3.1;
+	pixel_x = -16
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/brotherhood/operations)
 "xRW" = (
-/turf/closed/wall/f13/wood,
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/blueprint/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/flashlight/lamp{
+	light_color = "#00FFFF";
+	pixel_x = -14;
+	pixel_y = 9
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "xSb" = (
 /obj/structure/bookcase/manuals,
@@ -26411,27 +22108,10 @@
 	},
 /area/f13/followers)
 "xSi" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = 11;
-	pixel_y = 22
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 4;
-	pixel_y = 10
-	},
-/obj/machinery/computer/terminal{
-	dir = 4;
-	pixel_y = -6;
-	termtag = "Secret"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "xSY" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -26456,21 +22136,6 @@
 "xVz" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xVV" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_y = -32;
-	req_one_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "xVW" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/f13{
@@ -26478,8 +22143,8 @@
 	},
 /area/f13/clinic)
 "xXc" = (
-/obj/structure/decoration/smokeold,
-/turf/closed/wall/r_wall,
+/obj/structure/dresser,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "xXU" = (
 /obj/structure/closet,
@@ -26509,93 +22174,34 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier7,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"xYS" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/rnd)
 "xYV" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"xYX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 10
-	},
-/area/f13/brotherhood/mining)
-"xYY" = (
-/obj/structure/chair/bench{
-	icon_state = "dropshipright"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/rnd)
 "xZd" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"xZj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "xZH" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"xZI" = (
-/obj/structure/table/wood/fancy/black{
-	desc = "A set of thin pipes that no longer function.";
-	icon_state = "latticefull";
-	layer = 2.4;
-	name = "pipes"
-	},
-/obj/item/statuebust,
-/obj/structure/table{
-	icon_state = "1-f"
-	},
-/obj/structure/table{
-	icon_state = "2-f"
-	},
-/obj/structure/table{
-	icon_state = "3-f"
-	},
-/obj/structure/table{
-	icon_state = "4-f"
-	},
-/obj/structure/window/reinforced/clockwork/fulltile,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/rnd)
 "yaO" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/brotherhood/rnd)
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "ybf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"ybF" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/carpet/purple,
-/area/f13/brotherhood/rnd)
 "ycc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -26612,30 +22218,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ydv" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
-"ydE" = (
-/obj/structure/window/spawner/north,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
-"ydF" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
-"ydK" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 1
-	},
-/area/f13/brotherhood/mining)
 "ydV" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -26643,16 +22225,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "yej" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/door/window/northleft,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/operations)
 "yeD" = (
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/bodycontainer/morgue{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/brotherhood/medical)
 "yeZ" = (
 /obj/structure/table/booth,
@@ -26694,53 +22278,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"ygM" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "yhd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "yhT" = (
 /turf/closed/indestructible/opshuttle,
-/area/f13/brotherhood/offices2nd)
-"yjo" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	critical_machine = 1;
-	dir = 4;
-	flicker_chance = 0;
-	name = "light fixture"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/leisure)
-"ykT" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/caves)
 
 (1,1,1) = {"
 eLE
@@ -69409,7 +64958,7 @@ eLE
 uoO
 uoO
 aoj
-aoj
+aBQ
 aoj
 uoO
 uoO
@@ -71217,7 +66766,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
 aoj
 uoO
 uoO
@@ -71296,6 +66844,7 @@ uoO
 uoO
 aoj
 aoj
+uoO
 uoO
 uoO
 uoO
@@ -71465,7 +67014,6 @@ eLE
 uoO
 uoO
 uoO
-uoO
 aoj
 aoj
 aoj
@@ -71553,6 +67101,7 @@ uoO
 uoO
 aoj
 aoj
+uoO
 uoO
 uoO
 uoO
@@ -71719,12 +67268,6 @@ eLE
 "}
 (176,1,1) = {"
 eLE
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
 aoj
 uoO
 uoO
@@ -71810,6 +67353,12 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -71978,12 +67527,6 @@ eLE
 eLE
 uoO
 uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 uoO
@@ -72067,6 +67610,12 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -72235,12 +67784,6 @@ eLE
 eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -72304,9 +67847,19 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+scG
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 aoj
 aoj
@@ -72321,15 +67874,11 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
 uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -72492,12 +68041,6 @@ eLE
 eLE
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -72561,32 +68104,38 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
 uoO
 uoO
 uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -72749,12 +68298,6 @@ eLE
 eLE
 uoO
 uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -72818,6 +68361,18 @@ uoO
 uoO
 uoO
 uoO
+aoj
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -72826,12 +68381,8 @@ aoj
 aoj
 uoO
 uoO
+uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -72841,9 +68392,7 @@ aoj
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -73006,12 +68555,6 @@ eLE
 eLE
 uoO
 uoO
-uoO
-aoj
-uoO
-aoj
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -73044,40 +68587,21 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-uoO
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
+aBQ
 aoj
 aoj
 uoO
 aoj
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -73095,7 +68619,32 @@ uoO
 uoO
 uoO
 aoj
+xVz
+xVz
+xVz
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -73264,12 +68813,6 @@ eLE
 uoO
 uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 aoj
 aoj
 uoO
@@ -73332,6 +68875,12 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+xVz
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -73342,6 +68891,12 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -73351,13 +68906,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 uoO
@@ -73533,12 +69082,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
@@ -73587,6 +69130,13 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+aoj
+aoj
+aoj
+xVz
+aoj
 uoO
 uoO
 uoO
@@ -73598,13 +69148,12 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -73808,12 +69357,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -73846,17 +69389,11 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+xVz
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -73870,6 +69407,18 @@ uoO
 uoO
 aoj
 aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -74073,12 +69622,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -74103,16 +69646,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+xVz
+uiV
+aoj
 uoO
 uoO
 uoO
@@ -74127,6 +69664,18 @@ uoO
 uoO
 aoj
 aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -74316,12 +69865,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
@@ -74360,21 +69903,10 @@ aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+xVz
+xVz
+rZw
 uoO
 uoO
 uoO
@@ -74384,6 +69916,23 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -74551,12 +70100,6 @@ uoO
 uoO
 uoO
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 aoj
 aoj
 uoO
@@ -74618,13 +70161,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+rZw
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -74642,8 +70181,18 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
+aoj
+aoj
+uoO
 aoj
 aoj
 aoj
@@ -74807,12 +70356,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 aoj
@@ -74875,6 +70418,18 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -74884,19 +70439,13 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 aoj
@@ -75063,12 +70612,6 @@ eLE
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
@@ -75124,7 +70667,7 @@ uoO
 uoO
 uoO
 uoO
-lsy
+uoO
 aoj
 aoj
 aoj
@@ -75132,6 +70675,9 @@ uoO
 uoO
 uoO
 uoO
+xVz
+uoO
+xVz
 uoO
 uoO
 uoO
@@ -75139,6 +70685,8 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -75146,14 +70694,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 aoj
@@ -75317,12 +70866,6 @@ eLE
 "}
 (190,1,1) = {"
 eLE
-aoj
-uoO
-uoO
-uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -75388,29 +70931,35 @@ aoj
 uoO
 uoO
 uoO
+aoj
+xVz
+xVz
+xVz
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
 aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 aoj
@@ -75574,12 +71123,6 @@ eLE
 "}
 (191,1,1) = {"
 eLE
-aoj
-uoO
-uoO
-uoO
-aoj
-uoO
 uoO
 uoO
 uoO
@@ -75645,6 +71188,11 @@ aoj
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -75652,14 +71200,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -75841,12 +71390,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 uoO
@@ -75884,6 +71427,12 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -75899,6 +71448,8 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -75906,11 +71457,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -75920,7 +71470,6 @@ uoO
 uoO
 uoO
 aoj
-uoO
 uoO
 uoO
 uoO
@@ -76097,12 +71646,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -76144,6 +71687,11 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -76157,6 +71705,16 @@ uoO
 uoO
 uoO
 uoO
+xVz
+xVz
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -76167,22 +71725,13 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 aoj
@@ -76361,12 +71910,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
 aoj
@@ -76404,6 +71947,24 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+aoj
 uoO
 uoO
 uoO
@@ -76421,20 +71982,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -76604,6 +72153,20 @@ eLE
 eLE
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -76620,28 +72183,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -76675,6 +72218,10 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+xVz
+aoj
 uoO
 uoO
 uoO
@@ -76684,6 +72231,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -76691,14 +72247,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 aoj
@@ -76861,15 +72410,9 @@ eLE
 eLE
 uoO
 uoO
+uoO
 aoj
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -76890,17 +72433,17 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -76933,15 +72476,10 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+xVz
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -76955,7 +72493,18 @@ aoj
 uoO
 uoO
 uoO
+uoO
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
 uoO
 aoj
 aoj
@@ -77118,20 +72667,7 @@ eLE
 eLE
 uoO
 uoO
-aoj
-aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 aoj
 aoj
 uoO
@@ -77145,8 +72681,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
 uoO
 uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -77187,6 +72730,13 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
 uoO
 aoj
 aoj
@@ -77195,20 +72745,19 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -77376,14 +72925,8 @@ eLE
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -77402,7 +72945,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -77444,22 +72987,16 @@ uoO
 uoO
 uoO
 uoO
-uoO
-aoj
 aoj
 uoO
 uoO
 uoO
+xVz
+xVz
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -77467,9 +73004,21 @@ uoO
 uoO
 aoj
 aoj
+aoj
+uoO
 uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -77633,14 +73182,8 @@ eLE
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -77696,7 +73239,21 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -77705,14 +73262,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -77891,6 +73440,7 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
@@ -77911,15 +73461,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -77953,16 +73496,17 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -77975,7 +73519,12 @@ uoO
 uoO
 uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -77983,7 +73532,7 @@ aoj
 aoj
 aoj
 aoj
-aoj
+uoO
 uoO
 uoO
 uoO
@@ -78148,42 +73697,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -78212,6 +73727,49 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -78232,16 +73790,7 @@ uoO
 uoO
 uoO
 aoj
-aoj
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 aoj
 aoj
 aoj
@@ -78407,12 +73956,6 @@ uoO
 uoO
 aoj
 aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -78431,6 +73974,8 @@ aoj
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -78440,39 +73985,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -78490,14 +74011,42 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+aoj
 aoj
 uoO
 uoO
-aoj
+uoO
 aoj
 aoj
 aoj
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+aoj
 aoj
 aoj
 aoj
@@ -78658,32 +74207,11 @@ eLE
 "}
 (203,1,1) = {"
 eLE
-uoO
-uoO
-uoO
-uoO
-aoj
-uoO
 aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
-uoO
 aoj
 uoO
 uoO
@@ -78697,6 +74225,20 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -78706,34 +74248,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -78753,25 +74268,24 @@ uoO
 uoO
 aoj
 aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+xVz
+xVz
 aoj
 aoj
 uoO
 uoO
 uoO
-uoO
+xVz
+uiV
+aoj
 uoO
 uoO
 uoO
@@ -78782,6 +74296,41 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -78918,6 +74467,8 @@ eLE
 uoO
 uoO
 uoO
+uoO
+aoj
 aoj
 uoO
 uoO
@@ -78930,14 +74481,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
@@ -78950,29 +74493,9 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -79002,31 +74525,24 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
 aoj
 aoj
 uoO
 uoO
-uoO
+vOo
+xVz
+smf
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -79038,8 +74554,41 @@ uoO
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79177,71 +74726,12 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -79267,11 +74757,6 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-uoO
 uoO
 uoO
 uoO
@@ -79293,10 +74778,74 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+lEl
+rEl
 aoj
 aoj
 aoj
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79438,66 +74987,6 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
 aoj
 aoj
 uoO
@@ -79521,6 +75010,22 @@ aoj
 aoj
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -79532,7 +75037,59 @@ uoO
 aoj
 uoO
 uoO
-epe
+aoj
+aoj
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+xVz
+xVz
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79543,17 +75100,9 @@ uoO
 aoj
 aoj
 uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -79686,64 +75235,19 @@ eLE
 "}
 (207,1,1) = {"
 eLE
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-tHG
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
-oeY
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79753,11 +75257,16 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79780,13 +75289,26 @@ aoj
 aoj
 uoO
 uoO
+uoO
+uoO
 aoj
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
 uoO
 uoO
 aoj
+aoj
+aoj
+uoO
+uoO
+xVz
+uoO
+uoO
+uoO
 uoO
 xVz
 xVz
@@ -79795,8 +75317,33 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -79809,8 +75356,10 @@ uoO
 uoO
 aoj
 aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -79943,66 +75492,13 @@ eLE
 "}
 (208,1,1) = {"
 eLE
-tHG
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-oeY
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80012,10 +75508,18 @@ uoO
 aoj
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -80041,9 +75545,27 @@ uoO
 aoj
 aoj
 aoj
+aoj
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+xVz
+uoO
+uoO
+uoO
 xVz
 xVz
 xVz
@@ -80056,6 +75578,13 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80064,8 +75593,28 @@ aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80200,66 +75749,13 @@ eLE
 "}
 (209,1,1) = {"
 eLE
-tHG
-jZH
-nSI
-iDP
-cfA
-xeO
-cfA
-ryy
-mAQ
-ryy
-cfA
-cfA
-cfA
-cfA
-vnZ
-enl
-hJk
-xZj
-xZj
-xZj
-uLP
-hcx
-ppt
-ppt
-qZt
-pDU
-uKD
-oNM
-aYY
-hVk
-weu
-ujt
-iqN
-sam
-sef
-ujt
-qdj
-pAn
-vYw
-nwA
-isj
-nPp
-vYw
-ulA
-tKy
-vYw
-tKy
-saF
-tKy
-nHR
-qfK
-epa
-vYw
-oeY
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80268,6 +75764,18 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 uoO
 uoO
@@ -80288,11 +75796,12 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
 uoO
 uoO
 uoO
@@ -80301,9 +75810,28 @@ uoO
 uoO
 uoO
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+xVz
+uoO
+uoO
 xVz
 xVz
 xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -80316,16 +75844,37 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
 uoO
 uoO
 aoj
-uoO
+aoj
+aoj
+aoj
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80457,92 +76006,60 @@ eLE
 "}
 (210,1,1) = {"
 eLE
-tHG
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-oDP
-jZH
-jZH
-jZH
-jZH
-jZH
-qhw
-jZH
-jZH
-qhw
-jZH
-jZH
-jZH
-jZH
-jZH
-jZH
-oDP
-jZH
-jZH
-jZH
-vYw
-vYw
-vYw
-vYw
-vlo
-mZX
-mAm
-vYw
-dRZ
-ktE
-tlc
-vYw
-vwp
-aqB
-jYj
-vYw
-tvj
-tKy
-vOf
-tKy
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+yhT
 xmk
-dlT
-vYw
-qfK
-qfK
-vYw
-oeY
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
+xmk
+xmk
+xmk
+xmk
+xmk
+yhT
 uoO
 uoO
 uoO
@@ -80557,10 +76074,40 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 xVz
+uoO
+uoO
+uoO
+xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -80575,12 +76122,14 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80714,74 +76263,60 @@ eLE
 "}
 (211,1,1) = {"
 eLE
-tHG
+yhT
 jZH
-nCi
-haB
-vJC
-aHH
-tKJ
-arg
-kZQ
-ovL
-wJl
-nMG
-nMG
-fxA
-wdW
-dZW
-wdW
-obV
 jZH
-nWO
-faa
-cFd
-cfk
-uHP
 jZH
-oeJ
-hng
-kjU
-dEq
-lLA
-vYw
-bta
-mZX
-mAm
-ldi
-vQJ
-cly
-aej
-vYw
-bRN
-hoj
-vYw
-vYw
-tKy
-tKy
-bFi
-tKy
-tKy
-tKy
-vYw
-aHM
+jZH
+jZH
+jZH
+bOf
+yhT
+yhT
+yhT
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+yhT
+xmk
+hYS
 eub
-vYw
-oeY
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
+eub
+eub
+xmk
+yhT
 uoO
 uoO
 uoO
@@ -80792,33 +76327,46 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+lEl
 uoO
 uoO
 uoO
-uoO
-uoO
-aoj
-uoO
-aoj
 uoO
 uoO
 xVz
+xVz
+xVz
+xVz
+xVz
 uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -80831,13 +76379,14 @@ uoO
 uoO
 uoO
 aoj
-aoj
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -80971,60 +76520,28 @@ eLE
 "}
 (212,1,1) = {"
 eLE
-tHG
+yhT
 jZH
 pkW
-jZH
+aCS
 ajc
 aHH
 vkb
-arg
-tHq
-ucY
 jZH
-nMG
-kHh
-uml
-jSx
-jSx
-jSx
-mbV
 jZH
-liD
-uHP
-aDN
-uHP
-uHP
-ufZ
-uHP
-aDN
-uHP
-uHP
-tLS
-vYw
-mkC
-mZX
-mAm
-jcl
-ijT
-cly
-mqJ
-pgt
-ydF
-xwI
-gfz
-vYw
-tKy
-tKy
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-oeY
+jZH
+jZH
+yhT
+yhT
+yhT
+yhT
+yhT
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -81046,38 +76563,44 @@ uoO
 uoO
 uoO
 uoO
+yhT
+yhT
+yhT
+yhT
+xmk
+hYS
+ogl
+ogl
+ogl
+xmk
+yhT
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 aoj
 uoO
 uoO
-aoj
-aoj
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-aoj
+lEl
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 xVz
 uoO
 uoO
 uoO
 uoO
-uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -81090,11 +76613,37 @@ uoO
 aoj
 aoj
 uoO
-aoj
-aoj
+uoO
+uoO
 uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -81228,63 +76777,32 @@ eLE
 "}
 (213,1,1) = {"
 eLE
-tHG
+yhT
 jZH
 nCi
 vMx
-glQ
-mjU
-uwd
-arg
+ajc
+saw
+bxX
+bRN
+cus
+cus
 jZH
 jZH
 jZH
-eMO
-kHh
-jSx
-jSx
-jSx
-jSx
-mbV
 jZH
-rLI
-uHP
-wVN
-tXJ
-hpM
 jZH
-jge
-gse
-hng
-uHP
-tAD
-vYw
-xLA
-mZX
-fBQ
-aWq
-iqE
-cly
-heI
-vYw
-kbf
-aqB
-tVL
-vYw
-tKy
-tKy
-vYw
-tKy
-saF
-tKy
-nHR
-qfK
-epa
-vYw
-oeY
+jZH
+yhT
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
+uoO
 aoj
 uoO
 uoO
@@ -81301,42 +76819,67 @@ uoO
 uoO
 uoO
 uoO
-cSG
-cSG
-cSG
-cSG
-cSG
-cSG
-cSG
-cSG
-cSG
-cSG
-cSG
-cSG
-cSG
-cSG
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-cSG
-cSG
+yhT
+xmk
+xmk
+xmk
+xmk
+xmk
+nWG
+ogl
+ogl
+ogl
+pgS
+yhT
 uoO
 uoO
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+lEl
 xVz
-uiV
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+uoO
+xVz
+cSG
+uoO
+aoj
+uoO
+uoO
+uoO
+cSY
+cSY
+rEl
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -81346,12 +76889,18 @@ uoO
 uoO
 aoj
 aoj
-uoO
 aoj
 aoj
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
-aoj
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -81485,110 +77034,118 @@ eLE
 "}
 (214,1,1) = {"
 eLE
-tHG
+yhT
 jZH
-nCi
-haB
-glQ
+jZH
+jZH
+jZH
 uwd
-uwd
-arg
+saw
+saw
 saw
 lKh
 jZH
-cOC
-kHh
-jSx
-jSx
-jSx
-jSx
-mbV
+hkh
+dRm
+xrz
+eez
 jZH
-aiq
-uHP
-uTT
-ajZ
-aDN
-ufZ
-uHP
-uHP
-aDN
-cyO
-tLS
-vYw
-iIs
-mZX
-mZX
-cDp
-ijT
-cly
-mZX
-dUL
-aqB
-mtG
-wdL
-vYw
-tvj
-tKy
-vOf
-tKy
+yhT
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
 xmk
-dlT
-vYw
-qfK
-qfK
-vYw
-oeY
+mzX
+bVb
+coe
+xmk
+hYS
+ogl
+ogl
+ogl
+xmk
+yhT
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-cSG
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-vsI
-cSG
 uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+lEl
 xVz
 xVz
-amf
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+uoO
+xVz
+xVz
+xVz
+uoO
+cSY
+cSY
+cSY
+cSY
+cSY
+cSY
+rEl
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -81596,19 +77153,11 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
 uoO
 aoj
 aoj
 uoO
-aoj
-aoj
 uoO
 uoO
 uoO
@@ -81742,60 +77291,60 @@ eLE
 "}
 (215,1,1) = {"
 eLE
-tHG
+yhT
 jZH
-pkW
-jZH
-ajc
-aHH
-vkb
-arg
-jZH
-jZH
+ajZ
+aHj
+aHj
+brt
+bxX
+bTu
+cyO
+cyO
 jZH
 hkh
-kHh
-jSx
-jSx
-jSx
-jSx
-mbV
+xrz
+xrz
+eez
 jZH
-fNB
-uHP
-uHP
-aDN
-uHP
-jZH
-oeJ
-oeJ
-fRN
-kbZ
-xcx
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
 vYw
-iIs
-dbk
-vng
-pIX
-mZX
-cly
-tvN
 vYw
-lvt
-lok
-ifR
 vYw
-tKy
-tKy
-bFi
-tKy
-tKy
-tKy
 vYw
-aHM
-eub
 vYw
-oeY
+vYw
+vYw
+vYw
+xmk
+mAQ
+bVb
+nsN
+xmk
+hYS
+ogl
+ogl
+ogl
+xmk
+yhT
 uoO
 uoO
 uoO
@@ -81805,48 +77354,50 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-cSG
-vsI
-qmh
-qmh
-aZl
-rwk
-xkQ
-uYd
-cqY
-wef
-thO
-xkQ
-ufk
-qta
-qta
-psA
-qta
-qta
-qta
-psA
-gyp
-qmh
-ngP
-vsI
-vsI
-uoO
-uoO
-uoO
-amf
+xVz
+lEl
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 xVz
 xVz
 uoO
+xVz
+xVz
+xVz
+uoO
+uoO
+cSY
+cSY
+cSY
+cSY
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -81863,9 +77414,7 @@ uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -81999,33 +77548,33 @@ eLE
 "}
 (216,1,1) = {"
 eLE
-tHG
+yhT
 jZH
-nCi
-glQ
+alw
+vJC
 vJC
 aHH
-gYI
-arg
 saw
-lKh
-jZH
-kgv
-kHh
-jSx
+bTG
+bTG
+bTG
+dlw
+xrz
+xrz
+xrz
 jOE
-dSf
-jSx
-mbV
 jZH
-mWM
-uHP
-uNG
-qhw
-gEZ
-gEZ
-gEZ
-gEZ
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+jZH
+vYw
+vYw
 vYw
 vYw
 vYw
@@ -82037,72 +77586,59 @@ vYw
 vYw
 qrJ
 aYI
+kTP
 vYw
-vYw
-vYw
-vYw
-vYw
-vOf
-vOf
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
+qrJ
+aYI
+kTP
+xmk
+mAX
+bVb
+ntS
+nEt
+nWO
+ois
+owX
+ois
+xmk
 yhT
 yhT
 yhT
 yhT
 yhT
 yhT
-yhT
-yhT
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-vsI
-bGU
-aRj
-qWa
-vsI
-iPu
-rXR
-xkQ
-sWu
-xkQ
-xkQ
-ufk
-qta
-qta
-wyy
-qmh
-qmh
-qmh
-qmh
-rAt
-qmh
-qQI
-vsI
-vsI
+uoO
 uoO
 uoO
 uoO
 xVz
+lEl
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
+sgI
+xVz
+xVz
+xVz
+xVz
+xVz
+xVz
 xVz
 uoO
+cSY
+cSY
+cSY
+cSY
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -82117,6 +77653,18 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82124,6 +77672,7 @@ uoO
 uoO
 aoj
 aoj
+uoO
 uoO
 uoO
 uoO
@@ -82256,112 +77805,99 @@ eLE
 "}
 (217,1,1) = {"
 eLE
-tHG
-jZH
-glQ
-glQ
+yhT
 jZH
 jZH
 jZH
-arg
 jZH
+saw
+saw
+cej
+saw
+saw
+dlw
+xrz
+xrz
+xrz
+jOE
 jZH
-jZH
-axk
-kHh
-jSx
-jSx
-jSx
 cCQ
-mbV
-jZH
+sCB
+fkd
 nEC
-uHP
-uHP
-lia
-qaR
-ffA
-mYt
-puL
+nWg
+rAo
+rAo
+sDK
+xrz
 vYw
+puL
+wac
 nYR
 sWp
-qys
+ipv
 kWl
-isj
+vYw
 bCf
 xXc
-cSH
-uwA
-wOp
+vYw
+aYI
+aYI
 bfh
-rFJ
-wOp
-wOp
+vYw
+aYI
+aYI
 bfh
-wOp
-wOp
+xmk
+mDt
 bVb
 eOh
-tKy
-tKy
+ccb
+ccb
 dnM
-aHM
-aHM
-vYw
-yhT
-gul
-gul
-gul
-gul
-gul
-gul
-gul
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-vsI
-sOi
-lea
-qXo
-vsI
-rOb
-gWK
-gWK
-sXi
-gWK
-hpI
-pfv
-faR
-nld
-rAt
-eGI
-xGu
-vsI
-vsI
 oAp
-qIB
-vsI
-vsI
-vsI
+oRM
+xmk
+uAc
+uAc
+uAc
+uAc
+uAc
+uAc
+yhT
 uoO
 uoO
 uoO
 xVz
-uoO
+lEl
+xVz
+sam
+qjT
+xVz
+xoU
+sef
+shO
+xVz
+xVz
+xVz
+xVz
+xVz
 xVz
 uoO
 uoO
+cSY
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82376,11 +77912,24 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -82513,110 +78062,103 @@ eLE
 "}
 (218,1,1) = {"
 eLE
-tHG
-jZH
+yhT
+acv
 uTy
-uTy
+lZb
 jZH
 arg
 ovL
-arg
-saw
-lKh
 jZH
-sjA
-nMG
-flW
-yjo
+jZH
+jZH
+jZH
+jZH
 flW
 flW
-nMG
 jZH
-hox
-uHP
-aDN
 jZH
+eIJ
+xrz
+fkn
+xrz
+nWg
+rAo
+rAo
 sDK
-eRI
-eRI
-eRI
+xrz
 vYw
+hmP
+wac
 uqO
-qys
-jYi
+icI
+slg
 wac
 cqO
 vKF
+jJd
 vYw
-aqX
-azD
-jHR
-jHR
-jHR
-jHR
-jHR
-jHR
-jHR
-jHR
+keH
+vYw
+vYw
+vYw
+keH
+vYw
+vYw
+xmk
+mEf
 ccb
 coe
 hYS
 hYS
 dtm
-tKy
-tKy
-vYw
-yhT
-gul
+oCn
+oRZ
+xmk
+pDU
+xNs
 xiI
 xNs
-hIt
-gul
-iOt
-hlS
-iQt
-xhA
-xhA
-xhA
-yaO
+xNs
+uAc
+yhT
+uoO
+uoO
+uoO
+xVz
 lEl
-jPB
-jPB
-jPB
-jPB
+xVz
+lEl
+qjT
+qjT
+sdJ
+seJ
 qpe
-nXh
-xhA
-vsI
-mWD
-pIg
-qYS
-vsI
-kYh
-kYh
-pis
-pis
-pis
-tJT
-vsI
-vsI
-vsI
-wEX
-vsI
-vsI
-vsI
-vch
-uRE
-vrC
-ble
-vsI
+qoi
+rZw
+xVz
+xVz
+xVz
+xVz
+xVz
+uoO
+cSY
+uoO
 uoO
 uoO
 uoO
 aoj
-xVz
-xVz
-xVz
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82630,10 +78172,17 @@ uoO
 uoO
 uoO
 aoj
+aoj
 uoO
 uoO
 uoO
 aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -82770,118 +78319,87 @@ eLE
 "}
 (219,1,1) = {"
 eLE
-tHG
+yhT
 jZH
-jZH
-jZH
-jZH
-tiB
-wue
-jZH
-jZH
-jZH
-jZH
-omE
-baP
-omE
-nNF
-jZH
-jZH
-udU
+amf
+aQg
+aZl
+xrz
+xrz
+tyR
+czn
+czn
+czn
 jZH
 xrz
-huV
-dod
+xrz
+eeW
 jZH
-bDG
+eMO
+xrz
+fna
+xrz
+nWg
+rAo
+rAo
+sDK
 bjz
-gEZ
-dvP
 vYw
+dvP
+wac
 qys
 itI
 atO
-vYw
+wac
 dqp
-lSZ
+vKF
+jJB
 vYw
-aXP
-uwA
-wOp
+wac
+bdP
 biy
-bdP
-fXs
-bdP
-fXs
-bdP
-fXs
-cmy
-cyA
-tKy
-tKy
-ioQ
-tKy
-cyA
 vYw
-yhT
+wac
+bdP
+wac
+xmk
+mEm
+hYS
+cyA
+hYS
+nYw
+ioQ
+oCA
+oWc
+xmk
+pEG
 gcD
 goi
-goi
-goi
-hYI
-jrX
-jrX
-iST
-xhA
-fxM
+gcD
+qGz
+uAc
+yhT
+yhT
+yhT
+uoO
+xVz
 yaO
-kLA
-jPB
+xVz
+qjT
 lZF
-fFK
-fFK
-fFK
-fFK
+pNT
+cSY
+cSY
+sjA
 pDM
 vOo
-oWr
-xhA
-qgO
-vsI
-vsI
-rOp
-kYh
-pis
-pis
-pis
-tJU
-vsI
-uIq
-qmh
-rAt
-qmh
-xIN
-vsI
-vJX
-qRv
-tfd
-mYI
-vsI
-vsI
-uoO
-uoO
-aoj
-aoj
-aoj
+uiV
+rZw
 xVz
 xVz
+rEl
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+cSY
 uoO
 uoO
 uoO
@@ -82894,6 +78412,37 @@ uoO
 uoO
 uoO
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -83027,111 +78576,90 @@ eLE
 "}
 (220,1,1) = {"
 eLE
-tHG
-qno
-hPF
-eDd
-jZH
-geb
-eRI
-aHn
-owa
-phh
-jZH
-lsr
-fQF
-lsr
-nNF
-viv
-jFm
-gPq
-rzi
-sEK
-nWg
-nWg
-jZH
-kgs
-aIS
-eWj
-aTP
-vYw
-ukv
-vYw
-slg
-vYw
-vYw
-vYw
-vYw
-bfL
-uwA
-wOp
-cnm
-dSU
-wOp
-dSU
-wOp
-dSU
-wOp
-vYw
-cCx
-cZm
-tKy
-ioQ
-cZm
-cCx
-vYw
 yhT
-gul
-gfy
-goi
+jZH
+jZH
+jZH
+jZH
+fQF
+kNb
+ggq
+owa
+owa
+dur
+jZH
+fQF
+xrz
+xrz
+jZH
+jFm
+xrz
+rzi
+xrz
+nWg
+rAo
+rAo
+sDK
+xrz
+vYw
+hng
+wac
+ukv
+ifR
+slg
+wac
+vYw
+jfW
+jOU
+vYw
+keR
+dSU
+wac
+vYw
+keR
+dSU
+wac
+xmk
+mEv
+cZm
+cCx
+cZm
+xmk
+xmk
+xmk
+xmk
+xmk
+pFn
+vFa
+vFa
+quR
 hKI
-gul
-jrX
-jrX
-iVj
-xhA
-jYe
-jPB
-jPB
-jPB
+uAc
+uAc
+uAc
+iZQ
+rDr
+xVz
+xVz
+xVz
+fou
 fAJ
 byA
 vZr
-neP
-nxT
-wUT
+cSY
+cSY
+cSY
 neu
-pfC
-xhA
-qid
+vsI
+sll
 vsI
 vsI
-kYh
-kYh
-pis
-pis
-pis
-kYh
-vsI
-uay
-vHQ
-rAt
-icI
-xVV
-vsI
-wSC
-uRE
-vrC
-daK
-vsI
-vsI
+cSY
+cSY
+cSY
 uoO
-uoO
-uoO
-uoO
-uoO
-xVz
-xVz
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -83140,16 +78668,37 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
+aoj
 aoj
 uoO
 uoO
@@ -83284,111 +78833,111 @@ eLE
 "}
 (221,1,1) = {"
 eLE
-tHG
-jZH
-phh
+yhT
+aej
+uTy
 lZb
-lBX
-eRI
-cHA
-auO
-mkc
+jZH
+xrz
+xrz
+jZH
+oVE
+oVE
 oVE
 jZH
-vvR
-fQF
-vvR
-nNF
-viv
-tCw
-rcX
-eJh
-aXW
+dRZ
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
 nWg
 rAo
-bUR
-rVE
-aTP
-nzI
-aTP
+rAo
+sDK
+xrz
+vYw
+hnU
 oXD
 nOW
-sWp
-nOW
-iTW
-aSJ
+igr
+wac
+wac
+vYw
 aBq
+jTD
 vYw
-rFJ
-uwA
-wOp
-mXi
+kjU
+kAW
+wac
 vYw
-vYw
-vYw
-vYw
-vYw
-vYw
+wac
+wac
+wac
+xmk
+mHj
 jGX
 vNF
 jgd
-tKy
-dvK
+jgd
+xmk
 dWN
-dtm
-vYw
-yhT
-gul
-uuQ
+dWN
+uAc
+pIg
+vFa
+vFa
 fhk
-hKS
-gul
+vFa
+piT
 ilw
-jrX
+rfD
 iWR
-xhA
-jYP
-jPB
-kLU
-yaO
-mcC
-jPB
-efS
-xYS
-nIl
-jPB
-hrv
-pgS
-xhA
-qnC
-vsI
-vsI
+xVz
+xVz
+xVz
+xVz
+cSY
+cSY
+xVz
+mTj
+cSY
+cSY
+cSY
+cSY
+cSY
+slT
+cSY
+cSY
+cSY
 rOp
-kYh
-pis
-pis
-pis
-tJU
-vsI
-wfH
-sZn
-ois
-fIV
-ydv
-vsI
-eaR
-ldA
-hcC
-fai
-vsI
-mEf
+aoj
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-xVz
-xVz
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
 aoj
 aoj
 uoO
@@ -83405,8 +78954,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 aoj
 uoO
 uoO
@@ -83541,111 +79090,97 @@ eLE
 "}
 (222,1,1) = {"
 eLE
-tHG
+yhT
+jZH
+amf
+aRj
+bdK
+xrz
+xrz
 jZH
 jZH
 jZH
 jZH
-eRI
-geb
 jZH
-jZH
-jZH
-jZH
-vvR
-vrv
-vvR
-nNF
-viv
-cah
-jdI
-eJh
-aXW
-nWg
-nWg
-goQ
-pxS
-aTP
-kEP
-aTP
+waU
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
 vYw
-weR
-nOW
-chf
+vYw
+vYw
+vYw
+vYw
 nXS
-mAm
-pxy
+nXS
 vYw
-fXr
-uwA
+vYw
+vYw
+vYw
+vYw
 aYS
-wOp
 vYw
-bri
+vYw
+vYw
 shc
-bxq
+vYw
 rIl
 bEz
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
+jGX
+vNF
+jGX
+oaW
+xmk
+oGc
 euS
-vYw
-yhT
-gul
-gul
+pis
+pIx
 vFa
-xjE
+vFa
+vFa
+vFa
 sSP
 isG
-jrX
+riR
 iYI
-xhA
-jZg
-jPB
-kWH
-jPB
-mcC
-jPB
-mTj
-xYS
-nKk
-jPB
-hrv
-pwa
-xhA
-qnC
-vsI
-vsI
-kYh
-kYh
-pis
-pis
-pis
-kYh
-vsI
-ggm
-qeh
-fuc
-dhM
-ykT
-vsI
-vsI
-bdK
-qIB
-vsI
-vsI
-vsI
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 xVz
+xVz
+xVz
+xVz
+cSY
+cSY
+rEl
+mTj
+cSY
+cSY
+cSY
+cSY
+cSY
+cSY
+cSY
+cSY
+smy
+uoO
+aoj
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
 aoj
 uoO
 uoO
@@ -83659,10 +79194,24 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -83798,111 +79347,116 @@ eLE
 "}
 (223,1,1) = {"
 eLE
-tHG
-nTr
-hPF
-tnk
+yhT
+jZH
+jZH
+jZH
 jZH
 kNb
-geb
-psg
+xrz
+xrz
 sCB
-phh
-jZH
+daK
+xrz
 nNF
 waU
-nNF
-nNF
-viv
-wNJ
-rcX
-eJh
-aXW
-nWg
-nWg
-jZH
-pxS
-aTP
-aTP
-aTP
-vYw
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xrz
+xSi
+xSi
+xSi
+xSi
 eDy
-nOW
-qys
-azv
-mZX
-uXT
-vYw
+igV
+xSi
+xSi
+xSi
+xSi
+xSi
+kbf
 wOp
-sGY
 bbq
-biW
-vYw
-mAm
-bwd
+tEG
+ldP
+tEG
+tEG
 hro
-dKm
-mAm
-vYw
+xmk
+mLN
+nld
 uqU
 djs
 sJA
-dDE
-vYw
-eaz
-vYw
-yhT
-gul
-gim
-jrX
+xmk
+dWN
+oWr
+piT
+vFa
+vFa
+vFa
+vFa
 iOt
-xjE
-jrX
-agI
+uAc
+uAc
+uAc
 iZQ
-xhA
-kcD
-jPB
-yaO
-jPB
-coQ
-vyg
-gzD
-nsN
 rEj
-tYE
-bFa
-pwP
-xhA
-qoi
-vsI
-vsI
-vsI
-kYh
-pis
-pis
-pis
-kYh
-vsI
-tJL
-eVi
-wFF
-poa
-poa
-jzs
-mLN
-dSr
-spS
-czn
-vsI
-vsI
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
 xVz
+xVz
+xVz
+cSY
+cSY
+xVz
+cSY
+cSY
+cSY
+cSY
+qoi
+qoi
+xVz
+qoi
+xVz
+qoi
+uoO
+aoj
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
 aoj
 uoO
 uoO
@@ -83921,13 +79475,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aoj
-aoj
+aBQ
 uoO
 uoO
 uoO
@@ -84055,111 +79604,114 @@ eLE
 "}
 (224,1,1) = {"
 eLE
-tHG
-jZH
-phh
-jRI
-sWb
-cHA
-eRI
-kZq
-twR
-oVE
-jZH
-jZH
-jZH
-jZH
-jZH
-viv
-xGp
-jdI
-eJh
-aXW
-nWg
-kcF
-jZH
-tkO
-kvO
-tkO
-eWj
-vYw
-gjb
-qys
-nyK
-lmf
-hBF
-mAm
-vYw
-wOp
-uwA
-wOp
-wOp
-tEG
-mAm
-mAm
-mAm
-mAm
-mAm
-cnq
-mZX
-mZX
-mZX
-dGD
-vYw
-eaz
-vYw
 yhT
-gul
+aiq
+uTy
+lZb
+jZH
+cHA
+bCX
+xGp
+xGp
+xGp
+xGp
+dKo
+dSf
+xGp
+xGp
+epe
+xGp
+xGp
+xGp
+xGp
+xGp
+xGp
+xGp
+wOp
+kvO
+xSi
+xSi
+xSi
+xSi
+xSi
+xSi
+xSi
+hBF
+xSi
+hBF
+yhd
+xSi
+tEG
+tEG
+tEG
+tEG
+tEG
+tEG
+xmk
+mLP
+jGX
+nwf
+nIl
+obV
+xmk
+dWN
+oWr
+uAc
+pLl
+qeh
 gjB
-jrX
-hOJ
-gul
+qxo
+uAc
+uAc
 itP
 uAc
-jdN
-xhA
-keR
-yaO
-kLU
-jPB
-myA
-glq
-xkB
-nqE
-fFK
-fFK
-okm
-pwa
-xhA
-qpX
-xhA
-vsI
-vsI
-kYh
-snJ
-kYh
-snJ
-kYh
-vsI
-uJS
-fbP
-fbP
-wPV
-stU
-bKw
-stU
-stU
-qUR
-vAK
-vsI
-vsI
-uoO
-uoO
-uoO
-uoO
-uoO
-aoj
+uAc
+rEl
 xVz
+xVz
+xoU
+saz
+cSY
+xVz
+cSY
+nqE
+cSY
+sjA
+okm
+qpX
+qpX
+qpX
+qpX
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 aoj
 aoj
 uoO
@@ -84169,15 +79721,12 @@ uoO
 uoO
 uoO
 uoO
-aoj
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-uoO
-aoj
 uoO
 uoO
 uoO
@@ -84312,112 +79861,99 @@ eLE
 "}
 (225,1,1) = {"
 eLE
-tHG
+yhT
+jZH
+amf
+aSJ
+bfL
+xrz
+waU
 jZH
 jZH
 jZH
 jZH
-dcg
-eRI
-jZH
-uZa
-jZH
-jZH
-idU
-feu
-mLP
-dMm
-iUq
-wkR
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
 eJh
-eJh
-bMe
-nWg
 urc
-jZH
-tgY
-eRI
-ihz
-aTP
-kUd
+bMe
+eJh
+urc
+gHh
+xSi
+yhd
+xSi
+hoj
+lwz
 lwz
 iHs
-qys
+xSi
 wZZ
-mZX
-mAm
-vYw
-wOp
-uwA
-wOp
-wOp
-tEG
-mAm
-mAm
-mAm
-mAm
-mAm
+iZB
+jge
+jVx
+fXr
+klQ
 vYw
 vYw
+lea
+lpK
 vYw
 vYw
-vYw
-vYw
-eaz
-vYw
-yhT
-gul
-goG
-jrX
-rbu
+xmk
+mRK
+nnN
+xmk
+xmk
+xmk
+xmk
+oHT
+paF
+uAc
+uAc
+uAc
+uAc
+uAc
+uAc
 hZN
 iKl
 oBP
-jfW
 xhA
-xhA
-xhA
-xhA
-kAW
-jPB
-lnF
-riY
-lnF
-sll
+yhT
+uoO
+xVz
+rXl
+xVz
+fAJ
+pNT
+vZr
+cSY
+cSY
 nYD
-xhA
-xhA
-xhA
-qnC
-xhA
-vsI
-vsI
-saz
-vsI
-vsI
-vsI
-vsI
-bMA
-vEe
-vXr
-fna
-wQJ
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-uoO
-uoO
-aoj
+ovQ
+pNT
+qsa
+qsa
+qpX
 uoO
 uoO
 uoO
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 aoj
@@ -84429,11 +79965,24 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
 aoj
 uoO
 uoO
@@ -84569,103 +80118,90 @@ eLE
 "}
 (226,1,1) = {"
 eLE
-tHG
-esP
-hPF
-vrH
+yhT
 jZH
-geb
-eRI
+jZH
+jZH
+jZH
+fQF
+bEK
 tyR
-owa
-phh
-jZH
-sKW
+czn
+czn
+czn
+gEZ
 ooV
 uoI
-feu
-idU
+ehz
+erF
 dSd
-fIN
-exH
-juq
-nWg
-nWg
-lia
-hoh
-eRI
-tkO
-aTP
-vYw
-vYw
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gHi
+xSi
+yhd
+xSi
+hpI
+hHc
+hHc
 nPH
-vYw
-uri
-ruc
-uMD
-vYw
-fXr
+xSi
 uwA
-wOp
-wOp
-bmv
-mAm
-bwd
-hro
-dKm
-mAm
-cnq
-mZX
-mZX
-mZX
-dGD
+tOD
+uMD
+jXu
+fXr
+koC
 vYw
-eaz
-vYw
-yhT
-gul
+kWH
+wac
+wac
+wac
+kWH
+xhA
+mSc
+noI
+nwA
+nKk
+nKk
+olK
+onL
+paO
+pmV
+pNi
+qfB
 gpl
-jrX
-hPD
-hZN
+qFQ
+xhA
+qME
 xpu
-iKl
-iKl
-jEK
+xpu
 xhA
-xhA
-xhA
-xhA
-xhA
+yhT
+uoO
+rOb
+rXR
+sbj
+uoO
 mII
-ppw
-ppw
-xhA
-xhA
+qpX
+seL
+rOb
+sjR
 ovQ
-xhA
-xhA
+cSY
+cSY
 qsa
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-pFn
-uXY
-iKl
-iKl
-wVK
-xhA
-cus
-smy
-kTP
-kdH
-xhA
-xhA
+qpX
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -84673,11 +80209,10 @@ aoj
 uoO
 uoO
 uoO
-xVz
-xVz
 uoO
 uoO
 uoO
+aoj
 aoj
 uoO
 uoO
@@ -84689,6 +80224,20 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 aoj
@@ -84826,120 +80375,101 @@ eLE
 "}
 (227,1,1) = {"
 eLE
-tHG
+yhT
+ajJ
+uTy
+lZb
 jZH
-phh
-cxq
-vfQ
-geb
-eRI
+xrz
+waU
 ggq
-lDH
-oVE
-jZH
-feu
+owa
+owa
+dur
+gEZ
 rSw
 dBy
-feu
-idU
+ehT
+rSw
 xAn
 jJM
-cAB
-idU
-nWg
-rAo
-jZH
-hNy
-eDA
-tkO
-aTP
-gEZ
-gEZ
-fkh
-obS
-rFJ
-wOp
-wOp
-wOp
-rFJ
-uwA
-bdP
-fXs
-vYw
-gXH
-kSz
-bxq
-rIl
-edO
-vYw
-uqU
-djs
-sJA
-dHq
-vYw
-eaz
-iKQ
-yhT
-gul
-tmh
-huh
-jrX
-ifX
-iKl
-iKq
-iKl
-xpu
-kic
-iKl
-seP
-seP
-sNg
-hLL
-rEl
-ill
-rZw
 fnD
-bOf
-fkd
+jJM
+jJM
+ggm
+gKJ
+xSi
+yhd
+xSi
+rrh
+uMD
+uMD
+kxR
+xSi
+isj
+yej
+uMD
+jYe
+fXr
+jCU
+vYw
+fXs
+wac
+wac
+wac
+fXs
 xhA
-qtD
-eHy
-ryL
-rNi
-rNi
+edO
+usN
+nxT
+nLM
+nLM
+xjE
+xjE
+xjE
+xjE
+xjE
+xjE
+tmh
+xjE
+hBC
+ifX
+qVC
+xpu
 xhA
-xhA
-xhA
-xhA
-uhT
-uXY
-iKl
-rFc
-wWM
-xhA
-hUn
-pmV
-kdH
-sbj
-xhA
-xhA
+yhT
+uoO
+uoO
+uoO
+uoO
+uoO
+qpX
+cSY
+cSY
+cSY
+cSY
+cSY
+cSY
+qjT
+xoU
+uoO
 uoO
 uoO
 uoO
 aoj
 uoO
 uoO
+uoO
+uoO
+uoO
 aoj
-xVz
-uoO
-uoO
-uoO
-uoO
 aoj
 uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -84950,6 +80480,25 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85083,103 +80632,100 @@ eLE
 "}
 (228,1,1) = {"
 eLE
-tHG
+yhT
 jZH
+amf
+aWq
+ble
+xrz
+bEK
 jZH
-jZH
-jZH
-geb
-eRI
-jZH
-jZH
-bUR
-jZH
-dMm
+oVE
+oVE
+oVE
+gEZ
 feu
-feu
+dSr
 dMm
-idU
-xAn
-jJM
-cAB
-dMm
-nWg
-nWg
-jZH
-gEZ
-gEZ
-mrq
-rrh
-gEZ
-gEZ
-kxR
+esP
+eOx
+eVA
+eVA
+eVA
+eVA
+glq
+gMX
 wOp
+haB
+xSi
+rrh
+uMD
+uMD
+kxR
+xSi
 vKm
 yej
-yej
-yej
-jHR
+jii
+jYe
+fXr
 jCU
-dSU
-wOp
 vYw
-vYw
-vYw
-vYw
-qpc
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-vYw
-eaz
-iKQ
-gul
-gul
-gul
-gul
-gul
+kXA
+leG
+wac
+leG
+kXA
+xhA
+swY
+usN
 xhA
 xhA
-xhA
-iKl
-iKl
-kic
-iKl
+odG
+xjE
+xjE
+xjE
+xjE
+xjE
+xjE
+xjE
+qGe
+hBC
+qMO
 xpu
-qrl
-iKl
-iKl
-iKl
-iKl
-iKl
-iKl
-owX
-iKl
-wUr
-qyv
-eHy
-eHy
-rWh
-rWh
+xpu
 xhA
 xhA
-xGl
-tTB
-vBG
-vdk
-iKl
-iKl
-xdB
-xhA
-kdH
-kdH
-paO
-loJ
-xhA
-xhA
+yhT
+uoO
+uoO
+uoO
+uoO
+qpX
+cSY
+cSY
+cSY
+cSY
+cSY
+cSY
+xoU
+xoU
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -85187,8 +80733,9 @@ aoj
 uoO
 uoO
 aoj
-xVz
-xVz
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -85207,6 +80754,8 @@ uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85340,103 +80889,83 @@ eLE
 "}
 (229,1,1) = {"
 eLE
-tHG
-vfU
-hPF
-eDd
+yhT
 jZH
-axQ
-geb
+jZH
+jZH
+jZH
+xrz
+bEK
 gqR
-gZx
-gHh
 jZH
-pqi
-idU
-idU
-idU
-idU
-idU
-idU
-hBz
-idU
-nWg
-nWg
 jZH
-dgH
-bqU
-rsD
-rFJ
-qii
-kny
-fqU
-wOp
+jZH
+gEZ
+rSw
+rSw
+eiN
+exH
+gEZ
+gEZ
+gEZ
+gEZ
+fIN
+gEZ
+gEZ
+vgW
+yhd
+xSi
+hpI
+hHc
+hHc
+nPH
+xSi
 uwA
 tOD
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-uGO
+uMD
+jXu
+fXr
+kpd
+vYw
+kYh
+lgv
+lqC
+lDx
+wac
+xhA
 oUK
-oUK
-tcv
+usN
 cGq
 qoF
-qoF
-qoF
-ozI
+xjE
+xjE
+xjE
 eAw
-iKQ
-jUB
-jUB
-vxR
+poa
+xjE
+xjE
+xjE
 qFm
 hSU
-jUB
-jUB
-xhA
-iKl
-iKl
-xhA
-kOa
-sPl
-lkT
-iKl
-rPG
-qjT
-nwf
-lqC
-qjT
-qjT
-xoU
-tQe
-ybF
-teh
-rIS
-eHy
-sdJ
-xhA
-xhA
-tkU
-tTB
-vBG
-uXY
-iKl
-iKl
+qOJ
 xpu
-srb
-kdH
-cUC
+xpu
+xpu
 xhA
-xhA
-xhA
-xhA
+yhT
+uoO
+aoj
+uoO
+uoO
+qpX
+qjT
+cSY
+cSY
+cSY
+cSY
+xoU
+vOo
+uoO
 uoO
 uoO
 uoO
@@ -85444,8 +80973,28 @@ uoO
 uoO
 aoj
 aoj
-xVz
-xVz
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85462,8 +81011,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85597,104 +81146,82 @@ eLE
 "}
 (230,1,1) = {"
 eLE
-tHG
+yhT
 jZH
-phh
+aqX
 bMC
 mPa
-eRI
-geb
-geb
-eRI
-eRI
+xrz
+bEK
+xrz
+cDp
+dcf
 ber
-dGe
-bbO
-oyk
-xAn
-bbO
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
 cAB
 szW
 bbO
 oyk
-nWg
+fIV
 rHV
 gFv
-psv
-rFJ
-wOp
-wOp
+xSi
+azD
+xSi
+hpM
 bxG
-qii
-rFJ
-wOp
-uwA
+bxG
+iiE
+xSi
+wZZ
 nHN
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-lXy
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
+jrA
+jYj
+fXr
+klQ
+vYw
+vYw
+vYw
+vYw
+vYw
+vYw
+xhA
+mTF
+usN
+hBC
+nMB
+xjE
+omp
 ulr
 iKQ
-iKQ
-jUB
-xRW
-gsw
-uSG
-gxj
-xRW
-jUB
-xhA
-iKl
-iKl
-xhA
-kpd
-xhA
-qrl
-mJJ
-qWx
-mTt
-iKl
-hmP
-odG
-iKl
-qWx
-mJJ
-qFQ
-eez
-rJv
-eHy
-seL
-mJJ
-xhA
-qVC
-uWA
-vBG
-jrA
-vIL
-iKl
+ppt
+pPS
+sfi
+xjE
+xjE
+qIB
+qPN
+qWa
 xpu
-jXu
+xpu
 xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-kKy
+yhT
+uoO
+aoj
+aoj
+uoO
+uoO
+vOo
+cSY
+cSY
+cSY
+cSY
+pNT
+xoU
 uoO
 uoO
 uoO
@@ -85702,12 +81229,26 @@ uoO
 uoO
 uoO
 uoO
-xVz
+uoO
+uoO
 aoj
 aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
 aoj
 aoj
 aoj
@@ -85720,7 +81261,15 @@ uoO
 uoO
 uoO
 uoO
+aoj
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -85854,124 +81403,82 @@ eLE
 "}
 (231,1,1) = {"
 eLE
-tHG
-jZH
-jZH
-jZH
-jZH
-geb
-geb
-cHA
-cHA
-geb
-dUF
-qii
+yhT
+gkZ
+feM
+xrz
+xrz
+xrz
+bGU
+cfk
+cfk
+xGp
+xGp
 wOp
 wOp
-wOp
-wOp
-wOp
-wOp
+dTR
+xSi
+xSi
+slX
+xxn
 rFJ
+xxn
+xxn
+xxn
+slX
+xSi
+haW
 wOp
 wOp
-vUY
-vgW
 wOp
 wOp
 wOp
-rFJ
-qii
-vgW
 wOp
-wOp
-uwA
-cgy
+isU
 ftF
-eAO
+ftF
+ftF
 dZR
 qMm
 xRm
-crH
-kxR
 qPC
-gEZ
-sGY
-wOp
+xRm
+qPC
+xRm
+lXy
+mrV
 jsD
-dpR
-dpR
-dpR
-dpR
-gEZ
-eaz
-iKQ
-iKQ
+usN
+hBC
+nMN
+oei
+xjE
+xjE
+peK
+pqi
 xRW
-gcY
-jUB
-fUJ
-jUB
-xRW
-xRW
-xhA
-jgL
-iKl
-kiX
-iKl
-fzR
-pIx
-mjJ
-qWx
-fou
-cQR
-gnY
-seJ
+sfi
+xjE
+xjE
+xjE
+qQF
 xpu
-mxa
-iaI
-vBG
-qGz
-hNS
-kdH
-uGL
-leG
-tbg
-vBG
-qVC
-rfs
-vna
-kdH
-kdH
-kFc
-ydE
-clA
-bEK
-bEK
-bEK
-bEK
+rjQ
+jgL
 xhA
-kKy
+yhT
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-xVz
-xVz
-aoj
 aoj
 uoO
 uoO
-uoO
-xVz
-uiV
-aoj
-uoO
-uoO
-uoO
-uoO
+fou
+cSY
+cSY
+cSY
+cSY
+pNT
+vOo
 uoO
 uoO
 uoO
@@ -85984,7 +81491,49 @@ uoO
 uoO
 aoj
 uoO
+uoO
+uoO
+uoO
 aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -86111,124 +81660,81 @@ eLE
 "}
 (232,1,1) = {"
 eLE
-msV
+yhT
 gkZ
 feM
-eRI
-geb
-geb
-eRI
-geb
-geb
-geb
-hji
-mDe
-wtT
-sKB
-dMg
-vyQ
+xrz
+xrz
+bsF
+bJa
+cfA
+xrz
+xrz
+xrz
+xSi
+xSi
+yhd
+xSi
+xSi
 slX
-mHj
-wtT
-tLz
-dMg
-gMX
-vgW
-wOp
-wOp
-wOp
-wOp
-qii
-qii
-fqU
-wOp
-uwA
-rFJ
-wOp
-wOp
-wOp
+xxn
+fqz
+xxn
+fqz
+xxn
+slX
+xSi
+yhd
+xSi
+xSi
+xSi
+xSi
+xSi
+xSi
+azD
 jFC
-rFJ
-wOp
-rFJ
-wOp
-wOp
-uwA
-rFJ
-qqN
-dpR
-dpR
-dpR
-dpR
-gEZ
-eaz
-iKQ
-iKQ
-xRW
+xSi
+xSi
+xSi
+jFC
+jJM
+gWK
+jJM
+gWK
+jJM
+lYu
+mui
+swY
+usN
+hBC
+nMR
+xjE
+omp
+ulr
+pfv
+psA
+pVA
 sfi
-gxj
-fUJ
-cmE
-xRW
-fUJ
-qWq
-irr
-jJd
-rPG
-qjT
-fSW
-lqC
-qjT
-upI
-fDi
-ulZ
-dGu
-vid
-xND
-pAE
-sPC
-sPC
-vTk
-hNS
-kdH
-sgI
-bvC
-bvC
-bvC
-qPN
-bvC
-bvC
-vTk
-wNi
-kdH
-cFj
-nMB
-bEK
-bEK
-bEK
-bEK
+xjE
+xjE
+xjE
+qQF
+qXo
+xpu
+xpu
 xhA
-xhA
+yhT
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-xVz
-xVz
 aoj
 aoj
 uoO
-uoO
-dkT
-xVz
-sLF
-aoj
-uoO
-uoO
-uoO
-uoO
+pNT
+cSY
+cSY
+cSY
+cSY
+xoU
 uoO
 uoO
 uoO
@@ -86241,7 +81747,50 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -86368,130 +81917,81 @@ eLE
 "}
 (233,1,1) = {"
 eLE
-msV
-gkZ
-feM
-wtB
-geb
-eRI
-ulS
-mpX
-iBR
-geb
+yhT
+jZH
+jZH
+vYw
+vYw
+vYw
+vYw
 pXq
-qii
-wOp
-wOp
-hFb
-wOp
-wOp
-rFJ
-wOp
-hFb
-wOp
-wOp
-qii
-wOp
-nzX
-aER
-cbs
-gEZ
-gEZ
-npR
-wOp
+pXq
+pXq
+pXq
+pXq
+xSi
 azD
-jHR
-jHR
-jHR
-jHR
-jHR
-jHR
-jHR
-yej
-jHR
-jHR
+xSi
+xSi
+eQL
+vYw
+vYw
+vYw
+vYw
+vYw
+vYw
+gZx
+yhd
+xSi
+cbs
+hJk
+hJk
+npR
+xSi
+azD
+jcl
+hJk
+hJk
+hJk
+gEZ
+kEP
+lbt
+kEP
+lbt
+kEP
 bDi
 mhc
 swY
-dpR
-dpR
-dpR
-dpR
-gEZ
-eaz
-iKQ
-iKQ
-pvX
-fDW
-uSG
-hyR
-fUJ
-fUJ
-fUJ
+usN
+xhA
+nPp
+ofI
+xjE
+xjE
+pgt
+pxy
+xjE
+xjE
+xjE
+qFm
+qJc
+qQI
+qYS
 tuO
-cmE
-xgu
-qWx
-iKl
-kKx
-wCV
-mui
-qWx
-iKl
-dGu
-xrA
-oei
-xND
-pKf
-deX
-deX
-rKX
-rKE
-brt
-brt
-jGQ
-jGQ
-deX
-tXw
-deX
-deX
-vNU
-kFc
-kdH
-dRm
-uGg
-bEK
-bEK
-bEK
-bEK
+tuO
 xhA
 xhA
+yhT
+yhT
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-xVz
-xVz
-uoO
-uoO
-uoO
-uoO
-xVz
-xVz
-sXP
-fzT
-aoj
-aoj
-aoj
-aoj
-aoj
 aoj
 uoO
-uoO
-uoO
-uoO
+qQS
+cSY
+cSY
+cSY
+cSY
+vOo
 uoO
 uoO
 uoO
@@ -86499,6 +81999,55 @@ uoO
 uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -86625,124 +82174,87 @@ eLE
 "}
 (234,1,1) = {"
 eLE
-msV
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
+yhT
+yhT
+yhT
+vYw
+bmF
+kPE
+vYw
 sWX
-gEZ
-gEZ
-gEZ
-aue
-gEZ
-gEZ
-gEZ
-iDS
-gEZ
-gEZ
-iDS
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
+cEF
+ddQ
+dyR
+qXN
+xSi
+yhd
+nqF
+xSi
+vYw
+eXJ
+fNX
+fxA
+fLF
+gnY
+vYw
+xSi
+azD
+hcC
+hpT
 juU
-rFJ
-uwA
-wOp
-wOp
-wOp
-wOp
-wOp
-rFJ
-wOp
-wOp
-wOp
-rFJ
-wOp
-wOp
-gEZ
+juU
+juU
+vMm
+iAx
+juU
+juU
+juU
+hPn
+hPn
+kFc
+ldi
+lgA
+lsy
+lIH
+eHh
+mhc
+edO
 usN
-dpR
-dpR
-dpR
-gEZ
-beN
-iKQ
-iKQ
-xRW
-sfi
-gNG
-fUJ
-cmE
-xRW
-fUJ
-qWq
-jnO
-cmE
-qWx
-iKl
-kKx
-lLy
-iKl
-mRK
-fDi
-xrA
-dGu
-ofQ
-xND
-iKl
-seP
-seP
-kdH
-kdH
-kdH
-kdH
-seP
-seP
-seP
-ucQ
-seP
-seP
-vQZ
-kdH
-kdH
-dcf
-xhA
-oPU
-bEK
-bEK
-bEK
+nzl
+nSI
+nSI
+xjE
+xjE
+xjE
+xjE
+xjE
+xjE
+xjE
+qGe
+hBC
+qRv
+qZt
+rmv
+wDm
+rFc
 xhA
 xhA
+xhA
+yhT
+uoO
+uoO
+oEt
+cSY
+cSY
+cSY
+cSY
+xoU
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
-xVz
-xVz
-uoO
-uoO
-uoO
-uoO
-uoO
-xVz
-xVz
-uoO
-uoO
-uoO
-uoO
-aoj
 aoj
 aoj
 aoj
@@ -86753,8 +82265,45 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -86882,104 +82431,84 @@ eLE
 "}
 (235,1,1) = {"
 eLE
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-gEZ
+uoO
+uoO
+yhT
+vYw
+bmK
+aYI
+wJQ
+dEm
+cFd
+deX
+dyR
+qXN
+xSi
+yhd
+mpn
+eDd
+vYw
+faa
+fNX
+fNX
+fOH
+gse
+gTy
+xSi
+azD
+xSi
+hrq
+smq
+hTD
 fSI
-wOp
-uwA
+xCN
+tOi
 uUk
-ftF
+juq
 iav
-dZR
+hPn
 lCK
 eDu
-ftF
-ftF
-tgU
-gEZ
-rFJ
-cAQ
-jsD
-dpR
-dpR
-dpR
-dpR
-gEZ
-eaz
-iKQ
-iKQ
-xRW
-gcY
-jUB
-fUJ
-jUB
-xRW
-xRW
-xhA
+ldA
+liD
+uuN
+lLA
+uuN
+mhc
+mWD
+noI
+nzI
+nTr
+nTr
+onL
+oMK
+xjE
+xjE
+xjE
+xjE
+tmh
+xjE
+hBC
+qUL
+qZA
+rsM
 wDm
 rPG
 fME
 pWc
-bmK
-lSl
-xpu
-qWx
-fou
-nzl
-gnY
-seJ
-iKl
-baZ
-wKm
-xMa
-qZA
-kdH
-kdH
-nTN
-bor
-tcH
-xMa
-qVC
-dKo
-vsW
-vYx
-wNi
-kdH
-ydE
-clA
-bEK
-bEK
-bEK
-bEK
 xhA
-kKy
+yhT
+uoO
+uoO
+xoU
+cSY
+cSY
+cSY
+cSY
+pNT
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -86987,13 +82516,28 @@ uoO
 uoO
 uoO
 uoO
-xVz
 uoO
 uoO
 uoO
 uoO
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -87002,11 +82546,16 @@ uoO
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -87139,104 +82688,84 @@ eLE
 "}
 (236,1,1) = {"
 eLE
-msV
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-fbK
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-fqU
-wOp
+uoO
+uoO
+yhT
+vYw
+vYw
+vYw
+vYw
+ckm
+cFi
+cFi
+dEq
+dMW
+xSi
+yhd
+nqF
+xSi
+vYw
+fai
+frn
+vYw
+vYw
+vYw
+vYw
+xSi
+yhd
+heI
+hrq
+hKx
+xCN
+xCN
+xCN
 wFu
-ryV
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-pgi
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
+xCN
+xCN
+xCN
+kbH
+kqS
+uuN
+uuN
+uuN
+uuN
+uuN
+bhq
+xhA
+xhA
+xhA
+xhA
+xhA
+xhA
+osk
 emg
-iKQ
-iKQ
-jUB
-xRW
+xjE
+pzw
+pWr
+qfB
 gSN
-uSG
-gNG
-xRW
+qFQ
+xhA
+qUR
 iuL
-xhA
-iKl
 qWx
-xhA
+qWx
+qWx
+rKJ
 kpo
 xhA
-qrl
-mzX
-qWx
-oLf
-lZJ
-trr
-ogl
-iKl
-iKl
-mJJ
-mEv
-qZY
-iKl
-iKl
-shO
-mJJ
-xhA
-qVC
-uWA
-bxX
-vqm
-qWx
-iKl
-xks
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-kKy
+yhT
+uoO
+uoO
+xoU
+cSY
+cSY
+cSY
+cSY
+oEt
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -87244,13 +82773,8 @@ uoO
 uoO
 uoO
 uoO
-xVz
 uoO
 uoO
-uoO
-xVz
-xVz
-xVz
 uoO
 uoO
 uoO
@@ -87264,6 +82788,31 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -87396,103 +82945,85 @@ eLE
 "}
 (237,1,1) = {"
 eLE
-msV
-gEZ
-gEZ
-uIm
+uoO
+uoO
+yhT
+vYw
 hog
-eRI
+aYI
 wJQ
 dEm
-eRI
-geb
+cFd
+deX
 xNC
 jbP
-nnH
+wOp
 vDC
 mpn
-vDC
-nnH
-jbP
-gEZ
-geb
-eRI
-qii
-qii
-ahx
-qii
-ojR
-eFS
-qii
-tco
-wOp
-wOp
-wFu
-gAu
-hPn
-hPn
-hPn
-hPn
-hPn
-hPn
-nzw
-hPn
-pyl
+eDs
+vYw
+faR
+fNX
+fxM
+fSW
+gyp
+qXN
+xSi
+azD
+xSi
+vMm
+xCN
+xCN
+xCN
+xCN
+iDP
+lrP
+jyg
+xCN
+kbH
+kqS
+uuN
+uuN
+uuN
+uuN
+uuN
 bhq
-boI
+hPn
 hDX
 xfh
 oIP
-hPn
+xfh
 guw
-dKk
+gul
 mKE
-eBP
-iKQ
-jUB
-jUB
-vxR
+jPi
+xhA
+xhA
 hBC
-hSU
-jUB
-jUB
 xhA
-iKl
+hBC
+xhA
+xhA
+qZY
+rtf
+ryL
 mxa
-xhA
+rKX
 kOa
-lbt
-lkT
-xpu
-qWx
-iKl
-iKl
-iKl
-iKl
-iKl
-gnw
-xZI
-jVx
-rfD
-iKl
-iKl
-reN
-sHk
 xhA
-tna
-tTB
-vBG
-uXY
-qWx
-iKl
-jEK
-xMi
-rFn
-vOR
-vOR
-lDx
-xMi
-xMi
+yhT
+uoO
+uoO
+fou
+cSY
+cSY
+cSY
+cSY
+xoU
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -87501,12 +83032,17 @@ uoO
 uoO
 uoO
 uoO
-xVz
 uoO
 uoO
-xVz
-xVz
-xVz
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -87516,9 +83052,22 @@ uoO
 uoO
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -87653,119 +83202,118 @@ eLE
 "}
 (238,1,1) = {"
 eLE
-msV
-gEZ
-dok
-eiN
-geb
+uoO
+uoO
+yhT
+vYw
+bor
 kPE
-geb
+vYw
 sJm
 pXB
-dXe
+ddQ
 ttW
 vqo
-btW
-btW
-gEp
-btW
-vqo
+xSi
+yhd
+nqF
+xSi
+eRg
 tML
 vsT
-dXe
+fze
 aSW
-btW
-fMz
-fMz
-fMz
-jHR
+gyp
+qXN
+xSi
+azD
+xSi
 vMm
-fMz
-ups
+xCN
+xCN
 pIp
-jHR
-gzy
-aKH
-hPn
+pIp
+xCN
+xCN
+jzs
 fqK
 nzw
 kCg
 imc
-nzw
+uuN
 nWb
-nzw
-nzw
-nzw
-nzw
+uuN
+imc
+lZJ
 hPn
+mWM
 qBQ
-oVJ
+nBh
 sNB
-oVJ
-oVJ
+xfh
+otf
 tJM
-eCv
-jQs
-gul
-gul
-gul
-gul
-gul
-gul
-gul
+xjE
 xhA
-iKl
-qWx
-kic
-iKl
-xpu
-qrl
-iKl
-qWx
-xpu
-iKl
-xpu
-xpu
-qwp
-mNL
-wUr
-qJc
-iKl
-iKl
-iKl
+pXp
+xjE
+qmZ
+xjE
+qMn
+xhA
 reN
-sIK
-xhA
-toO
-tTB
-vBG
-uXY
-qWx
-iKl
-xnb
-xMi
+rvb
+ryL
 rFn
-xMi
-xMi
-xMi
-xMi
-xMi
+rKX
+rUF
+xhA
+yhT
+uoO
+uoO
+qQS
+cSY
+cSY
+cSY
+xoU
+xoU
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
+aoj
 uoO
 uoO
 uoO
-xVz
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
-xVz
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -87787,9 +83335,10 @@ uoO
 uoO
 uoO
 uoO
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -87910,121 +83459,98 @@ eLE
 "}
 (239,1,1) = {"
 eLE
-msV
+uoO
+yhT
 gEZ
-nLM
-geb
-pXB
-rmv
-dXe
-hKx
-voZ
-skL
-bNA
-bxG
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
 vgW
 yhd
-qii
-vgW
-bxG
-vgW
+mpn
+eDd
+vYw
+fbP
 fNX
-eRI
-gEZ
-gEZ
-gEZ
-bJv
-bJv
+fzR
+fSW
+gyp
+qXN
+xSi
+azD
 eZh
-bJv
-gEZ
-gEZ
-fqU
-wOp
-uwA
-eNq
-dbT
-pzO
-clT
+hrv
+hNm
+xCN
+xCN
+xCN
+xCN
+xCN
+tOi
+vQU
+hPn
 mlC
-dHn
+uuN
 lGo
-oXG
-eQF
-pzO
+uuN
+lGo
+uuN
 ecp
 hPn
-hPn
-oOw
-oVJ
-hPn
-oVJ
-dUW
-oVJ
-eER
-eXJ
+mYt
+xfh
+nDb
+xfh
+xfh
+gul
+tJM
+xjE
+xhA
 fqM
 xjE
-xjE
+qno
 xjE
 eME
-xDy
-iuX
 xhA
+iuX
+rwk
 pxI
 jLX
-kic
-iKl
-tnF
-tnF
-wwp
-mxa
-qrl
-xpu
-nMN
-fnD
-oDV
-fkd
-pXp
-qMn
-iKl
-iKl
-iKl
-reN
-sHk
+rLI
+rWh
 xhA
-xhA
-xhA
-vBG
-uXY
-qWx
-xpu
-wWM
-xMi
-hNm
-xMi
-dyR
-dyR
-xMi
-xMi
-pzw
+yhT
 uoO
-bCX
+uoO
+xoU
+cSY
+cSY
+cSY
+pNT
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
-xVz
-xVz
-xVz
-xVz
-xVz
 uoO
 aoj
 aoj
 aoj
+uoO
+uoO
 aoj
+uoO
+uoO
 aoj
 uoO
 uoO
@@ -88036,6 +83562,17 @@ uoO
 uoO
 uoO
 uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
 uoO
 uoO
 uoO
@@ -88046,7 +83583,19 @@ uoO
 uoO
 aoj
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -88167,130 +83716,80 @@ eLE
 "}
 (240,1,1) = {"
 eLE
-msV
+uoO
+yhT
 gEZ
-noI
-dXe
 goR
-muD
-geb
+goR
+gEZ
+bKw
 lXw
 skL
-skL
-gEZ
+dhM
+dGe
 wKL
-nnH
-vDC
+xSi
+yhd
 nqF
-vDC
-nnH
+xSi
+vYw
 jQD
 suk
-eRI
-gEZ
-msV
+fzT
+fSW
+gyp
 qXN
-ucV
-apt
+xSi
+azD
 bVO
 vof
 smq
-uWn
-rvG
-wOp
-uwA
-lpe
+xCN
+xCN
+xCN
+iGY
+xCN
 tOi
-aOT
+jMM
+hPn
+ksU
 nXm
-lAw
-nXm
-lAw
+uyl
 uuN
 uyl
-jEM
+nXm
 rsj
-tFl
 hPn
-hPn
-hPn
-pzO
-sdz
-hPn
-hPn
-hPn
+mYI
+xfh
+xfh
+xfh
+xfh
 gul
+tJM
+xjE
+xhA
 ftt
-gul
+xjE
 gTT
-gul
+xjE
 pld
-pld
-iwO
-gul
+xhA
 jyc
-gul
+ryy
+jyc
+qZt
+rNi
+rUF
 xhA
-xhA
-xhA
-xhA
-xhA
-mSc
-xhA
-nBh
-xhA
-xhA
+yhT
+uoO
+uoO
+xoU
+cSY
+cSY
+cSY
 oEt
-xhA
-xhA
-qME
-iKl
-iKl
-jJB
-slT
-xhA
-xhA
-xhA
-xhA
-uZS
-quR
-mxa
-iKl
-wVK
-xMi
-vOR
-kJW
-sAL
-sAL
-xMi
-xMi
-xVz
-uoO
-bCX
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-uoO
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -88303,6 +83802,56 @@ uoO
 uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -88424,130 +83973,111 @@ eLE
 "}
 (241,1,1) = {"
 eLE
-msV
+uoO
+yhT
 gEZ
-gEZ
-vmx
-nUF
-pVA
-geb
-snL
-geb
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-msV
-dMW
-xoo
-oZm
-bTN
-bTN
-rFJ
+xxn
+xxn
+xxn
+xxn
+xxn
+xxn
+xxn
+dGu
+wKL
+xSi
+yhd
+mpn
+eGI
+eVi
+vYw
+vYw
+vYw
+fZB
+fZB
+vYw
+xSi
+yhd
+xSi
+hpT
+hNS
 jnI
-ixU
-wOp
-uwA
-rFJ
-bqZ
+jnI
+hNS
+iPu
+xCN
+tOi
 lAw
-lAw
-lAw
-lAw
-lAw
-lAw
-lAw
-lAw
-lAw
-onL
 hPn
-oVJ
-oVJ
-oVJ
-oVJ
-dVj
-dVj
-eFE
+hPn
+kGx
+hPn
+llp
+hPn
+kGx
+eHh
+hPn
+neP
+xfh
+xfh
+xfh
+ofQ
 gul
+dVj
+xjE
+xhA
 fwX
-kzn
+xjE
 hac
-sgm
+xjE
 sUs
-sUs
-sUs
-ipv
-jyg
-vQx
 xhA
-mnj
-lbG
-mnj
-mnj
-ukT
+xhA
+xhA
+xhA
+xhA
+xhA
+xhA
+xhA
+yhT
+uoO
+uoO
 pNT
-nDb
-omp
-omp
-lbG
-mnj
-xhA
-wPy
-tsq
-tsq
-sUH
-slT
-cZP
-cFi
-cZP
-peK
-umw
-iKl
-qWx
-iKl
-wWM
-xMi
-hNm
-xMi
-bTu
-dyR
-xMi
-xMi
-xVz
-uoO
-bCX
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
+cSY
+cSY
+cSY
+xoU
 uoO
 uoO
 uoO
-xVz
-pzw
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 aoj
 uoO
 uoO
 uoO
-qxo
-qxo
-xVz
+aoj
 uoO
 uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -88558,9 +84088,28 @@ aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
 aoj
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -88681,131 +84230,131 @@ eLE
 "}
 (242,1,1) = {"
 eLE
-msV
+uoO
+yhT
 gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-hji
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-xpo
-pxV
-bZQ
-bTN
-miX
-mnH
-kxR
-wOp
-uwA
-lpe
-pHQ
+aXP
+xxn
+xxn
+xxn
+xxn
+xxn
+xxn
+xxn
+aJR
+xSi
+yhd
+xSi
+xSi
+xSi
+xSi
+xSi
+xSi
+ikI
+ikI
+gWK
+xSi
+yhd
+xSi
+hxB
+xCN
+xCN
+xCN
+xCN
+iQt
+xCN
+tOi
 vQU
-lAw
-lAw
-lAw
-lAw
-lAw
-lAw
-lAw
-lAw
-lAw
-kQy
+hPn
+ktE
+xCN
+xCN
+xCN
+lvt
+lMT
+mcC
+hPn
+gul
 wTF
-oVJ
-oVJ
-oVJ
-oVJ
-oVJ
+gul
+gul
+gul
+gul
+mKE
 jPi
-gul
+xhA
 fxu
-gul
+xjE
 hhZ
-gul
+xjE
 oYG
-pld
+qVt
 iyJ
 vQx
-vQx
-vQx
+rAt
+jNr
 xhA
-mnj
-uMJ
-cEF
-uMJ
-ukT
-mUS
-nDb
-uMJ
-cEF
-uMJ
-mnj
-tKr
-vMi
-riR
-tsq
-sUH
-gKJ
-cFi
-cFi
-cFi
-peK
-upu
-xpu
-qWx
-iKl
-wWM
-xMi
-vOR
-xMi
-xMi
-fze
-xMi
-xMi
-xVz
-uoO
-bCX
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-uoO
-uoO
-xVz
-xVz
-xVz
-uoO
-qxo
-qxo
-qxo
-qxo
-qxo
-qxo
-xVz
+yhT
+yhT
 uoO
 uoO
 uoO
+oEt
+cSY
+cSY
+cSY
+xoU
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 aoj
@@ -88815,8 +84364,8 @@ aoj
 uoO
 uoO
 uoO
-aoj
-aoj
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -88938,131 +84487,131 @@ eLE
 "}
 (243,1,1) = {"
 eLE
-msV
+uoO
+yhT
 gEZ
-mxh
 mxh
 tSI
-mxh
-mxh
-jDt
-mxh
-mxh
-oCn
+bta
+bKG
+tSI
+cFj
+xxn
+xxn
 aJR
-xxn
-xxn
-nlc
-gEZ
-lMC
+xSi
+vZj
 wOp
-jqX
+wOp
 tnh
-iJK
+tnh
+tnh
+tnh
+kur
 kur
 bDG
-cKQ
+tnh
 kiV
-xNC
+xSi
 wQS
-hqO
-jnI
-uvB
-rFJ
+xCN
+hUn
+xCN
+iqE
 dRc
-pnX
-dbT
-jMM
-xqa
-xqa
-jMM
-aLN
-hFc
-lAw
-lAw
-lAw
-lAw
-kQy
-wTF
-oVJ
-oVJ
-oVJ
-oVJ
-oVJ
-jPi
-gul
-ftt
-gul
-gul
-gul
-oYG
-dxx
-cCv
-iLO
-vQx
-vQx
-klQ
-mnj
-mnj
-omp
-omp
-ukT
-mWp
-nDb
-mnj
-mnj
-mnj
-mnj
-xhA
-xRU
-rsM
-rsM
-rXl
-xhA
-sLI
-xhA
-sLI
-xhA
-uKn
-vqH
-mxa
-iKl
-wVK
-xMi
+pIp
 jzC
-xMi
-jFd
-paF
-xMi
-xMi
-xVz
+jMM
+hPn
+xqa
+xCN
+xCN
+xCN
+lBX
+xCN
+mjJ
+hPn
+kQy
+xfh
+qsM
+mTr
+dRA
+gul
+tJM
+xjE
+jQs
+xjE
+xjE
+xjE
+xjE
+xjE
+dxx
+tCe
+tCe
+qfu
+qfu
+xhA
+yhT
 uoO
-bCX
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
+aoj
+aoj
 uoO
-xVz
-xVz
-xVz
-uoO
-uoO
-qxo
-qxo
-qxo
-qxo
+pNT
+cSY
+cSY
+cSY
+xoU
 uoO
 uoO
 uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -89195,131 +84744,131 @@ eLE
 "}
 (244,1,1) = {"
 eLE
-msV
+uoO
+yhT
 gEZ
-mxh
-mxh
-mxh
-toP
-mxh
-mxh
-mxh
-mxh
+aYY
+xxn
+bum
+bMA
+xxn
+cHw
+xxn
 omk
 bTN
-xxn
-xxn
-xxn
-sKf
-mVw
-wOp
-wOp
+xSi
+dUW
+xSi
+xSi
+xSi
+xSi
+xSi
 bbs
 ikI
-wOp
-gEZ
-gEZ
-gEZ
-gEZ
-tqS
-gEZ
-bPW
+ikI
+gWK
+xSi
+yhd
+xSi
+vof
+hPD
+hUV
 eGW
-rFJ
-wOp
+iqN
+iUq
 xCN
-aEq
-lAw
-lAw
-lAw
-lAw
-yeD
-lAw
-lAw
-dVs
-yeD
-iVx
+tOi
+xCN
 hPn
-eZX
+yeD
+yeD
+yeD
+xCN
+lBX
+dVs
+mkC
+hPn
+ngP
+xfh
 cIS
-oVJ
+nTN
 vfx
-oVJ
-cIS
-khb
-jQs
-qOT
-oTk
-fqM
 gul
-oYG
-vrD
-izo
-vQx
-jzX
-vQx
+tJM
+xjE
+jQs
+xjE
+xjE
+qpc
+xjE
+xjE
 xhA
-aSI
-qQS
-cEF
-uMJ
-ukT
-nby
-nDb
-uMJ
-cEF
-qQS
-pNi
+iAm
+tCe
+qfu
+rIS
 xhA
-tSH
-rtf
-xhA
-xhA
-xhA
-sOf
-xhA
-sOf
-xhA
-bxX
-uXY
-qWx
-iKl
-wWM
-xMi
-lpK
-xMi
-paF
-paF
-xMi
-xMi
-xVz
+yhT
 uoO
-bCX
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-lgA
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
+aoj
+aoj
 uoO
-qxo
-qxo
-qxo
-qxo
+xoU
+cSY
+cSY
+cSY
+qQS
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
 uoO
 aoj
 aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -89452,122 +85001,122 @@ eLE
 "}
 (245,1,1) = {"
 eLE
-msV
+uoO
+yhT
 gEZ
-mxh
 toP
-mxh
-mxh
-mxh
-mxh
-mxh
-mxh
-omk
-bTN
+boI
+bvC
+bNA
+clA
+cLJ
 xxn
-qLb
 xxn
-sKf
-wug
-wOp
-wOp
-wOp
-wOp
-wOp
-wOp
-wOp
-sWB
-jrn
-wOp
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+fBQ
+gbA
+gbA
+gEZ
+xSi
+yhd
+xSi
+hPn
 kny
 bVY
-wOp
-rFJ
-wOp
-xCN
-pzS
-lAw
-buZ
-lAw
-qMO
+ill
 eRw
-bmF
-lAw
-dVs
-lAw
-eHh
+iVx
+xCN
+tOi
+xCN
+buZ
 hPn
-fqz
-oVJ
+hPn
+eRw
+hPn
+hPn
+hPn
+hPn
+eHh
+gul
+gul
+gul
+gul
+gul
 jKo
-aLN
-jKo
-oVJ
+oNu
 hYT
-jQs
-ftt
 gul
-hrq
+qci
+qci
 gul
-gul
-gul
-gul
-gul
-gul
-gul
-klQ
-roa
-roa
-roa
-roa
-kXA
-neq
-eeH
-mpY
-mpY
-mpY
-mpY
+qci
+qci
 xhA
+rfs
+tCe
+tCe
+rJv
 xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-uvd
-vdk
-qWx
-iKl
-xnV
-xMi
-lpK
-xMi
-paF
-paF
-xMi
-xMi
-xVz
+yhT
 uoO
-bCX
-xVz
-lIH
-vLy
-xVz
-xVz
-dWT
-cHw
-xVz
-xVz
-xVz
-xVz
-xVz
-xVz
+aoj
+aoj
+uoO
+xoU
+cSY
+cSY
+cSY
+qQS
 uoO
 uoO
-qxo
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -89709,122 +85258,111 @@ eLE
 "}
 (246,1,1) = {"
 eLE
-msV
+yhT
 gEZ
-toP
-mxh
-mxh
-mxh
-mxh
-mxh
-mxh
-mxh
-omk
-bTN
-xxn
-xxn
-kVP
-sKf
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+dkT
+dkT
+gEZ
+gEZ
 oZd
-wOp
-wOp
-wOp
-wOp
-wOp
-wOp
-wOp
-wOp
-jrn
-wOp
-kny
-bVY
-kxR
-vIu
+kVP
+tsm
+oZd
+kVP
+tsm
+fEs
+xxn
+xxn
+gEZ
+xSi
+yhd
+hhn
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
 kkB
 xCN
-pHQ
+jAd
 lrP
 jtx
 vPB
 tMw
-tlr
+tMw
 iMP
-tBw
-bdV
+tMw
+iMP
 fVx
 uWC
-hPn
-kAm
-cLp
-qbK
-pzO
-qbK
-cLp
-kAm
-pLl
-fCf
+uWC
+uWC
+uWC
+uWC
+uWC
+uWC
+oNM
+dFh
 gul
+fCf
+qgO
 tls
 hGF
 hVy
-aBQ
-iAm
-aVV
-jBc
 gul
+iAm
+tCe
+qfu
+rKE
 xhA
-kxu
-rKJ
-rKJ
-nIB
-frn
-rzQ
+yhT
+uoO
+uoO
+uoO
+uoO
+vOo
 fuQ
-dZE
-hhn
-oNj
-eeH
-qci
-xcC
-rvb
-xcC
-rvb
-xcC
-hHc
-uJx
-txU
-xMi
-xMi
-xMi
-wmE
-xMi
-xMi
-xMi
-osk
-xMi
-jFd
-jFd
-xMi
-xMi
-dkT
+cSY
+cSY
+pNT
 uoO
-bCX
-xVz
-xQT
-qUL
-qUL
-qGe
-ajJ
-upA
-rDr
-amf
-xVz
-xVz
-xVz
-xVz
-xVz
 uoO
-qxo
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -89841,8 +85379,19 @@ uoO
 uoO
 uoO
 uoO
+uoO
 aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -89966,127 +85515,98 @@ eLE
 "}
 (247,1,1) = {"
 eLE
-msV
+yhT
 gEZ
-mxh
-mxh
-bIS
-mxh
-mxh
-bIS
-mxh
-mxh
-mxh
-bTG
 xxn
 xxn
-ddJ
-bIN
-wOp
+bIS
+bpH
+xxn
+clT
+cQR
+xxn
+xxn
+gEZ
+gEZ
+dWT
 jrn
 tsm
+dWT
 jrn
-jFC
+tsm
+fEs
+xxn
 llQ
-vqD
-hlH
+gEZ
+xSi
 vZj
-vZj
-vZj
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-iMc
-hPn
-acJ
+wOp
+hBz
+hPF
+hVk
+hVk
+hVk
+iXC
+lrP
+jFd
+xCN
 rRQ
-bCh
-pzO
-hPn
-hPn
+xCN
 uIZ
-hPn
-hPn
-hPn
-hPn
-hPn
-cXG
-hPn
-hPn
-hPn
-cXG
+uIZ
+lok
+uIZ
+lok
 dFh
-jQs
-ftt
-gul
+dFh
+dFh
+dFh
+dFh
+nUF
+dFh
+dFh
+dFh
+dFh
+pAn
+vVg
+qhw
 xmQ
 fYf
-hXf
+vVg
 rJn
-iEg
+tCe
 tCe
 qfu
-eSC
-mgt
-nIB
-jIm
-jIm
-nIB
-kXA
-nkx
-xpu
-xpu
-xpu
-xpu
-fuQ
+qfu
 xhA
-qOJ
-cTh
-cTh
-cTh
-xcC
-wbM
-srH
-tzx
-xMi
-qqJ
-mEm
-oRZ
-qtL
-bKG
-fLF
-ddQ
-xMi
-eOx
-trJ
-xMi
-xMi
-xVz
-xVz
-fkn
-xVz
-oMK
-iGY
-hTD
-otf
-qxo
-suF
-eRg
-dWT
-uiV
-amf
-xVz
-xVz
-xVz
+yhT
 uoO
-qxo
+uoO
+uoO
+uoO
+pNT
+cSY
+kCz
+xoU
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
 uoO
 uoO
+aoj
 uoO
 uoO
 uoO
@@ -90099,7 +85619,36 @@ uoO
 uoO
 uoO
 aoj
+uoO
+uoO
+uoO
 aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -90223,128 +85772,79 @@ eLE
 "}
 (248,1,1) = {"
 eLE
-msV
+yhT
+gEZ
+xxn
+xxn
+bpH
+xxn
+xxn
+coQ
+cSH
+xxn
+xxn
 gEZ
 gEZ
+tsm
+ejQ
+tsm
+tsm
+ejQ
+tsm
+xxn
+xxn
+xxn
 gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-bPW
 xSi
-tkD
-hUV
+xSi
+xSi
 gEZ
-gEZ
-gEZ
+hQt
+hWJ
 eEL
-aCS
+eEL
+hPn
 eqD
-gEZ
-msV
-msV
-msV
-msV
-msV
+eqD
+jYP
 hPn
+gul
+gul
+gul
+gul
 lXT
-hPn
-vXo
-vXo
-vXo
-vXo
-vXo
-vXo
-vXo
-hPn
+liM
 nWW
 liM
-nnN
-fDp
 gul
-xmQ
-qKP
+gul
+gul
+gul
+gul
+liM
+nWW
+liM
+gul
+fDp
 vVg
-igV
+qqJ
+vVg
+vVg
+gul
 oxw
 iIQ
-oxw
+rAt
 jNr
-mgt
-nIB
-nIB
-lYu
-kBT
-fOH
-eeH
-eeH
-kCz
-oja
-nIB
-pWr
 xhA
-xcC
-xYY
-xYY
-xYY
-xcC
-uJx
-tnl
-tHM
-xMi
-oRM
-llp
-tAi
-mrx
-xsk
-mTF
-ydK
-xMi
-xMi
-xMi
-xMi
-eIJ
-xVz
-xVz
-xVz
-xVz
-nYw
-dur
-ofI
-dlw
-qxo
-qxo
-pPS
-gTy
-gTy
-oaW
-qGe
-qGe
-qxo
-otf
-qxo
-uoO
-aoj
-aoj
+yhT
 uoO
 uoO
 uoO
+uoO
+pNT
+seP
+kCz
+xoU
 uoO
 uoO
 uoO
@@ -90357,9 +85857,58 @@ uoO
 uoO
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -90480,128 +86029,85 @@ eLE
 "}
 (249,1,1) = {"
 eLE
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+yhT
 gEZ
-tZc
-hpT
-tZc
-gEZ
-qmL
-qQF
-mDt
-bbw
-sxs
-bvP
-ctL
+auO
 xxn
-ejQ
+xxn
+xxn
+xxn
+coQ
+cTh
+xxn
+omk
+gEZ
+gEZ
+dZE
+xxn
+xxn
+xxn
+xxn
+xxn
+xxn
+xxn
+bbw
+gEZ
+xSi
+xSi
+xSi
+gEZ
 qpd
 dLF
-gEZ
 iAs
-aHj
+iAs
+hPn
 oSq
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-hPn
-ueZ
-hPn
-hPn
-hPn
-hPn
-hPn
-hPn
-hPn
-hPn
-hPn
-cna
-weF
-jQs
-jQs
+jGQ
+jGQ
+kcD
 gul
-xmQ
+kJW
+dRA
+gul
+ueZ
+cna
+cna
+muD
+gul
+kJW
+dRA
+gul
+ueZ
+cna
+cna
+muD
+gul
+qdj
+vVg
+qta
 vrD
-hXn
-iIQ
-oxw
-iIQ
-iIQ
-rJn
-koC
-kBT
-kBT
-fOH
-vDn
-sjR
-aCO
-nEt
-vDn
-ukP
-nIB
-eeH
-qci
-xcC
-xcC
-xcC
-xcC
-xcC
-srH
-ksU
-tIz
-xMi
-rjQ
-mrV
-wDq
-lMT
-ldP
-hQt
-vCL
-eeW
-gHi
-gHi
-haW
-tYy
-xVz
-xVz
-xVz
-uoO
-qxo
-otf
-oaW
-fZB
-qxo
-qxo
-qxo
-qxo
-qxo
-tha
-qxo
-qxo
-qxo
-jAd
-aoj
+vVg
+gul
+xhA
+xhA
+xhA
+xhA
+xhA
+yhT
 uoO
 aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+xoU
+cSY
+xoU
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -90617,6 +86123,49 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -90737,128 +86286,86 @@ eLE
 "}
 (250,1,1) = {"
 eLE
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+yhT
 gEZ
 xxn
 xxn
-xxn
-uZG
-xxn
-qLb
+bpH
 xxn
 xxn
+coQ
+cUC
+xxn
+xxn
+gEZ
+gEZ
 xxn
 xxn
 xxn
 xxn
-ejQ
 xxn
-vPd
+xxn
+xxn
+gfz
+gzD
+gEZ
+gHh
+hcx
+hlS
 gEZ
 gEZ
 gEZ
+gEZ
+gEZ
+hPn
 llZ
-gEZ
-egd
-pRD
-pRD
-dqh
-ukN
-bJa
-jPz
-bKT
-sdw
-snP
-vUF
+jGQ
+jZg
+kdH
+gul
 pud
 xlL
-ehz
-dtO
+gul
+ueZ
+sdw
+sdw
+snP
+gul
+pud
+xlL
+gul
+ueZ
 vKT
-cuN
-eLG
+vKT
+snP
+gul
+gul
+qmh
+gul
+gul
+gul
 gul
 yhT
-gul
-gul
-gul
-gul
-gul
-iJD
-gul
-oxw
-jOL
-mgt
-pEG
-pEG
-nIB
-mAX
+yhT
+yhT
+yhT
+yhT
+uoO
+uoO
+aoj
+uoO
+uoO
+xoU
 xcC
-nkL
-xcC
-nNi
-ukP
-nIB
-pWr
-xhA
-xcC
-cTh
-cTh
-cTh
-xcC
-sPa
-tnl
-tJH
-xMi
-mrV
-oRM
-mTF
-mTF
-thr
-iAx
-aQg
-xYX
-tYy
-gHi
-alw
-uFn
-xVz
-xVz
-xVz
+xoU
 uoO
-otf
-otf
-oaW
-fZB
-qxo
-qxo
-qxo
-qxo
-qxo
-qxo
-qxo
-qxo
-smf
 uoO
-aoj
 uoO
-aoj
-aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -90872,8 +86379,50 @@ uoO
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
+uoO
+uoO
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -90994,128 +86543,116 @@ eLE
 "}
 (251,1,1) = {"
 eLE
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+yhT
+gEZ
+xxn
+xxn
+bri
+xxn
+xxn
+cqY
+cZP
+xxn
+dKk
+gEZ
+gEZ
 gEZ
 utP
-xxn
-xxn
+eHy
+gEZ
 uZG
+fuc
 xxn
 xxn
-xxn
-qLb
-xxn
-xxn
-qLb
-iZB
-ehT
-xxn
-xJR
+rFJ
 gEZ
-egd
-pRD
+gEZ
+gEZ
+gEZ
+gEZ
+yhT
+yhT
+yhT
+yhT
+hPn
 pRW
-gEZ
+jIm
 tem
 quB
-igr
-gEZ
-gEZ
-hPn
-hPn
-hPn
-hPn
-hPn
-qmZ
-hPn
-hPn
-hPn
-hPn
-hPn
-hPn
-hPn
 gul
-yhT
+kLA
+xfh
+loJ
+cna
+sdw
+mqJ
+cna
 gul
+kLA
+xfh
+loJ
+cna
+vKT
+oPU
+cna
+gul
+xfh
+qsM
 qsM
 mTr
 dRA
-xDy
-fYf
 gul
-bsF
-jOU
-mgt
-bpH
-lgv
-nIB
-xcC
-kGx
-umZ
-gsc
-nWG
-ukP
-oWc
-eeH
-xhA
-qOJ
-xYY
-xYY
-xYY
-xcC
-sUy
-srH
-tzx
-xMi
-olK
-sUF
-wuE
-mTF
-xss
-xMi
-eDs
-xMi
-xMi
-xMi
-xMi
-eIJ
-xVz
-xVz
-xVz
+yhT
 uoO
-otf
-otf
-oaW
-qxo
-qxo
-qxo
-qxo
-rDr
-rDr
-oaW
-rDr
-oaW
-rDr
+uoO
+uoO
+uoO
+uoO
 uoO
 aoj
 uoO
+uoO
+uoO
+xoU
+uoO
+uoO
+uoO
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-aoj
-aoj
-aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -91131,6 +86668,18 @@ aoj
 aoj
 aoj
 aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
 aoj
@@ -91251,121 +86800,90 @@ eLE
 "}
 (252,1,1) = {"
 eLE
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+yhT
 gEZ
 gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+gEZ
+dZW
+enl
 abY
 gEZ
-gEZ
+fdN
 dJD
-nMR
-hxB
-hxB
-jii
-bcf
-onU
-pSY
-uMR
-sFl
-uMR
-gEZ
-vjx
+xxn
+xxn
 gEZ
 gEZ
-gEZ
-tem
-quB
-quB
-gEZ
-msV
-vXo
-vXo
-vXo
-vXo
-vXo
-tGm
+yhT
+yhT
+yhT
+yhT
+yhT
+uoO
+uoO
+yhT
+hPn
+hPn
+hPn
+hPn
+hPn
+gul
 weF
 qHi
-keH
+gul
 xak
 igo
+mrx
+myA
+gul
 weF
+qHi
+gul
+xak
+igo
+mrx
+myA
+gul
 weF
+qmL
+qtL
+nTN
+vfx
+gul
 yhT
-yhT
-gul
-gTT
-mTr
-gul
-iiE
-iuX
-gul
-cLJ
-jTD
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-eeH
-qfB
-xcC
-gsc
-xcC
-gsc
-xcC
-hHc
-sPa
-txU
-xMi
-scG
-vyb
-sUF
-wNs
-sUF
-cej
-qVt
-aQg
-aQg
-bum
-xMi
-xMi
-xVz
-xVz
-xVz
-xVz
-wqL
-otf
-oaW
-qxo
-eQL
-qxo
-suF
-cHw
-oaW
-oaW
-oaW
-xVz
-xVz
 uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 aoj
 uoO
 uoO
@@ -91376,6 +86894,37 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -91509,57 +87058,53 @@ eLE
 (253,1,1) = {"
 eLE
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
 gEZ
+eaR
 fpv
-xxn
-xxn
+dWT
 gEZ
-rUF
-xxn
-xxn
-xxn
-xxn
-xxn
-wao
-pSY
-erF
-xxn
-ygM
 gEZ
-tfI
-pRD
-pRD
-hoz
-pjX
-vTF
-quB
 gEZ
-msV
-hPn
-hPn
-hPn
-hPn
-hPn
-uJG
-sSF
-oGc
+gEZ
+gEZ
+gEZ
+yhT
+yhT
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+gul
+gul
+gul
+gul
+gul
+gul
+gul
+gul
+gul
+gul
+gul
 bKi
-xly
-oHT
-weF
-eVA
 gul
 gul
 gul
@@ -91571,57 +87116,16 @@ gul
 gul
 gul
 gul
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xhA
-xMi
-uwV
-xMi
-wxb
-xMi
-xCf
-xMi
-dTR
-acv
-qVt
-ucw
-xMi
-xMi
-xVz
-bCX
-xVz
-uTL
-xVz
-dur
-hTD
-dlw
-qxo
-oNu
-suF
-upA
-hnU
-oaW
-xVz
-xVz
-fzT
+yhT
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -91632,6 +87136,51 @@ uoO
 uoO
 uoO
 uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -91776,104 +87325,104 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-gEZ
-fpv
-bTG
-xxn
-gEZ
-lHS
-mrX
-lfJ
-stJ
-ugR
-piT
-hWJ
-gEZ
-ckm
-tJW
-ntS
+yhT
 gEZ
 gEZ
 gEZ
 gEZ
 gEZ
-gEZ
-gEZ
-gEZ
-gEZ
-msV
+yhT
+yhT
+yhT
+yhT
+yhT
 uoO
 uoO
 uoO
 uoO
-hPn
-afZ
-gcK
-pBa
-huv
-eQh
-weF
-weF
-eLG
-fcn
-fKn
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-kKy
-wox
-uFO
-iXC
-iXC
-iXC
-iXC
-xMi
-xMi
-xMi
-xMi
-xMi
-xMi
-wox
-bCX
 uoO
-vxo
-isU
-oCA
 uoO
-fEs
-xVz
-gbA
-dkT
-kqS
-kbH
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+yhT
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
+uoO
 uoO
 uoO
 uoO
@@ -92035,46 +87584,6 @@ eLE
 eLE
 eLE
 eLE
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-vXx
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-msV
-eLE
-eLE
-eLE
-eLE
-dFh
-dFh
-dFh
-dFh
-dFh
-dFh
-dFh
-dFh
-dFh
-fdN
 eLE
 eLE
 eLE
@@ -92106,19 +87615,59 @@ eLE
 eLE
 eLE
 eLE
-wox
-wox
-wox
-wox
-wox
-wox
-wox
-wox
-wox
-wox
-wox
-wox
-wox
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
+eLE
 eLE
 eLE
 eLE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -17435,7 +17435,6 @@
 	doc_title_5 = "Doctrine pt. 5";
 	icon = 'icons/obj/machines/particle_accelerator.dmi';
 	icon_keyboard = "generic_key";
-	icon_screen = generic;
 	icon_state = "control_boxp";
 	idle_power_usage = 1;
 	light_color = "#6e1722";


### PR DESCRIPTION
## About The Pull Request

https://imgur.com/HsDs0a6
Full base

https://imgur.com/hCWg7vX
Dorms corner, featuring; removed sauna, greatly reduced pool area, generally compressed bathroom with the return of shower rows. Some dorms have been removed, but overall bed space has been increased in the form of public bunks. Also, personal lockers are back.

https://imgur.com/34PVCf2
Knight Corner. Public Knight desks, Star Knight and Head Knight offices are all within close proximity to the armory and the brig.

https://imgur.com/zjzTlbJ
New kitchen/gym. Compressed kitchen, to emphasise use of the surface kitchen. Small functional gym takes some of the space previously taken by the massive pool.

https://imgur.com/vD0KK3V
Paladin Corner + Briefing/Ceremony area. Ceremony Hall got moved from its old spot to a main area of the first floor, where it can also be used for general briefings with good access to all other departments.

https://imgur.com/PkjRuc1
Medical + Psych Office. Medical's mostly the same, but in removing maintenance areas there was space to add in a private psych office.

https://imgur.com/fgRrEAG
Archives + Proctor/Head Scribe/Elder Offices. All down here immediately next to the Archives/RnD.

https://imgur.com/9IXgTmZ
Reactor + Mining. Knight related areas are all to the left side of RnD.

https://imgur.com/JmV433x
Research + Workshop. Workshop got swapped to the South East of general RnD. Scribe areas are generally to the South and East of RnD now.

https://imgur.com/zMv42iU
Archives + Codex/Hall of Remembrance. Codex room redecorated without the Clockwork Cult tiles and structures, but now also serves dual-purpose as a remembrance area.

https://imgur.com/U69oL35
New Mine Exterior. Given that the mines were moved much further west than their original position, the neat water area was extended to the East. Mirelurks were added to the far side of the underground river to tie in thematically with the Mirelurk river to the East of the surface camp. The Rockclaw was moved further from the new mine entrance, but also there's a couple more out there now.

** images are slightly out of date, missing mostly minor cosmetic improvements, but are 98% accurate

## Why It's Good For The Game
Greatly reduced underground bunker size, mainly revolving around removal of the elevator and subsequent reorientation of the base. Additions include a small office for medical psych discussion, and a general purpose area for briefing/ceremonies.

## Changelog
:cl:
del: Removed the last two vendors in the surface camp. People in the camp can just ask the Brotherhood members for trade, and people outside the camp will use the window.
del: Lots of excess space in the BoS bunker, approximately 40% of its previous size, including all maintenance areas.
tweak: Most of the BoS Underground has been reduced, reoriented or transplanted to another part of the bunker.
tweak: Minor reorientation of BoS surface ladder room to maintain verisimilitude with lower ladder room.
add: Extended the water themed mining area to compensate for its relocation, expanding the area Eastwards to represent a 'breach' from the mirelurk area East of the surface camp.
add: Added mirelurks in the extended mine river.
tweak: The water is now walkable to represent it being shallow. This means enemies can walk across it too.
add: Added 2 extra Rockclaws to populate the extra mine space between the BoS, NCR and Legion.
add: Adopted mouse to the Star Paladin offices.
:cl: