### PR TITLE
South Map Overhaul/Zone Fixes

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -50,10 +50,6 @@
 	icon_state = "horizontalbottombordertop2"
 	},
 /area/f13/wasteland)
-"acn" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "acs" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -363,7 +359,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "alE" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
@@ -499,6 +495,28 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"apU" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"aqh" = (
+/obj/structure/showcase/machinery/oldpod{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "aqD" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
@@ -588,6 +606,10 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"atK" = (
+/obj/structure/table/booth,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "atL" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/desert,
@@ -729,6 +751,26 @@
 /obj/item/clothing/gloves/boxing,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"aym" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1"
+	},
+/area/f13/building)
+"ayv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "ayJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/two_tire,
@@ -866,6 +908,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"aCV" = (
+/obj/structure/simple_door/metal,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "aDb" = (
 /obj/structure/pondlily_small,
 /turf/open/indestructible/ground/outside/water{
@@ -944,18 +993,44 @@
 "aFF" = (
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "aFM" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aFO" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
+"aFY" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "aGb" = (
 /obj/structure/closet/fridge/meat,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"aGr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "aGv" = (
 /obj/structure/destructible/tribal_torch{
 	pixel_y = 20
@@ -967,6 +1042,16 @@
 "aGw" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"aGP" = (
+/obj/structure/showcase/machinery/tv{
+	name = "Pre-war television"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "aGX" = (
 /obj/structure/bed/dogbed{
@@ -1046,6 +1131,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/city)
+"aKc" = (
+/obj/item/stack/f13Cash/random/low,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/clinic)
 "aKs" = (
 /obj/item/clothing/shoes/sneakers/black,
 /turf/open/floor/f13/wood,
@@ -1104,6 +1195,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"aMn" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/clinic)
 "aMp" = (
 /obj/structure/closet,
 /turf/open/floor/plasteel/barber{
@@ -1340,6 +1439,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aVh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "aVk" = (
 /obj/structure/easel,
 /turf/open/floor/f13/wood{
@@ -1369,6 +1474,14 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/city)
+"aVE" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/cctv{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "aVF" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/ruins{
@@ -1395,12 +1508,9 @@
 	},
 /area/f13/brotherhood)
 "aWz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
+/obj/structure/ore_box,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aWF" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -1502,13 +1612,12 @@
 	},
 /area/f13/brotherhood)
 "aYY" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
+/obj/structure/simple_door/metal/fence,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/wasteland)
 "aZn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -1523,12 +1632,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aZF" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"aZH" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
 "aZJ" = (
@@ -1627,7 +1747,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bej" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalcorroded"
@@ -1716,6 +1836,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"bhV" = (
+/obj/structure/displaycase,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "bia" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1735,9 +1864,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "bix" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/f13/wood,
+/turf/closed/wall/f13/wood/house/broken,
 /area/f13/clinic)
 "biN" = (
 /obj/machinery/hydroponics/constructable,
@@ -1904,6 +2031,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"bmA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/processor,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bmK" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -1917,6 +2050,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
+"bmN" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bmW" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2034,6 +2174,21 @@
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bpu" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "bpA" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/head/helmet/f13/raidercombathelmet,
@@ -2082,9 +2237,7 @@
 	},
 /area/f13/followers)
 "bqB" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
 "bqC" = (
 /obj/machinery/jukebox,
@@ -2118,6 +2271,13 @@
 /obj/structure/table,
 /obj/item/trash/sosjerky,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"bsJ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/building)
 "bsV" = (
 /obj/machinery/biogenerator,
@@ -2162,7 +2322,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "buO" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -2188,6 +2348,12 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"bvD" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "bvO" = (
 /obj/item/ammo_casing/c10mm/ap,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2215,6 +2381,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bwB" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "bwE" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2402,6 +2576,14 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"bBu" = (
+/obj/structure/fluff/arc,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "bBG" = (
 /obj/structure/chair/sofa/corp,
 /obj/effect/decal/cleanable/dirt,
@@ -2424,6 +2606,14 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bCa" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "bCG" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -2444,12 +2634,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bDt" = (
-/obj/structure/fence,
-/obj/structure/fence/corner{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/building)
+"bDE" = (
+/obj/structure/simple_door/blast,
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "bDO" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -2459,6 +2656,15 @@
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"bEe" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bEo" = (
@@ -2545,6 +2751,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"bFR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "bFV" = (
 /obj/structure/rack,
 /obj/item/bikehorn,
@@ -2590,11 +2803,10 @@
 	},
 /area/f13/building)
 "bHa" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner"
 	},
-/obj/item/clothing/under/f13/tribal,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "bHo" = (
 /obj/effect/decal/remains/human,
@@ -2609,8 +2821,9 @@
 	},
 /area/f13/followers)
 "bIh" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/clinic)
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "bIp" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/brotherhood)
@@ -2642,7 +2855,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bJB" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -2702,6 +2915,15 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bMl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "bMB" = (
 /obj/structure/table/wood/settler,
 /obj/item/stack/medical/bruise_pack,
@@ -2742,6 +2964,15 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"bNW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "bOe" = (
 /obj/structure/debris/v3,
@@ -2789,13 +3020,11 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bPH" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/obj/item/storage/bag/ore,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bQh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2833,6 +3062,12 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/followers)
+"bRt" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "bRz" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2943,6 +3178,12 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"bXe" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "bXl" = (
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -2968,6 +3209,10 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"bYq" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/building)
 "bZk" = (
 /obj/structure/sink{
 	dir = 8;
@@ -3022,11 +3267,22 @@
 "cbr" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"cce" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "ccF" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetgrey"
 	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ccM" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cdc" = (
@@ -3072,6 +3328,22 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
+"cfY" = (
+/obj/structure/sign/map/left{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"cgI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "cht" = (
 /obj/structure/fence{
 	dir = 1
@@ -3163,12 +3435,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "cjG" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/table,
+/obj/item/clothing/gloves/color/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
 	},
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "cjS" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
@@ -3270,6 +3543,18 @@
 /obj/structure/girder,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
+"cmL" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus4";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "cmR" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -3327,11 +3612,14 @@
 	},
 /area/f13/building)
 "cph" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/building)
 "cpu" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3364,6 +3652,16 @@
 /obj/item/soap/homemade,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"cqv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "cqA" = (
 /obj/item/pet_carrier,
 /turf/open/floor/f13/wood,
@@ -3412,6 +3710,19 @@
 "csQ" = (
 /turf/open/floor/wood/f13,
 /area/f13/building)
+"csR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/stack/f13Cash/random/low,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "csY" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
@@ -3426,15 +3737,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ctE" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/closet,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/building)
 "ctJ" = (
@@ -3455,6 +3761,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"cuh" = (
+/obj/structure/simple_door/metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "cuv" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
@@ -3480,6 +3792,12 @@
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/water,
 /area/f13/caves)
+"cuY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "cvp" = (
 /obj/structure/chair/comfy/plywood{
 	dir = 4
@@ -3509,6 +3827,12 @@
 /obj/item/pickaxe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"cvJ" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "cvO" = (
 /obj/structure/flora/tree/tall{
 	pixel_x = -14;
@@ -3560,6 +3884,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"cxq" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2top"
+	},
+/area/f13/wasteland)
 "cxy" = (
 /obj/machinery/power/solar,
 /obj/structure/cable{
@@ -3585,6 +3920,20 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"cyL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"czw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "czx" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -3664,6 +4013,12 @@
 /mob/living/simple_animal/hostile/raider/thief,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"cEt" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cFe" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -3684,11 +4039,14 @@
 	},
 /area/f13/farm)
 "cGj" = (
-/obj/structure/chair/comfy/black{
+/obj/machinery/light/small/broken{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "cGs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3705,6 +4063,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"cGy" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/f13Cash/random/low,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "cGL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -3759,20 +4130,32 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"cIe" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "cIh" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cIm" = (
-/obj/structure/chair{
-	dir = 1
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerbordercorner"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/wasteland)
 "cIA" = (
 /mob/living/simple_animal/hostile/stalker,
 /turf/open/indestructible/ground/outside/desert,
@@ -3783,6 +4166,22 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"cJg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	desc = "A stack of various papers, all saying you really shouldnt see this. The name Dr. Possum is signed at the bottom."
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"cJk" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cJy" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3811,6 +4210,10 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
+"cKm" = (
+/obj/item/clothing/head/cone,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/building)
 "cKN" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -3939,6 +4342,10 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
+/area/f13/wasteland)
+"cPM" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "cPR" = (
 /obj/structure/chair/wood/fancy,
@@ -4129,7 +4536,12 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
+"cVW" = (
+/obj/structure/simple_door/interior,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cWq" = (
 /obj/structure/closet/crate/freezer/blood{
 	pixel_y = -5
@@ -4159,7 +4571,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "cWU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4189,12 +4601,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cXn" = (
-/obj/structure/destructible/tribal_torch,
-/obj{
-	name = "---Merge conflict marker---"
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/building)
 "cXB" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -4273,6 +4687,12 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"daj" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dau" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
@@ -4369,15 +4789,15 @@
 	},
 /area/f13/ncr)
 "dcQ" = (
-/obj/structure/mirror{
-	pixel_y = 30
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
 	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
 "dcY" = (
@@ -4414,6 +4834,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"deL" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "deQ" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
@@ -4423,6 +4849,13 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland)
+"dfg" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "dfo" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/decal/cleanable/dirt,
@@ -4506,6 +4939,19 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"dhr" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
+"dhs" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1"
+	},
+/area/f13/building)
 "dhB" = (
 /obj/machinery/light/sign,
 /obj/structure/barricade/wooden,
@@ -4600,6 +5046,17 @@
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"djX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/prewar/poster88{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "dkd" = (
 /obj/structure/rack,
 /obj/item/watertank,
@@ -4611,12 +5068,11 @@
 	},
 /area/f13/wasteland)
 "dkj" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -3
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
 "dkF" = (
@@ -4639,6 +5095,17 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/village)
+"dkZ" = (
+/obj/structure/showcase/cyborg/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "dlb" = (
 /mob/living/simple_animal/hostile/wolf,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4655,6 +5122,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"dlJ" = (
+/obj/structure/displaycase,
+/obj/item/reagent_containers/food/drinks/bottle/nukashine,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "dlR" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
@@ -4668,7 +5143,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "dlV" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -4743,11 +5218,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "dol" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "dop" = (
@@ -4840,9 +5315,10 @@
 	},
 /area/f13/city)
 "dqc" = (
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "dqf" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -4851,6 +5327,14 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"dqh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "dqn" = (
 /obj/item/clothing/under/f13/cowboyg,
 /turf/open/floor/f13/wood,
@@ -4914,12 +5398,11 @@
 	},
 /area/f13/wasteland)
 "dtq" = (
-/obj/structure/chair/stool{
-	icon_state = "bench"
-	},
-/obj/effect/spawner/lootdrop/trash,
+/obj/structure/filingcabinet/employment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "floordirty"
 	},
 /area/f13/building)
 "dts" = (
@@ -4964,6 +5447,18 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"duE" = (
+/obj/item/stack/f13Cash/random/low,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"duY" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "duZ" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -5000,6 +5495,12 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dvI" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dvQ" = (
 /obj/structure/barricade/bars,
 /obj/structure/window/fulltile/house,
@@ -5047,6 +5548,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dxt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	termtag = "Secret"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dxx" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5075,6 +5583,12 @@
 /obj/structure/closet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dyx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dyH" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5106,6 +5620,10 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"dzj" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "dzE" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -5293,9 +5811,10 @@
 	},
 /area/f13/wasteland)
 "dGK" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/building)
 "dGL" = (
 /obj/structure/flora/grass/wasteland{
@@ -5343,6 +5862,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"dIM" = (
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "dIN" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5496,6 +6019,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"dNx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dNT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
@@ -5629,7 +6158,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "dTY" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood/house,
@@ -5734,6 +6263,11 @@
 /obj/item/stack/f13Cash/random/ncr/low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dZp" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dZE" = (
 /obj/structure/fireplace,
 /turf/open/floor/carpet/black,
@@ -5760,6 +6294,11 @@
 /obj/item/stack/sheet/mineral/wood/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"eaH" = (
+/obj/machinery/vending/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "eaO" = (
 /obj/item/ammo_casing/a50MG,
 /turf/open/indestructible/ground/outside/road{
@@ -5782,6 +6321,14 @@
 "ebc" = (
 /turf/open/floor/plasteel/chapel,
 /area/f13/village)
+"ebe" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ebl" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -5803,7 +6350,7 @@
 	dir = 6
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "ecm" = (
 /obj/structure/table/snooker{
 	dir = 1
@@ -5817,6 +6364,12 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/tunnel)
+"ecX" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "edA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -6031,6 +6584,12 @@
 /obj/item/flashlight,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ekK" = (
+/obj/structure/simple_door/metal/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "ekW" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -6130,6 +6689,16 @@
 /obj/structure/decoration/clock/old,
 /turf/closed/wall/f13/store,
 /area/f13/building)
+"enJ" = (
+/obj/structure/simple_door/metal/store,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "enL" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -6183,6 +6752,14 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"eoL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/building)
 "epa" = (
 /obj/machinery/seed_extractor,
 /turf/open/indestructible/ground/outside/desert,
@@ -6219,6 +6796,11 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"epY" = (
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/building)
 "eqo" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -6255,10 +6837,27 @@
 	icon_state = "housebase"
 	},
 /area/f13/village)
+"eqP" = (
+/obj/structure/fluff/empty_terrarium,
+/obj/machinery/light/fo13colored/Pink,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "erx" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"erU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/obj/structure/sign/poster/prewar/poster92{
+	pixel_y = -32
+	},
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "erY" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -6398,10 +6997,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "exj" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/f13Cash/random/low,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "exm" = (
 /obj/structure/fence{
 	dir = 4
@@ -6426,6 +7026,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
+"eyd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eyg" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -6505,6 +7111,12 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland)
+"ezM" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/building)
 "ezX" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
@@ -6595,6 +7207,25 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"eCY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 32
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
+"eDc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "eDg" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -6622,11 +7253,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "eEt" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = -4;
+	pixel_y = 13
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "eEz" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6676,6 +7309,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"eFs" = (
+/obj/effect/decal/remains/human,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eFA" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -6685,6 +7325,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"eFF" = (
+/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
+/obj/structure/displaycase,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "eFW" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -6793,6 +7442,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
+"eJs" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "eJu" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -6840,10 +7496,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"eKN" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "eKP" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6880,6 +7532,20 @@
 /obj/item/kitchen/fork,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"eMl" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "eMs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/debris/v3,
@@ -6962,11 +7628,10 @@
 	},
 /area/f13/wasteland)
 "eOK" = (
-/obj/structure/chair/wood/modern{
-	dir = 4;
-	icon_state = "wooden_chair_old"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/machinery/light/small{
+/obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
@@ -6978,8 +7643,8 @@
 	},
 /area/f13/wasteland)
 "eOZ" = (
-/obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical,
+/obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ePh" = (
@@ -7275,8 +7940,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "eXw" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/building)
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "eXA" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab"
@@ -7299,7 +7966,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "eXR" = (
 /obj/structure/closet,
 /obj/item/picket_sign,
@@ -7321,6 +7988,13 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"eYv" = (
+/obj/structure/sign/poster/prewar/vault_tec{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "eYT" = (
 /obj/structure/displaycase,
 /turf/open/floor/f13/wood{
@@ -7343,9 +8017,10 @@
 	},
 /area/f13/building)
 "eZg" = (
-/obj/machinery/vending/cola/random,
-/turf/closed/mineral/random/low_chance,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "eZs" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -7425,7 +8100,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "fbE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7511,6 +8186,16 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"feO" = (
+/obj/effect/decal/waste{
+	pixel_x = 20;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/building)
 "feR" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -7531,7 +8216,9 @@
 	},
 /area/f13/village)
 "ffy" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "ffA" = (
@@ -7669,6 +8356,21 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
+"fjI" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "fjR" = (
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/f13/wood,
@@ -7842,13 +8544,21 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"fpE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "fpF" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"fpH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "fqa" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -7857,8 +8567,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fqg" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Secret"
+	},
+/obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fqi" = (
@@ -7867,6 +8580,11 @@
 	pixel_y = 25
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"fqB" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
 "fqL" = (
 /turf/open/floor/f13/wood{
@@ -7945,11 +8663,15 @@
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
 "frY" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "carshop";
+	pixel_x = -30
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/building)
 "fsl" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7988,6 +8710,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"fth" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/black,
+/obj/item/stack/f13Cash/random/med,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "ftz" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13{
@@ -8010,18 +8741,10 @@
 	},
 /area/f13/wasteland)
 "fuj" = (
-/obj/structure/closet/cabinet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/clothing/under/f13/classdress,
-/obj/item/clothing/mask/society,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "fum" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
@@ -8096,6 +8819,15 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/city)
+"fxv" = (
+/obj/structure/displaycase/trophy{
+	start_showpiece_type = "/obj/item/relic";
+	start_showpieces = newlist()
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/accessory/medal/gold,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fxx" = (
 /obj/item/picket_sign,
 /turf/open/indestructible/ground/outside/road{
@@ -8112,6 +8844,13 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"fxY" = (
+/obj/structure/wreck/trash/four_barrels,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "fyf" = (
@@ -8299,6 +9038,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"fDI" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
+"fDT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "fEg" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/computer/terminal{
@@ -8397,6 +9151,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"fIo" = (
+/obj/structure/bed,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "fIF" = (
 /obj/machinery/light{
 	dir = 4
@@ -8409,13 +9167,11 @@
 	},
 /area/f13/ncr)
 "fJj" = (
-/obj/structure/chair/stool{
-	icon_state = "bench_center"
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
 /area/f13/clinic)
 "fJl" = (
 /obj/structure/bonfire,
@@ -8428,6 +9184,13 @@
 	icon_state = "verticalleftborderrightbottom"
 	},
 /area/f13/wasteland)
+"fJD" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "fJU" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8437,6 +9200,12 @@
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
+"fKA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/building)
 "fKN" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/wolf/alpha{
@@ -8523,6 +9292,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"fNT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "fOe" = (
 /obj/effect/landmark/start/f13/sheriff,
 /obj/effect/decal/cleanable/dirt,
@@ -8561,14 +9338,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood)
-"fPN" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "fPT" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8604,6 +9373,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"fQy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "fQz" = (
 /obj/structure/table/wood/poker{
 	name = "felt table"
@@ -8625,19 +9402,6 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"fQY" = (
-/obj/structure/closet/cabinet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/item/clothing/under/f13/classdress,
-/obj/item/clothing/mask/society,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "fRi" = (
 /obj/machinery/light{
 	dir = 1
@@ -8798,13 +9562,10 @@
 	},
 /area/f13/wasteland)
 "fXj" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "fXs" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
@@ -8882,6 +9643,11 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"gay" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "gaV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8973,6 +9739,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"gev" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "gez" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13,
@@ -9011,6 +9786,13 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"ggm" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "ggo" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -9128,6 +9910,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"gjr" = (
+/obj/structure/simple_door/house{
+	icon_state = "interior"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gjs" = (
 /obj/structure/closet/crate{
 	anchored = 1;
@@ -9191,6 +9979,11 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"gkq" = (
+/obj/structure/showcase/machinery/implanter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "gkZ" = (
 /obj/structure/table/wood/poker,
 /obj/item/radio/intercom{
@@ -9459,15 +10252,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
 "gsu" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "gsB" = (
 /obj/machinery/washing_machine,
 /obj/item/crafting/abraxo,
@@ -9500,11 +10289,11 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "gtv" = (
-/obj/machinery/icecream_vat,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/gloves,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "gtz" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -9515,6 +10304,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"gtX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "gtY" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
@@ -9570,18 +10366,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gvN" = (
-/obj/structure/closet/cabinet,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/item/clothing/under/f13/classdress,
-/obj/item/clothing/mask/society,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "gvW" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
@@ -9610,13 +10394,9 @@
 	},
 /area/f13/wasteland)
 "gwB" = (
-/obj/item/clothing/under/f13/police,
-/obj/item/clothing/head/f13/police,
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "gwJ" = (
 /obj/machinery/light/small{
@@ -9716,21 +10496,20 @@
 	},
 /area/f13/city)
 "gzQ" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/clothing/under/f13/classdress,
-/obj/item/clothing/mask/society,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"gzW" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/clinic)
+"gzW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
 "gzY" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/f13/steak,
@@ -9850,11 +10629,17 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "gDs" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"gDN" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "gDZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -10012,6 +10797,15 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"gIs" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gIA" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -10046,6 +10840,23 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "bar"
+	},
+/area/f13/building)
+"gKe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/button/door{
+	id = "mus1";
+	pixel_x = 7;
+	pixel_y = -30
+	},
+/obj/machinery/button/door{
+	id = "mus2";
+	pixel_x = -7;
+	pixel_y = -30
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
 "gKG" = (
@@ -10104,12 +10915,11 @@
 	},
 /area/f13/ncr)
 "gMV" = (
-/obj/structure/table/wood,
-/obj/item/pen,
-/obj/item/paper,
-/obj/item/pen,
-/obj/item/reagent_containers/syringe/medx,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "gNe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10191,6 +11001,14 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"gPE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/building)
 "gPI" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10208,9 +11026,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "gPQ" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gPR" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -10251,6 +11070,12 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13,
 /area/f13/building)
+"gQH" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "gQL" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
@@ -10279,11 +11104,10 @@
 	},
 /area/f13/wasteland)
 "gRf" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/legion)
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gRk" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -10307,6 +11131,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"gRx" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "gSf" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -10408,7 +11238,9 @@
 /area/f13/city)
 "gVQ" = (
 /obj/structure/table/wood,
-/obj/item/documents,
+/obj/item/documents{
+	desc = "Documents and maps concerning the local Legion presence."
+	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/legion)
 "gWh" = (
@@ -10439,6 +11271,13 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"gXi" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
 "gXm" = (
@@ -10515,9 +11354,8 @@
 /area/f13/building)
 "gYp" = (
 /obj/structure/closet,
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gYu" = (
@@ -10538,10 +11376,23 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"gZb" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "gZi" = (
 /obj/structure/mirelurkegg,
 /turf/open/water,
 /area/f13/caves)
+"gZB" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "gZD" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -10622,6 +11473,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"hbU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hbW" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
@@ -10694,12 +11551,19 @@
 	},
 /area/f13/wasteland)
 "hfh" = (
-/obj/structure/flora/tree/tall{
-	layer = 4;
-	pixel_y = 9
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 25;
+	pixel_y = 18
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
+"hfo" = (
+/obj/machinery/vending/nukacolavend,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "hft" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
@@ -10731,7 +11595,7 @@
 /obj/item/cultivator,
 /obj/item/shovel/spade,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "hgg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -10779,7 +11643,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "hgS" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
@@ -10829,14 +11693,10 @@
 	},
 /area/f13/building)
 "hiG" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "hiS" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -10861,12 +11721,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "hjw" = (
-/obj/structure/chair/stool{
-	icon_state = "bench"
-	},
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/building)
 "hjA" = (
@@ -10924,6 +11781,13 @@
 	icon_state = "verticalleftborderleft3"
 	},
 /area/f13/wasteland)
+"hln" = (
+/obj/structure/car,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "hlo" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
@@ -10955,12 +11819,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"hmy" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "hmP" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light/small/broken{
@@ -11060,6 +11918,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/city)
+"hqd" = (
+/obj/structure/tires/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "hqr" = (
 /obj/machinery/vending/games,
 /turf/open/floor/f13/wood,
@@ -11155,6 +12020,15 @@
 /obj/effect/spawner/lootdrop/clothing_middle,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hsX" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "htf" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -11231,6 +12105,14 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"hvm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "hvp" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -11305,9 +12187,9 @@
 	},
 /area/f13/followers)
 "hxp" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/building)
 "hxt" = (
@@ -11360,13 +12242,6 @@
 /obj/item/storage/bag/ore,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"hyf" = (
-/obj/structure/chair/stool,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "hyj" = (
 /obj/structure/bed/dogbed,
 /turf/open/floor/f13/wood{
@@ -11446,6 +12321,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"hAf" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hAC" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33"
@@ -11480,10 +12361,18 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "hBr" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"hBM" = (
+/obj/structure/sign/plaques/thunderdome{
+	pixel_y = 30
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "hBN" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
@@ -11520,10 +12409,11 @@
 	},
 /area/f13/wasteland)
 "hCF" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalright"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
 "hDf" = (
@@ -11604,6 +12494,12 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
+"hGl" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hGr" = (
 /obj/machinery/shower{
 	dir = 4
@@ -11613,6 +12509,12 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"hGB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/building)
 "hGJ" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalbottom"
@@ -11621,6 +12523,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"hGQ" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/building)
 "hGT" = (
 /obj/structure/decoration/vent,
 /turf/open/floor/f13{
@@ -11655,13 +12564,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "hHC" = (
-/obj/structure/closet,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalcorroded"
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
 "hHD" = (
@@ -11694,12 +12603,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
-"hHY" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"hIy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "hIB" = (
 /obj/structure/table/wood,
@@ -11792,10 +12706,21 @@
 	},
 /area/f13/ncr)
 "hKY" = (
-/obj/structure/table/wood,
-/obj/item/folder/yellow,
-/obj/item/reagent_containers/pill/patch/jet,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"hLf" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/building)
 "hLm" = (
 /obj/structure/barricade/wooden/strong,
@@ -11833,12 +12758,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "hMM" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/effect/decal/cleanable/oil,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "hMQ" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -11937,6 +12861,12 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hSy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/building)
 "hSD" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -11949,6 +12879,11 @@
 	icon_state = "horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
+"hST" = (
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hTh" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11968,6 +12903,14 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"hTm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "hTn" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12184,13 +13127,11 @@
 	},
 /area/f13/wasteland)
 "hYy" = (
-/obj/structure/barricade/sandbags,
-/obj/structure/destructible/tribal_torch,
-/obj{
-	name = "---Merge conflict marker---"
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/building)
 "hYE" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/reagentgrinder,
@@ -12231,7 +13172,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "hZD" = (
 /obj/structure/chair,
 /turf/open/floor/f13,
@@ -12468,6 +13409,17 @@
 /obj/effect/landmark/start/f13/shopkeeper,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"ihy" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "iic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
@@ -12521,6 +13473,15 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"ijb" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "ijg" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/village)
@@ -12621,6 +13582,24 @@
 	},
 /turf/open/water,
 /area/f13/radiation)
+"ilN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
+"ilY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "ime" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12684,9 +13663,12 @@
 /turf/open/water,
 /area/f13/caves)
 "ioh" = (
-/obj/structure/chair/wood/modern,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/clinic)
 "ioi" = (
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/desert,
@@ -12757,6 +13739,14 @@
 /obj/structure/stone_tile/surrounding/burnt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"ire" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "irk" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -12824,6 +13814,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"isQ" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontaldegraded"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "isV" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -12841,11 +13840,9 @@
 	},
 /area/f13/brotherhood)
 "itm" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/structure/table/reinforced,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "itI" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -12882,13 +13879,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/ncr)
-"iuS" = (
-/obj/structure/chair/wood/modern{
-	dir = 4;
-	icon_state = "wooden_chair_old"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "ivi" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3";
@@ -12896,6 +13886,13 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ivu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "ivJ" = (
 /obj/structure/table/glass,
 /turf/open/floor/f13,
@@ -12987,11 +13984,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "iyR" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheethos"
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "iyV" = (
 /obj/machinery/vending/clothing,
@@ -13020,13 +14018,21 @@
 	},
 /area/f13/building)
 "iAz" = (
-/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iAB" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/f13/raider_leather,
 /turf/open/floor/f13,
+/area/f13/building)
+"iAI" = (
+/obj/structure/bookcase/random/adult,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/building)
 "iAP" = (
 /obj/structure/chair/office/dark,
@@ -13066,15 +14072,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "iBK" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
 "iBT" = (
@@ -13115,6 +14116,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"iEW" = (
+/obj/structure/fluff/paper/stack{
+	desc = "A stack of various papers, all saying you really shouldnt see this. The name Dr. Possum is signed at the bottom."
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2top"
+	},
+/area/f13/wasteland)
 "iEX" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/cracker_pack,
@@ -13158,6 +14167,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"iFS" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "iFT" = (
 /obj/item/ammo_casing/c10mm/ap,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13180,10 +14197,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "iGi" = (
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/machinery/door/poddoor/shutters{
+	id = "carshop"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
 "iGt" = (
@@ -13310,6 +14328,18 @@
 	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland)
+"iIv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	dir = 4;
+	name = "prewar lounge chair"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "iIx" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -13402,13 +14432,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/caves)
-"iKO" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/item/clothing/under/f13/female/tribal,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
 "iLc" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/city)
@@ -13433,6 +14456,21 @@
 /obj/item/cultivator,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"iLF" = (
+/obj/machinery/doorButtons/wornvaultButton,
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
+"iLP" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "iLQ" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -13694,13 +14732,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "iRr" = (
-/obj/structure/closet,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "iRv" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -13805,9 +14841,10 @@
 	},
 /area/f13/city)
 "iTk" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/building)
 "iTx" = (
 /mob/living/simple_animal/hostile/raider/tribal,
@@ -13832,10 +14869,11 @@
 /turf/open/water,
 /area/f13/caves)
 "iTJ" = (
-/obj/structure/table/wood,
-/obj/structure/bedsheetbin,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/building)
 "iTL" = (
@@ -13850,6 +14888,17 @@
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"iUe" = (
+/obj/structure/sign/departments/medbay,
+/turf/closed/wall/f13/wood/house,
+/area/f13/clinic)
+"iUQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "iVd" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13873,7 +14922,13 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
+"iVP" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iVW" = (
 /obj/structure/sink{
 	dir = 8
@@ -13908,6 +14963,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/city)
+"iXF" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "iXX" = (
 /obj/structure/rack,
 /obj/item/clothing/neck/tie,
@@ -13918,6 +14980,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"iYi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "iYs" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -13925,11 +14994,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "iYv" = (
-/obj/structure/chair/stool{
-	icon_state = "bench_center"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "iYw" = (
 /obj/structure/barricade/wooden/planks,
 /obj/structure/window/fulltile/house/broken,
@@ -13941,6 +15010,13 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"iYP" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "iYY" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -13984,6 +15060,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"jaL" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "jaU" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/lights/bulbs,
@@ -14020,14 +15105,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "jbw" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
 	},
-/area/f13/building)
-"jbx" = (
-/obj/structure/simple_door/glass,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
 /area/f13/building)
 "jbI" = (
 /obj/structure/table/wood,
@@ -14061,6 +15145,14 @@
 "jcl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"jco" = (
+/obj/structure/displaycase/trophy{
+	start_showpiece_type = "/obj/item/relic";
+	start_showpieces = newlist()
+	},
+/obj/item/clothing/accessory/medal/plasma/nobel_science,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jcp" = (
@@ -14131,7 +15223,9 @@
 /area/f13/legion)
 "jfx" = (
 /obj/structure/car,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain3"
+	},
 /area/f13/wasteland)
 "jfD" = (
 /obj/structure/decoration/rag,
@@ -14169,6 +15263,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"jgz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "jgE" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -14205,6 +15303,13 @@
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jhS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "jix" = (
 /obj/machinery/autolathe/constructionlathe,
 /obj/machinery/light{
@@ -14408,6 +15513,11 @@
 /obj/effect/landmark/start/f13/pusher,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"joq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "jos" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_br,
@@ -14416,6 +15526,13 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_r,
 /area/f13/bar)
+"jpr" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "jps" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
@@ -14518,18 +15635,44 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/city)
+"jtE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/camera_assembly,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"jtP" = (
+/obj/structure/displaycase/trophy{
+	start_showpiece_type = "/obj/item/relic";
+	start_showpieces = newlist()
+	},
+/obj/item/clothing/accessory/medal/conduct,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "juc" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "juw" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"juC" = (
+/obj/structure/fluff/empty_sleeper{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "juD" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
@@ -14629,8 +15772,10 @@
 	},
 /area/f13/village)
 "jxk" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jxq" = (
@@ -14673,6 +15818,11 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"jyg" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "jyC" = (
 /obj/structure/car/rubbish3,
@@ -14726,14 +15876,13 @@
 	},
 /area/f13/brotherhood)
 "jAZ" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/sign/poster/prewar/vault_tec{
+	pixel_y = 30
 	},
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/camera_assembly,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
 "jBH" = (
 /obj/structure/barricade/sandbags,
@@ -14805,7 +15954,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "jEX" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14933,6 +16082,20 @@
 /obj/item/clothing/suit/f13/sexymaid,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"jKi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
+"jKu" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "jKM" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15036,6 +16199,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"jNY" = (
+/obj/structure/shuttle/engine/large{
+	desc = "A very large bluespace engine made by Aerojet before the war."
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "jOq" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -15150,6 +16322,16 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"jSt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "jSw" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small,
@@ -15189,7 +16371,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "jTX" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/button{
@@ -15213,9 +16395,8 @@
 	},
 /area/f13/city)
 "jTZ" = (
-/obj/structure/closet,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1"
 	},
 /area/f13/building)
 "jUe" = (
@@ -15238,6 +16419,10 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13,
 /area/f13/building)
+"jUt" = (
+/obj/machinery/grill,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "jUS" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -15339,6 +16524,18 @@
 "jXj" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
+"jXp" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "jXu" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15447,6 +16644,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"kbk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "kbw" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -15460,11 +16664,12 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
 "kbS" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "kbU" = (
 /obj/structure/bed/mattress/pregame,
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -15650,11 +16855,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "kfR" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_2"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/f13Cash/random/low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kfU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/four_barrels,
@@ -15698,6 +16903,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"khd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "khn" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
@@ -15781,6 +16994,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"kjK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kjQ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2bottom"
@@ -15841,6 +17059,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/city)
+"kml" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kmn" = (
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/machinery/door/poddoor/shutters{
@@ -15872,6 +17095,16 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kng" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/building)
 "knw" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -15939,6 +17172,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"kps" = (
+/obj/structure/simple_door/interior,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kpA" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -15984,11 +17225,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "kqc" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "floordirty"
 	},
 /area/f13/building)
 "kqe" = (
@@ -15998,6 +17238,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"kqg" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "kqk" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13/wood,
@@ -16109,7 +17359,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "kuI" = (
 /obj/item/toy/beach_ball/holoball{
 	pixel_x = 15
@@ -16137,6 +17387,14 @@
 /obj/structure/bed,
 /turf/open/floor/carpet/black,
 /area/f13/city)
+"kwd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "kwe" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16200,10 +17458,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"kxt" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_x = -31;
+	pixel_y = -11
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "kxv" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"kxE" = (
+/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "kxK" = (
 /obj/structure/legion_extractor,
 /turf/open/floor/f13/wood,
@@ -16270,6 +17543,16 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"kzv" = (
+/obj/structure/billboard/cola/pristine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "kzB" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16392,6 +17675,14 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"kDv" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "kDx" = (
 /obj/structure/sink{
 	dir = 8;
@@ -16505,9 +17796,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kGL" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "kGV" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
@@ -16607,6 +17898,13 @@
 /obj/item/chair/wood,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"kLf" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kLv" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -16647,12 +17945,25 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"kMv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "kMG" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
+"kMJ" = (
+/obj/structure/fluff/empty_sleeper/syndicate{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "kMS" = (
 /obj/structure/fence{
 	dir = 1
@@ -16663,7 +17974,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "kNh" = (
 /obj/machinery/mineral/wasteland_vendor/clothing,
 /turf/open/floor/plating/f13/inside,
@@ -16717,7 +18028,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "kPZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -16774,6 +18085,22 @@
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"kSM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
+"kTa" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontaldegraded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "kTf" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16808,11 +18135,8 @@
 	},
 /area/f13/wasteland)
 "kUe" = (
-/obj/structure/toilet,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/turf/closed/wall/f13/wood/house,
+/area/f13/clinic)
 "kUk" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -16838,7 +18162,14 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
+"kUI" = (
+/obj/structure/rack,
+/obj/item/wirerod,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "kUU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16888,6 +18219,25 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kWq" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/camera,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"kWu" = (
+/obj/structure/sign/departments/medbay,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "kWC" = (
 /obj/structure/table/wood,
 /obj/item/storage/backpack/satchel/leather,
@@ -16942,12 +18292,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "kYz" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "kYH" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -16974,7 +18322,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "kZh" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17019,6 +18367,9 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/grimy,
 /area/f13/village)
+"laE" = (
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/building)
 "laZ" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -17032,15 +18383,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood)
 "lda" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "ldb" = (
 /obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt,
@@ -17055,6 +18402,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/ncr)
+"ldi" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "ldy" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17106,6 +18462,16 @@
 /obj/structure/bed,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"leL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "leM" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17572,6 +18938,14 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"lsR" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "lsS" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -17681,6 +19055,14 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"lvE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pen/fountain,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/building)
 "lvF" = (
 /obj/structure/table/wood/poker,
@@ -17843,6 +19225,25 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"lAd" = (
+/obj/structure/displaycase,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/shoes/jackboots,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3";
+	name = "Museum shutters"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
+"lAe" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "lAn" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -17850,6 +19251,16 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"lAo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/obj/structure/sign/poster/prewar/poster86{
+	pixel_y = -32
+	},
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "lAw" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/f13/rag,
@@ -17869,6 +19280,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lAV" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "lBv" = (
 /obj/structure/window/spawner,
 /obj/structure/curtain{
@@ -18244,6 +19659,15 @@
 	icon_state = "housebase"
 	},
 /area/f13/village)
+"lME" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/fluff/paper/stack,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/building)
 "lNa" = (
 /obj/structure/closet/fridge/standard,
 /turf/open/floor/f13/wood,
@@ -18294,7 +19718,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "lOY" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/autolathe,
@@ -18331,6 +19755,15 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
 /area/f13/caves)
+"lQf" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "lQu" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -18394,12 +19827,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
 "lRZ" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "lSD" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -18415,6 +19846,13 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"lTr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "lTv" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -18446,6 +19884,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/brotherhood)
+"lTX" = (
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/closet/fridge/standard,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "lTZ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -18511,6 +19954,14 @@
 /obj/item/clothing/mask/bandana/skull,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"lUI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
 "lVa" = (
@@ -18621,6 +20072,20 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"maw" = (
+/obj/structure/vaultdoor{
+	icon_state = "open";
+	name = "vault door 454"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "may" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -18650,6 +20115,12 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"mbx" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "mbz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/jet,
@@ -18663,6 +20134,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"mbG" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2right"
+	},
+/area/f13/wasteland)
 "mco" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18688,6 +20167,12 @@
 /area/f13/building)
 "mcN" = (
 /turf/closed/wall/f13/tunnel,
+/area/f13/wasteland)
+"mcP" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "mcW" = (
 /obj/structure/statue/sandstone/mars,
@@ -18809,6 +20294,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"mgr" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mgu" = (
 /obj/structure/closet/bus{
 	pixel_x = -107;
@@ -18827,6 +20320,14 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/village)
+"mgW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "mhJ" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -18920,12 +20421,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "mmj" = (
-/obj/structure/fence/corner{
-	dir = 5
-	},
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "mmq" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13/wood,
@@ -19134,6 +20634,13 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"mrT" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "mrY" = (
 /obj/structure/closet/cabinet,
 /turf/open/indestructible/ground/outside/ruins{
@@ -19171,7 +20678,11 @@
 	},
 /area/f13/wasteland)
 "msS" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/displaycase/trophy{
+	start_showpiece_type = "/obj/item/relic";
+	start_showpieces = newlist()
+	},
+/obj/item/clothing/accessory/medal/gold/heroism,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mtl" = (
@@ -19348,6 +20859,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"mzE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"mzU" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/syringe/medx,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "mzY" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -19399,7 +20926,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "mCO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19425,6 +20952,18 @@
 /obj/machinery/trading_machine/armor,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"mDT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/item/restraints/handcuffs,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/under/f13/police,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "mEh" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal,
@@ -19473,6 +21012,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"mGj" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2top"
+	},
+/area/f13/wasteland)
 "mGo" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/table/wood,
@@ -19501,16 +21046,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "mGZ" = (
-/obj/structure/closet/crate/bin,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/chair,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mHt" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "floor5-old"
+/obj/structure/simple_door/metal,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
 	},
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "mHv" = (
 /obj/structure/chair/booth{
@@ -19571,6 +21115,14 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
+"mJX" = (
+/obj/structure/chair{
+	dir = 1;
+	icon_state = "chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mKe" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -19637,6 +21189,11 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mLw" = (
+/obj/structure/fluff/empty_cryostasis_sleeper,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "mLN" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -19651,6 +21208,12 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/city)
+"mMw" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "mMI" = (
 /obj/structure/simple_door/house{
 	icon_state = "glassclosing"
@@ -19788,6 +21351,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"mRp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "mSs" = (
 /obj/structure/decoration/rag{
 	icon_state = "flag_ncr";
@@ -19799,6 +21370,14 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
+"mSB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mSD" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/f13{
@@ -19872,7 +21451,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "mUO" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19933,6 +21512,16 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mVK" = (
+/obj/structure/simple_door/metal/store,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus4";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/building)
 "mVR" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/floor/f13/wood,
@@ -19958,6 +21547,10 @@
 /obj/item/clothing/under/f13/greendress,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mWx" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "mWy" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife/combat/bone,
@@ -19966,6 +21559,14 @@
 /obj/item/kitchen/knife/combat/bone,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"mWY" = (
+/mob/living/simple_animal/hostile/handy,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "mXA" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/city)
@@ -19999,6 +21600,14 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"mYw" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "mYz" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedvertical"
@@ -20145,6 +21754,13 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"ndd" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "ndx" = (
 /obj/structure/chair/booth{
 	dir = 4
@@ -20174,6 +21790,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
+"neH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "neN" = (
 /obj/structure/destructible/tribal_torch{
 	pixel_x = 10
@@ -20189,21 +21813,18 @@
 	},
 /area/f13/wasteland)
 "neS" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
-/obj/structure/mirror{
-	dir = 8;
-	pixel_y = 28
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"neZ" = (
-/mob/living/simple_animal/hostile/radroach,
+/obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
+/area/f13/clinic)
+"neZ" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
 /area/f13/building)
 "nff" = (
 /obj/machinery/vending/cola,
@@ -20357,6 +21978,20 @@
 	dir = 10
 	},
 /area/f13/village)
+"nkU" = (
+/obj/structure/displaycase,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shield/riot,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3";
+	name = "Museum shutters"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "nla" = (
 /obj/machinery/workbench/forge,
 /turf/open/indestructible/ground/inside/dirt,
@@ -20402,6 +22037,17 @@
 "nlU" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
+"nlV" = (
+/obj/machinery/vending/nukacolavend,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "nmc" = (
 /obj/structure/table,
@@ -20463,6 +22109,19 @@
 	icon_state = "horizontaltopbordertopleft"
 	},
 /area/f13/wasteland)
+"npa" = (
+/obj/structure/displaycase,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/vault/v13,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3";
+	name = "Museum shutters"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "npl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -20501,6 +22160,18 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"nrg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/obj/structure/sign/poster/prewar/poster84{
+	pixel_x = -32
+	},
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "nrw" = (
 /obj/structure/displaycase,
@@ -20543,6 +22214,16 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"nsT" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "ntg" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
@@ -20579,6 +22260,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
+"nui" = (
+/mob/living/simple_animal/hostile/stalker,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "nuk" = (
 /obj/structure/flora/grass/wasteland{
 	layer = 4.2;
@@ -20586,10 +22271,20 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"nut" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
+"nuY" = (
+/mob/living/simple_animal/hostile/stalkeryoung,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "nvr" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/legion)
+/area/f13/wasteland)
 "nvH" = (
 /obj/structure/closet/crate/freezer/blood{
 	pixel_y = 20
@@ -20746,6 +22441,11 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"nAp" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "nAr" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/white/box,
@@ -20767,6 +22467,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"nAS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"nBm" = (
+/obj/structure/displaycase,
+/obj/item/healthanalyzer/advanced,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "nBn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -20800,12 +22516,9 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/wasteland)
 "nCS" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "nDd" = (
@@ -20816,7 +22529,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "nDe" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -20871,11 +22584,27 @@
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"nFG" = (
+/obj/machinery/light/small/broken,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "nFL" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "shadowleft"
 	},
 /area/f13/wasteland)
+"nFU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "nGc" = (
 /obj/structure/simple_door/fakeglass,
 /turf/open/floor/f13{
@@ -20925,6 +22654,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"nGy" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "nHi" = (
 /obj/machinery/vending/snack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20941,6 +22678,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nHH" = (
+/obj/structure/simple_door/metal,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus5"
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "nHL" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/tunnel)
@@ -21033,6 +22779,13 @@
 /obj/item/clothing/mask/bandana/gold,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nLn" = (
+/obj/structure/table/wood/fancy/black,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "nLL" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
@@ -21042,6 +22795,18 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"nMh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nMk" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
@@ -21133,6 +22898,16 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
+"nPl" = (
+/obj/structure/sign/map/right{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "nPq" = (
 /obj/machinery/light{
 	dir = 1
@@ -21176,6 +22951,13 @@
 /obj/effect/turf_decal/stripes/white/full,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"nQJ" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nQP" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
@@ -21187,15 +22969,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "nRc" = (
-/obj/structure/chair{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "nRr" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"nRt" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "nRu" = (
 /obj/structure/barricade/wooden,
@@ -21212,7 +23000,7 @@
 	icon_state = "gibmid1"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "nSc" = (
 /obj/structure/rack,
 /obj/item/flashlight/seclite,
@@ -21222,6 +23010,11 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"nSl" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nSC" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /obj/item/seeds/agave,
@@ -21259,7 +23052,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "nTO" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21317,10 +23110,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/village)
 "nUT" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2top"
+	},
+/area/f13/wasteland)
 "nVb" = (
 /obj/structure/closet/fridge,
 /turf/open/floor/f13/wood,
@@ -21344,6 +23138,10 @@
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"nVK" = (
+/obj/structure/sign/warning/nosmoking/circle,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "nVM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -21371,6 +23169,13 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nYb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/house,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "nYI" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/folder/blue,
@@ -21406,9 +23211,10 @@
 	},
 /area/f13/wasteland)
 "nZV" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/effect/decal/remains/human,
+/obj/item/stack/f13Cash/random/med,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "oat" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife,
@@ -21427,7 +23233,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "oay" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -21473,7 +23279,7 @@
 	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "oco" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -21596,6 +23402,14 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"ofz" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ofL" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -21626,14 +23440,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/city)
-"ohk" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Business"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "ohx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/comfy/beige,
@@ -21689,6 +23495,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"ojI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ojL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21753,9 +23565,10 @@
 	},
 /area/f13/wasteland)
 "olN" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
 "olP" = (
@@ -21765,8 +23578,11 @@
 	},
 /area/f13/building)
 "olW" = (
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
 /area/f13/building)
 "olZ" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -21945,17 +23761,11 @@
 	},
 /area/f13/wasteland)
 "oqm" = (
-/obj/structure/mirror{
-	pixel_y = 30
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/clinic)
+/area/f13/building)
 "oqp" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -21999,6 +23809,14 @@
 /obj/machinery/light/sign,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/city)
+"orS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "orZ" = (
 /obj/structure/table/wood/settler,
 /obj/structure/guillotine,
@@ -22069,6 +23887,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"ouC" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ouS" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13{
@@ -22210,14 +24035,22 @@
 	},
 /area/f13/village)
 "ozI" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/legion)
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "oAe" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
+"oAo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
 "oAB" = (
 /obj/structure/barricade/bars,
@@ -22234,7 +24067,7 @@
 "oBQ" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
+	dir = 10;
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
@@ -22260,7 +24093,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "oCS" = (
 /obj/structure/decoration/cctv,
 /turf/closed/wall/r_wall/rust,
@@ -22514,6 +24347,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"oLm" = (
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "oLL" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22564,6 +24403,13 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"oNj" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "oNC" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood{
@@ -22585,6 +24431,13 @@
 /obj/structure/chair/stool,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
+"oNL" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/wirerod,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "oNR" = (
@@ -22616,10 +24469,11 @@
 	},
 /area/f13/wasteland)
 "oOZ" = (
-/obj/structure/toilet,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
 	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
 /area/f13/clinic)
 "oPB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22685,6 +24539,15 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/village)
+"oRN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "oRQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/boozeomat{
@@ -22746,7 +24609,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "oSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22872,6 +24735,11 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"oWM" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/fluff/broken_flooring,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/building)
 "oWU" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -23075,7 +24943,7 @@
 	},
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "pek" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -23096,6 +24964,14 @@
 	dir = 6
 	},
 /area/f13/village)
+"peL" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	termtag = "Secret"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "peX" = (
 /obj/structure/mirror,
 /turf/closed/wall/f13/wood,
@@ -23173,6 +25049,17 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"pgK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/button/door{
+	id = "mus5"
+	},
+/obj/item/paper_bin,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "phu" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -23507,7 +25394,7 @@
 "prP" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "prR" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1;
@@ -23541,6 +25428,19 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
+"psO" = (
+/obj/structure/filingcabinet/employment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
+"psP" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/fo13colored/Pink,
+/obj/item/coin/twoheaded,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/building)
 "psR" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
@@ -23573,17 +25473,44 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pud" = (
-/turf/closed/wall/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood,
 /area/f13/clinic)
+"puf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/item/restraints/handcuffs,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/under/f13/police,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "puP" = (
 /obj/structure/rack,
 /obj/item/seeds/cannabis,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"puU" = (
+/obj/structure/table/reinforced,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "puX" = (
 /obj/item/claymore/machete/training,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "pvn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -23601,6 +25528,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pvL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "pwc" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -23616,18 +25550,22 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"pxc" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "pxd" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "pxf" = (
-/obj/structure/table/wood,
-/obj/item/stack/cable_coil,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/clinic)
 "pxw" = (
 /obj/structure/fence/pole_b,
@@ -23638,6 +25576,11 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/caves)
+"pxJ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pxN" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -23708,7 +25651,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "pzm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -23732,6 +25675,10 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"pAf" = (
+/mob/living/simple_animal/hostile/stalkeryoung,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pAg" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/fakelattice{
@@ -23854,16 +25801,6 @@
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"pEs" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "pEt" = (
 /obj/structure/window/fulltile/ruins,
 /obj/structure/curtain{
@@ -23924,13 +25861,8 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
 "pHi" = (
-/obj/structure/bed,
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "pHm" = (
@@ -23938,15 +25870,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "pHx" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/area/f13/clinic)
 "pHy" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13/wood{
@@ -24059,12 +25988,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pKP" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife,
-/obj/item/screwdriver,
-/obj/item/hatchet,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "pKY" = (
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24092,6 +26022,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"pLt" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pLD" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/dirt{
@@ -24144,6 +26081,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pNz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/melee/classic_baton,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "pNF" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -24185,15 +26131,23 @@
 /obj/item/paper_bin,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/legion)
+"pOf" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pOo" = (
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "pOw" = (
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/clinic)
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pOC" = (
 /obj/structure/fence/post{
 	desc = "A wooden post.";
@@ -24227,6 +26181,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"pPv" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "pPF" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
@@ -24352,11 +26312,8 @@
 	},
 /area/f13/building)
 "pTE" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/pill/charcoal,
-/obj/item/reagent_containers/pill/charcoal,
-/turf/open/floor/f13/wood,
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "pTM" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -24393,6 +26350,15 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"pVo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "pVp" = (
 /obj/item/reagent_containers/food/drinks/bottle/brown/greenwine{
 	anchored = 1;
@@ -24488,9 +26454,12 @@
 	},
 /area/f13/wasteland)
 "pYa" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/structure/car/rubbish2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "pYj" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
@@ -24536,13 +26505,8 @@
 	},
 /area/f13/brotherhood)
 "qai" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
 "qal" = (
@@ -24582,6 +26546,19 @@
 	dir = 4
 	},
 /turf/open/floor/wood/f13/carpet,
+/area/f13/building)
+"qbQ" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "qbX" = (
 /obj/structure/flora/grass/wasteland{
@@ -24686,6 +26663,14 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/city)
+"qef" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "qer" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -24718,6 +26703,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"qgA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qgO" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
@@ -24760,13 +26750,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "qhs" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
-"qij" = (
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/structure/wreck/trash/one_tire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "qik" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24787,7 +26775,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "qiN" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
@@ -24856,6 +26844,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qko" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "qkO" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24873,15 +26867,21 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
 "qlv" = (
-/obj/structure/table/wood,
-/obj/item/weldingtool,
-/obj/item/crowbar,
-/obj/item/wirecutters{
-	icon_state = "cutters"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/reagent_containers/pill/patch/jet,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder"
+	},
+/area/f13/building)
+"qlC" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "qlE" = (
 /obj/structure/decoration/hatch{
 	dir = 8
@@ -25014,6 +27014,16 @@
 /obj/machinery/mineral/wasteland_vendor/general,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"qpV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "qpY" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -25039,12 +27049,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "qrw" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/machinery/icecream_vat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/building)
 "qrL" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light/small{
@@ -25058,6 +27066,12 @@
 /obj/structure/decoration/vent,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"qst" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "qsz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -25103,20 +27117,30 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"qtr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "qub" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qul" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "quy" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/legion)
+/obj/structure/table/booth,
+/obj/item/stack/f13Cash/random/low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "quP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25209,15 +27233,10 @@
 /turf/open/floor/wood/f13/stage_tl,
 /area/f13/wasteland)
 "qwr" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
+/obj/structure/closet/crate/trashcart,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "qwS" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -25257,6 +27276,12 @@
 	icon_state = "horizontaltopbordertop2right"
 	},
 /area/f13/tunnel)
+"qyg" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "qyj" = (
 /obj/item/toy/cattoy,
 /turf/open/floor/f13/wood,
@@ -25276,13 +27301,6 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
-"qzr" = (
-/obj/structure/rack,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "qzt" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25384,6 +27402,13 @@
 /obj/item/bedsheet/brown,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"qCF" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qCX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -25462,13 +27487,20 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
+"qEP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "qEU" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "qFk" = (
 /turf/closed/wall/f13/wood,
 /area/f13/village)
@@ -25495,6 +27527,12 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"qGy" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/building)
 "qGZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outermaincornerinner"
@@ -25550,7 +27588,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "qHR" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -25646,12 +27684,23 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"qKB" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/stack/f13Cash/random/low,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qKU" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"qKW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "qLa" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/desert,
@@ -25698,11 +27747,9 @@
 	},
 /area/f13/ncr)
 "qMp" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 25
-	},
+/obj/structure/camera_assembly,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "qMA" = (
@@ -25754,6 +27801,14 @@
 	icon_state = "housewindowbroken"
 	},
 /obj/structure/decoration/rag,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"qNE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qNM" = (
@@ -25870,6 +27925,13 @@
 	icon_state = "horizontaloutermainleft"
 	},
 /area/f13/city)
+"qQb" = (
+/obj/item/storage/trash_stack,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "qQe" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/f13/wood,
@@ -25918,6 +27980,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"qQT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/cctv{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "qQW" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken{
@@ -25995,7 +28066,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "qTe" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
@@ -26115,10 +28186,11 @@
 	},
 /area/f13/village)
 "qXk" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/shuttle/engine/router,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "qXo" = (
 /obj/structure/destructible/tribal_torch,
@@ -26172,6 +28244,11 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"raO" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "raV" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Armory";
@@ -26186,6 +28263,16 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland)
+"rbg" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus2";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "rbi" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -26212,7 +28299,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "rco" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -26249,6 +28336,14 @@
 /obj/structure/rack,
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"rdv" = (
+/obj/item/clothing/head/cone,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "rdy" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -26307,6 +28402,12 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"rfG" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rfP" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/barber{
@@ -26360,6 +28461,17 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"rhU" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus2";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "ril" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -26378,11 +28490,18 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "rja" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
 /area/f13/clinic)
+"rjz" = (
+/obj/structure/rack,
+/obj/item/stack/f13Cash/random/med,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "rjD" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
@@ -26496,6 +28615,14 @@
 	icon_state = "verticalleftborderright3"
 	},
 /area/f13/wasteland)
+"rnL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "rnO" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/redeveninggown,
@@ -26612,6 +28739,12 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"ruk" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "ruD" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/turbo,
@@ -26634,6 +28767,10 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/village)
+"rvK" = (
+/obj/structure/sign/warning/enginesafety,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "rvT" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -26746,7 +28883,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "rzV" = (
-/mob/living/simple_animal/hostile/radroach,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "rAe" = (
@@ -26812,10 +28953,24 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"rBU" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "rCt" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"rCv" = (
+/obj/item/mop,
+/obj/structure/janitorialcart,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "rDa" = (
 /mob/living/simple_animal/hostile/wolf,
 /turf/open/indestructible/ground/outside/road{
@@ -26867,9 +29022,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "rEB" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/freezer,
+/area/f13/building)
 "rFc" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood{
@@ -26909,6 +29065,13 @@
 /obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"rGS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "rHE" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_middle,
@@ -26935,6 +29098,22 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/carpet,
+/area/f13/building)
+"rIC" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "rIR" = (
 /obj/structure/cross,
@@ -27007,7 +29186,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "rMz" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -27102,6 +29281,19 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ncr)
+"rPY" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "mus4";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "rQe" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27211,6 +29403,17 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"rTa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Private"
+	},
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "rTt" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -27232,6 +29435,15 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"rTT" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "rTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -27453,11 +29665,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "scY" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/simple_door/house,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "sdo" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -27479,6 +29689,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building)
+"sdR" = (
+/obj/structure/car/rubbish3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "sed" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -27492,6 +29709,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"sen" = (
+/obj/structure/displaycase,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pda,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3";
+	name = "Museum shutters"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
+"sep" = (
+/obj/structure/bookcase/random/fiction,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "sew" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -27740,6 +29977,17 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sjH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "sjX" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/small{
@@ -27747,6 +29995,19 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"sjY" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "skh" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -28034,6 +30295,14 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building)
+"sru" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "srw" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
@@ -28129,6 +30398,13 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"sve" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "svF" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -28182,8 +30458,8 @@
 	},
 /area/f13/building)
 "swx" = (
-/obj/item/mining_scanner,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/sign/poster/prewar/protectron,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "swH" = (
 /obj/structure/window/fulltile/house{
@@ -28380,11 +30656,25 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"sBU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "sCf" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"sCg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "sCh" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -28435,13 +30725,13 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "sDj" = (
 /obj/structure/fence/corner{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "sDp" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -28449,7 +30739,7 @@
 "sDr" = (
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "sDI" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -28583,7 +30873,7 @@
 /obj/item/reagent_containers/glass/bucket/wood,
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "sJw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
@@ -28595,7 +30885,7 @@
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "sJP" = (
 /obj/structure/sign/poster/contraband/pinup_shower,
 /turf/closed/wall/f13/wood/house,
@@ -28723,6 +31013,13 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"sNN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "sNT" = (
 /obj/structure/chair{
 	dir = 4
@@ -28778,6 +31075,12 @@
 /obj/structure/tires,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"sQf" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
 /area/f13/wasteland)
 "sQj" = (
 /obj/machinery/smartfridge/bottlerack/gardentool,
@@ -28852,6 +31155,19 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"sSE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
+"sSH" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "sSJ" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/barber{
@@ -28964,6 +31280,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"sVE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
 "sVF" = (
@@ -29100,7 +31424,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/floor/wood/f13/old,
-/area/f13/legion)
+/area/f13/wasteland)
 "sZT" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -29192,12 +31516,31 @@
 /obj/item/trash/syndi_cakes,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tbJ" = (
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tbO" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"tbU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "tch" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -29240,18 +31583,38 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"tdL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"tdO" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tdU" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tdW" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tem" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/coffee,
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tep" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
@@ -29320,17 +31683,9 @@
 	},
 /area/f13/brotherhood)
 "tha" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
 "thb" = (
 /mob/living/simple_animal/hostile/handy,
@@ -29416,6 +31771,21 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
 /area/f13/city)
+"tjz" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus4";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "tjB" = (
 /obj/item/ammo_casing/a50MG,
 /turf/open/indestructible/ground/outside/road{
@@ -29423,17 +31793,25 @@
 	},
 /area/f13/wasteland)
 "tjI" = (
+/obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
+	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "tjQ" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/pill/patch/jet,
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tjU" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tka" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
@@ -29444,9 +31822,12 @@
 	},
 /area/f13/building)
 "tkm" = (
-/mob/living/simple_animal/hostile/handy,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/item/weldingtool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "tkO" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13{
@@ -29465,9 +31846,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tkY" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "tlj" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -29633,11 +32015,11 @@
 	},
 /area/f13/tunnel)
 "tpA" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "tpD" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29713,6 +32095,17 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"trU" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "trW" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -29728,12 +32121,17 @@
 	},
 /area/f13/village)
 "tsr" = (
-/mob/living/simple_animal/hostile/handy,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "tsB" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/clinic)
 "tsF" = (
 /turf/open/floor/f13{
@@ -29802,12 +32200,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"tvj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "tvl" = (
 /obj/effect/landmark/latejoin,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/tunnel)
+"tvm" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "tvp" = (
 /obj/item/candle/infinite,
 /obj/structure/table/wood,
@@ -29884,19 +32295,34 @@
 /obj/structure/billboard/cola/pristine,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"twY" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/clothing_low,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"twR" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"twY" = (
+/obj/structure/decoration/clock/old/active{
+	pixel_y = 25
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "txb" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"txn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/house,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "txr" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalright"
@@ -29932,6 +32358,13 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
+"tyr" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "tyw" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass{
@@ -29959,6 +32392,15 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"tyT" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "tzf" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -29980,6 +32422,12 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"tzI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "tAg" = (
 /obj/structure/fence{
 	dir = 4
@@ -30028,6 +32476,15 @@
 /obj/item/clothing/head/helmet/f13/deathskull,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"tBA" = (
+/obj/structure/displaycase,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "tBB" = (
 /obj/effect/decal/cleanable/blood/innards,
 /turf/open/indestructible/ground/outside/dirt{
@@ -30144,6 +32601,16 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
+"tEt" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"tEW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "tEZ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -30229,6 +32696,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"tGq" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus4";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "tGx" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -30250,6 +32728,19 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/brotherhood)
+"tHi" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "tHw" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -30314,7 +32805,7 @@
 /turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
 "tJx" = (
-/obj/machinery/vending/medical,
+/obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "tJz" = (
@@ -30369,12 +32860,10 @@
 	},
 /area/f13/caves)
 "tLW" = (
-/obj/structure/destructible/tribal_torch,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "tMm" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/armor/f13/kit,
@@ -30419,6 +32908,18 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"tNM" = (
+/obj/structure/sign/poster/prewar/vault_tec{
+	pixel_y = 30
+	},
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "tNX" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/desert,
@@ -30469,8 +32970,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tPt" = (
-/obj/structure/simple_door/brokenglass,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/clinic)
 "tPy" = (
 /turf/open/indestructible/ground/outside/road{
@@ -30519,6 +33022,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"tQK" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tQU" = (
 /obj/structure/mirror,
 /turf/closed/wall/f13/wood,
@@ -30572,8 +33082,11 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
 "tSQ" = (
-/obj/structure/closet,
-/obj/item/storage/box/gloves,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "tSV" = (
@@ -30583,6 +33096,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tTd" = (
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tTV" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/bars,
@@ -30608,7 +33130,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "tUf" = (
 /obj/structure/safe,
 /turf/open/floor/f13/wood,
@@ -30835,13 +33357,15 @@
 	},
 /area/f13/wasteland)
 "uag" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "uar" = (
-/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/iv_drip,
+/obj/structure/decoration/clock/old/active{
+	pixel_y = 25
+	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "ubd" = (
@@ -30880,11 +33404,33 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"ucf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "ucs" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uct" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "ucw" = (
 /obj/structure/fence{
 	dir = 1;
@@ -31040,6 +33586,13 @@
 /obj/structure/barricade/wooden,
 /turf/open/water,
 /area/f13/caves)
+"ufR" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ugm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -31058,6 +33611,22 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/bar)
+"ugx" = (
+/obj/structure/tires/half,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1"
+	},
+/area/f13/building)
+"uhe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/cctv{
+	pixel_x = 30
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "uhh" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/small{
@@ -31136,15 +33705,26 @@
 "ukl" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"ukD" = (
+/obj/structure/rack,
+/obj/item/broom,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "ukQ" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/wasteland)
 "ulc" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
+/obj/structure/simple_door/metal/store,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus2";
+	name = "Museum shutters"
 	},
-/area/f13/legion)
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/building)
 "ulf" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -31336,6 +33916,13 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ncr)
+"uqz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uqE" = (
 /obj/effect/decal/remains/human,
 /obj/item/ammo_casing/caseless{
@@ -31356,9 +33943,8 @@
 	},
 /area/f13/ncr)
 "uqW" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "urg" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -31367,10 +33953,12 @@
 	},
 /area/f13/wasteland)
 "urt" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/syringe/medx,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/freezer,
+/area/f13/building)
 "uru" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt{
@@ -31454,6 +34042,21 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"utQ" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/f13Cash/random/low,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "utT" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/curtain{
@@ -31500,6 +34103,10 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"uvu" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "uvC" = (
 /obj/item/shovel,
 /turf/open/indestructible/ground/outside/dirt,
@@ -31601,15 +34208,39 @@
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"uza" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uzn" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
 "uzs" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "floor2-old"
+/obj/structure/shuttle/engine/router,
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"uzw" = (
+/obj/structure/table/reinforced,
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus2";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/building)
 "uzG" = (
 /obj/effect/landmark/start/f13/ncrfirstsergeant,
@@ -31619,10 +34250,11 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "uzJ" = (
-/obj/structure/chair{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "uzU" = (
 /obj/effect/decal/cleanable/dirt{
@@ -31633,6 +34265,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"uAe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/building)
 "uAm" = (
 /obj/item/ammo_casing/c10mm/ap,
 /turf/open/floor/f13/wood,
@@ -31778,9 +34417,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "uFp" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench_center"
+/obj/effect/decal/waste{
+	pixel_x = 20;
+	pixel_y = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
@@ -31873,6 +34512,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"uHv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "uHA" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13{
@@ -31889,6 +34536,12 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"uHC" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uHT" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/desert,
@@ -31902,6 +34555,14 @@
 /obj/item/clothing/under/f13/legslavef,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"uHW" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/building)
 "uIh" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31946,6 +34607,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"uJH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "uJP" = (
 /obj/structure/closet/crate/trashcart,
@@ -32018,6 +34686,14 @@
 /obj/item/kitchen/knife/cosmicdirty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
+"uLg" = (
+/obj/structure/sign/poster/prewar/vault_tec{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "uLK" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/f13{
@@ -32066,9 +34742,14 @@
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
 "uNQ" = (
-/obj/structure/closet/cabinet,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/clinic)
 "uNR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -32124,6 +34805,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"uOU" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "uPj" = (
 /obj/structure/fence{
 	dir = 4
@@ -32133,13 +34820,9 @@
 	},
 /area/f13/wasteland)
 "uPr" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
 "uPw" = (
 /obj/structure/window/fulltile/house{
@@ -32214,6 +34897,16 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
+"uRX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "uSj" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal,
@@ -32278,11 +34971,12 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "uTA" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/machinery/light/small/broken,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
 	},
-/area/f13/clinic)
+/area/f13/wasteland)
 "uTG" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -32324,6 +35018,14 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"uUH" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "uUJ" = (
 /obj/structure/destructible/tribal_torch{
 	pixel_y = 20
@@ -32427,6 +35129,21 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/brotherhood)
+"uWU" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "uWX" = (
 /obj/structure/chair{
 	dir = 1
@@ -32440,7 +35157,7 @@
 /obj/structure/simple_door/metal/fence,
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
 "uXj" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -32494,10 +35211,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uZg" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
+/obj/machinery/iv_drip,
+/obj/structure/decoration/clock/old/active{
+	pixel_y = 25
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "uZj" = (
@@ -32513,6 +35231,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
+"uZm" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uZp" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/inside/mountain,
@@ -32557,6 +35281,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"vbr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/freezer,
+/area/f13/building)
 "vbA" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife,
@@ -32653,12 +35384,8 @@
 	},
 /area/f13/wasteland)
 "veO" = (
-/obj/structure/closet/cabinet,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/clothing/under/f13/blackdress,
-/obj/item/clothing/gloves/f13/lace,
+/obj/structure/simple_door/metal/store,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vfc" = (
@@ -32728,6 +35455,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"vgK" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "vgZ" = (
 /obj/structure/fence{
 	dir = 8
@@ -32806,11 +35539,8 @@
 	},
 /area/f13/brotherhood)
 "viv" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "viD" = (
@@ -32846,6 +35576,20 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
+"vjF" = (
+/obj/structure/displaycase,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/energy/laser/wattz,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3";
+	name = "Museum shutters"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "vjO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -32862,6 +35606,11 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"vks" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "vkB" = (
 /obj/structure/chair/wood/modern,
@@ -32927,10 +35676,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"vno" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "vnR" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -32968,6 +35713,13 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
+"vpq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "vpx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -32997,6 +35749,12 @@
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
+"vqC" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2top"
+	},
+/area/f13/wasteland)
 "vqF" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -3
@@ -33007,6 +35765,20 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vqP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "vrc" = (
 /obj/structure/rack,
 /obj/item/cultivator,
@@ -33075,15 +35847,6 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
-"vtv" = (
-/obj/structure/chair/stool{
-	icon_state = "bench_center"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "vtH" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
@@ -33129,6 +35892,12 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"vvI" = (
+/mob/living/simple_animal/hostile/retaliate/goat/bighorn,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "vvU" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -33143,10 +35912,6 @@
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
-"vwn" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
 "vwt" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/cow/brahmin,
@@ -33251,6 +36016,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vzS" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
+"vzV" = (
+/mob/living/simple_animal/hostile/stalkeryoung,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/building)
 "vzW" = (
 /obj/structure/car/rubbish1,
 /obj/effect/decal/remains/human,
@@ -33329,6 +36107,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"vBM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vBO" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -33359,6 +36143,12 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
+"vCX" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1"
+	},
+/area/f13/wasteland)
 "vDb" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/oil{
@@ -33438,6 +36228,18 @@
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vFI" = (
+/obj/structure/displaycase,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3";
+	name = "Museum shutters"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "vFL" = (
 /obj/effect/landmark/start/f13/ncroffduty,
 /turf/open/floor/f13{
@@ -33624,6 +36426,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"vKi" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vKl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -33667,6 +36474,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"vMs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/building)
 "vMu" = (
 /obj/machinery/light{
 	dir = 4;
@@ -33677,6 +36492,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"vMF" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vMN" = (
 /obj/machinery/light{
 	dir = 8;
@@ -33687,10 +36507,13 @@
 	},
 /area/f13/ncr)
 "vMR" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/displaycase,
+/obj/item/clothing/glasses/hud/health/f13,
+/obj/machinery/light/floor,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "vMU" = (
@@ -33759,7 +36582,18 @@
 	},
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/wasteland)
+"vPL" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/f13Cash/random/low,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus2";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "vPQ" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt,
@@ -33966,6 +36800,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"vWZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "vXh" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -33987,6 +36828,26 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"vXR" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	name = "Museum shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"vYc" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
 "vYe" = (
 /obj/structure/barricade/sandbags,
@@ -34014,6 +36875,14 @@
 "vYX" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"vZh" = (
+/obj/structure/rack,
+/obj/item/clothing/under/rank/curator/treasure_hunter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "vZl" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor1-old"
@@ -34062,23 +36931,43 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"wcg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/button/door{
+	id = "mus4";
+	pixel_x = -3
+	},
+/obj/machinery/button/door{
+	id = "mus3";
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "wcu" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
 "wcA" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "wcO" = (
-/obj/structure/chair/stool,
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
 /area/f13/building)
 "wcS" = (
 /obj/structure/rack,
@@ -34109,6 +36998,15 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"wec" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/waste{
+	pixel_x = 18;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/building)
 "wef" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/ruins,
@@ -34121,7 +37019,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "weJ" = (
 /obj/structure/decoration/clock{
 	pixel_y = 32
@@ -34204,6 +37102,18 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/city)
+"wif" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
+"wik" = (
+/obj/structure/table/wood,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "wim" = (
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_tiled,
@@ -34394,14 +37304,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wpo" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	termtag = "Business"
-	},
+/obj/structure/rack,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "wpx" = (
 /obj/structure/simple_door/house,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"wpO" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wqe" = (
@@ -34477,6 +37392,14 @@
 /obj/effect/landmark/start/f13/villager,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"wss" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/employment,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "wsy" = (
 /obj/machinery/trading_machine,
 /turf/open/floor/f13/wood,
@@ -34660,6 +37583,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"wzi" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus2";
+	name = "Museum shutters"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "wzm" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
@@ -34742,6 +37676,10 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"wBe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "wBo" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
@@ -34758,7 +37696,7 @@
 	icon_state = "fence_wood"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/legion)
+/area/f13/wasteland)
 "wBC" = (
 /obj/structure/rack,
 /obj/item/clothing/head/crown,
@@ -34861,11 +37799,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "wFp" = (
-/obj/structure/chair{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "wFG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -34908,6 +37845,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"wHm" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/structure/camera_assembly{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "wHu" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -34944,6 +37888,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"wIq" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "wIK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderlefttop"
@@ -34985,6 +37937,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/caves)
+"wKK" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
 "wKU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -35102,6 +38060,11 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"wOc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "wOh" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -35243,6 +38206,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"wQO" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wQR" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -35283,6 +38251,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"wRQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Secret"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "wSd" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -35331,9 +38311,14 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/city)
 "wSJ" = (
-/obj/structure/simple_door/wood,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "wSP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/settler,
@@ -35353,6 +38338,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"wTa" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "wTU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -35614,6 +38607,12 @@
 /obj/item/mining_scanner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/brotherhood)
+"xbp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "xbv" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
@@ -35622,6 +38621,12 @@
 /obj/structure/sign/poster/prewar/poster83,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"xbC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/building)
 "xbK" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -35717,11 +38722,18 @@
 	},
 /area/f13/village)
 "xdG" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/building)
+"xdN" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "xed" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -35755,26 +38767,47 @@
 	},
 /area/f13/brotherhood)
 "xes" = (
-/turf/open/floor/wood/f13/old,
-/area/f13/legion)
-"xeG" = (
-/obj/structure/chair{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
+"xeG" = (
+/obj/structure/table/reinforced,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/building)
 "xeK" = (
 /obj/structure/curtain{
 	color = "#845f58"
 	},
 /turf/closed/wall/f13/wood/interior,
 /area/f13/ncr)
+"xeP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "xeQ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"xeU" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "xeY" = (
@@ -35913,6 +38946,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xiF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/building)
 "xiH" = (
 /obj/structure/rack,
 /obj/item/clothing/under/lawyer/female{
@@ -35955,7 +38995,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "xkj" = (
 /obj/machinery/mineral/wasteland_vendor/advcomponents,
 /turf/open/floor/f13{
@@ -36231,6 +39271,13 @@
 /obj/structure/sign/poster/contraband/pinup_pink,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
+"xrn" = (
+/obj/structure/rack,
+/obj/item/storage/bag/trash,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "xrA" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36249,6 +39296,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"xsk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "xsl" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -36312,6 +39366,14 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
+"xtz" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "xtG" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -36465,6 +39527,13 @@
 	icon_state = "plating"
 	},
 /area/f13/building)
+"xyi" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/structure/table/wood,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
 "xys" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -36494,11 +39563,10 @@
 	},
 /area/f13/wasteland)
 "xAq" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/legion)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/f13Cash/random/low,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "xAB" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -36549,6 +39617,23 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
+"xBO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"xCb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
 	},
 /area/f13/building)
 "xCo" = (
@@ -36673,6 +39758,11 @@
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xGG" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "xGH" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
@@ -36698,6 +39788,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"xHE" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/building)
 "xIh" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -36760,9 +39855,15 @@
 	},
 /area/f13/wasteland)
 "xJd" = (
-/obj/structure/chair/stool,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontal"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "xJA" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -36772,11 +39873,13 @@
 	},
 /area/f13/followers)
 "xJY" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/small/broken{
+	dir = 8
 	},
-/area/f13/legion)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
 "xKb" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -36927,11 +40030,12 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
 "xNQ" = (
-/obj/machinery/light{
-	dir = 4
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "xOi" = (
 /obj/structure/table/wood,
 /obj/item/pda,
@@ -36986,9 +40090,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xQu" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/clinic)
 "xQz" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -37116,10 +40220,13 @@
 	},
 /area/f13/wasteland)
 "xUc" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
-/area/f13/clinic)
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building)
 "xUO" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -37163,11 +40270,11 @@
 	},
 /area/f13/village)
 "xVN" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	icon_state = "floor4-old"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "xVT" = (
 /obj/machinery/light{
 	dir = 1
@@ -37175,11 +40282,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xVZ" = (
-/obj/structure/chair/wood/modern{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/clinic)
+"xWj" = (
+/obj/structure/stalkeregg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "xWk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shower{
@@ -37190,7 +40298,9 @@
 	},
 /area/f13/legion)
 "xWu" = (
-/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "xWF" = (
@@ -37213,15 +40323,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xXl" = (
-/obj/item/clothing/under/f13/police,
-/obj/item/clothing/head/f13/police,
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
 "xXo" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -37278,7 +40384,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "xZh" = (
 /obj/machinery/iv_drip,
 /obj/machinery/light{
@@ -37388,13 +40494,19 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"ybq" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"ybo" = (
+/obj/structure/simple_door/house{
+	icon_state = "interior"
 	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
 /area/f13/building)
+"ybq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/clinic)
 "ybw" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road,
@@ -37447,6 +40559,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"ycK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/building)
 "ydm" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -37599,9 +40718,11 @@
 	},
 /area/f13/wasteland)
 "yhv" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "yhB" = (
@@ -37648,13 +40769,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ykq" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/area/f13/building)
+/area/f13/clinic)
 "ykx" = (
 /obj/item/clothing/head/ushanka,
 /obj/structure/displaycase,
@@ -41454,7 +44576,7 @@ cos
 cos
 gcK
 gcK
-ggK
+aWz
 ggK
 ggK
 gbL
@@ -41713,7 +44835,7 @@ mvv
 rjE
 rjE
 ggK
-xKr
+bPH
 ggK
 gcK
 gcK
@@ -63672,7 +66794,7 @@ fyf
 fyf
 fyf
 fyf
-tBN
+vvI
 mvv
 mvv
 odZ
@@ -65211,7 +68333,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+wjt
 fyf
 fyf
 oFP
@@ -66750,7 +69872,7 @@ mvv
 bpD
 fyf
 fyf
-fyf
+kxt
 fyf
 oFP
 wER
@@ -67514,7 +70636,7 @@ fyf
 fyf
 fyf
 fyf
-dWt
+fyf
 fyf
 nlO
 mfD
@@ -67525,7 +70647,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+lHo
 fyf
 fyf
 fyf
@@ -67788,7 +70910,7 @@ igz
 igz
 igz
 bEw
-fyf
+hfh
 fyf
 gcK
 nzL
@@ -68782,9 +71904,9 @@ kaM
 qoS
 btW
 fvz
-kaM
-btW
-kaM
+erY
+ehN
+ehN
 kaM
 kaM
 kaM
@@ -68817,7 +71939,7 @@ huu
 koD
 dMW
 fyf
-fyf
+lHo
 gcK
 dfR
 sxT
@@ -69038,11 +72160,11 @@ ees
 ees
 ees
 ees
-ees
-ees
-ees
-ees
-ees
+muk
+bJB
+erY
+erY
+geM
 ees
 ees
 ees
@@ -69295,12 +72417,12 @@ ptf
 ptf
 owG
 oBQ
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
+unI
+erY
+bJB
+erY
+koD
+sUX
 ptf
 ptf
 ptf
@@ -69330,7 +72452,7 @@ ptf
 ptf
 ptf
 edA
-fyf
+qod
 fyf
 gcK
 gcK
@@ -69541,6 +72663,7 @@ fyf
 fyf
 fyf
 fyf
+lHo
 fyf
 fyf
 fyf
@@ -69550,43 +72673,42 @@ fyf
 fyf
 fyf
 fyf
+kGc
+unI
+erY
+erY
+rbe
+koD
+dMW
+jJb
 fyf
 fyf
 fyf
 fyf
+lRT
+fyf
+xTK
 fyf
 fyf
 fyf
+ivi
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 fyf
 fyf
 gcK
@@ -69793,6 +72915,28 @@ erY
 koD
 dMW
 fyf
+trW
+fyf
+fyf
+fyf
+jcp
+fyf
+fyf
+fyf
+trW
+fyf
+fyf
+fyf
+sJM
+fyf
+fyf
+kGc
+unI
+rbe
+erY
+erY
+koD
+dMW
 fyf
 fyf
 fyf
@@ -69807,43 +72951,21 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-qOV
-cWG
-cWG
-cWG
-wDc
-bDt
-uxC
-uxC
-uxC
-uxC
-uxC
-uxC
-uxC
-wEo
-hYy
-fyf
-fyf
-fyf
-tlD
-uxC
-uxC
-uxC
-uxC
-uxC
-uxC
-uxC
-wEo
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+aqh
+djX
+juC
+nrg
+kMJ
+gts
+gts
+gts
+tOL
+tOL
+tOL
+tOL
+lME
+gts
 fyf
 fyf
 gcK
@@ -70052,6 +73174,7 @@ dMW
 fyf
 fyf
 fyf
+eEt
 fyf
 fyf
 fyf
@@ -70064,43 +73187,42 @@ fyf
 fyf
 fyf
 fyf
+nJW
+rAt
+grp
+wKo
+erY
+koD
+dMW
 fyf
 fyf
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
+fyf
 gts
 gts
 gts
 gts
 gts
 gts
-fyf
-fyf
 gts
 gts
 gts
 gts
 gts
+rPY
+rPY
+rPY
+tjz
+rPY
 gts
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+tOL
+tOL
+tOL
+tOL
+psP
+gts
 fyf
 fyf
 gcK
@@ -70321,43 +73443,43 @@ uxC
 uxC
 uxC
 uxC
-uxC
 wEo
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-gts
-xXl
-fXj
-ctE
-gwB
-gts
+fyf
+fyf
+mEL
+eMD
+hzb
+jMC
+fyf
+lRT
 fyf
 fyf
 gts
-vYv
+jSt
+ecX
+qKW
+fJD
+xCb
 dtq
-iBK
-vYv
-kIl
 gts
+tha
+wBe
 gts
+uOQ
+hTm
+uOQ
+uOQ
+rnL
+tGq
+mLw
 gts
+tOL
+tOL
+tOL
+tOL
+bYq
 gts
-gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 gcK
@@ -70575,46 +73697,46 @@ fyf
 fyf
 fyf
 fyf
-hYy
 fyf
 fyf
 fyf
 thG
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+dXc
+fyf
+dva
 gts
-vYv
-vYv
-vYv
-vYv
+hBM
+nLn
+lvE
+ycK
+mRp
+psO
 gts
-fyf
-fyf
-toB
-ouS
-olP
-ybq
-ouS
-vYv
+oAo
+gDN
 gts
-olP
-olP
-pjD
+jpr
+iUQ
+nBm
+kMv
+duE
+cmL
+lAo
 gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+bYq
+bYq
+bYq
+bYq
+oWM
+gts
 fyf
 fyf
 gcK
@@ -70825,55 +73947,55 @@ thG
 fyf
 sYX
 sYX
-xIq
+ovN
 sYX
 sYX
-xIq
+ovN
 sYX
 sYX
-xIq
+ovN
 sYX
-fyf
 fyf
 fyf
 thG
+dva
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-gts
-gts
-gts
-vYv
-gts
-gts
+fyf
+fyf
+kbS
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 gts
+ycK
+cqv
+rTa
+qKW
 kqc
-dtq
-pHx
-vYv
-vYv
+fth
 gts
+uLg
+wBe
+kWu
 qMp
-vYv
+fQy
 dol
+hvm
+cJg
+tGq
+eqP
+gts
+xHE
+gts
+gts
+gts
+gts
 gts
 fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+eEt
 gcK
 hBr
 hUV
@@ -71080,58 +74202,58 @@ dMW
 fyf
 thG
 fyf
-cuv
-exj
-rpu
+kGD
+iGO
+gwB
 gYp
-sYX
-rpu
+uCO
+tem
 jxk
-jxk
-iAz
+xde
+qKB
 sYX
-fyf
 fyf
 fyf
 thG
 fyf
-tBN
-uRa
-mvv
-mvv
-bpD
-toB
-ybq
-uKY
-vYv
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gts
-fyf
-fyf
-fyf
-mFe
-vYv
-vYv
-vYv
-vYv
-vYv
-olP
-vYv
-vYv
+qKW
+wcg
+pgK
+qKW
+qlC
+bXe
+gts
+wBe
+sBU
+mVK
+epY
+rGS
 vMR
+rGS
+vpq
+tGq
+erU
+gts
+ezM
+rdv
+wec
+dGK
+dGK
 gts
 fyf
 fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+lHo
 gcK
 gcK
 gcK
@@ -71338,59 +74460,59 @@ fyf
 thG
 fyf
 sYX
-rpu
-klA
-hmy
-sYX
+bDt
+gzW
+jxk
+gjr
 iAz
-rpu
-rpu
-rpu
+qfV
+dyx
+xdN
 sYX
 sYX
 sYX
 sYX
-thG
 fyf
-tBN
-mvv
-mvv
-mvv
-lRH
-toB
-ykq
-vYv
-scY
+fyf
+fyf
+sJM
+fyf
+qod
+fyf
+fyf
+lWZ
+fyf
+fyf
+gts
+xtz
+qKW
+qKW
+kqc
+xtz
+bXe
+gts
+tha
+uPr
+mVK
+epY
+uhe
+uRX
+pPv
+xAD
+tGq
+gkq
+gts
+cKm
+feO
+uzJ
+hLf
+mbx
 gts
 fyf
-rsE
-fyf
-mFe
-vYv
-vYv
-vYv
-iPf
-vYv
-olP
-vYv
-iPf
-pjD
-gts
+hfh
 fyf
 fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kbS
 gcK
 gcK
 gcK
@@ -71596,57 +74718,57 @@ thG
 fyf
 sYX
 eOK
-klA
-rpu
-sYX
-iRr
-rpu
-rpu
-iAz
-sYX
-dcQ
+hiG
+olN
+uCO
+pVX
+gRf
+pxJ
+vcM
+gjr
+pqf
 dkj
 sYX
-vxC
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-toB
-twY
-vYv
-vYv
-gts
+hfh
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
 gts
-vYv
-hjw
-gsu
-vYv
-vYv
-vMR
-gtv
-vYv
-qai
+gts
+gts
+pTE
+aCV
+gts
+gts
+gts
+bqB
+bqB
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+hfo
+bCa
+nGy
+dGK
+qko
 gts
 fyf
 fyf
-thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+wjt
 fyf
 gcK
 gcK
@@ -71851,55 +74973,55 @@ dMW
 fyf
 thG
 fyf
-cuv
+kGD
 eOZ
 fqg
-klA
-sYX
-iAz
-rpu
-rpu
-rpu
-jgq
-dhC
-aZF
-sYX
+vcM
+uCO
+gwB
+wFp
+puU
+aug
+xeG
+tEt
+wdV
+nQJ
 fyf
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-toB
-iHj
-vYv
-vYv
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gts
-fyf
-fyf
-fyf
-toB
-ouS
-onQ
-onQ
-hyf
-vYv
-rVK
-vYv
-vYv
-vYv
 gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+maw
+vYc
+wBe
+wBe
+aVE
+xJY
+wBe
+wBe
+nVK
+gev
+uzJ
+dGK
+sve
+pim
+uzJ
+sru
+gts
+hfo
+dGK
+iAI
+bwB
+xsk
+gts
 fyf
 fyf
 fyf
@@ -72109,58 +75231,58 @@ fyf
 thG
 fyf
 sYX
-tLW
 sYX
-sDp
+sYX
+veO
 sYX
 iTk
-rpu
-rpu
-jxk
-uqa
-uqa
+vcM
+vBM
+eyd
+xeG
+ojI
+qCF
 sYX
-sYX
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-gts
-gts
-gts
-mFe
-gts
+pKP
+noK
+plq
+plq
+uPP
 fyf
 fyf
 fyf
+fyf
+ofz
+fyf
 gts
-iPf
-bzb
+laE
+tyT
+dzj
+tzI
+wBe
+bqB
 tha
-vYv
-auU
+fDI
+wBe
 gts
 uPr
-uPr
-vYv
+xAq
+fqB
+wif
+sSE
+wBe
+aFO
+pTE
+ihy
+dGK
+bsJ
+lUI
+dGK
 gts
 fyf
 fyf
-thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kxt
 fyf
 gcK
 gcK
@@ -72364,60 +75486,60 @@ koD
 dMW
 fyf
 thG
-rsE
 fyf
-fyf
-rsE
-fyf
+aYY
+rRt
+cpK
+cpK
 sYX
-iAz
-rpu
-rpu
-iAz
+gPQ
+wSJ
+aug
+dvI
+ebe
+fDT
+tdO
 sYX
-qfh
-wEO
-sYX
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+bJB
+erY
+pWN
+oCi
+bEw
 fyf
 fyf
 fyf
 fyf
 gts
 gts
+tyT
+wBe
+sve
+npa
+pim
+vjF
+uzJ
+wBe
+ulc
+uAe
+uzJ
+uzJ
+sVE
+dGK
+xsk
+wHm
 gts
-gts
-gts
-gts
-gts
-gts
-gts
-hCa
+qef
+uzJ
+wIq
+uzJ
+dGK
 gts
 fyf
 fyf
-thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qod
 fyf
 gcK
 gcK
@@ -72622,55 +75744,55 @@ dMW
 fyf
 thG
 fyf
-fyf
-fyf
 sYX
 sYX
 sYX
 sYX
 sYX
-sDp
+uCO
+uCO
+ybo
+uCO
+uCO
+uCO
+uCO
 sYX
-sYX
-dcQ
-olN
-uqa
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rsE
-fyf
+kGc
+ajD
+erY
+erY
+ubg
+koD
+dMW
 fyf
 fyf
 fyf
 fyf
 gts
-pMz
-sCf
-wPl
+gts
+tNM
+wBe
 dGK
-olW
+dGK
+pim
+uzJ
+kSM
+wBe
+ulc
+hSy
+dGK
+uzw
+wzi
+rhU
+dGK
+wBe
 gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+rjz
+uzJ
+wTa
+dGK
+qko
+gts
 fyf
 fyf
 fyf
@@ -72879,57 +76001,57 @@ dMW
 fyf
 thG
 fyf
-fyf
-fyf
 sYX
+bHa
+frY
 hxp
-dhC
+wcO
 iTJ
-sCf
-rpu
-rpu
-sYX
-uCO
-sDp
-uqa
+xdG
+eoL
+xdG
+wcO
+hjw
+gPE
+vks
+kGc
+unI
+erY
+erY
+erY
+koD
+dMW
+fyf
+kxt
 fyf
 fyf
-nlO
-tem
-mfD
-mfD
-hCg
-fyf
-fyf
-sju
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-cuv
-rpu
-rpu
-rpu
-rpu
-rpu
+gts
+iLF
+tyT
+sBU
+uzJ
+nkU
+uzJ
+sen
+dGK
+wOc
+gts
+eYv
+dGK
+wzi
+bBu
+wzi
+uzJ
+wBe
+gts
+iLP
+ndd
+vZh
+dGK
+sNN
 gts
 fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+lHo
 fyf
 fyf
 gcK
@@ -73136,55 +76258,55 @@ dMW
 fyf
 thG
 fyf
-rsE
-fyf
 sYX
+cjG
+hMM
 hCF
-dhC
-dhC
-rpu
-rpu
-rpu
-rpu
-rpu
-rpu
-sYX
-mGZ
+pYa
+iyR
+xJd
+hqd
+kxE
+isQ
+sdR
+fKA
+vks
+kGc
+unI
+erY
+snB
+erY
+koD
+dMW
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-mGZ
 gts
-klA
-rpu
-rkZ
-ohk
-rpu
 gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+tyT
+wBe
+dGK
+dGK
+iYP
+dGK
+iYi
+fpH
+gts
+dzj
+uzJ
+vPL
+rbg
+wzi
+dGK
+tvm
+pTE
+uOU
+uzJ
+sep
+dGK
+jKu
+gts
 fyf
 fyf
 fyf
@@ -73393,55 +76515,55 @@ cOk
 dDC
 thG
 fyf
-fyf
-fyf
 sYX
+cph
+hYy
 hHC
-dhC
+qai
 jbw
-rpu
-rpu
-rpu
-rpu
-rpu
-rpu
-wpx
+xUc
+hln
+dhr
+kTa
+oqm
+vMs
+sYX
+kGc
+unI
+erY
+snB
+erY
+koD
+dMW
+nxY
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-xJd
-fyf
-rsE
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-acn
-rpu
-rpu
-bqB
-uzJ
-rpu
 gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+bDE
+tyT
+nAp
+xsk
+lAd
+uzJ
+vFI
+dGK
+tha
+gts
+bqB
+lAe
+dGK
+pim
+dGK
+mgW
+wBe
+gts
+qyg
+uzJ
+xsk
+dGK
+oNj
+gts
 fyf
 fyf
 fyf
@@ -73650,55 +76772,55 @@ dMW
 fyf
 thG
 fyf
-fyf
-fyf
-uqa
-hHY
-dhC
-dhC
-dhC
-rpu
-rpu
-rpu
+sYX
+ctE
+iyR
+jbw
+qhs
+tkm
+qai
+oqm
+iBK
+bvD
 neZ
 olW
-sYX
+vks
+kGc
+unI
+erY
+erY
+ubg
+koD
+dMW
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-wrg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-acn
-rpu
-rpu
-jAZ
-rpu
-rpu
+trW
 gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+tyT
+xes
+fpH
+wBe
+wBe
+gRx
+bqB
+mWx
+gts
+jAZ
+fqB
+wBe
+bqB
+tha
+dzj
+wBe
+gts
+qpV
+lQf
+nGy
+dGK
+ire
+gts
 wjt
 fyf
 fyf
@@ -73907,55 +77029,55 @@ dMW
 fyf
 thG
 fyf
-fyf
-fyf
-uqa
-hxp
-dhC
-hxp
+sYX
+cXn
+iBK
+oqm
+qlv
+tpA
 jTZ
-rkZ
-rkZ
-rkZ
-rpu
-rpu
-cuv
-fyf
-fyf
-fyf
-qOV
-cWG
-cWG
-cWG
-wDc
-fyf
-xJd
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+jTZ
+dhs
+aym
+ugx
+uHW
+vks
+kGc
+pBv
+erY
+erY
+snB
+koD
+jkJ
+igz
+igz
+igz
+uTA
 gts
-kYz
-rpu
-bqB
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+ldi
 uzJ
-rpu
+pim
+pim
+uzJ
+pim
+bMl
+nHH
+dGK
+uzJ
+dGK
+xyi
+wik
 gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-wjt
-fyf
 fyf
 fyf
 fyf
@@ -74164,55 +77286,55 @@ dMW
 fyf
 thG
 fyf
-fyf
-cXn
-uqa
+sYX
+sYX
+iGi
+iGi
 sYX
 sYX
 sYX
 sYX
 sYX
-uqa
-xIq
-uqa
 sYX
 sYX
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-cuv
+sYX
+sYX
+hgX
+ajD
+erY
+liv
+erY
+koD
+rRt
+xKx
+xKx
+cpK
+cpK
+vjd
+rRt
+qul
+qwr
+qwr
+fmQ
+xKx
+bet
 iYv
-rpu
-dGK
-rpu
-rpu
+iYv
 gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+gts
+gts
+gts
+enJ
+enJ
+pTE
+gts
+gts
+gts
+gts
+pTE
+gts
+gts
 fyf
 fyf
 fyf
@@ -74421,57 +77543,57 @@ dMW
 fyf
 thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-pIn
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-cXn
-nZS
+hej
+aXL
+ehN
+ehN
+cGj
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+onk
+erY
+erY
+mmK
+koD
+wVn
+xKx
+xKx
+cpK
+glZ
+fmQ
+xKx
+wVn
+bet
+xKx
+vjd
+tkY
+wVn
+vqC
+atX
 gts
-lRZ
-rpu
-rpu
-rpu
-olW
+kzv
+sjY
+xbp
+qQT
+gZb
+xGG
+bNW
+xbp
+eDc
+gts
+iIv
+sjH
+jKi
 gts
 fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-wjt
-fyf
+eEt
 fyf
 gcK
 gcK
@@ -74678,34 +77800,27 @@ dMW
 fyf
 thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sYX
-sYX
-uqa
-uqa
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hej
+aXL
+rbe
+ehN
+xNQ
+idu
+idu
+uVo
+idu
+idu
+idu
+idu
+idu
+idu
+snB
+erY
+ubg
+erY
+koD
+cpK
+cpK
 gts
 gts
 gts
@@ -74713,20 +77828,27 @@ gts
 gts
 gts
 gts
-aOc
-rVK
 gts
 gts
+xkC
+nUT
+cxq
+jaL
 gts
+ruk
+sjY
+gMV
+uHv
+ivu
+xbp
+kDv
+qtr
+cyL
 gts
+wRQ
+pNz
+sSH
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -74935,57 +78057,57 @@ dMW
 fyf
 thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sYX
-dhC
-wEO
-uqa
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hej
+unI
+ehN
+ubg
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+kaM
+ubg
+bJB
+kaM
+kaM
+erY
+uVo
+erY
+koD
+xKx
 gts
+vcM
+pOf
+ulL
+ulL
+ulL
+qfV
+uJH
+vcM
 veO
-rpu
-msS
-nUT
+cpK
+glZ
+tkY
+xKx
 gts
-iuS
-rpu
-rpu
-rpu
-sDp
-dhC
-dkj
+dlJ
+sjY
+xbp
+cyL
+jXp
+vXR
+bpu
+cyL
+lsR
+gts
+eCY
+oRN
+xbC
 gts
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hfh
 fyf
 gcK
 gcK
@@ -75192,55 +78314,55 @@ dMW
 fyf
 thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sYX
-neS
-iGi
-sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-mfD
-mfD
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hej
+cIm
+dNT
+dNT
+dNT
+dNT
+dNT
+dNT
+dNT
+dNT
+vCX
+dNT
+dNT
+dNT
+muk
+erY
+erY
+uVo
+koD
+cpK
 gts
-tUf
-rpu
-rpu
-nUT
+nSl
+kjK
+ufR
+daj
+cJk
+wAd
+vBM
+tbJ
 gts
+bTf
+bet
+uag
+iYv
 pTE
-rpu
-rpu
-iuS
+bhV
+uct
+cyL
+orS
+tHi
+aGP
+uct
+xbp
+xbp
+cuh
+xbC
+kwd
+gKe
 gts
-dcQ
-usW
-gts
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -75449,55 +78571,55 @@ dMW
 fyf
 thG
 fyf
-fyf
-sYX
-sYX
-xIq
-sYX
-sYX
 kUe
-dhC
-sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-xJd
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kUe
+kUe
+oOZ
+kUe
+kUe
+kUe
+kUe
+kUe
+nPg
+ybI
+ybI
+ybI
+ybI
+onk
+erY
+erY
+sCK
+koD
+cpK
 gts
-rpu
-xNQ
-rpu
-iyR
-rVK
-xVZ
-jhp
-ioh
-rkZ
+raO
+uZm
+mSB
+mzE
+mSB
+vKi
+dyx
+deL
 gts
+bTf
+iEW
+cpK
+atX
 gts
+nlV
+uct
+cyL
+tvj
+dcQ
+jgz
+uct
+gXi
+tdL
 gts
+mDT
+puf
+wss
 gts
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -75706,55 +78828,55 @@ dMW
 fyf
 thG
 fyf
-fyf
-sYX
-fuj
-rpu
-rkZ
-uCO
-uCO
-sDp
-sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-xJd
-wrg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kUe
+dqc
+ucf
+xQu
+neS
+tsB
+jhS
+joq
+kUe
+pBv
+erY
+liv
+erY
+erY
+erY
+wkd
+erY
+erY
+koD
+cpK
 gts
-vug
+tzk
+vcM
+wpO
+vcM
+vcM
+vcM
+vcM
+dZp
 gts
+jUt
+cpK
+cpK
+cce
 gts
+uWU
+fjI
+cyL
+cyL
+dcQ
+eFF
+apU
+cyL
+cyL
 gts
+tEW
+czw
+cuY
 gts
-aYG
-rpu
-ioh
-hKY
-gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -75963,58 +79085,58 @@ dMW
 fyf
 thG
 fyf
-fyf
-cuv
-ccF
-rpu
-rpu
-jbx
-rpu
-rpu
-sYX
-fyf
-fyf
-fyf
-cXn
-fyf
-fyf
-xJd
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-cuv
-rpu
-iGO
-rkZ
-rpu
+aZF
+exj
+iRr
+pud
+xVZ
+lda
+eZg
+aMn
+kUe
+unI
+bRt
+bRt
+uYf
+erY
+ubg
+erY
+erY
+erY
+koD
+wVn
 gts
-rpu
-rpu
-ioh
+gts
+gts
+gts
+gts
+gts
+gts
+wpx
+gts
+gts
+gts
+gts
+jgz
+jgz
+gts
+cfY
+cyL
 gMV
+cyL
+cGy
+jgz
+apU
+cyL
+tvj
+cvJ
+bFR
+vqP
+aGr
 gts
 fyf
 fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+wjt
 fyf
 gcK
 gcK
@@ -76220,57 +79342,57 @@ dMW
 fyf
 thG
 fyf
-fyf
-sYX
-uCO
-uCO
-uCO
-uCO
-rpu
-rpu
-cuv
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kUe
+xQu
+mmj
+xQu
+xVZ
+twY
+lRZ
+mrT
+aZF
+sQf
+erY
+bJB
+ubg
+erY
+gWo
+wKo
+erY
+bJB
+wKK
+cpK
 gts
-aYG
+cEt
+pVT
+rpu
+vcM
+vcM
+vKi
+rpu
+uJH
+gts
 msS
-dpO
-rpu
+tQK
+fxv
+qNE
 gts
-rpu
-rpu
-ioh
-rkZ
+nPl
+xbp
+eDc
+cyL
+dcQ
+tBA
+apU
+sCg
+cyL
+gts
+xeP
+dqh
+ilY
 gts
 fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qod
 fyf
 fyf
 gcK
@@ -76477,58 +79599,58 @@ dMW
 fyf
 thG
 fyf
-fyf
-cuv
-ccF
-rpu
-rpu
-jbx
-rpu
-rpu
-sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+aZF
+eZg
+xQu
+pxf
+rja
+xQu
+xVN
+qst
+kUe
+pBv
+bRt
+bRt
+bRt
+uYf
+pWN
+rkr
+erY
+erY
+koD
+nFG
 gts
-rpu
-wcA
-dGK
-rpu
-sDp
-rpu
-rpu
-rpu
-cGj
+vMF
+pVX
+xeG
+wQO
+vBM
+pVX
+vcM
+qgA
+gts
+nMh
+nMh
+nMh
+trU
+gts
+jtE
+pvL
+xbp
+orS
+kWq
+cIe
+fjI
+cyL
+uHv
+gts
+xiF
+xiF
+xiF
 gts
 fyf
 fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+lHo
 fyf
 gcK
 gcK
@@ -76734,60 +79856,60 @@ dMW
 fyf
 thG
 fyf
-fyf
-sYX
-fPN
-hJF
+kUe
+khd
+lda
+pHi
 itm
-uCO
+iRr
 kYz
+eZg
+tyr
+ajD
+erY
+ubg
+erY
+erY
+erY
+erY
+erY
+erY
+koD
+cpK
+nQJ
+vcM
+gwB
+dxt
+mJX
+pVX
+dNx
+wpO
+vcM
 rpu
-sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-cuv
-rpu
-xNQ
-rpu
-rpu
+vcM
+vBM
+hGl
+pVX
+hGQ
+hSy
+cyL
+cyL
+neH
+cyL
+pvL
+cyL
+hKY
+twR
 gts
-iGO
-iGO
-rpu
-olW
+nYb
+cuY
+txn
 gts
 fyf
 fyf
-thG
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hfh
 gcK
 gcK
 gcK
@@ -76991,55 +80113,55 @@ dMW
 fyf
 thG
 fyf
-fyf
-sYX
-uCO
-uCO
-uCO
-uCO
+kUe
+ffy
+kYz
+xQu
+rzV
+tJx
 lda
-rpu
-cuv
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+mrT
+iUe
+mbG
+bRt
+uYf
+erY
+uYf
+qnz
+erY
+bJB
+erY
+koD
+wVn
+nQJ
+bHo
+vcM
+peL
+mJX
+pVX
+vcM
+pVX
+pVX
+vcM
+vKi
+pVX
+dyx
+vBM
+hGQ
+qGy
+cyL
+kDv
+neH
+cyL
+xbp
+ayv
+cyL
+xbp
 gts
+eMl
+jgz
+csR
 gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-gts
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -77248,57 +80370,57 @@ dMW
 fyf
 thG
 fyf
-fyf
-sYX
-fQY
-rpu
-rpu
-jbx
-jhp
-rpu
-sYX
+kUe
+fpF
+gzQ
+eZg
+xVZ
+tLW
+nAS
+mrT
+aZF
+unI
+bJB
+erY
+mmK
+erY
+snB
+erY
+bJB
+erY
+koD
+nFG
+gts
 mGZ
+wpO
+wQO
+wQO
+wpO
+vcM
+vBM
+pVX
+jgz
+hIy
+hIy
+hIy
+hIy
+gts
+cyL
+hKY
+cyL
+xbp
+xbp
+nVK
+gts
+gts
+pTE
+gts
+gts
+jgz
+jgz
+gts
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+eEt
 fyf
 fyf
 fyf
@@ -77505,54 +80627,54 @@ dMW
 fyf
 thG
 fyf
-fyf
-cuv
-ccF
-rpu
-rkZ
-uCO
-bxl
-rpu
-sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+aZF
+xVZ
+neS
+xVZ
+xVZ
+xVZ
+xVZ
+xVZ
+kUe
+unI
+bRt
+uYf
+bRt
+uYf
+erY
+snB
+erY
+rbe
+koD
+xKx
+gts
 mGZ
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uqz
+qgA
+rpu
+vcM
+pVX
+pVX
+voC
+gts
+jco
+wQR
+jtP
+wQR
+gts
+leL
+cyL
+orS
+cyL
+uHv
+pTE
+nut
+qQb
+iFS
+oNL
+dkZ
+uUH
+gts
 fyf
 fyf
 fyf
@@ -77762,60 +80884,60 @@ dMW
 fyf
 thG
 fyf
+kUe
+fJj
+xQu
+kYz
+scY
+tPt
+viv
+gZB
+kUe
+unI
+erY
+bJB
+erY
+erY
+erY
+bJB
+erY
+ubg
+koD
+cpK
+gts
+gts
+gts
+gts
+gts
+gts
+jgz
+jgz
+jgz
+gts
+gts
+gts
+gts
+gts
+rvK
+qbQ
+utQ
+vXR
+bpu
+cyL
+gts
+vWZ
+xeU
+fNT
+aVh
+mWY
+hsX
+gts
 fyf
-sYX
-uCO
-uCO
-uCO
-uCO
-rpu
-rpu
-wpx
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-bIh
-tpA
-pud
-bIh
-wSJ
-tpA
-bIh
-bIh
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tlD
-uxC
-uxC
-uxC
-uxC
-uxC
-sYX
-sYX
-sYX
-sYX
-sYX
-sYX
-sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kxt
 fyf
 fyf
+fyf
+kxt
 fyf
 gcK
 gcK
@@ -78019,61 +81141,61 @@ dMW
 fyf
 thG
 fyf
+kUe
+mYw
+xQu
+nRc
+xVZ
+tSQ
+xWu
+lRZ
+kUe
+cIm
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+sVF
+caa
+cpK
+xKx
+cpK
+xKx
+cpK
+cpK
+cpK
+vjd
+wVn
+cpK
+dMW
 fyf
-sYX
-gvN
-rpu
-rpu
-jbx
-rpu
-rpu
-sYX
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-bIh
-tsB
-uFp
-uZg
-qij
-qij
-bix
-bIh
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-thG
-qOV
-cWG
-cWG
-cWG
-cWG
-sYX
-eKN
-cbr
-cbr
-cbr
+kbS
+gts
+eJs
+qXk
+jNY
+rIC
+cyL
 mHt
-sYX
+aVh
+tbU
+lTr
+gtX
+aFY
+xrn
+gts
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+qod
 gcK
 gcK
 ktB
@@ -78276,57 +81398,57 @@ dMW
 fyf
 thG
 fyf
+aZF
+gsu
+nCS
+fuj
+xVZ
+uar
+xXl
+fIo
+kUe
+pxc
+cpK
+cpK
+xKx
+cpK
+cpK
+mGj
+xKx
+cpK
+cpK
+xKx
+cpK
+cpK
+rRt
+cpK
+wVn
+xKx
+cpK
+fmQ
+cpK
+cpK
+dMW
 fyf
-cuv
-ccF
-rpu
-rkZ
-uCO
-xQu
-rpu
-cuv
 fyf
 fyf
-fyf
-bIh
-bIh
-bIh
-bIh
-fJj
-qij
-qij
-qij
-qij
-cjG
-bIh
-tpA
-bIh
-tpA
-pud
-fyf
-fyf
-thG
-tBN
-mvv
-mvv
-mvv
-mvv
-sYX
+gts
+eJs
 uzs
-iKO
-cbr
-cbr
+tsr
+aZH
+kbk
 swx
-sYX
+ilN
+gtX
+cgI
+fxY
+lTr
+kUI
+gts
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+wjt
 fyf
 fyf
 fyf
@@ -78533,59 +81655,59 @@ dMW
 fyf
 gcK
 fyf
-fyf
+kUe
+gtv
+kYz
+pHx
+xVZ
+xVZ
+xVZ
+xVZ
+kUe
+cpK
+cpK
+caa
+cpK
+cpK
+xKx
+cpK
+cpK
 sYX
-uCO
-uCO
-uCO
-uCO
-rpu
-rpu
 sYX
-fyf
-fyf
-fyf
-bIh
-oOZ
-pOw
-pud
-tJx
-qij
-qij
-tkm
-qij
-nRc
-bIh
-fpF
-nCS
-fpF
-pud
-fyf
-fyf
-thG
-tBN
-mvv
-mvv
-mvv
-mvv
 sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+ggm
+ptf
+edA
+fyf
+qod
+fyf
+gts
+eJs
 qXk
-cbr
-cbr
-cbr
-cbr
-sYX
+jNY
+uct
+xbp
+gts
+iXF
+vzS
+lTr
+gtX
+ijb
+rCv
+gts
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kbS
 fyf
 fyf
 gcK
@@ -78790,56 +81912,56 @@ dMW
 gcK
 gcK
 gcK
-fyf
-sYX
+kUe
+fXj
 gzQ
-rpu
-rpu
-jbx
-rpu
-rpu
+xQu
+scY
+uFp
+ybq
+nsT
+kUe
+bia
+ekK
+bia
+bIh
+cpK
+cpK
+mcP
+cpK
+nQJ
+hbU
+uza
+ccM
+qgA
+vKi
+pVX
+xBO
+vcM
+hST
 sYX
 fyf
 fyf
 fyf
-bIh
-oqm
-pOw
-rja
-qij
-qij
-qij
-qij
-ffy
-qij
-bIh
-yhv
-qij
-rzV
-pud
 fyf
+ivi
 fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-mvv
-cbr
-cbr
+gts
+kqg
 tsr
-cbr
-cbr
-cbr
-sYX
+tsr
+sjY
+mMw
+pTE
+rBU
+ukD
+nRt
+dfg
+pVo
+vgK
+gts
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+dXc
 fyf
 fyf
 fyf
@@ -79047,54 +82169,54 @@ dMW
 gcK
 gcK
 gcK
+kUe
+fXj
+lRZ
+kYz
+xVZ
+uNQ
+yhv
+aKc
+kUe
+xKx
+cpK
+wVn
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+uHC
+uHC
+uHC
+pVX
+pVX
+bEe
+pLt
+ccM
+wpO
+sYX
 gcK
-sYX
-bxl
-rpu
-iuS
-uCO
-wPl
-jhp
-sYX
-fyf
-fyf
-fyf
-bIh
-pud
-pud
-bIh
-bIh
-bIh
-viv
-xdG
-xUc
-qij
-bIh
-qij
-qhs
-cph
-pud
-fyf
-fyf
-thG
-tBN
-mvv
-mvv
-mvv
-dqc
-sYX
-cbr
-cbr
-cbr
-bHa
-cbr
-sYX
+dva
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
+gts
+gts
+gts
+gts
+rvK
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
 fyf
 fyf
 fyf
@@ -79304,48 +82426,48 @@ dMW
 gcK
 gcK
 gcK
-gcK
-sYX
-ccF
-ioh
-rkZ
-uCO
+kUe
+gsu
 kYz
-rpu
+ioh
+xVZ
+uZg
+xXl
+fIo
+kUe
+cpK
+rRt
+cpK
 sYX
-fyf
-fyf
-fyf
-bIh
-pxf
-pYa
-wFp
-tSQ
-bIh
-vno
-xeG
-vwn
-qij
-bIh
-tPt
-pud
-pud
-pud
-pud
-fyf
-thG
-tBN
-mvv
-mvv
-mvv
-mvv
+iVP
+bmA
+duY
+kml
+uCO
+tdW
+tdW
+tdW
+uHC
+pVX
+bmN
+ozI
+pqf
+ccM
 sYX
-cbr
-cbr
-cbr
-xVN
-cbr
-sYX
+gcK
+gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+kbS
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -79561,48 +82683,38 @@ dMW
 gcK
 gcK
 gcK
+bix
+qEP
+nRc
+xQu
+xVZ
+xVZ
+xVZ
+xVZ
+kUe
+bAh
+wVn
+nFG
+sYX
+gIs
+mgr
+kLf
+ccM
+yjG
+ccM
+wpO
+tdW
+jyg
+vcM
+rfG
+rfG
+uZm
+tjU
+sYX
 gcK
-tKZ
-uCO
-uCO
-uCO
-uCO
-vtv
-rpu
-cuv
-fyf
-fyf
-fyf
-bIh
-pHi
-qij
-rzV
-qij
-uTA
-qij
-qij
-qij
-qij
-pud
-qij
-bIh
-gzW
-hMM
-bIh
-fyf
-thG
-nlO
-mfD
-mfD
-mfD
-mfD
-sYX
-cbr
-cbr
-cbr
-cbr
-uNQ
-sYX
+gcK
+gcK
+gcK
 fyf
 fyf
 fyf
@@ -79611,7 +82723,17 @@ fyf
 fyf
 fyf
 fyf
+sqA
 fyf
+kbS
+fyf
+wjt
+fyf
+fyf
+fyf
+fyf
+fyf
+lHo
 fyf
 mwp
 dcY
@@ -79820,52 +82942,52 @@ gcK
 gcK
 gcK
 eXw
-ccF
-ioh
-rkZ
-uCO
+gay
+pHx
+scY
+viv
 lRZ
-rpu
+eaH
+kUe
+cpK
+cpK
+wVn
+cVW
+vKi
+hbU
+ccM
+qgA
+uCO
+kfR
+ccM
+atK
+jyg
+pVX
+ouC
+tTd
+dNx
+quy
 sYX
+gcK
+gcK
+gcK
+gcK
 fyf
 fyf
-fyf
-bIh
-pKP
-qlv
-qij
-uar
-pud
-vwn
-qij
-qij
-qij
-tPt
-qij
-tPt
-qij
-qij
-bIh
-fyf
-mmj
-uxC
-uxC
-uxC
-uxC
-uxC
-sYX
-sYX
-sYX
-sYX
-sYX
-sYX
-sYX
+dXc
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+eEt
+fyf
+fyf
+fyf
+fyf
+fyf
+sqA
 fyf
 fyf
 fyf
@@ -80076,33 +83198,42 @@ gcK
 gcK
 gcK
 gcK
-eXw
+gcK
 eXw
 xQu
 xVZ
+wcA
+ykq
+uvu
+kUe
+cpK
+cpK
+rRt
+sYX
+sYX
 uCO
-rpu
-rpu
-kGD
-fyf
-fyf
-fyf
-bIh
-bIh
-bIh
 rEB
-bIh
-bIh
-wpo
-cIm
-xWu
-aYY
-pud
-qij
-bIh
-hiG
-fpF
-bIh
+uCO
+uCO
+nfp
+rpu
+kps
+hbU
+hAf
+rpu
+uqz
+qgA
+oLm
+sYX
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+fyf
+fyf
+wjt
 fyf
 fyf
 fyf
@@ -80111,16 +83242,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
+gQH
 fyf
 fyf
 fyf
@@ -80333,42 +83455,42 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
 eXw
-eXw
-eXw
-rpu
-jbx
-rpu
-rpu
+xVZ
+wpo
+nFU
+mzU
+kUe
+cPM
+cPM
+cpK
+bAh
 sYX
-fyf
-fyf
-fyf
-fyf
-bIh
 qrw
-qij
-qij
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-bIh
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hGB
+kng
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+kbS
 fyf
 fyf
 gcK
@@ -80378,7 +83500,7 @@ gcK
 gcK
 fyf
 fyf
-fyf
+gQH
 fyf
 gcK
 gcK
@@ -80590,34 +83712,34 @@ fyf
 gcK
 gcK
 gcK
-eZg
-eXw
-eXw
-tKZ
+gcK
+gcK
+gcK
+bix
+kUe
+kUe
+kUe
+kUe
 sYX
 sYX
 sYX
 sYX
-fyf
-fyf
-fyf
-fyf
-bIh
-qzr
-pEs
+sYX
 urt
-bIh
-fyf
+vbr
+vzV
+fpE
+lTX
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -80859,14 +83981,25 @@ gcK
 gcK
 gcK
 gcK
+sYX
+sYX
+dIM
+mwp
+mwp
+kGL
+wjU
+gbL
+gcK
+wjU
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -80875,21 +84008,10 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-fyf
-fyf
-fyf
-fyf
-fyf
 gcK
 gcK
 gcK
@@ -81118,14 +84240,14 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+mwp
+mwp
+mwp
+nui
+mwp
+mwp
+lAV
+mwp
 gcK
 gcK
 gcK
@@ -81142,10 +84264,10 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -81376,14 +84498,14 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+xWj
+mwp
+mwp
+nZV
+mwp
+mwp
+nui
+xWj
 gbL
 gbL
 gbL
@@ -81399,10 +84521,10 @@ gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -81634,31 +84756,31 @@ gcK
 gbL
 gbL
 gbL
+aVn
+mwp
+mwp
+nuY
+mwp
+mwp
+aVn
+gbL
+gbL
+gbL
 gbL
 gbL
 gbL
 gcK
 gcK
 gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
-gcK
 gbL
 gbL
 gcK
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -81891,6 +85013,22 @@ gcK
 gcK
 gbL
 gbL
+xWj
+lAV
+mwp
+mwp
+mwp
+mwp
+gcK
+gcK
+gbL
+gbL
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
@@ -81899,22 +85037,6 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
-gcK
-gbL
-gbL
-gcK
-gcK
-gcK
-gcK
-fyf
-fyf
 fyf
 gcK
 gcK
@@ -82148,12 +85270,12 @@ gcK
 gcK
 gcK
 gcK
+wjU
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+mwp
+mwp
 gcK
 gcK
 gcK
@@ -82170,7 +85292,7 @@ gcK
 gcK
 gcK
 gcK
-fyf
+gcK
 fyf
 fyf
 fyf
@@ -82388,12 +85510,12 @@ dMW
 fyf
 fyf
 fyf
+trW
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
+lRT
 fyf
 fyf
 fyf
@@ -82409,8 +85531,8 @@ gcK
 gcK
 sYX
 sYX
-sYX
-sYX
+mwp
+nui
 sYX
 sYX
 gcK
@@ -82427,7 +85549,7 @@ gcK
 gcK
 gcK
 gcK
-fyf
+gcK
 fyf
 wjt
 fyf
@@ -82922,9 +86044,9 @@ fyf
 gcK
 gcK
 tKZ
-rpu
+eFs
 mdv
-gvW
+pOw
 gvW
 sYX
 gcK
@@ -82941,7 +86063,7 @@ gcK
 gcK
 gcK
 gcK
-fyf
+gcK
 fyf
 fyf
 wjt
@@ -83172,7 +86294,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+fXP
 fyf
 fyf
 fyf
@@ -83437,8 +86559,8 @@ fyf
 fyf
 nlN
 jRV
+pAf
 rpu
-qfV
 rpu
 sYX
 sYX
@@ -83694,9 +86816,9 @@ fyf
 fyf
 nlN
 gvW
-wcO
+qDs
 rpu
-rpu
+bHo
 wtp
 iGE
 sYX
@@ -83932,6 +87054,7 @@ fyf
 fyf
 fyf
 fyf
+sqA
 fyf
 fyf
 fyf
@@ -83939,8 +87062,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
+fXP
 fyf
 fyf
 fyf
@@ -83962,7 +87084,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+wjt
 fyf
 fyf
 fyf
@@ -84467,7 +87589,7 @@ igz
 igz
 igz
 igz
-igz
+rTT
 igz
 igz
 igz
@@ -84496,7 +87618,7 @@ igz
 igz
 igz
 bEw
-fyf
+wjt
 fyf
 mwp
 mwp
@@ -85983,7 +89105,7 @@ erY
 bWB
 koD
 nPg
-ybI
+sTa
 ybI
 jps
 sTa
@@ -85991,7 +89113,7 @@ sTa
 ybI
 nkp
 cpK
-cpK
+xKx
 sUX
 ptf
 ptf
@@ -86504,7 +89626,7 @@ sQX
 gGp
 sQX
 koD
-cpK
+xKx
 cpK
 gts
 lMr
@@ -86541,7 +89663,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+wjt
 fyf
 fyf
 fyf
@@ -86761,8 +89883,8 @@ qci
 qci
 qci
 koD
-cpK
-cpK
+pqL
+xKx
 lMr
 lMr
 mZH
@@ -87275,7 +90397,7 @@ dFQ
 sgz
 sgz
 koD
-cpK
+xKx
 cpK
 gts
 lMr
@@ -87532,8 +90654,8 @@ isJ
 iwa
 iwa
 koD
-cpK
-cpK
+xKx
+pqL
 gts
 gts
 gts
@@ -88303,7 +91425,7 @@ qci
 qci
 qci
 koD
-cpK
+xKx
 cpK
 gts
 jnN
@@ -88561,7 +91683,7 @@ rbe
 sQX
 koD
 cpK
-cpK
+xKx
 gts
 xff
 fUb
@@ -89362,7 +92484,7 @@ uOr
 qbe
 qbe
 hom
-nfu
+fyf
 gcK
 gcK
 hom
@@ -89619,8 +92741,8 @@ qbe
 qbe
 bmM
 hom
-quy
-uag
+qOV
+cWG
 gcK
 hom
 kSt
@@ -89876,9 +92998,9 @@ qbe
 liT
 uOr
 hom
-ozI
-pIz
-frY
+tBN
+mvv
+bpD
 hom
 crt
 xys
@@ -90133,9 +93255,9 @@ smd
 hom
 dvo
 hom
-ozI
-pIz
-frY
+tBN
+mvv
+bpD
 hom
 mmc
 oMY
@@ -90390,8 +93512,8 @@ oMY
 ijF
 oMY
 hom
-ozI
-pIz
+tBN
+mvv
 hgM
 hom
 hom
@@ -90648,8 +93770,8 @@ oMY
 oMY
 rgS
 jEp
-pIz
-frY
+mvv
+bpD
 pkf
 oMY
 edZ
@@ -90905,8 +94027,8 @@ bla
 xNm
 rgS
 jEp
-pIz
-frY
+mvv
+bpD
 dvo
 oMY
 xNm
@@ -91162,8 +94284,8 @@ ucJ
 oMY
 rgS
 jEp
-pIz
-frY
+mvv
+bpD
 hom
 hom
 hom
@@ -91390,15 +94512,15 @@ fyf
 fyf
 vAe
 pea
-ozI
-pIz
+tBN
+mvv
 rbJ
-nfu
-nfu
+fyf
+fyf
 bea
-uag
-uag
-uag
+cWG
+cWG
+cWG
 tTV
 xDE
 xNm
@@ -91418,9 +94540,9 @@ rXz
 oXi
 eLb
 hom
-qwr
-pIz
-frY
+dgB
+mvv
+bpD
 nfu
 gcK
 gcK
@@ -91647,15 +94769,15 @@ qOV
 cWG
 cWG
 gDn
-kbS
-pIz
-tjI
-uag
-uag
-kbS
-pIz
-pIz
-pIz
+daU
+mvv
+doX
+cWG
+cWG
+daU
+mvv
+mvv
+mvv
 dvo
 xNm
 xNm
@@ -91675,8 +94797,8 @@ ime
 xNm
 oMY
 saf
-pIz
-pIz
+mvv
+mvv
 hgM
 hom
 hom
@@ -91903,15 +95025,15 @@ fyf
 nlO
 xGH
 mvv
-uqW
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
+iWi
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 cVV
 tTV
 xNm
@@ -91922,7 +95044,7 @@ xgk
 oeh
 hom
 gcK
-syr
+uXj
 gcK
 hom
 bla
@@ -91933,8 +95055,8 @@ bla
 oMY
 hom
 qEj
-pIz
-frY
+mvv
+bpD
 rgS
 hUf
 let
@@ -92161,15 +95283,15 @@ fyf
 nlO
 mfD
 dlS
-xJY
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-frY
+xGH
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
 hom
 xNm
 xNm
@@ -92178,8 +95300,8 @@ hom
 pBM
 vWC
 hom
-syr
-syr
+uXj
+uXj
 gcK
 hom
 kkP
@@ -92189,9 +95311,9 @@ xjW
 hHi
 xNm
 rgS
-ozI
-pIz
-tjI
+tBN
+mvv
+doX
 hom
 xNm
 vDg
@@ -92425,8 +95547,8 @@ qTa
 qTa
 qTa
 juc
-pIz
-frY
+mvv
+bpD
 hom
 uGF
 dvo
@@ -92435,8 +95557,8 @@ hom
 hom
 hom
 hom
-syr
-syr
+uXj
+uXj
 gcK
 hom
 qms
@@ -92446,9 +95568,9 @@ oXi
 lOi
 oMY
 rgS
-ozI
-pIz
-pIz
+tBN
+mvv
+mvv
 vme
 xNm
 dUv
@@ -92681,9 +95803,9 @@ nTm
 nTm
 nTm
 sDj
-pIz
-pIz
-frY
+mvv
+mvv
+bpD
 hom
 vpx
 xPI
@@ -92692,8 +95814,8 @@ jIn
 hFW
 szJ
 hom
-syr
-syr
+uXj
+uXj
 hom
 hom
 hom
@@ -92703,9 +95825,9 @@ hom
 hom
 hom
 hom
-ozI
-pIz
-ulc
+tBN
+mvv
+aBH
 hom
 xNm
 xNm
@@ -92934,13 +96056,13 @@ gcK
 gsV
 mCG
 puX
-pIz
-pIz
-pIz
+mvv
+mvv
+mvv
 dTT
-tkY
-pIz
-frY
+mEy
+mvv
+bpD
 hom
 tvp
 xPI
@@ -92949,19 +96071,19 @@ jIn
 hFW
 jIn
 hom
-syr
-syr
+uXj
+uXj
 buG
 xYS
-uag
-eEt
-quy
-uag
-uag
-uag
+cWG
+wDc
+qOV
+cWG
+cWG
+cWG
 kut
-ozI
-pIz
+tBN
+mvv
 hgM
 hom
 hom
@@ -93190,14 +96312,14 @@ fyf
 gcK
 jmv
 mCG
-pIz
-pIz
+mvv
+mvv
 prP
-pIz
+mvv
 obV
-pIz
-pIz
-frY
+mvv
+mvv
+bpD
 hom
 fpg
 jIn
@@ -93206,20 +96328,20 @@ jIn
 jIn
 jIn
 hom
-syr
-syr
+uXj
+uXj
 buG
 jEp
-nZV
-xkl
-ozI
+pSC
+tjI
+tBN
 aFF
-pIz
+mvv
 sDr
-frY
-ozI
-pIz
-frY
+bpD
+tBN
+mvv
+bpD
 hom
 kpd
 xNm
@@ -93447,14 +96569,14 @@ gcK
 gcK
 uNK
 kUA
-pIz
-pIz
-pIz
-pIz
+mvv
+mvv
+mvv
+mvv
 uXa
-pIz
-pIz
-frY
+mvv
+mvv
+bpD
 hom
 tvp
 jIn
@@ -93463,20 +96585,20 @@ jIn
 hFW
 jIn
 hom
-syr
-syr
+uXj
+uXj
 buG
 jEp
-nZV
-xkl
-ozI
-pIz
-pIz
-pIz
-frY
-ozI
-pIz
-frY
+pSC
+tjI
+tBN
+mvv
+mvv
+mvv
+bpD
+tBN
+mvv
+bpD
 hom
 qBu
 dUv
@@ -93705,13 +96827,13 @@ gcK
 uNK
 mCG
 nRz
-pIz
-pIz
+mvv
+mvv
 qEU
 obV
-pIz
-pIz
-frY
+mvv
+mvv
+bpD
 hom
 kKs
 xPI
@@ -93720,20 +96842,20 @@ jIn
 hFW
 jWx
 hom
-syr
-syr
+uXj
+uXj
 buG
 jEp
-nZV
-xkl
-ozI
+pSC
+tjI
+tBN
 sDr
-pIz
+mvv
 aFF
-frY
-ozI
-pIz
-frY
+bpD
+tBN
+mvv
+bpD
 rgS
 nMk
 dUv
@@ -93961,14 +97083,14 @@ gcK
 gcK
 uNK
 mCG
-pIz
-pIz
-pIz
+mvv
+mvv
+mvv
 puX
 dTT
 vPA
-pIz
-frY
+mvv
+bpD
 hom
 hom
 wxR
@@ -93977,20 +97099,20 @@ wxR
 hom
 xqQ
 hom
-syr
-syr
+uXj
+uXj
 buG
 hAX
-pIz
-frY
-gRf
-xJY
-pIz
-ulc
+mvv
+bpD
+nlO
+xGH
+mvv
+aBH
 qip
-ozI
-pIz
-frY
+tBN
+mvv
+bpD
 hom
 gMi
 dUv
@@ -94223,31 +97345,31 @@ nTm
 nTm
 nTm
 ebT
-pIz
-pIz
-tjI
+mvv
+mvv
+doX
 tUc
-uag
+cWG
 iVE
-uag
-uag
+cWG
+cWG
 tUc
-kbS
+daU
 hZw
 sZQ
 sZQ
 jTJ
-kbS
-pIz
-tjI
-uag
-kbS
-pIz
-tjI
-uag
-kbS
-pIz
-frY
+daU
+mvv
+doX
+cWG
+daU
+mvv
+doX
+cWG
+daU
+mvv
+bpD
 hom
 jIt
 dUv
@@ -94480,31 +97602,31 @@ oaw
 oaw
 oaw
 oaw
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-xes
-xes
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-pIz
-frY
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+lwj
+lwj
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
 rgS
 sge
 dUv
@@ -94731,36 +97853,36 @@ ktB
 gbL
 gcK
 uNK
-gRf
-xAq
-xAq
-xAq
-xAq
-xAq
-xAq
-xAq
-xAq
-xAq
-xAq
-xAq
-xJY
-pIz
-pIz
-pIz
-pIz
-xes
-xes
-pIz
-pIz
-ulc
-xAq
-xAq
+nlO
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+xGH
+mvv
+mvv
+mvv
+mvv
+lwj
+lwj
+mvv
+mvv
+aBH
+mfD
+mfD
 wel
-xAq
-xAq
-xAq
-xAq
-xAq
+mfD
+mfD
+mfD
+mfD
+mfD
 oCG
 hom
 jIt
@@ -95000,15 +98122,15 @@ kZb
 kZb
 kZb
 rMq
-ozI
-pIz
-ulc
-xAq
+tBN
+mvv
+aBH
+mfD
 kPX
 sZQ
 sZQ
 bJo
-pIz
+mvv
 oSC
 hom
 hom
@@ -95254,19 +98376,19 @@ rEk
 xNm
 xYS
 iVE
-uag
-eEt
+cWG
+wDc
 buG
-ozI
-pIz
+tBN
+mvv
 xjZ
-nfu
+fyf
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
-pIz
+mvv
+mvv
 dvo
 xys
 dUv
@@ -95509,21 +98631,21 @@ gcK
 hom
 cTN
 xNm
-ozI
-qul
-qul
-frY
+tBN
+rjH
+rjH
+bpD
 buG
-ozI
-pIz
-frY
-gPQ
+tBN
+mvv
+bpD
+rtR
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
-ulc
+mvv
+aBH
 hom
 dUv
 xys
@@ -95766,21 +98888,21 @@ gcK
 hom
 sgJ
 xNm
-ozI
-qul
-qul
-frY
+tBN
+rjH
+rjH
+bpD
 buG
-ozI
-pIz
-frY
-hfh
+tBN
+mvv
+bpD
+ids
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
-frY
+mvv
+bpD
 rgS
 asj
 jei
@@ -96023,21 +99145,21 @@ gcK
 hom
 mVR
 xNm
-ozI
-qul
-qul
-frY
+tBN
+rjH
+rjH
+bpD
 buG
-ozI
-pIz
-frY
-nfu
+tBN
+mvv
+bpD
+fyf
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
-frY
+mvv
+bpD
 rgS
 kih
 yir
@@ -96279,22 +99401,22 @@ pIz
 pIz
 hom
 hom
-kGL
-ozI
-qul
-qul
-frY
+rVr
+tBN
+rjH
+rjH
+bpD
 wBx
-ozI
-pIz
-frY
-nfu
+tBN
+mvv
+bpD
+fyf
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
-frY
+mvv
+bpD
 hom
 pon
 oxA
@@ -96536,21 +99658,21 @@ piw
 pIz
 pIz
 hom
-nfu
-ozI
-qul
-qul
-frY
+fyf
+tBN
+rjH
+rjH
+bpD
 buG
-ozI
-pIz
-frY
-nfu
+tBN
+mvv
+bpD
+fyf
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
+mvv
 hgM
 hom
 hom
@@ -96794,21 +99916,21 @@ pIz
 pIz
 okZ
 sJr
-ozI
-qul
-qul
-frY
+tBN
+rjH
+rjH
+bpD
 buG
-ozI
-pIz
-frY
-nfu
+tBN
+mvv
+bpD
+fyf
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
-tjI
+mvv
+doX
 gpo
 hom
 fsV
@@ -97050,22 +100172,22 @@ pIz
 sUl
 pIz
 iLQ
-nfu
-ozI
-qul
-qul
-frY
+fyf
+tBN
+rjH
+rjH
+bpD
 buG
-ozI
-pIz
-frY
+tBN
+mvv
+bpD
 sJM
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
-pIz
+mvv
+mvv
 xkl
 hom
 dZE
@@ -97309,20 +100431,20 @@ pIz
 okZ
 hge
 sDc
-xAq
-xAq
+mfD
+mfD
 all
 buG
-ozI
-pIz
-frY
-kfR
+tBN
+mvv
+bpD
+sND
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
-ulc
+mvv
+aBH
 lGd
 hom
 moX
@@ -97571,14 +100693,14 @@ hom
 rgS
 egn
 fbD
-pIz
-frY
-nfu
+mvv
+bpD
+fyf
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
+mvv
 hgM
 uNK
 hom
@@ -97827,16 +100949,16 @@ xNm
 uIV
 xNm
 dvo
-pIz
-pIz
-frY
-nfu
+mvv
+mvv
+bpD
+fyf
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
-frY
+mvv
+bpD
 hom
 dnU
 mTN
@@ -98084,16 +101206,16 @@ xNm
 oMY
 fNB
 hom
-pIz
-pIz
-frY
-nfu
+mvv
+mvv
+bpD
+fyf
 buG
-syr
-syr
+uXj
+uXj
 eXO
-pIz
-frY
+mvv
+bpD
 hom
 eQH
 oMY
@@ -98341,15 +101463,15 @@ uFt
 awT
 xNm
 rgS
-pIz
-pIz
-tjI
-eEt
-syr
-syr
-syr
+mvv
+mvv
+doX
+wDc
+uXj
+uXj
+uXj
 eXO
-pIz
+mvv
 rbJ
 hom
 eaA
@@ -98598,15 +101720,15 @@ oMY
 oMY
 cWq
 hom
-pIz
-pIz
-pIz
-syr
-syr
-syr
-bPH
+mvv
+mvv
+mvv
+uXj
+uXj
+uXj
+xTK
 eXO
-pIz
+mvv
 hgM
 hom
 hom
@@ -98855,19 +101977,19 @@ eQH
 xNm
 lAD
 hom
-tkY
-pIz
-pIz
-syr
-syr
+mEy
+mvv
+mvv
+uXj
+uXj
 hom
 hom
 hom
-pIz
-tjI
-uag
-uag
-uag
+mvv
+doX
+cWG
+cWG
+cWG
 cWS
 nvr
 nvr
@@ -99115,19 +102237,19 @@ kRD
 wPS
 wPS
 wPS
-syr
-syr
+uXj
+uXj
 hom
 kQJ
 oMY
-pIz
-pIz
-pIz
+mvv
+mvv
+mvv
 juc
-pIz
-pIz
-pIz
-wPS
+mvv
+mvv
+mvv
+uqW
 lVe
 wPS
 wPS
@@ -99371,20 +102493,20 @@ abC
 hom
 wPS
 wPS
-syr
-syr
+uXj
+uXj
 wPS
 hom
 wFo
 bwM
 oMY
-aWz
+fSE
 pyZ
-xJY
-pIz
+xGH
+mvv
 qHQ
 pyZ
-wPS
+uqW
 cUK
 wPS
 wPS
@@ -99628,8 +102750,8 @@ udT
 fBx
 wPS
 wPS
-syr
-syr
+uXj
+uXj
 wPS
 hom
 kIs
@@ -99885,8 +103007,8 @@ hom
 mCf
 wPS
 syr
-syr
-syr
+uXj
+uXj
 wPS
 hom
 mgg

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -503,8 +503,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -1644,8 +1643,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -2182,8 +2180,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -3548,8 +3545,7 @@
 /obj/structure/railing,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus4";
-	name = "Museum shutters"
+	id = "mus3"
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -4069,8 +4065,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/f13Cash/random/low,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -4137,8 +4132,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -4793,8 +4787,7 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -6692,8 +6685,7 @@
 "enJ" = (
 /obj/structure/simple_door/metal/store,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/f13{
 	icon_state = "floordirty"
@@ -8364,8 +8356,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -10850,11 +10841,6 @@
 	pixel_x = 7;
 	pixel_y = -30
 	},
-/obj/machinery/button/door{
-	id = "mus2";
-	pixel_x = -7;
-	pixel_y = -30
-	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -12610,8 +12596,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -16529,8 +16514,7 @@
 /obj/structure/railing/corner,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -18227,8 +18211,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/camera,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -19229,11 +19212,10 @@
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/jackboots,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3";
-	name = "Museum shutters"
-	},
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -20081,8 +20063,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/railing,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus3";
-	name = "Museum shutters"
+	id = "mus3"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
@@ -21515,8 +21496,7 @@
 "mVK" = (
 /obj/structure/simple_door/metal/store,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus4";
-	name = "Museum shutters"
+	id = "mus3"
 	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -21983,11 +21963,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shield/riot,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3";
-	name = "Museum shutters"
-	},
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -22113,11 +22092,10 @@
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/under/f13/vault/v13,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3";
-	name = "Museum shutters"
-	},
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -22479,6 +22457,9 @@
 /obj/item/healthanalyzer/advanced,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -22802,8 +22783,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -26553,8 +26533,7 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -28266,8 +28245,7 @@
 "rbg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus2";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -28465,8 +28443,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus2";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -29108,8 +29085,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -29287,8 +29263,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters{
-	id = "mus4";
-	name = "Museum shutters"
+	id = "mus3"
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -29713,11 +29688,10 @@
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pda,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3";
-	name = "Museum shutters"
-	},
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -30001,8 +29975,7 @@
 	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -31779,8 +31752,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus4";
-	name = "Museum shutters"
+	id = "mus3"
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -32101,8 +32073,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -32396,8 +32367,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/railing,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus3";
-	name = "Museum shutters"
+	id = "mus3"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
@@ -32700,8 +32670,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/railing,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus4";
-	name = "Museum shutters"
+	id = "mus3"
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -32734,8 +32703,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -32915,8 +32883,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/railing,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus3";
-	name = "Museum shutters"
+	id = "mus3"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
@@ -33424,8 +33391,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -33718,8 +33684,7 @@
 "ulc" = (
 /obj/structure/simple_door/metal/store,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus2";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -34050,8 +34015,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/f13Cash/random/low,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -34235,8 +34199,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus2";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -35137,8 +35100,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -35581,11 +35543,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/energy/laser/wattz,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3";
-	name = "Museum shutters"
-	},
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -36231,11 +36192,10 @@
 "vFI" = (
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3";
-	name = "Museum shutters"
-	},
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -36512,6 +36472,9 @@
 /obj/structure/displaycase,
 /obj/item/clothing/glasses/hud/health/f13,
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -36587,8 +36550,10 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/f13Cash/random/low,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus2";
-	name = "Museum shutters"
+	id = "mus1"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -36836,8 +36801,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus1";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -36934,10 +36898,6 @@
 "wcg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/fancy/black,
-/obj/machinery/button/door{
-	id = "mus4";
-	pixel_x = -3
-	},
 /obj/machinery/button/door{
 	id = "mus3";
 	pixel_x = -3;
@@ -37587,8 +37547,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
-	id = "mus2";
-	name = "Museum shutters"
+	id = "mus1"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -8811,12 +8811,9 @@
 	},
 /area/f13/city)
 "fxv" = (
-/obj/structure/displaycase/trophy{
-	start_showpiece_type = "/obj/item/relic";
-	start_showpieces = newlist()
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/accessory/medal/gold,
+/obj/structure/displaycase,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fxx" = (
@@ -15133,11 +15130,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jco" = (
-/obj/structure/displaycase/trophy{
-	start_showpiece_type = "/obj/item/relic";
-	start_showpieces = newlist()
-	},
 /obj/item/clothing/accessory/medal/plasma/nobel_science,
+/obj/structure/displaycase,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jcp" = (
@@ -15631,11 +15625,8 @@
 	},
 /area/f13/building)
 "jtP" = (
-/obj/structure/displaycase/trophy{
-	start_showpiece_type = "/obj/item/relic";
-	start_showpieces = newlist()
-	},
 /obj/item/clothing/accessory/medal/conduct,
+/obj/structure/displaycase,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "juc" = (
@@ -19213,9 +19204,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/jackboots,
 /obj/machinery/light/floor,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3"
-	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -20659,11 +20647,8 @@
 	},
 /area/f13/wasteland)
 "msS" = (
-/obj/structure/displaycase/trophy{
-	start_showpiece_type = "/obj/item/relic";
-	start_showpieces = newlist()
-	},
 /obj/item/clothing/accessory/medal/gold/heroism,
+/obj/structure/displaycase,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mtl" = (
@@ -21964,9 +21949,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shield/riot,
 /obj/machinery/light/floor,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3"
-	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -22093,9 +22075,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/under/f13/vault/v13,
 /obj/machinery/light/floor,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3"
-	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -29689,9 +29668,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pda,
 /obj/machinery/light/floor,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3"
-	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -35544,9 +35520,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/energy/laser/wattz,
 /obj/machinery/light/floor,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3"
-	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -36193,9 +36166,6 @@
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
-/obj/machinery/door/poddoor/shutters{
-	id = "mus3"
-	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -55,7 +55,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "acW" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/f13{
@@ -196,7 +196,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "ahs" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced,
@@ -293,7 +293,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "ajX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
@@ -411,9 +411,9 @@
 	},
 /area/f13/building)
 "anb" = (
-/obj/structure/wreck/trash/halftire,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall/rust,
+/area/f13/wasteland)
 "anl" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_l,
@@ -551,13 +551,6 @@
 	icon_state = "verticalrightborderrighttop"
 	},
 /area/f13/wasteland)
-"arx" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 5
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "arC" = (
 /obj/structure/chair{
 	dir = 4
@@ -634,12 +627,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"auw" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "aux" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
@@ -739,17 +726,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"axX" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "aya" = (
 /obj/item/clothing/gloves/boxing,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "aym" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
@@ -774,7 +754,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/wasteland)
 "aze" = (
 /obj/structure/closet/cabinet,
 /obj/item/stack/sheet/metal,
@@ -1037,7 +1017,7 @@
 /obj/structure/wreck/trash/three_barrels,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/area/f13/wasteland)
 "aGw" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
@@ -1408,11 +1388,6 @@
 /obj/machinery/biogenerator,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"aUc" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/city)
 "aUl" = (
 /obj/structure/fence,
 /obj/structure/fence,
@@ -1468,11 +1443,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"aVC" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right"
-	},
-/area/f13/city)
 "aVE" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
@@ -1609,7 +1579,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "aYY" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1624,7 +1594,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "aZz" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -1773,10 +1743,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"beG" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "bfq" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -2333,7 +2299,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "bvd" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -2695,13 +2661,7 @@
 "bER" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
-"bEX" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "bEZ" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -2821,9 +2781,6 @@
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"bIp" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood)
 "bIV" = (
 /obj/structure/chair/bench,
 /obj/effect/landmark/start/f13/settler,
@@ -3300,10 +3257,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
-"ceT" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "cfn" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -3570,7 +3523,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "cnX" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
@@ -3756,7 +3709,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "cuh" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -4245,7 +4198,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "cLZ" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -4284,7 +4237,7 @@
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "cOi" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -4314,7 +4267,7 @@
 	dir = 5
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "cOU" = (
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4356,13 +4309,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/village)
-"cPZ" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "cQs" = (
 /obj/structure/simple_door/tent,
 /turf/open/floor/f13/wood{
@@ -4390,7 +4336,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "cRH" = (
 /obj/machinery/mineral/wasteland_vendor/advcomponents,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4451,9 +4397,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/brotherhood)
-"cTc" = (
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "cTp" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
@@ -5374,10 +5317,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dsL" = (
-/obj/structure/flora/grass/wasteland,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "dsW" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/f13/wood{
@@ -5560,12 +5499,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"dxJ" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_2"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "dys" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -5975,7 +5908,7 @@
 "dLl" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "dLB" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
@@ -6382,10 +6315,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"edO" = (
-/obj/structure/flora/grass/wasteland,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "edZ" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -6402,12 +6331,6 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/wood/f13,
 /area/f13/building)
-"efO" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/brotherhood)
 "egb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -6529,7 +6452,7 @@
 	name = "Salvaged Beer"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "ejk" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6871,7 +6794,7 @@
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "esE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
@@ -6972,7 +6895,7 @@
 "evU" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "evV" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -7612,7 +7535,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "eOd" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7645,7 +7568,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "ePw" = (
 /obj/structure/table/wood,
 /obj/item/lipstick/random,
@@ -7860,7 +7783,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "eUI" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -8117,7 +8040,7 @@
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "fcH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
@@ -8452,12 +8375,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"fmX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright1"
-	},
-/area/f13/city)
 "fnB" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8809,7 +8726,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "fxv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/accessory/medal/gold,
@@ -9093,13 +9010,6 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"fFT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "fGc" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9380,7 +9290,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outermaincornerinner"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "fQW" = (
 /obj/item/folder/yellow,
 /obj/item/folder/yellow,
@@ -9427,7 +9337,7 @@
 	icon_state = "tall_grass_7"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/area/f13/wasteland)
 "fSE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -9829,7 +9739,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "ghG" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -9847,12 +9757,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/store,
 /area/f13/caves)
-"gin" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "gip" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/fprostitute,
@@ -9891,7 +9795,7 @@
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "gjp" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -10100,7 +10004,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "goU" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -10183,12 +10087,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/city)
-"grc" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "grf" = (
 /obj/structure/chair/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -10478,11 +10376,6 @@
 /obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"gzG" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom2left"
-	},
-/area/f13/city)
 "gzQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -10557,7 +10450,7 @@
 "gCb" = (
 /obj/structure/closet/crate/miningcar,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "gCd" = (
 /obj/structure/fence{
 	dir = 4
@@ -10668,7 +10561,7 @@
 	},
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/area/f13/wasteland)
 "gEY" = (
 /obj/structure/simple_door/house{
 	icon_state = "room"
@@ -10924,12 +10817,6 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"gND" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "gOf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -11547,12 +11434,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"hft" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "hfz" = (
 /obj/machinery/computer/arcade,
 /obj/effect/decal/cleanable/dirt,
@@ -11645,27 +11526,7 @@
 	icon_state = "tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
-"hhG" = (
-/obj/structure/fence/post{
-	desc = "A wooden post.";
-	icon_state = "end_wood";
-	name = "pole"
-	},
-/obj/structure/sign/warning{
-	pixel_y = 22
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
-"hhK" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
-/area/f13/city)
+/area/f13/wasteland)
 "hio" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/balaclava,
@@ -11968,11 +11829,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
-"hsj" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "hsy" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -12103,7 +11959,7 @@
 	pixel_y = 13
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "hvu" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -12187,7 +12043,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/caves)
 "hxy" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pestspray,
@@ -12765,10 +12621,6 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
-"hNC" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "hNL" = (
 /obj/structure/table/wood/fancy,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -12854,7 +12706,7 @@
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/caves)
 "hSR" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13097,7 +12949,7 @@
 	dir = 8;
 	icon_state = "outerpavement"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "hYh" = (
 /obj/item/clothing/shoes/laceup,
 /turf/open/floor/f13/wood,
@@ -13419,14 +13271,6 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
-"iiq" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/rock/jungle,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "iiE" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -13438,7 +13282,7 @@
 	pixel_y = 9
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/area/f13/wasteland)
 "iiH" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -13472,12 +13316,12 @@
 	pixel_y = -33
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "ijm" = (
 /obj/structure/simple_door/metal/fence,
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/wasteland)
 "ijF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -13532,7 +13376,7 @@
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
 /turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood)
+/area/f13/caves)
 "ilq" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
@@ -13549,7 +13393,7 @@
 	icon_state = "tall_grass_8"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/area/f13/wasteland)
 "ilL" = (
 /obj/structure/fence{
 	dir = 4
@@ -13654,7 +13498,7 @@
 "ioi" = (
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "ioP" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -13820,7 +13664,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "itm" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13/wood,
@@ -13958,7 +13802,7 @@
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/caves)
 "iyD" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -14290,7 +14134,7 @@
 /obj/machinery/light/small,
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "iHV" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -14573,7 +14417,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "iOd" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
@@ -14813,14 +14657,6 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/city)
-"iSV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
 /area/f13/city)
 "iTk" = (
 /obj/effect/decal/remains/human,
@@ -15261,7 +15097,7 @@
 "jgY" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "jha" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -16200,7 +16036,7 @@
 	},
 /obj/effect/decal/cleanable/vomit,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/wasteland)
 "jPN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16697,7 +16533,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "kcQ" = (
 /obj/structure/chair/wood/modern{
 	dir = 8;
@@ -17284,7 +17120,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "krJ" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17350,7 +17186,7 @@
 "kvB" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "kvT" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -19144,7 +18980,7 @@
 	req_access_txt = "120"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "lyk" = (
 /obj/effect/landmark/start/f13/prospector,
 /turf/open/floor/f13{
@@ -19204,6 +19040,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/jackboots,
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -19281,12 +19120,6 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"lCc" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
-/area/f13/brotherhood)
 "lCe" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -19341,7 +19174,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "lDd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/iv_drip,
@@ -19361,7 +19194,7 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "lDx" = (
 /obj/structure/barricade/bars,
 /obj/structure/fence,
@@ -19853,7 +19686,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "lTX" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/structure/closet/fridge/standard,
@@ -20118,14 +19951,14 @@
 "mcp" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "mcz" = (
 /obj/machinery/vending/nukacolavend,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "mcD" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -20151,7 +19984,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/wasteland)
 "mdv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
@@ -20452,7 +20285,7 @@
 	pixel_x = -3
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "moi" = (
 /obj/item/ammo_casing/caseless{
 	dir = 10;
@@ -20541,11 +20374,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"mqp" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/brotherhood)
 "mqs" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
@@ -20767,9 +20595,6 @@
 "mwp" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"mwt" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "mwO" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20893,13 +20718,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"mCO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerbordercorner"
-	},
-/area/f13/city)
 "mDf" = (
 /obj/structure/wreck/trash/machinepiletwo{
 	layer = 3
@@ -20913,7 +20731,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "mDr" = (
 /obj/machinery/trading_machine/armor,
 /turf/open/floor/f13/wood,
@@ -20990,7 +20808,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "mGr" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -21167,13 +20985,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"mMe" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "mMw" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -21402,10 +21213,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"mUo" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
 "mUx" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -21636,7 +21443,7 @@
 	},
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/wasteland)
 "naP" = (
 /obj/structure/chair{
 	dir = 8
@@ -21867,12 +21674,6 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"nhf" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "nhp" = (
 /obj/machinery/door/poddoor/preopen{
 	id = 42
@@ -21949,6 +21750,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shield/riot,
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -22075,6 +21879,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/under/f13/vault/v13,
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -22093,7 +21900,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "nqb" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/ruins{
@@ -22365,11 +22172,6 @@
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
-"nzq" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "nzJ" = (
 /obj/item/seeds/poppy/broc,
 /turf/open/indestructible/ground/outside/dirt,
@@ -22490,16 +22292,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"nDe" = (
-/obj/structure/flora/grass/wasteland{
-	pixel_x = 9;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "nDk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/two_tire,
@@ -22656,12 +22448,6 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
-"nIj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/city)
 "nIp" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
@@ -22710,7 +22496,7 @@
 /obj/effect/landmark/start/f13/settler,
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/area/f13/wasteland)
 "nJz" = (
 /obj/structure/fence/end{
 	dir = 8
@@ -22754,7 +22540,7 @@
 "nMd" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "nMh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -23049,7 +22835,7 @@
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "nUm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -23267,7 +23053,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/wasteland)
 "ocV" = (
 /obj/structure/sink{
 	pixel_y = 25
@@ -23315,9 +23101,6 @@
 /obj/item/pickaxe,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"odS" = (
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
 "odW" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/light,
@@ -23407,7 +23190,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "ohU" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/broken,
@@ -23464,10 +23247,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"okc" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
 "okt" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_t,
@@ -23870,10 +23649,6 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ovE" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "ovN" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -23881,13 +23656,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ovO" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 5
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "ovR" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -24332,12 +24100,6 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
-"oMn" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "oMA" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -25611,12 +25373,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"pzm" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
-	},
-/area/f13/city)
 "pzJ" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/relaxedwear,
@@ -25703,10 +25459,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
-"pBX" = (
-/obj/structure/wreck/trash/one_barrel,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "pCf" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -26127,7 +25879,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "pOM" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -26377,7 +26129,7 @@
 /obj/structure/table/wood,
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "pWH" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block,
@@ -26553,7 +26305,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "qcV" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -26568,7 +26320,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "qdD" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -26620,7 +26372,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "qef" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -26674,7 +26426,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "qgZ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27406,12 +27158,6 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland)
-"qDU" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outermaincornerouter"
-	},
-/area/f13/city)
 "qDV" = (
 /obj/item/trash/sosjerky{
 	pixel_x = -6
@@ -27476,10 +27222,6 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
-"qGa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
 "qGx" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -27882,7 +27624,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "qQb" = (
 /obj/item/storage/trash_stack,
 /obj/structure/spider/stickyweb,
@@ -27986,20 +27728,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ncr)
-"qSs" = (
-/obj/structure/fence/post{
-	desc = "A wooden post.";
-	icon_state = "end_wood";
-	name = "pole"
-	},
-/obj/structure/sign/warning{
-	pixel_y = 22
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "qSM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/bars,
@@ -28098,10 +27826,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"qUO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "qUZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -28791,15 +28515,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"ryH" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "ryO" = (
 /obj/structure/rack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28830,7 +28545,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2top"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "rzR" = (
 /obj/machinery/light{
 	dir = 8
@@ -29668,6 +29383,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pda,
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -30006,7 +29724,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "slM" = (
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
@@ -30639,7 +30357,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "sCu" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31061,7 +30779,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "sQC" = (
 /obj/structure/table/wood,
 /obj/item/pen/fountain,
@@ -31630,7 +31348,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "tha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -31760,9 +31478,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tka" = (
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "tkh" = (
 /obj/structure/chair,
 /turf/open/floor/f13{
@@ -31822,7 +31537,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "tlD" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -31830,11 +31545,6 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"tlI" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/rock/jungle,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "tlN" = (
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -32208,7 +31918,7 @@
 /obj/structure/flora/grass/wasteland,
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/area/f13/wasteland)
 "two" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -32534,7 +32244,7 @@
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/wasteland)
 "tEr" = (
 /obj/structure/closet/crate{
 	anchored = 1;
@@ -33154,7 +32864,7 @@
 	dir = 1;
 	icon_state = "outermaincornerouter"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "tVi" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
@@ -33578,7 +33288,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "uhi" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/water,
@@ -33678,7 +33388,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "ulC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -33733,12 +33443,6 @@
 /obj/item/toy/eightball,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
-"umW" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 7;
-	icon_state = "outerpavement"
-	},
-/area/f13/city)
 "unp" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -34016,7 +33720,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "uuB" = (
 /obj/structure/toilet{
 	dir = 4
@@ -34970,7 +34674,7 @@
 	pixel_y = 20
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/area/f13/wasteland)
 "uUL" = (
 /obj/item/flag,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -35067,7 +34771,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "uWU" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -35520,6 +35224,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/energy/laser/wattz,
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -35616,7 +35323,7 @@
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/caves)
 "voC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -35665,7 +35372,7 @@
 "vpM" = (
 /obj/structure/flora/rock/jungle,
 /turf/closed/indestructible/rock,
-/area/f13/brotherhood)
+/area/f13/caves)
 "vqc" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -35745,7 +35452,7 @@
 /obj/structure/decoration/vent/rusty,
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "vsm" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/fence/wooden{
@@ -35899,15 +35606,6 @@
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"vyb" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outermaincornerinner"
-	},
-/area/f13/city)
-"vye" = (
-/obj/structure/tires/five,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "vzb" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/trash,
@@ -35981,7 +35679,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "vAt" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -36166,6 +35864,9 @@
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus3"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -36290,7 +35991,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "vIr" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/dirt,
@@ -36379,12 +36080,6 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
-"vLj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
-/area/f13/city)
 "vMh" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -36792,7 +36487,7 @@
 "vYf" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "vYp" = (
 /obj/structure/dresser,
 /turf/open/indestructible/ground/inside/mountain,
@@ -37025,13 +36720,6 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"whS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerbordercorner"
-	},
-/area/f13/city)
 "wif" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37399,7 +37087,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "wvq" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small{
@@ -37564,7 +37252,7 @@
 	pixel_y = 13
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/area/f13/wasteland)
 "wAd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood{
@@ -37914,7 +37602,7 @@
 "wLO" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "wLU" = (
 /obj/structure/closet,
 /obj/item/lighter,
@@ -38065,15 +37753,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"wOL" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "wPl" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13/wood,
@@ -38096,7 +37775,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "wPG" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -38275,12 +37954,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"wTU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/city)
 "wUc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -38456,12 +38129,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"wYn" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood)
 "wYv" = (
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
@@ -38535,17 +38202,13 @@
 /obj/item/mining_scanner,
 /obj/item/mining_scanner,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "xbp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"xbv" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "xbA" = (
 /obj/structure/sign/poster/prewar/poster83,
 /turf/closed/wall/f13/supermart,
@@ -39094,7 +38757,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "xow" = (
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -39570,7 +39233,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "xDA" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/f13{
@@ -39976,7 +39639,7 @@
 "xOt" = (
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "xOZ" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -40031,7 +39694,7 @@
 "xQL" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "xRg" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -40188,10 +39851,6 @@
 "xVu" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/farm)
-"xVC" = (
-/obj/structure/reagent_dispensers/barrel/three,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood)
 "xVI" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -40460,7 +40119,7 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "yci" = (
 /mob/living/simple_animal/hostile/wolf{
 	desc = "The dogs that survived the Great War are a larger, and tougher breed, size of a wolf.<br>This one looks mangy, with mud stuck to his hair and flies buzzing around him.";
@@ -40581,7 +40240,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "yga" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -40746,12 +40405,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"ylJ" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/brotherhood)
 "ylP" = (
 /obj/structure/fence{
 	dir = 1
@@ -57218,7 +56871,7 @@ iiH
 qWG
 dTY
 kru
-nzq
+dkg
 cpK
 sfB
 brH
@@ -57475,8 +57128,8 @@ iLc
 gIA
 iLc
 ryO
-aUc
-odS
+uaf
+cpK
 sfB
 brH
 gcK
@@ -57989,7 +57642,7 @@ lTZ
 gIA
 qWG
 iLc
-aUc
+uaf
 sfB
 brH
 brH
@@ -58246,7 +57899,7 @@ gIA
 qWG
 qWG
 iLc
-aUc
+uaf
 sfB
 brH
 gcK
@@ -58503,7 +58156,7 @@ gIA
 qWG
 djk
 iLc
-pzm
+ptf
 sfB
 brH
 gcK
@@ -58760,7 +58413,7 @@ hxU
 gRs
 gof
 iLc
-cTc
+fyf
 sfB
 brH
 gcK
@@ -58990,7 +58643,7 @@ lil
 hHz
 hHz
 nwB
-vyb
+qGZ
 abd
 wSC
 ulC
@@ -59247,7 +58900,7 @@ iLc
 rRo
 hHz
 iLc
-qDU
+jMC
 iGP
 wSC
 cNH
@@ -59258,7 +58911,7 @@ iGN
 iGN
 iGN
 wSC
-fFT
+pjQ
 ddR
 rAf
 cGw
@@ -59274,7 +58927,7 @@ iLc
 iLc
 nfz
 fVn
-cTc
+fyf
 sfB
 brH
 gcK
@@ -59504,7 +59157,7 @@ cwB
 hHz
 hHz
 tja
-beG
+cTp
 ghx
 wSC
 hET
@@ -59515,7 +59168,7 @@ eDT
 kjB
 lDd
 wSC
-fFT
+pjQ
 jmz
 rAf
 ekp
@@ -59531,7 +59184,7 @@ wqi
 hpY
 hpY
 fVn
-cTc
+fyf
 sfB
 brH
 brH
@@ -59762,7 +59415,7 @@ hHz
 hHz
 bEP
 nJc
-qUO
+ghx
 wSC
 wSC
 wSC
@@ -59772,7 +59425,7 @@ wSC
 wSC
 wSC
 wSC
-qGa
+bet
 iLc
 iLc
 iLc
@@ -60018,18 +59671,18 @@ iLc
 pHm
 mDr
 iLc
-beG
-qUO
-arx
-umW
-aVC
+cTp
+ghx
+nxY
+kGc
+cam
 yfI
 ijm
-qGa
-vLj
-vLj
-vLj
-qGa
+bet
+jPN
+jPN
+jPN
+bet
 dTY
 sfB
 sfB
@@ -60045,7 +59698,7 @@ lGV
 lGV
 qMj
 fVn
-cTc
+fyf
 gET
 sfB
 brH
@@ -60282,11 +59935,11 @@ kYv
 slM
 fVn
 fVn
-fFT
-qGa
-nIj
-mMe
-qGa
+pjQ
+bet
+cNE
+iIG
+bet
 iLc
 sfB
 mJu
@@ -60302,8 +59955,8 @@ lGV
 lGV
 lGV
 fVn
-cTc
-cTc
+fyf
+fyf
 sfB
 brH
 gcK
@@ -60528,12 +60181,12 @@ oDm
 iLc
 iLc
 iLc
-odS
-qGa
+cpK
+bet
 fQE
 tUS
 wzN
-qUO
+ghx
 fVn
 kqe
 hHz
@@ -60542,8 +60195,8 @@ fVn
 ohx
 wvm
 fxf
-mMe
-qGa
+iIG
+bet
 dTY
 sfB
 iGN
@@ -60560,7 +60213,7 @@ usO
 agP
 fVn
 tvP
-cTc
+fyf
 sfB
 brH
 gcK
@@ -60784,8 +60437,8 @@ sfB
 ayJ
 naF
 jPG
-qGa
-qGa
+bet
+bet
 fVn
 fVn
 fVn
@@ -60798,9 +60451,9 @@ hHz
 fVn
 uul
 vAm
-nIj
-okc
-qGa
+cNE
+lKG
+bet
 iLc
 sfB
 kiP
@@ -60816,8 +60469,8 @@ rDT
 lFI
 fEg
 fVn
-beG
-edO
+cTp
+jcp
 sfB
 brH
 gcK
@@ -61047,7 +60700,7 @@ fVn
 gDl
 fVn
 mdc
-odS
+cpK
 fVn
 mtX
 hHz
@@ -61073,8 +60726,8 @@ lGV
 jkj
 wFL
 fVn
-cTc
-cTc
+fyf
+fyf
 sfB
 brH
 gcK
@@ -61298,13 +60951,13 @@ gKG
 gKG
 gKG
 gKG
-cTc
+fyf
 fVn
 vve
 hHz
 slM
-wTU
-odS
+lEG
+cpK
 fVn
 fVn
 fVn
@@ -61314,7 +60967,7 @@ tEp
 tEp
 pOL
 nUj
-gzG
+bfu
 iLc
 iLc
 iLc
@@ -61323,7 +60976,7 @@ iLc
 iLc
 iLc
 iLc
-cTc
+fyf
 fVn
 gFV
 woF
@@ -61555,39 +61208,39 @@ bqw
 cmF
 unr
 gKG
-cTc
+fyf
 fVn
 kKZ
 hHz
 kYv
-wTU
-odS
-qGa
-fFT
-fFT
-fFT
+lEG
+cpK
+bet
+pjQ
+pjQ
+pjQ
 qed
-iSV
-qGa
-whS
-fmX
-mCO
-fFT
-fFT
-fFT
-fFT
-fFT
+oON
+bet
+xSm
+cWB
+aTE
+pjQ
+pjQ
+pjQ
+pjQ
+pjQ
 aZn
 ocy
-hhK
-cTc
+dMW
+fyf
 tpN
 tpN
 tpN
 tpN
 tpN
 tpN
-cTc
+fyf
 sfB
 brH
 brH
@@ -61812,12 +61465,12 @@ bqw
 bqw
 euL
 gKG
-cTc
+fyf
 fVn
 chX
 meU
 fVn
-wTU
+lEG
 sfB
 sfB
 sfB
@@ -61837,14 +61490,14 @@ tjy
 sfB
 sfB
 sfB
-cTc
-cTc
+fyf
+fyf
 bER
-arx
-cTc
-cTc
-cTc
-cTc
+nxY
+fyf
+fyf
+fyf
+fyf
 sfB
 brH
 gcK
@@ -62069,7 +61722,7 @@ bqw
 bqw
 alM
 gKG
-cTc
+fyf
 fVn
 fVn
 fVn
@@ -62326,9 +61979,9 @@ bqw
 bqw
 avx
 gKG
-ovE
-umW
-wTU
+dux
+kGc
+lEG
 ePh
 cRk
 ghE
@@ -77024,8 +76677,8 @@ edB
 edB
 xTw
 prI
-nDe
-oMn
+iVE
+cWG
 uWT
 gcK
 gcK
@@ -77281,8 +76934,8 @@ dER
 edB
 edB
 ixI
-mwt
-mwt
+mvv
+mvv
 cnD
 gcK
 gcK
@@ -77538,10 +77191,10 @@ ewd
 edB
 xTw
 gBd
-mwt
-mwt
-gND
-nhf
+mvv
+mvv
+bpD
+thG
 nMd
 gcK
 iFI
@@ -77549,8 +77202,8 @@ anP
 wmI
 iFI
 iFI
-mwt
-mwt
+mvv
+mvv
 uhh
 jem
 iFI
@@ -77795,10 +77448,10 @@ cKg
 eZs
 cKg
 laZ
-mwt
-mwt
-gND
-hNC
+mvv
+mvv
+bpD
+dRo
 vrG
 gcK
 iFI
@@ -77806,9 +77459,9 @@ wmI
 iFI
 iFI
 jem
-mwt
-mwt
-gND
+mvv
+mvv
+bpD
 jem
 iFI
 qaq
@@ -77816,7 +77469,7 @@ qPL
 qPL
 iFI
 gcK
-tlI
+fYW
 ktB
 ktB
 ktB
@@ -78052,10 +77705,10 @@ yga
 yga
 yga
 sNB
-bEX
-mwt
+xGH
+mvv
 buW
-nhf
+thG
 nMd
 gcK
 iFI
@@ -78063,16 +77716,16 @@ iFI
 iFI
 jem
 jem
-mwt
-mwt
-gND
-dxJ
+mvv
+mvv
+bpD
+sND
 iFI
 wpd
 wpd
 wpd
 iFI
-xVC
+fFu
 vYf
 ktB
 ktB
@@ -78304,8 +77957,8 @@ ktB
 "}
 (147,1,1) = {"
 ktB
-bIp
-tka
+gcK
+fyf
 bbS
 hbA
 bbS
@@ -78319,15 +77972,15 @@ bbS
 bbS
 bbS
 bbS
-hsj
-mwt
-mwt
+tBN
+mvv
+mvv
 itj
-tka
+fyf
 iFI
 lxW
-mwt
-mwt
+mvv
+mvv
 iFI
 gCb
 vYf
@@ -78561,8 +78214,8 @@ ktB
 "}
 (148,1,1) = {"
 ktB
-bIp
-tka
+gcK
+fyf
 bbS
 prR
 yeL
@@ -78577,17 +78230,17 @@ eWH
 xzd
 bbS
 xCo
-mwt
-mwt
-gND
-tka
+mvv
+mvv
+bpD
+fyf
 aYV
-mwt
-cPZ
-mwt
+mvv
+tlj
+mvv
 eUz
 gCb
-tka
+fyf
 iKG
 ktB
 ktB
@@ -78819,7 +78472,7 @@ ktB
 (149,1,1) = {"
 ktB
 gcK
-tka
+fyf
 fkP
 jbm
 tep
@@ -78833,18 +78486,18 @@ frK
 uKJ
 iyv
 opY
-hsj
-mwt
-mwt
-gND
-tka
-hsj
-mwt
-mwt
-mwt
-gND
-tka
-tlI
+tBN
+mvv
+mvv
+bpD
+fyf
+tBN
+mvv
+mvv
+mvv
+bpD
+fyf
+fYW
 ktB
 ktB
 ktB
@@ -79076,7 +78729,7 @@ ktB
 (150,1,1) = {"
 ktB
 gcK
-tka
+fyf
 bbS
 enL
 tep
@@ -79091,16 +78744,16 @@ mup
 paM
 bbS
 lCM
-mwt
-mwt
-hft
-oMn
-gin
-mwt
-mwt
-mwt
-hft
-qSs
+mvv
+mvv
+doX
+cWG
+daU
+mvv
+mvv
+mvv
+doX
+pOC
 hxv
 ktB
 ktB
@@ -79333,7 +78986,7 @@ ktB
 (151,1,1) = {"
 ktB
 gcK
-tka
+fyf
 gnU
 kGV
 tep
@@ -79347,17 +79000,17 @@ iyv
 iyv
 iyv
 hDf
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 hvp
-mwt
-mwt
-mwt
-mwt
+mvv
+mvv
+mvv
+mvv
 vnR
 ktB
 ktB
@@ -79590,7 +79243,7 @@ ktB
 (152,1,1) = {"
 ktB
 gcK
-tka
+fyf
 bbS
 lqU
 tep
@@ -79605,16 +79258,16 @@ thO
 bCG
 bbS
 wPE
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 hSD
 ktB
 ktB
@@ -79847,7 +79500,7 @@ ktB
 (153,1,1) = {"
 ktB
 gcK
-tka
+fyf
 fOf
 lzE
 tep
@@ -79861,17 +79514,17 @@ frK
 oRS
 iyv
 opY
-hsj
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
+tBN
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 iyy
 ktB
 ktB
@@ -80104,7 +79757,7 @@ ktB
 (154,1,1) = {"
 ktB
 gcK
-tka
+fyf
 bbS
 qQD
 tGg
@@ -80119,17 +79772,17 @@ mup
 xzd
 bbS
 xCo
-mwt
-mwt
-grc
-wYn
-wYn
-wYn
-wYn
-wYn
-wYn
-hhG
-iiq
+mvv
+mvv
+aBH
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
+pQX
+kXK
 ktB
 ktB
 kXK
@@ -80361,7 +80014,7 @@ ktB
 (155,1,1) = {"
 ktB
 gcK
-tka
+fyf
 bbS
 hbA
 bbS
@@ -80375,17 +80028,17 @@ opY
 opY
 bbS
 bbS
-gin
-mwt
-mwt
-gND
-vCw
-tka
+daU
+mvv
+mvv
+bpD
+anb
+fyf
 gjj
-vCw
-iFI
+anb
+pMI
 pWx
-tka
+fyf
 vpM
 ktB
 ktB
@@ -80618,32 +80271,32 @@ ktB
 (156,1,1) = {"
 ktB
 gcK
-tka
-hsj
+fyf
+tBN
 sQv
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 sQv
-mwt
-mwt
-mwt
-mUo
-mwt
-mwt
-mwt
-gND
+mvv
+mvv
+mvv
+iWi
+mvv
+mvv
+mvv
+bpD
 xOt
-tka
-tka
+fyf
+fyf
 xOt
-iFI
+pMI
 esD
-tka
-tlI
+fyf
+fYW
 ktB
 ktB
 ktB
@@ -80875,7 +80528,7 @@ ktB
 (157,1,1) = {"
 ktB
 gcK
-tka
+fyf
 bav
 fzT
 dvQ
@@ -80890,17 +80543,17 @@ dvQ
 vCw
 iFI
 tgF
-mwt
-mwt
-gND
-tka
-tka
-tka
-tka
-tka
-tka
-tka
-tlI
+mvv
+mvv
+bpD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fYW
 ktB
 ktB
 ktB
@@ -81146,17 +80799,17 @@ wsM
 nUm
 bbN
 ldb
-hsj
-mwt
-mwt
-gND
-tka
-tka
-tka
-tka
-tka
-tka
-tka
+tBN
+mvv
+mvv
+bpD
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 ill
 ktB
 ktB
@@ -81389,7 +81042,7 @@ ktB
 (159,1,1) = {"
 ktB
 gcK
-tka
+fyf
 qRg
 hIJ
 nUm
@@ -81403,18 +81056,18 @@ wsM
 nUm
 ely
 dvQ
-hsj
+tBN
 hhC
-mwt
-gND
+mvv
+bpD
 ioi
-tka
-tka
+fyf
+fyf
 ioi
-iFI
+pMI
 jgY
-tka
-tlI
+fyf
+fYW
 ktB
 ktB
 ktB
@@ -81646,7 +81299,7 @@ ktB
 (160,1,1) = {"
 ktB
 gcK
-tka
+fyf
 dvQ
 sLi
 nUm
@@ -81661,16 +81314,16 @@ nUm
 rrl
 dvQ
 sCj
-mwt
-mwt
-gND
-vCw
-tka
+mvv
+mvv
+bpD
+anb
+fyf
 gjj
-vCw
-iFI
+anb
+pMI
 xaM
-tka
+fyf
 gcK
 ktB
 ktB
@@ -81903,7 +81556,7 @@ ktB
 (161,1,1) = {"
 ktB
 gcK
-tka
+fyf
 iFI
 tAN
 nUm
@@ -81917,16 +81570,16 @@ nUm
 nUm
 nUm
 qFF
-mwt
-mwt
-mwt
-hft
-oMn
-oMn
-oMn
-oMn
-oMn
-ylJ
+mvv
+mvv
+mvv
+doX
+cWG
+cWG
+cWG
+cWG
+cWG
+wDc
 hbm
 hbm
 hbm
@@ -82160,7 +81813,7 @@ ktB
 (162,1,1) = {"
 ktB
 gcK
-tka
+fyf
 iFI
 kFw
 nUm
@@ -82174,16 +81827,16 @@ nUm
 nUm
 nUm
 qFF
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-cPZ
-hft
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+tlj
+doX
 hbm
 tGY
 tUr
@@ -82417,7 +82070,7 @@ ktB
 (163,1,1) = {"
 ktB
 gcK
-tka
+fyf
 qRg
 sLi
 nUm
@@ -82432,15 +82085,15 @@ nUm
 kAh
 dvQ
 ahh
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 hxt
 jAG
 iNp
@@ -82674,7 +82327,7 @@ ktB
 (164,1,1) = {"
 ktB
 gcK
-tka
+fyf
 fkj
 kQq
 nUm
@@ -82688,25 +82341,25 @@ nUm
 nUm
 biN
 qRg
-hsj
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-grc
+tBN
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+aBH
 hbm
 iHR
 tqN
 tGY
 hbm
-ovO
-mqp
-oMn
-oMn
+nxY
+qOV
+cWG
+cWG
 qdm
 qfo
 rRT
@@ -82945,26 +82598,26 @@ whm
 iic
 kAh
 qRg
-efO
-wYn
-wYn
-wYn
-wYn
-wYn
-bEX
-mwt
-mwt
-gND
+nlO
+mfD
+mfD
+mfD
+mfD
+mfD
+xGH
+mvv
+mvv
+bpD
 hbm
 hbm
 iYw
 jeO
 hbm
 mDn
-gin
-mwt
-mwt
-mwt
+daU
+mvv
+mvv
+mvv
 qzC
 rRT
 rRT
@@ -83188,7 +82841,7 @@ ktB
 (166,1,1) = {"
 ktB
 gcK
-tka
+fyf
 iFI
 vCw
 iFI
@@ -83203,25 +82856,25 @@ bav
 fzT
 bav
 eiB
-tka
-xbv
+fyf
+cTp
 dLl
 dLl
-xbv
-hsj
-mwt
-mwt
-hft
-oMn
+cTp
+tBN
+mvv
+mvv
+doX
+cWG
 cLX
-oMn
-oMn
-oMn
-gin
-mwt
-mwt
-mwt
-mwt
+cWG
+cWG
+cWG
+daU
+mvv
+mvv
+mvv
+mvv
 jem
 sfc
 rRJ
@@ -83445,9 +83098,9 @@ ktB
 (167,1,1) = {"
 ktB
 gcK
-tka
+fyf
 aYV
-mwt
+mvv
 iFI
 ooe
 tXY
@@ -83457,27 +83110,27 @@ tXY
 tXY
 tXY
 bav
-xVC
+fFu
 bav
 evU
-tka
-xbv
+fyf
+cTp
 dLl
 dLl
-xbv
-hsj
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
+cTp
+tBN
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 lTT
 jem
 hcL
@@ -83702,9 +83355,9 @@ ktB
 (168,1,1) = {"
 ktB
 gcK
-ovO
-hsj
-mwt
+nxY
+tBN
+mvv
 iFI
 dRd
 uEg
@@ -83714,32 +83367,32 @@ pqr
 kLv
 lhA
 bav
-xVC
+fFu
 bav
 dLl
-tka
-xbv
+fyf
+cTp
 dLl
 dLl
-xbv
-hsj
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-hft
-oMn
-oMn
+cTp
+tBN
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+doX
+cWG
+cWG
 tly
-oMn
+cWG
 isO
 cWG
 cWG
@@ -83960,8 +83613,8 @@ ktB
 ktB
 gcK
 gcK
-hsj
-mwt
+tBN
+mvv
 iFI
 fzT
 bav
@@ -83971,32 +83624,32 @@ iFI
 iFI
 vCw
 iFI
-tka
+fyf
 iFI
 qgO
-oMn
-oMn
-oMn
-oMn
-oMn
-gin
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
+cWG
+cWG
+cWG
+cWG
+cWG
+daU
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 mvv
 mvv
 mvv
@@ -84217,42 +83870,42 @@ ktB
 ktB
 gcK
 gcK
-hsj
-mwt
+tBN
+mvv
 ulu
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-hft
-ryH
-oMn
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+doX
+bnY
+cWG
 iFI
-gin
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-mwt
-grc
+daU
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+aBH
 goT
-mwt
-grc
-wYn
-wYn
-wYn
-wYn
-wYn
-wYn
+mvv
+aBH
+mfD
+mfD
+mfD
+mfD
+mfD
+mfD
 vIl
 slG
-wYn
+mfD
 slG
 mfD
 mfD
@@ -84475,29 +84128,29 @@ ktB
 gcK
 gcK
 lDv
-wYn
-wYn
+mfD
+mfD
 ajW
-axX
-axX
-axX
-axX
+igc
+igc
+igc
+igc
 ctZ
-wYn
-bEX
-mwt
-mUo
-mwt
-grc
+mfD
+xGH
+mvv
+iWi
+mvv
+aBH
 eNT
-wYn
-wYn
-wYn
+mfD
+mfD
+mfD
 goT
-mwt
-mwt
-grc
-lCc
+mvv
+mvv
+aBH
+hCg
 hbm
 jUn
 jeO
@@ -84505,7 +84158,7 @@ neo
 wIO
 neo
 hbm
-tka
+fyf
 kvB
 jem
 jem
@@ -84733,19 +84386,19 @@ gcK
 gcK
 gcK
 gcK
-vye
-nhf
+pEv
+thG
 aya
-tka
-tka
-anb
-nhf
-tka
+fyf
+fyf
+qLa
+thG
+fyf
 ych
-wYn
-wOL
-wYn
-lCc
+mfD
+vtb
+mfD
+hCg
 hbm
 jeO
 hbm
@@ -84753,8 +84406,8 @@ hbm
 hbm
 qYD
 hbm
-lCc
-ovO
+hCg
+nxY
 hbm
 tqN
 uom
@@ -84762,8 +84415,8 @@ tqN
 hWd
 tqN
 hbm
-ovO
-tka
+nxY
+fyf
 qzM
 irQ
 tGx
@@ -84990,19 +84643,19 @@ gcK
 gcK
 gcK
 gcK
-xVC
-nhf
-tka
-tka
-tka
-tka
-hNC
-tka
-xbv
+fFu
+thG
+fyf
+fyf
+fyf
+fyf
+dRo
+fyf
+cTp
 dLl
-nhf
-tka
-ovO
+thG
+fyf
+nxY
 hbm
 xSC
 tcX
@@ -85010,8 +84663,8 @@ fJU
 tcX
 jmt
 hbm
-tka
-tka
+fyf
+fyf
 hbm
 jVO
 tqN
@@ -85019,8 +84672,8 @@ tqN
 uom
 oSA
 hbm
-tka
-tka
+fyf
+fyf
 qPG
 irQ
 rRT
@@ -85248,18 +84901,18 @@ gcK
 gcK
 gcK
 gcK
-nhf
-tka
-tka
-tka
-tka
-nhf
-tka
-xbv
+thG
+fyf
+fyf
+fyf
+fyf
+thG
+fyf
+cTp
 dLl
-nhf
-vye
-tka
+thG
+pEv
+fyf
 hbm
 vCK
 jmt
@@ -85267,8 +84920,8 @@ tcX
 tcX
 tcX
 jeO
-ovO
-tka
+nxY
+fyf
 hbm
 kfU
 nDk
@@ -85276,8 +84929,8 @@ lFD
 lFD
 lFD
 hbm
-tka
-tka
+fyf
+fyf
 rrC
 rRT
 rRT
@@ -85505,18 +85158,18 @@ gcK
 gcK
 gcK
 gcK
-nhf
-tka
-tka
-tka
+thG
+fyf
+fyf
+fyf
 aya
-nhf
-tka
-xbv
+thG
+fyf
+cTp
 dLl
-nhf
+thG
 xQL
-tka
+fyf
 hbm
 bpQ
 tcX
@@ -85524,8 +85177,8 @@ omF
 tcX
 gyi
 hbm
-tka
-tka
+fyf
+fyf
 hbm
 hbm
 hbm
@@ -85533,8 +85186,8 @@ hbm
 jeO
 hbm
 hbm
-tka
-tka
+fyf
+fyf
 rrC
 rRT
 rRT
@@ -85762,18 +85415,18 @@ gcK
 gcK
 gcK
 gcK
-auw
-ceT
-ceT
-ceT
-ceT
+dje
+uxC
+uxC
+uxC
+uxC
 cOE
-dsL
-vye
-ovO
-nhf
-xVC
-tka
+jcp
+pEv
+nxY
+thG
+fFu
+fyf
 hbm
 hbm
 hbm
@@ -85782,15 +85435,15 @@ hbm
 hbm
 hbm
 fcE
-tka
-tka
-tka
-tka
-tka
+fyf
+fyf
+fyf
+fyf
+fyf
 mnC
-tka
-tka
-tka
+fyf
+fyf
+fyf
 iHS
 jem
 jem
@@ -85798,7 +85451,7 @@ tSA
 jem
 jem
 gcK
-hwC
+gcK
 pLJ
 uJr
 fyf
@@ -86027,10 +85680,10 @@ ktB
 gcK
 gcK
 gcK
-vye
-nhf
-xVC
-vye
+pEv
+thG
+fFu
+pEv
 gcK
 gcK
 gcK
@@ -86041,13 +85694,13 @@ gcK
 gcK
 gcK
 gcK
-vye
-ovO
-tka
+pEv
+nxY
+fyf
 mcp
-pBX
-vye
-xVC
+slt
+pEv
+fFu
 gcK
 ktB
 ktB


### PR DESCRIPTION
new map stuff to fight

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Essentially, I've reworked the old BD deathclaw area (the one where ghoul vault was RIP) and essentially gave it a bit of a facelift since it really looked dated compared to the rest of the map. So I've added a couple of things to the area to give it a fresh overhaul, and also try to keep it with current map standards, and I've also added another mini-dungeon to the map called the Museum taken inspiration from St.Jeromes. It also fixes a lot of the zones that are lazily slapped onto areas, (Legion/BoS/Oasis) areas that should be getting rain and weather were being nulled because of lazy zoning without proper placement, this essentially makes it so that weather effects are noticeable in these places, meaning go indoors if heatwave or cold-snap comes and you'll be fine.

## Why It's Good For The Game

The old BD area was a thing of the past, ive decided to overhaul it completely and here is the new results.

**BEFORE**
![StrongDMM_Qo49rfShO3](https://user-images.githubusercontent.com/62493359/119196106-4b165380-ba4b-11eb-994a-9d9e88cab405.png)
**AFTER**
![StrongDMM_Pch8ZqH7pH](https://user-images.githubusercontent.com/62493359/119196115-4ea9da80-ba4b-11eb-87d3-2ab7b94f2a1f.png)

I've reworked the old clinic in that area, changed the laundry place (or whatever it was) to a car shop with more flavor to it. The old diner area or cafeteria that used to exist was changed to a small restaurant that now actually connects to the shack on the other side with a night stalker den, why night stalkers? because they could use more attention and I'm a fan of enemy variety. Lastly, the biggest one is essentially the new mini-dungeon. The Museum, like the one on St.Jeromes and taken inspiration from while also giving it my own spin to it. I think it fits well into the map from the amount of editing I did, and also perhaps will lead to a bigger dungeon if I ever get to feel it. Also, the zoning normalizes map quality by fixing and tweaking zoning areas. Like the NCR and Tribals, this just fixes weather problems.

## Changelog
:cl:
add: museum mini-dungeon
add: more decoration
add: night stalker cave
add: car shop
add: restaurant
del: old BD area
tweak: map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
