### PR TITLE
Fixes an Typo in the burn arrow description 

### DIFF
--- a/code/modules/projectiles/ammunition/caseless/arrow.dm
+++ b/code/modules/projectiles/ammunition/caseless/arrow.dm
@@ -23,7 +23,7 @@
 
 /obj/item/ammo_casing/caseless/arrow/burning
 	name = "burn arrow"
-	desc = "A sumple arrow slathered in a paste that burns skin on contact."
+	desc = "A simple arrow slathered in a paste that burns skin on contact."
 	projectile_type = /obj/item/projectile/bullet/reusable/arrow/burning
 	icon_state = "arrow_burning"
 


### PR DESCRIPTION

## About The Pull Request
Fixes a typo in the burn arrow description and should fix lando_the_randos complaint of the issue. Was not tested on my own but should work as no one really touches the arrows much so shouldn't have an conflict with others.

## Why It's Good For The Game
This should fix typo in the burn arrow, people shouldn't really know a change.

## Changelog
:cl:
tweak: fixes an simple typo in the description in the burn arrow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
