### PR TITLE
Distilling and Mortar/Pestle Additions

### DIFF
--- a/code/__DEFINES/botany.dm
+++ b/code/__DEFINES/botany.dm
@@ -10,3 +10,7 @@
 
 //Seed flags.
 #define MUTATE_EARLY	(1<<0)
+
+//Mortar grinding/juicing modes
+#define MORTAR_JUICE	0
+#define MORTAR_GRIND	1

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -19,8 +19,6 @@
 	. += "<span class='notice'>It is currently [open?"open, letting you pour liquids in.":"closed, letting you draw liquids from the tap."]</span>"
 
 /obj/structure/fermenting_barrel/proc/makeWine(obj/item/reagent_containers/food/snacks/grown/fruit)
-	if(fruit.reagents)
-		fruit.reagents.trans_to(src, fruit.reagents.total_volume)
 	var/amount = fruit.seed.potency / 4
 	if(fruit.distill_reagent)
 		reagents.add_reagent(fruit.distill_reagent, amount)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -449,7 +449,7 @@
 			to_chat(user, "<span class='notice'>You start grinding...</span>")
 			if((do_after(user, 25, target = src)))
 				user.adjustStaminaLoss(20)
-				if(grinded.juice_results && (mortar_mode== MORTAR_JUICE)) //prioritize juicing
+				if(grinded.juice_results && (mortar_mode== MORTAR_JUICE)) // will prioritize juicing IF the Mortar's toggled to juice.
 					grinded.on_juice()
 					reagents.add_reagent_list(grinded.juice_results)
 					to_chat(user, "<span class='notice'>You juice [grinded] into a fine liquid.</span>")

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -437,7 +437,7 @@
 		return TRUE
 	else
 		mortar_mode = !mortar_mode
-		to_chat(user, "<span class='notice'>You decide to hold the [src] differently to [mortar_mode == MORTAR_JUICE ? "juice the harvest" : "grind the harvest"].</span>")
+		to_chat(user, "<span class='notice'>You decide to hold [src] differently to [mortar_mode == MORTAR_JUICE ? "juice the harvest" : "grind the harvest"].</span>")
 
 /obj/item/reagent_containers/glass/mortar/attackby(obj/item/I, mob/living/carbon/human/user)
 	..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -419,7 +419,7 @@
 
 /obj/item/reagent_containers/glass/mortar
 	name = "bone mortar"
-	desc = "A specially formed bowl of ancient design. It is possible to crush or juice items placed in it using a pestle; however the process, unlike modern methods, is slow and physically exhausting. Alt click to eject the item."
+	desc = "A specially formed bowl of ancient design. It is possible to crush or juice items placed in it using a pestle; however the process, unlike modern methods, is slow and physically exhausting. Alt click to eject any item put inside. Alt click while empty to change between grind/juice mode."
 	icon_state = "bone_mortar"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -427,14 +427,17 @@
 	reagent_flags = OPENCONTAINER
 	spillable = TRUE
 	var/obj/item/grinded
+	var/mortar_mode = MORTAR_JUICE
 
 /obj/item/reagent_containers/glass/mortar/AltClick(mob/user)
-	. = ..()
 	if(grinded)
 		grinded.forceMove(drop_location())
 		grinded = null
 		to_chat(user, "<span class='notice'>You eject the item inside.</span>")
 		return TRUE
+	else
+		mortar_mode = !mortar_mode
+		to_chat(user, "<span class='notice'>You decide to hold the [src] differently to [mortar_mode == MORTAR_JUICE ? "juice the harvest" : "grind the harvest"].</span>")
 
 /obj/item/reagent_containers/glass/mortar/attackby(obj/item/I, mob/living/carbon/human/user)
 	..()
@@ -444,9 +447,9 @@
 				to_chat(user, "<span class='warning'>You are too tired to work!</span>")
 				return
 			to_chat(user, "<span class='notice'>You start grinding...</span>")
-			if((do_after(user, 25, target = src)) && grinded)
+			if((do_after(user, 25, target = src)))
 				user.adjustStaminaLoss(20)
-				if(grinded.juice_results) //prioritize juicing
+				if(grinded.juice_results && (mortar_mode== MORTAR_JUICE)) //prioritize juicing
 					grinded.on_juice()
 					reagents.add_reagent_list(grinded.juice_results)
 					to_chat(user, "<span class='notice'>You juice [grinded] into a fine liquid.</span>")
@@ -454,9 +457,9 @@
 					return
 				grinded.on_grind()
 				reagents.add_reagent_list(grinded.grind_results)
-				if(grinded.reagents) //food and pills
+				if(grinded.reagents && (mortar_mode== MORTAR_GRIND)) //food and pills
 					grinded.reagents.trans_to(src, grinded.reagents.total_volume)
-				to_chat(user, "<span class='notice'>You break [grinded] into powder.</span>")
+				to_chat(user, "<span class='notice'>You grind [grinded] into a fine powder.</span>")
 				QDEL_NULL(grinded)
 				return
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Mortar can now be toggled between two different modes when it's empty: Grind and Juice. If you have Grind, you will get the raw materials of the goods you ground, while if you have Juice, you will attempt to juice it before it gets ground. If the item cannot be juiced, it'll be ground.
- Putting plants into Fermenting Barrel will no longer give you the reagents within the plants: it'll only produce pure, raw, beautiful ferment-juice to drink.
- Added new DEFINES into botany.dm to help with the mortar grinding/juicing code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now the Legion and the Wayfarers (and just about anyone else) can set if they want to be able to get the raw materials of a plant (maybe you want the Radium from Mutfruit) in which before you couldn't, because the juice check would override the grind check. This is no longer the case, and instead now it depends on the player's choice. You can now ferment plants and not have to bother about your weight, as it'll produce the pure goods of the plants as oppose to anything 'extra'.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: New Grinding/Juicing mode for the Mortar/Pestle!
del: Fermenting Barrel no longer gives you the reagents a plant held - and instead gives you pure distilled action instead!
code: Added new defines into the botany.dm code to help with the Mortar/Pestle grind/juice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
