### PR TITLE
How to save the Leather Club/Biogenerator Biomass' Leather drain reverted

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -145,7 +145,7 @@
 	name = "Sheet of Leather"
 	id = "leather"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 6000)
+	materials = list(/datum/material/biomass = 150)
 	build_path = /obj/item/stack/sheet/leather
 	category = list("initial","Organic Materials")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Biogenerator's biomass cost for leather production has gone down from the *HUGE* price of 6000 biomass/leather sheet, down to 150 (it's base cost). maintainers from merging your PR! -->

## Why It's Good For The Game
The reason behind this is simple: Leather can no longer be sold for caps anymore, and this change was introduced to punish those who did just that. Given you can no longer earn caps with it, the nerf should be undone, and that's what I seek to do, as leather can still be used to create super stimpaks, cosmetics, items and what not. You can revert this or request for the value to be higher, but it's not going to 6000 or 3000 again unless the leather selling gets added back in.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Biomass cost of Leather Production gone down from 6000/unit to 150/unit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
