### PR TITLE
Mob amount reduction/individual buff

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -1622,12 +1622,6 @@
 /obj/item/kitchen/knife,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bgo" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "bgz" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -2773,7 +2767,6 @@
 /area/f13/wasteland)
 "bTf" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/ncr_k_ration,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "bTh" = (
@@ -3302,13 +3295,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
-"csz" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "csO" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -4195,11 +4181,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
-"dbG" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "dbH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4259,11 +4240,6 @@
 /area/f13/village)
 "ddd" = (
 /obj/item/trash/f13/dog,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"ddG" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ddR" = (
@@ -4941,8 +4917,6 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/smelling_salts/wayfarer,
 /obj/item/smelling_salts/wayfarer,
-/obj/item/stack/medical/poultice,
-/obj/item/stack/medical/poultice,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "dAg" = (
@@ -5017,7 +4991,6 @@
 /area/f13/wasteland)
 "dBM" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/ncr_k_ration,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -5151,13 +5124,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"dHY" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2left"
-	},
-/area/f13/wasteland)
 "dIN" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5316,7 +5282,6 @@
 	dir = 1;
 	pixel_y = 6
 	},
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "dNW" = (
@@ -8801,7 +8766,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -11930,22 +11894,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "idS" = (
@@ -12180,12 +12128,6 @@
 	},
 /turf/open/water,
 /area/f13/radiation)
-"ilT" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "ime" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13344,13 +13286,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/city)
-"iTf" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/ncr)
 "iTk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -13664,8 +13599,6 @@
 /area/f13/city)
 "jfu" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
-/obj/item/reagent_containers/food/snacks/f13/canned/dog,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
@@ -16470,10 +16403,6 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
-"lcx" = (
-/obj/machinery/chem_master/primitive,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
 "lda" = (
 /obj/structure/decoration/clock{
 	pixel_y = 30
@@ -18054,14 +17983,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"mbo" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
-/turf/open/floor/carpet,
-/area/f13/ncr)
 "mbz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/jet,
@@ -21154,10 +21075,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"onR" = (
-/obj/machinery/chem_master/primitive,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "onU" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood{
@@ -21222,7 +21139,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/stack/medical/poultice,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "opW" = (
@@ -21608,7 +21524,6 @@
 /obj/machinery/iv_drip,
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/stack/medical/poultice,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "oFJ" = (
@@ -21941,7 +21856,6 @@
 /area/f13/village)
 "oQM" = (
 /obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "oRq" = (
@@ -29135,7 +29049,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/effect/spawner/lootdrop/f13/ncr_c_ration,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
@@ -33594,11 +33507,6 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"wBh" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/ncr_k_ration,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "wBo" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
@@ -34901,10 +34809,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"xnY" = (
-/obj/machinery/chem_master/primitive,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "xnZ" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/oil{
@@ -37312,7 +37216,7 @@ svP
 rUp
 rrE
 sUP
-mbo
+sZT
 rrE
 sUP
 sZT
@@ -38843,7 +38747,7 @@ pOM
 pOM
 pOM
 xnt
-iTf
+pOM
 nss
 pQx
 tUj
@@ -43728,7 +43632,7 @@ sGG
 cpK
 uok
 atX
-wBh
+atX
 uok
 cpK
 cpK
@@ -43984,7 +43888,7 @@ lvS
 eJe
 cpK
 uok
-dbG
+atX
 atX
 uok
 cpK
@@ -44499,7 +44403,7 @@ eJe
 cpK
 uok
 atX
-dbG
+atX
 uok
 cpK
 cpK
@@ -45342,7 +45246,7 @@ gke
 qFk
 otr
 otr
-lcx
+otr
 qFk
 gcK
 gcK
@@ -51004,7 +50908,7 @@ vsm
 uRJ
 wsq
 uRJ
-xnY
+uRJ
 iWc
 tBN
 mvv
@@ -64638,7 +64542,7 @@ koD
 bFJ
 gjP
 jTq
-bgo
+vFz
 lly
 uRJ
 cbk
@@ -68941,7 +68845,7 @@ xKx
 gts
 kIl
 iPf
-jYn
+vYv
 vYv
 vYv
 gts
@@ -73825,7 +73729,7 @@ gts
 vYv
 vYv
 vYv
-jYn
+vYv
 vYv
 vYv
 vYv
@@ -74348,7 +74252,7 @@ kGc
 ofX
 hbW
 erY
-dHY
+ubg
 koD
 pcG
 pcG
@@ -92062,7 +91966,7 @@ fyf
 fyf
 fyf
 tKZ
-csz
+guh
 cAM
 cqA
 nqG
@@ -92578,7 +92482,7 @@ jVC
 sYX
 nrw
 cSE
-ddG
+cSH
 cSH
 rpu
 aug
@@ -92586,7 +92490,7 @@ sKH
 rpu
 rpu
 rpu
-ilT
+cSH
 tKZ
 fyf
 fyf
@@ -93100,7 +93004,7 @@ rpu
 rpu
 iwR
 sKH
-ddG
+cSH
 tKZ
 fyf
 fyf
@@ -98390,7 +98294,7 @@ tZW
 tZW
 lez
 vHR
-onR
+xNm
 udT
 fBx
 wPS

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2636,13 +2636,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"cJp" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/tunnel)
 "cJF" = (
 /obj/structure/decoration/vent{
 	layer = 2.8
@@ -54966,7 +54959,7 @@ riF
 tFH
 fET
 fEJ
-cJp
+wgg
 fwZ
 wgg
 uLN

--- a/_maps/map_files/templates/dungeons/north_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_2.dmm
@@ -181,11 +181,6 @@
 /obj/item/seeds/ambrosia/gaia,
 /turf/open/floor/grass,
 /area/f13/bunker)
-"ee" = (
-/mob/living/simple_animal/hostile/alien,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "eq" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/tarantula,
 /obj/structure/spider/stickyweb,
@@ -384,11 +379,6 @@
 /area/f13/bunker)
 "hI" = (
 /obj/structure/table_frame,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"hS" = (
-/mob/living/simple_animal/hostile/alien,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ia" = (
@@ -742,6 +732,10 @@
 "pt" = (
 /obj/item/stack/medical/mesh,
 /turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"pA" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/turf/open/floor/grass,
 /area/f13/bunker)
 "pI" = (
 /obj/structure/spider/stickyweb,
@@ -3049,7 +3043,7 @@ xG
 eG
 sJ
 XS
-Eg
+qV
 xG
 Rl
 Rl
@@ -3725,7 +3719,7 @@ Rl
 xG
 IY
 pQ
-DM
+go
 oj
 Pp
 XM
@@ -3994,7 +3988,7 @@ XM
 mj
 XM
 xG
-hS
+gk
 xG
 AE
 Bw
@@ -4537,7 +4531,7 @@ Om
 Om
 KY
 nu
-fy
+nu
 nu
 Om
 nu
@@ -4614,7 +4608,7 @@ QJ
 Ed
 nu
 nu
-dj
+pA
 nu
 nu
 dj
@@ -5018,7 +5012,7 @@ PF
 oj
 hI
 go
-ee
+Hi
 oj
 YR
 gu

--- a/_maps/map_files/templates/dungeons/north_sewer_1.dmm
+++ b/_maps/map_files/templates/dungeons/north_sewer_1.dmm
@@ -193,12 +193,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"kt" = (
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 8
-	},
-/area/f13/tunnel)
 "kz" = (
 /obj/machinery/light/small,
 /obj/machinery/conveyor/auto{
@@ -347,7 +341,6 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "pi" = (
-/mob/living/simple_animal/hostile/supermutant,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral/side,
 /area/f13/tunnel)
@@ -549,7 +542,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8
 	},
@@ -716,11 +708,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"Hu" = (
-/mob/living/simple_animal/hostile/supermutant,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/neutral,
-/area/f13/tunnel)
 "HI" = (
 /obj/structure/nest/deathclaw,
 /turf/open/water,
@@ -747,17 +734,6 @@
 	dir = 8
 	},
 /area/f13/tunnel)
-"IO" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/supermutant,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 4
-	},
-/area/f13/tunnel)
 "IW" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -766,8 +742,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "IZ" = (
-/mob/living/simple_animal/hostile/supermutant,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/supermutant/legendary,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "Jh" = (
@@ -856,7 +832,6 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "No" = (
-/mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/neutral/side{
 	dir = 10
 	},
@@ -878,15 +853,16 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"Oe" = (
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
 "Of" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
+"Or" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/turf/open/floor/plasteel/neutral,
 /area/f13/tunnel)
 "OI" = (
 /obj/structure/simple_door/bunker,
@@ -1096,13 +1072,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
-"Yj" = (
-/mob/living/simple_animal/hostile/supermutant,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 4
-	},
 /area/f13/tunnel)
 "Yr" = (
 /obj/structure/simple_door/bunker,
@@ -2075,9 +2044,9 @@ AV
 AV
 pG
 TP
-Yj
 AV
-IO
+AV
+vD
 us
 kE
 mZ
@@ -2109,14 +2078,14 @@ pi
 sw
 sw
 gM
+Or
 sw
-Hu
 sw
 gM
 FL
+Or
 sw
 sw
-Hu
 EW
 iV
 NS
@@ -2151,7 +2120,7 @@ lm
 lm
 QF
 wj
-kt
+In
 In
 wO
 za
@@ -2298,7 +2267,7 @@ iY
 Kr
 mT
 iY
-Oe
+Qs
 Rj
 Qs
 iY
@@ -2414,7 +2383,7 @@ Kr
 iY
 Rj
 Jh
-Oe
+Qs
 iY
 hL
 Rj
@@ -2490,7 +2459,7 @@ Kr
 iY
 jZ
 Jh
-Oe
+Qs
 iY
 iu
 qv

--- a/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
@@ -1249,14 +1249,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"xb" = (
-/mob/living/simple_animal/hostile/ghoul/coldferal,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
 "xs" = (
 /mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/floor/mineral/plastitanium,
@@ -4114,7 +4106,7 @@ lp
 Qv
 lp
 SL
-xb
+lp
 lp
 rW
 Ua

--- a/code/modules/fallout/obj/structures/mob_spawners.dm
+++ b/code/modules/fallout/obj/structures/mob_spawners.dm
@@ -106,13 +106,14 @@
 //the nests themselves
 /obj/structure/nest/ghoul
 	name = "ghoul nest"
+	max_mobs = 2
 	mob_types = list(/mob/living/simple_animal/hostile/ghoul = 5, 
 					/mob/living/simple_animal/hostile/ghoul/reaver = 3, 
 					/mob/living/simple_animal/hostile/ghoul/glowing = 1)
 
 /obj/structure/nest/deathclaw
 	name = "deathclaw nest"
-	max_mobs = 2
+	max_mobs = 1
 	spawn_time = 50 SECONDS
 	mob_types = list(/mob/living/simple_animal/hostile/deathclaw = 19, 
 					/mob/living/simple_animal/hostile/deathclaw/mother = 1)
@@ -120,32 +121,36 @@
 /obj/structure/nest/scorpion
 	name = "scorpion nest"
 	spawn_time = 40 SECONDS
-	max_mobs = 4
+	max_mobs = 2
 	mob_types = list(/mob/living/simple_animal/hostile/radscorpion = 1,
 					/mob/living/simple_animal/hostile/radscorpion/black = 1)
 
 /obj/structure/nest/radroach
 	name = "radroach nest"
+	max_mobs = 2
 	mob_types = list(/mob/living/simple_animal/hostile/radroach = 1)
 
 /obj/structure/nest/fireant
 	name = "fireant nest"
+	max_mobs = 2
 	mob_types = list(/mob/living/simple_animal/hostile/fireant = 1,
 					/mob/living/simple_animal/hostile/giantant = 1)
 
 /obj/structure/nest/wanamingo
 	name = "wanamingo nest"
 	spawn_time = 40 SECONDS
-	max_mobs = 4
+	max_mobs = 2
 	mob_types = list(/mob/living/simple_animal/hostile/alien = 1)
 
 /obj/structure/nest/molerat
 	name = "molerat nest"
+	max_mobs = 2
 	mob_types = list(/mob/living/simple_animal/hostile/molerat = 1)
 	spawn_time = 20 SECONDS //They just love tunnelin'.. And are pretty soft
 
 /obj/structure/nest/mirelurk
 	name = "mirelurk nest"
+	max_mobs = 2
 	mob_types = list(/mob/living/simple_animal/hostile/mirelurk = 2,
 					/mob/living/simple_animal/hostile/mirelurk/hunter = 1,
 					/mob/living/simple_animal/hostile/mirelurk/baby = 5)

--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -24,12 +24,12 @@
 	response_help_simple  = "pets"
 	response_disarm_simple = "gently pushes aside"
 	response_harm_simple   = "hits"
-	maxHealth = 550
-	health = 550
+	maxHealth = 750
+	health = 750
 	obj_damage = 200
 	armour_penetration = 0.7
-	melee_damage_lower = 60
-	melee_damage_upper = 65
+	melee_damage_lower = 80
+	melee_damage_upper = 85
 	attack_verb_simple = "claws"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	faction = list("deathclaw")
@@ -59,8 +59,8 @@
 	name = "mother deathclaw"
 	desc = "A massive, reptilian creature with powerful muscles, razor-sharp claws, and aggression to match. This one is an angry mother."
 	gender = FEMALE
-	maxHealth = 750
-	health = 750
+	maxHealth = 1000
+	health = 1000
 	stat_attack = UNCONSCIOUS
 	melee_damage_lower = 76
 	melee_damage_upper = 78

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -11,12 +11,12 @@
 	speak_emote = list("growls")
 	emote_see = list("screeches")
 	a_intent = INTENT_HARM
-	maxHealth = 40
-	health = 40
-	speed = 2
+	maxHealth = 80
+	health = 80
+	speed = 3
 	harm_intent_damage = 8
-	melee_damage_lower = 10
-	melee_damage_upper = 10
+	melee_damage_lower = 15
+	melee_damage_upper = 15
 	attack_verb_simple = "claw"
 	attack_sound = 'sound/hallucinations/growl1.ogg'
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
@@ -46,11 +46,11 @@
 	icon_living = "ghoulreaver"
 	icon_dead = "ghoulreaver_dead"
 	speed = 2
-	maxHealth = 100
-	health = 100
+	maxHealth = 150
+	health = 150
 	harm_intent_damage = 8
-	melee_damage_lower = 15
-	melee_damage_upper = 15
+	melee_damage_lower = 25
+	melee_damage_upper = 25
 
 /mob/living/simple_animal/hostile/ghoul/reaver/Initialize()
 	. = ..()
@@ -111,12 +111,12 @@
 	icon_state = "glowinghoul"
 	icon_living = "glowinghoul"
 	icon_dead = "glowinghoul_dead"
-	maxHealth = 80
-	health = 80
+	maxHealth = 160
+	health = 160
 	speed = 2
 	harm_intent_damage = 8
-	melee_damage_lower = 20
-	melee_damage_upper = 20
+	melee_damage_lower = 25
+	melee_damage_upper = 25
 
 /mob/living/simple_animal/hostile/ghoul/glowing/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Buffs individual mobs but reduces the amount spawned by nests.
Removes some mobs from dungeons and replaces them with a few legendary versions. Will need a full sweep later.
Additionally incentivizes players to clean up ghoul and monster holes in general by spawning a random gun when covered. Removes the ability to crowbar holes open.

## Why It's Good For The Game
Reduces the amount of lag resulting from the idling mobs subsystem.
Went from around 150ms to around 130ms on my system. Results may vary.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
