### PR TITLE
Bunkees 'n poultice 'n shit

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -4941,6 +4941,8 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/smelling_salts/wayfarer,
 /obj/item/smelling_salts/wayfarer,
+/obj/item/stack/medical/poultice,
+/obj/item/stack/medical/poultice,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "dAg" = (
@@ -21220,6 +21222,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/stack/medical/poultice,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "opW" = (
@@ -21605,6 +21608,7 @@
 /obj/machinery/iv_drip,
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/stack/medical/poultice,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "oFJ" = (

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -8557,11 +8557,6 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"ixT" = (
-/obj/structure/rack,
-/obj/item/book/granter/crafting_recipe/gunsmith_one,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
 "ixX" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /obj/effect/decal/cleanable/dirt,
@@ -12860,7 +12855,7 @@
 "noe" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "noI" = (
@@ -56731,7 +56726,7 @@ uoO
 eoy
 vxm
 ygg
-ixT
+iCS
 tQD
 eoy
 uoO

--- a/_maps/map_files/templates/dungeons/north_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_2.dmm
@@ -739,6 +739,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/f13/bunker)
+"pt" = (
+/obj/item/stack/medical/mesh,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "pI" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -828,8 +832,7 @@
 /turf/open/floor/grass,
 /area/f13/bunker)
 "rC" = (
-/obj/machinery/porta_turret/syndicate,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/medical/suture,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "rJ" = (
@@ -841,7 +844,7 @@
 /turf/open/floor/grass,
 /area/f13/bunker)
 "rM" = (
-/obj/machinery/porta_turret/syndicate,
+/obj/machinery/porta_turret/syndicate/vehicle_turret,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "rY" = (
@@ -936,6 +939,10 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/bunker)
+"tF" = (
+/obj/item/pickaxe,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "tK" = (
 /obj/item/pizzabox/mushroom,
@@ -3212,7 +3219,7 @@ wN
 oj
 rM
 YR
-rC
+go
 xG
 Rl
 Rl
@@ -3554,7 +3561,7 @@ oj
 oj
 rM
 wP
-rM
+oj
 xG
 Rl
 Rl
@@ -4972,7 +4979,7 @@ xG
 RB
 FV
 go
-oj
+rC
 oj
 KH
 qb
@@ -4983,7 +4990,7 @@ gB
 Rl
 Rl
 xG
-oj
+tF
 oj
 Ub
 go
@@ -5126,7 +5133,7 @@ oj
 CM
 oh
 oh
-oj
+pt
 Ee
 oj
 go

--- a/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
@@ -1351,10 +1351,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "yx" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "yA" = (
@@ -2277,7 +2277,7 @@
 "Ow" = (
 /obj/structure/rack,
 /obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "OB" = (
@@ -2303,10 +2303,10 @@
 /area/f13/radiation)
 "Pg" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "PH" = (


### PR DESCRIPTION
## About The Pull Request

A couple requested mapping fixes.
The loot in my oasis alt, because no one wants to fight a whole bunch of giant robos for a hunting rifle.
The turrets in my north alt because these ones can for some reason see in the dark. I changed them to the right ones and also reduced it so there are only four not six, if you walked in and got shot it was literally  just a kill box and absolutely no fun. 
Changed a couple of the sewer static book spawners to random book spawners because random is better. 
Added mourning poultices to the legion and tribal medical areas, only two each. 

## Why It's Good For The Game

Makes the north bunker alt back room actually playable and not a single shot faction wiper.
Makes Oasis bunkee alt more worth it.
Gives the primitive healers a little help. 

## Changelog
:cl:
add: Mourning poultice in tribe and legion
tweak: Tier of gun that spawns in oasis bunker alt
tweak: A couple static book spawns to random book spawns
fix: Turrets in north bunker alt 
/:cl:

