### PR TITLE
Mourning Poultice buff, Mortar buff with clarification, Gaia fix.

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -524,8 +524,8 @@
 	merge_type = /obj/item/stack/medical/poultice
 	novariants = TRUE
 
-/obj/item/stack/medical/poultice/one
-	amount = 1
+/obj/item/stack/medical/poultice/ten
+	amount = 10
 
 /obj/item/stack/medical/poultice/five
 	amount = 5
@@ -548,4 +548,4 @@
 /datum/chemical_reaction/mourningpoultice/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
 	for(var/i = 1, i <= multiplier, i++)
-		new /obj/item/stack/medical/poultice/one(location)
+		new /obj/item/stack/medical/poultice/five(location)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -319,7 +319,7 @@
 	. += "<span class='info'>Water: [waterlevel]/[maxwater].</span>\n"+\
 	"<span class='info'>Nutrient: [reagents.total_volume]/[maxnutri].</span>"
 	if(self_sustaining)
-		. += "<span class='info'>The tray's autogrow is active, halving active reagent drain, and actively maintaning the plant.</span>"
+		. += "<span class='info'>The tray's autogrow is active, halting reagent drain, and actively maintaning the plant.</span>"
 
 	if(weedlevel >= 5)
 		to_chat(user, "<span class='warning'>It's filled with weeds!</span>")
@@ -381,7 +381,7 @@
 				to_chat(user, "<span class='notice'>The plant's lifepsan is counted in weeks.</span>")
 			if(90 to 100)
 				to_chat(user, "<span class='nicegreen'>The plant's lifespan is forevermore. Treat it well, and it will not abandon you.</span>")
-		switch(src.myseed.instability)
+		switch(src.myseed.instability)		// Checks Instability
 			if(0 to 20)
 				to_chat(user, "<span class='nicegreen'>The plant's stability is solid, the foundation secure.</span>")
 			if(21 to 40)
@@ -392,7 +392,7 @@
 				to_chat(user, "<span class='notice'>The plant's unstable, it actively morphs and tries to push itself to something greater.</span>")
 			if(81 to 100)
 				to_chat(user, "<span class='warning'>The plant's unstable, the earth beneath moans and croaks, roots bend and insidious liquids seep from the skin.</span>")
-		switch(src.myseed.weed_rate)
+		switch(src.myseed.weed_rate)		//Checks Weed Growth Rate
 			if(0 to 2)
 				to_chat(user, "<span class='nicegreen'>The weed growth around the plant appear to be of a miniscule amount...</span>")
 			if(3 to 5)
@@ -401,7 +401,7 @@
 				to_chat(user, "<span class='notice'>The weed growth would in but a few moments overwhelm the plant...</span>")
 			if(8 to 10)
 				to_chat(user, "<span class='warning'>The weed growth could instantly put down the plant..!</span>")
-		switch(src.myseed.weed_chance)
+		switch(src.myseed.weed_chance)		//Checks weed growth chance
 			if(0 to 20)
 				to_chat(user, "<span class='nicegreen'>... and the chance of the weeds to grow are highly unlikely.</span>")
 			if(21 to 40)
@@ -759,7 +759,7 @@
 		name = initial(name)
 		desc = initial(desc)
 		TRAY_NAME_UPDATE
-		if(self_sustaining) //No reason to pay for an empty tray.
+		if(self_sustaining && !/obj/machinery/hydroponics/soil) //No reason to pay for an empty tray. But also alot of reasons to keep paying if it's a soil.
 			idle_power_usage = 0
 			self_sustaining = FALSE
 	update_icon()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -419,7 +419,7 @@
 
 /obj/item/reagent_containers/glass/mortar
 	name = "bone mortar"
-	desc = "A specially formed bowl of ancient design. It is possible to crush or juice items placed in it using a pestle; however the process, unlike modern methods, is slow and physically exhausting. Alt click to eject any item put inside. Alt click while empty to change between grind/juice mode."
+	desc = "A specially formed bowl of ancient design. It is possible to crush or juice items placed in it using a pestle; however the process, unlike modern methods, is slow and physically exhausting."
 	icon_state = "bone_mortar"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50)
@@ -428,6 +428,11 @@
 	spillable = TRUE
 	var/obj/item/grinded
 	var/mortar_mode = MORTAR_JUICE
+
+/obj/item/reagent_containers/glass/mortar/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Alt-click to eject any item put inside.</span>"
+	. += "<span class='notice'>Alt-click while the mortar is empty to change between grind/juice mode.</span>"
 
 /obj/item/reagent_containers/glass/mortar/AltClick(mob/user)
 	if(grinded)
@@ -448,7 +453,7 @@
 				return
 			to_chat(user, "<span class='notice'>You start grinding...</span>")
 			if((do_after(user, 25, target = src)))
-				user.adjustStaminaLoss(20)
+				user.adjustStaminaLoss(15)
 				if(grinded.juice_results && (mortar_mode== MORTAR_JUICE)) // will prioritize juicing IF the Mortar's toggled to juice.
 					grinded.on_juice()
 					reagents.add_reagent_list(grinded.juice_results)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Mourning Poultice mix-recipe has been buffed from 1 mourning poultice per reaction to 5. This buff was done due to the other reactions that can be done rewards the player with a full stack. While I'm not willing to grant that instantly, I'll grant a significant buff instead.
- Fixed Gaia soil losing it's blessing if you harvest it while keeping the buffed up light, confusing players.
- Mortar's description in regards to removing items and changing juice/grind mode has been more clarified, put aside to ensure people will not miss that feature. The stamina drain has been lowered from 20 to 15, to allow more grinding, as otherwise, it just becomes a GRINDFEST.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These will fix some issues that came up with the remaking of the Mortar Pestle, as the description became freaking super long and everyone just pulled the classic TL;DR. It'll also make the mourning poultice grind less grindy but keep it so you still need atleast some materials to commit into it. Also, the Gaia thing is working as it was always supposed to.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Mortar's description now set to be more staggered, with clear instruction on how to use the Alt+Click for each mode.
balance: Mourning Poultice recipe now grants 5 poultices instead of only 1.
balance: Mortar+Pestle now drains 15 stamina as oppose to 20.
fix: Gaia soil no longer lost from soils when you harvest a plant that doesn't have the repeatable harvest trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
