### PR TITLE
Human Tongue now can speak Wayfarer

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -25,6 +25,7 @@
 		/datum/language/slime,
 		/datum/language/vampiric,
 		/datum/language/dwarf,
+		/datum/language/wayfarer,
 	))
 	healing_factor = STANDARD_ORGAN_HEALING*5 //Fast!!
 	decay_factor = STANDARD_ORGAN_DECAY/2


### PR DESCRIPTION
## About The Pull Request
So, this has been an problem for a bit now and I had someone figure it out for me so. This was tested on my own and it worked successful with no bugs or glitches. Basically this PR edits the tongue so people can actually speak the language on the human tongue. Before this it was an problem and this seems to help super when he does come back to the language.

## Why It's Good For The Game
Makes Human Tongue speak Wayfarer Language. They have there own language.

## Changelog
:cl:
tweak: fixes the human tongue to speak wayfarer language./
/:cl:

