### PR TITLE
Spirit Cleanser readdition, Buffalo distilling fix

### DIFF
--- a/code/modules/fallout/obj/food_and_drinks/wastefood.dm
+++ b/code/modules/fallout/obj/food_and_drinks/wastefood.dm
@@ -28,7 +28,13 @@
 	tastes = list("buttery flesh" = 1, "creamy soup" = 1)
 	foodtype = VEGETABLES
 
-
+//DRINK MIXING FALLOUT 13/////
+/datum/chemical_reaction/spiritcleanser
+	name = "Spirit Cleanser"
+	id = /datum/reagent/consumable/ethanol/spiritcleanser
+	results = list(/datum/reagent/consumable/ethanol/spiritcleanser = 2)
+	required_reagents = list(/datum/reagent/consumable/ethanol/pungajuice = 1, /datum/reagent/consumable/ethanol/daturatea = 1)
+	
 /////PLANTS Fallout 13///////
 
 /obj/item/seeds/buffalogourd
@@ -58,7 +64,7 @@
 	filling_color = "#008000"
 	bitesize_mod = 3
 	foodtype = FRUIT
-	distill_reagent = "buffalo"
+	distill_reagent = /datum/reagent/consumable/ethanol/buffalo
 
 /obj/item/seeds/coyotetobacco
 	name = "pack of coyote tobacco seeds"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Spirit Cleanser can now be made again, by mixing pungajuice with datura tea like before!
- Buffalo gourds can now be distilled into the liquid known as Buffalo.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Spirit Cleanser is a drink that existed prior but was removed with a massive wave of other drinks - and considering that it's a flavour drink primarily prepared by the Tribals, I see that it's more of a beneficial thing and the effects seem mild and understandable given what's within the drink, and as such could be accepted back in.
- Buffalo gourds should've always distilled into Buffalo, the fact it didn't was the cause of a mere mishap in taking the code back over to Rebase.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Spirit Cleanser can now be mixed with Pungajuice and Daturatea.
fix: Buffalo Gourds can now be distilled into proper Buffalo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
