### PR TITLE
Alchemy Table fix + Grown Bin addition

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -4403,7 +4403,11 @@
 /turf/closed/wall/rust,
 /area/f13/caves)
 "dfY" = (
-/obj/structure/simple_door/wood,
+/obj/machinery/door/unpowered/wooddoor{
+	max_integrity = 300;
+	obj_integrity = 300;
+	req_access_txt = "131"
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "dgt" = (
@@ -10355,6 +10359,10 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"gZE" = (
+/obj/machinery/chem_master/primitive,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
 "hab" = (
 /obj/structure/chair/left{
 	dir = 4
@@ -11242,6 +11250,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"hzx" = (
+/obj/machinery/chem_master/primitive,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "hzG" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13432,9 +13444,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iPB" = (
-/obj/structure/rack,
 /obj/item/reagent_containers/glass/bucket/wood,
 /obj/item/reagent_containers/glass/bucket/wood,
+/obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -18104,6 +18116,10 @@
 	icon_state = "verylittleshadowright"
 	},
 /area/f13/wasteland)
+"lQS" = (
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "lRd" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -21123,6 +21139,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"oau" = (
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oav" = (
 /turf/closed/wall/f13/wood,
 /area/f13/bar)
@@ -25817,6 +25837,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"qYr" = (
+/obj/machinery/chem_master/primitive,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "qYD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -26539,10 +26563,7 @@
 	},
 /area/f13/tunnel)
 "rEk" = (
-/obj/structure/fermenting_barrel{
-	pixel_x = -5;
-	pixel_y = 7
-	},
+/obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "rEB" = (
@@ -31282,6 +31303,7 @@
 	light_color = "red"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
 "uEK" = (
@@ -46005,7 +46027,7 @@ gke
 qFk
 otr
 otr
-otr
+gZE
 qFk
 gcK
 gcK
@@ -50379,7 +50401,7 @@ iRv
 otr
 otr
 qFk
-iWc
+lQS
 uRJ
 cqr
 uRJ
@@ -51667,7 +51689,7 @@ vsm
 uRJ
 wsq
 uRJ
-uRJ
+qYr
 iWc
 tBN
 mvv
@@ -54321,7 +54343,7 @@ bfu
 uCW
 ajD
 lPT
-gNB
+oau
 rjH
 mvv
 rjH
@@ -99053,7 +99075,7 @@ tZW
 tZW
 lez
 vHR
-xNm
+hzx
 udT
 fBx
 wPS


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- The Wayfarer Tribe and the Legion have their Alchemy Tables reinstated.
- Wayfarer, Oasis, Legion, NCR, Brotherhood now have grown bins in their camps, located where I thought they would be appropriate.
- Wayfarer's door to the scoutpoint is now only accessible by the tribe. No more accidental break ins!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These changes are **necessary** primarily for the Alchemy Tables as the Wayfarer **completely** missing theirs while Legion must do a Dungeon to get ahold of theirs is completely ridicolous. Of course nobody deserves to get hung out in the streets like a degenerate for allowing this to happen, just a big no good!
The Grown Bins are meant to help reduce abit of the lag and also make it so farms look abit more neat! It's real easy just follow the beat.
Wayfarers door now being only accessible to the Tribe means no more accidental looting of their armoury by the unknowing. Now it's a whole lot more knowful if you smash down a locked door!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Grownbins have been added to Wayfarer Tribe, Legion, NCR, Oasis, Brotherhood. It should be around the Kitchen or Farming area.
balance: Wayfarer scouting point now has a proper lock on it - no accidental looting, naughty boys!
fix: Alchemy Tables now exist in Wayfarer and Legion again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
