### PR TITLE
Tribal starts with there language.

### DIFF
--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -25,6 +25,7 @@
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_TRAPPER, src)
 	ADD_TRAIT(H, TRAIT_MACHINE_SPIRITS, src)
+	H.grant_language(/datum/language/wayfarer)
 
 /*
 Tribal Chief


### PR DESCRIPTION
## About The Pull Request

This fixes the tribals to respawn with there language. Which was an issue before, as we needed to ahelp before to get it, before the recent fix for the tongue to speak the language. This PR was helped by SabreML
## Why It's Good For The Game

"Allows for more immersive roleplay with tribe and gives the tribe something special" - Bengal 2021
This gives the tribe the ability to speak it without ahelping for the language which makes it easier on the admins work.

## Changelog
:cl:
add: Fixes tribals with to speak there language on spawn
/:cl:
