### PR TITLE
Loot Fixes

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -3253,11 +3253,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"eRb" = (
-/turf/closed/wall/r_wall/f13composite{
-	icon_state = "rubblepillar"
-	},
-/area/f13/caves)
 "eRf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -7447,7 +7442,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/attachments,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier9,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -8080,9 +8075,7 @@
 "mas" = (
 /obj/structure/timeddoor,
 /obj/machinery/light/fo13colored/Red,
-/turf/closed/wall/r_wall/f13composite{
-	icon_state = "rubblepillar"
-	},
+/turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
 "mav" = (
 /obj/structure/table/wood,
@@ -8273,12 +8266,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"mmk" = (
-/obj/structure/timeddoor,
-/turf/closed/wall/r_wall/f13composite{
-	icon_state = "rubblepillar"
-	},
-/area/f13/bunker)
 "mmy" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -15772,12 +15759,6 @@
 	},
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"xph" = (
-/obj/structure/timeddoor,
-/turf/closed/wall/r_wall/f13composite{
-	icon_state = "rubbleslab"
-	},
 /area/f13/bunker)
 "xpD" = (
 /turf/closed/wall/f13/tunnel,
@@ -46336,7 +46317,7 @@ bsh
 bsh
 bsh
 bsh
-mmk
+qYk
 aUx
 cIT
 cIT
@@ -46592,8 +46573,8 @@ bsh
 bsh
 bsh
 bsh
-eRb
-xph
+bsh
+qYk
 gwy
 fku
 qsb
@@ -46850,7 +46831,7 @@ byG
 bsh
 bsh
 bsh
-mmk
+qYk
 gwy
 qsb
 qsb
@@ -48392,7 +48373,7 @@ bsh
 bsh
 rog
 bsh
-xph
+qYk
 wvj
 vwf
 vId
@@ -49174,7 +49155,7 @@ cIT
 bQs
 gwy
 ibz
-vPZ
+uXT
 gwy
 laJ
 koh

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1116,7 +1116,10 @@
 				/obj/effect/spawner/bundle/f13/plasmapistol,
 				/obj/effect/spawner/bundle/f13/deagle,
 				/obj/effect/spawner/bundle/f13/commando,
-				/obj/effect/spawner/bundle/f13/mk23
+				/obj/effect/spawner/bundle/f13/mk23,
+				/obj/effect/spawner/bundle/f13/revolverm29,
+				/obj/effect/spawner/bundle/f13/needler,
+				/obj/effect/spawner/bundle/f13/neostead
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier8
@@ -1125,15 +1128,12 @@
 				/obj/effect/spawner/bundle/f13/r84,
 				/obj/effect/spawner/bundle/f13/assault_rifle,
 				/obj/effect/spawner/bundle/f13/marksman,
-				/obj/effect/spawner/bundle/f13/revolverm29,
-				/obj/effect/spawner/bundle/f13/neostead,
 				/obj/effect/spawner/bundle/f13/aer9,
 				/obj/effect/spawner/bundle/f13/ionrifle,
 				/obj/effect/spawner/bundle/f13/mp5,
 				/obj/effect/spawner/bundle/f13/citykiller,
-				/obj/effect/spawner/bundle/f13/needler,
 				/obj/effect/spawner/bundle/f13/brushgun,
-				/obj/effect/spawner/bundle/f13/thatgun
+				/obj/effect/spawner/bundle/f13/infiltrator
 				)
 
 /obj/effect/spawner/bundle/f13/r82
@@ -1159,27 +1159,29 @@
 		/obj/item/gun/ballistic/shotgun/automatic/combat/citykiller,
 		/obj/item/ammo_box/shotgun/buck
 	)
-/obj/effect/spawner/bundle/f13/thatgun
-	name = "556 pistol spawner"
-	items = list(
-				/obj/item/gun/ballistic/revolver/thatgun
-	)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier9
 	name = "tier 9 gun"
-	loot = list(/obj/effect/spawner/bundle/f13/infiltrator,
-				/obj/effect/spawner/bundle/f13/rangemaster,
+	loot = list(/obj/effect/spawner/bundle/f13/rangemaster,
 				/obj/effect/spawner/bundle/f13/wattz2k,
 				/obj/effect/spawner/bundle/f13/rcw,
 				/obj/effect/spawner/bundle/f13/breacher,
 				/obj/effect/spawner/bundle/f13/beam,
-				/obj/effect/spawner/bundle/f13/aer12
+				/obj/effect/spawner/bundle/f13/aer12,
+				/obj/effect/spawner/bundle/f13/hunting
 				)
 
 /obj/effect/spawner/bundle/f13/beam
 	name = "medbeam spawner"
 	items = list(
 				/obj/item/gun/medbeam
+	)
+
+/obj/effect/spawner/bundle/f13/hunting
+	name = "hunting revolver spawner"
+	items = list(
+				/obj/item/gun/ballistic/revolver/hunting,
+				/obj/item/ammo_box/tube/c4570
 	)
 
 /obj/effect/spawner/bundle/f13/breacher
@@ -1190,7 +1192,7 @@
 	)
 
 /obj/effect/spawner/bundle/f13/aer12
-	name = "breacher and ammo spawner"
+	name = "aer12 and ammo spawner"
 	items = list(
 				/obj/item/gun/energy/laser/aer12,
 				/obj/item/stock_parts/cell/ammo/mfc

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -19,15 +19,11 @@
 	name = "7.62 JHP bullet casing"
 	projectile_type = /obj/item/projectile/bullet/a762/jhp
 
-/obj/item/ammo_casing/a762/jsp
-	name = "7.62 JSP bullet casing"
-	projectile_type = /obj/item/projectile/bullet/a762/jsp
-
 /obj/item/ammo_casing/a762/match
 	name = "7.62 match bullet casing"
 	projectile_type = /obj/item/projectile/bullet/a762/match
 
-// 5.56mm 
+// 5.56mm
 /obj/item/ammo_casing/a556
 	name = "5.56mm FMJ bullet casing"
 	desc = "A 5.56mm bullet casing."

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -320,11 +320,6 @@
 	ammo_type = /obj/item/ammo_casing/a762/ap
 	custom_materials = list(/datum/material/iron = 20000, /datum/material/titanium = 5000, /datum/material/blackpowder = 2000)
 
-/obj/item/ammo_box/a762box/jsp
-	name = "ammo box (7.62x51 JSP)"
-	ammo_type = /obj/item/ammo_casing/a762/jsp
-	custom_materials = list(/datum/material/iron = 24000, /datum/material/blackpowder = 3500)
-
 /obj/item/ammo_box/a762box/match
 	name = "ammo box (7.62x51 Match)"
 	ammo_type = /obj/item/ammo_casing/a762/match

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -576,7 +576,7 @@
 	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/energy/laser/aer12
-	name = "\improper AER14 laser rifle"
+	name = "\improper AER12 laser rifle"
 	desc = "The AER12, a successor to the AER9, is a cutting-edge state of the art laser rifle employed pre-war in specialty units, featuring green-beams and associated green-trim"
 	icon_state = "aer12"
 	item_state = "laser-rifle9"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -396,7 +396,7 @@
 	name = "laser beam"
 	damage = 34
 	armour_penetration = 0.55
-	icon_state = "u_laser"
+	icon_state = "xray"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -27,13 +27,6 @@
 	wound_bonus = 10
 	bare_wound_bonus = -10
 
-/obj/item/projectile/bullet/a762/jsp
-	name = "7.62 JSP bullet"
-	damage = 55 //48
-	armour_penetration = 0.1 //0.5
-	wound_bonus = 20
-	bare_wound_bonus = 20
-
 /obj/item/projectile/bullet/a762/match
 	name = "7.62 match bullet"
 	damage = 47 //50

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -469,12 +469,12 @@
 	build_path = /obj/item/ammo_box/a762box/ap
 	category = list("initial", "Intermediate Ammo")
 
-/datum/design/ammolathe/a45op
+/*/datum/design/ammolathe/a45op
 	name = ".45 ACP +P ammo box"
 	id = "a45op"
 	materials = list(/datum/material/iron = 14000, /datum/material/blackpowder = 2000)
 	build_path = /obj/item/ammo_box/c45/op
-	category = list("initial", "Intermediate Ammo")
+	category = list("initial", "Intermediate Ammo")*/
 
 /* --Tier 4 Ammo and Magazines-- */
 //Tier 4 Magazines
@@ -536,12 +536,12 @@
 	build_path = /obj/item/ammo_box/magazine/m2mm
 	category = list("initial", "Advanced Ammo")
 
-/datum/design/ammolathe/a9mmop
+/*/datum/design/ammolathe/a9mmop
 	name = "9mm +P ammo box"
 	id = "a9mmop"
 	materials = list(/datum/material/iron = 19000, /datum/material/blackpowder = 3500)
 	build_path = /obj/item/ammo_box/c9mm/op
-	category = list("initial", "Advanced Ammo")
+	category = list("initial", "Advanced Ammo")*/
 
 /datum/design/ammolathe/a4570swc
 	name = ".45-70 SWC ammo box"

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -22,7 +22,7 @@
 	build_path = /obj/item/stack/ore/blackpowder
 	category = list("initial", "Materials")
 	maxstack = 50
-	
+
 /datum/design/ammolathe/titanium
 	name = "Titanium"
 	id = "titanium"
@@ -548,13 +548,6 @@
 	id = "a4570swc"
 	materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 3500)
 	build_path = /obj/item/ammo_box/c4570box/swc
-	category = list("initial", "Advanced Ammo")
-
-/datum/design/ammolathe/a762jsp
-	name = "7.62mm JSP ammo box"
-	id = "a762jsp"
-	materials = list(/datum/material/iron = 24000, /datum/material/blackpowder = 3500)
-	build_path = /obj/item/ammo_box/a762box/jsp
 	category = list("initial", "Advanced Ammo")
 
 /datum/design/ammolathe/a762match


### PR DESCRIPTION
## About The Pull Request
Fixes the AER12's name in-game and the beam colour + sprite, among some other things and some minor loot rebalances for the higher tiers as to prevent some odd spawns from taking place, see changelog for more detail. Also replaces the T8 with a T9 for the loot in the minibunker by North Sewer Bunker
## Why It's Good For The Game
Simple & Basic fixes, vital for the AER12 while also rebalancing the higher tiers for QoL to ensure they're worth it.
## Changelog
- Fixes the AER12's name in-game
- Fixes the AER12's beam
- Swaps Chew-Chews gained weapon from a T8 to a T9
- Adds Hunting Revolver to T9
- Fixes AER12 spawner name
- Moves Infil to T8
- Removes .223 pistol spawner
- Moves Needler, M29 and Neostead to T7
- Delete's JSP
- Removes 9MM + .45 +P crafting pending a rework.