### PR TITLE
Fixes Ripper and Legion Armor to be compatible with each other.

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -414,6 +414,7 @@
 	item_state = "chainswordon"
 	name = "ripper"
 	desc = "A miniature chainsaw, as amazing as it sounds."
+	w_class = WEIGHT_CLASS_BULKY
 	force = 45
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -197,7 +197,7 @@
 	lefthand_file = 'icons/mob/inhands/clothing_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/clothing_righthand.dmi'
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola, /obj/item/twohanded, /obj/item/melee/smith, /obj/item/melee/smith/twohand)
+	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola, /obj/item/twohanded, /obj/item/melee/smith, /obj/item/melee/smith/twohand, /obj/item/nullrod/claymore/chainsaw_sword)
 	armor = list("tier" = 3, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 20, "fire" = 50, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/legion/recruit


### PR DESCRIPTION


## About The Pull Request
This was needed to be fixed for the future updates to the legion loadouts, so that the Decanus can use the ripper in there armor slot. This PR modifies the ripper and the armor to be compatible with each other. This fix was requested by Myrios for loadout changes. This was also tested on my own private server too.

## Why It's Good For The Game
This fixes the armor to fit the ripper so in future updates that the Prime Decanus can use it in there future loadouts.

## Changelog
:cl:
tweak: fixes the ripper to fit in legion armor and fixes the ripper to be bulky not heavy.
/:cl:
