### PR TITLE
Display correct casing for custom say verbs in chat

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -54,6 +54,25 @@
 
 	usr.emote("me",1,message,TRUE)
 
+/**
+ * Ensure that the first word of a sentence gets transformed into lower case
+ * e.g. `Nods her head and stares at McMullen` becomes
+ * `nods her head and stares at McMullen`.
+ */
+/proc/lowertext_first_word(sentence)
+	var/list/words_in_sentence = splittext(sentence, regex(@"[ ]+"))
+	var/treated_sentence = ""
+	var/sentence_len = length(words_in_sentence)
+	if(sentence_len == 0)
+		return sentence
+	var/i = 0
+	for(var/word_in_sentence in words_in_sentence)
+		treated_sentence += i == 0 ? lowertext(word_in_sentence) : word_in_sentence
+		if (i != sentence_len - 1)
+			treated_sentence += " "
+		i += 1
+	return treated_sentence
+
 /mob/say_mod(input, message_mode)
 	if(message_mode == MODE_WHISPER_CRIT)
 		return ..()
@@ -63,7 +82,7 @@
 	var/customsayverb = findtext(input, "*")
 	if(customsayverb)
 		message_mode = MODE_CUSTOM_SAY
-		return lowertext(copytext_char(input, 1, customsayverb))
+		return lowertext_first_word(copytext_char(input, 1, customsayverb))
 	return ..()
 
 /proc/uncostumize_say(input, message_mode)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Apart from the first verb word, subsequent verbs in a custom say verb sentence will preserve the input casing given by the user input. This will allow words like names, which are in upper case, from being forced transformed into lower case.

![Screenshot 2021-05-03 150033](https://user-images.githubusercontent.com/59653547/116869073-9a364900-ac42-11eb-91f3-32dcdeddcb25.png)

In the chat bar, type `say "looks at McMullen*How do you mean?`:

Currently, the chat log generates a custom say verb entry as: `XX looks at mcmullen, "How do you mean?"`

![Screenshot 2021-05-03 150047](https://user-images.githubusercontent.com/59653547/116869090-a6220b00-ac42-11eb-82a2-aeb4eb23446f.png)

With this PR, the entry will be  `XX looks at McMullen, "How do you mean?"`

![Screenshot 2021-05-03 185411](https://user-images.githubusercontent.com/59653547/116869110-afab7300-ac42-11eb-867a-8b54b106b9ed.png)

![Screenshot 2021-05-03 191207](https://user-images.githubusercontent.com/59653547/116869556-83dcbd00-ac43-11eb-888a-b6c9a22df44d.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Quality of life when speaking in character

## Changelog
:cl:
fix: Display correct casing for custom say verbs in chat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
