### PR TITLE
Tweak train and monster announcements and deep space reference

### DIFF
--- a/code/controllers/subsystem/monster_wave.dm
+++ b/code/controllers/subsystem/monster_wave.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(monster_wave)
 		return // 50/50 chance for it to either fire or not fire
 	successful_firing++
 	addtimer(CALLBACK(src, .proc/spawn_monsterwave), 10 SECONDS)
-	priority_announce("WARNING: A large amount of monster activity has been detected. It is estimated that the monsters will breach the ground in a few moments. Please report the location of the breach once found.", "Monster Alert", sender_override = "Monster Reporting Division")
+	priority_announce("Monsters must have broken through the barricades of an old nest, allowing a wave of them to roam its vicinity once more.", null, sender_override = "Roars echo throughout the valley...")
 
 /datum/controller/subsystem/monster_wave/proc/spawn_monsterwave()
 	var/pick_unfortune = pick("Ghoul", "Deathclaw", "Radscorpion", "Wanamingo", "Fireant", "Molerat", "Mirelurk")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -366,7 +366,7 @@
 				msg += "[t_He] [t_is] barely conscious.\n"
 		if(getorgan(/obj/item/organ/brain))
 			if(!key)
-				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
+				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)
 				msg += "[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.\n"
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -340,7 +340,11 @@
 		SSshuttle.emergencyLastCallLoc = null
 
 	if(!silent)
-		priority_announce("The train has been called. [redAlert ? "Red Alert state confirmed: Dispatching priority train. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/f13/quest.ogg', "Vault-Tec")
+		var/red_alert_msg = redAlert ? "Judging from the sounds, the train will arrive sooner than usual this week. " : ""
+		var/arrival_time_msg = "It will arrive in [timeLeft(600)] minutes."
+		var/trace_msg = SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : ""
+		var/combined_train_text = "[red_alert_msg][arrival_time_msg][trace_msg]"
+		priority_announce(combined_train_text, null, 'sound/f13/quest.ogg', "Vault-Tec", "Sounds of a train echo throughout the valley...")
 
 /obj/docking_port/mobile/emergency/cancel(area/signalOrigin)
 	if(mode != SHUTTLE_CALL)
@@ -355,7 +359,7 @@
 		SSshuttle.emergencyLastCallLoc = signalOrigin
 	else
 		SSshuttle.emergencyLastCallLoc = null
-	priority_announce("The train has been recalled.[SSshuttle.emergencyLastCallLoc ? " Recall signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/f13/quest.ogg', "Vault-Tec")
+	priority_announce("The train seems to have been diverted to another track away from the valley.[SSshuttle.emergencyLastCallLoc ? " Recall signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/f13/quest.ogg', "Vault-Tec", "The approching train echos start to fade away...")
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked()
 	return hijack_status == HIJACKED
@@ -400,7 +404,7 @@
 				mode = SHUTTLE_DOCKED
 				setTimer(SSshuttle.emergencyDockTime)
 				send2irc("Server", "The train has arrived at the station.")
-				priority_announce("The train has arrived the station. You have [timeLeft(600)] minutes to board the train.", null, 'sound/f13/quest.ogg', "Vault-Tec")
+				priority_announce("It sounds like the train has arrived at the station. You know from experience that the train will only stay for [timeLeft(600)] minutes.", null, 'sound/f13/quest.ogg', "Vault-Tec", "A loud train whistle echoes throughout the valley...")
 				ShuttleDBStuff()
 
 
@@ -451,7 +455,7 @@
 				mode = SHUTTLE_ESCAPE
 				launch_status = ENDGAME_LAUNCHED
 				setTimer(SSshuttle.emergencyEscapeTime * engine_coeff)
-				priority_announce("The train has left the station. Estimate [timeLeft(600)] minutes until the train arrives to the target destination.", null, null, "Vault-Tec")
+				priority_announce("It seems like the train has left the station. You estimate [timeLeft(600)] minutes until the sounds of the train completely fades away.", null, null, "Vault-Tec", "Sounds of the train start to fade away...")
 
 		if(SHUTTLE_STRANDED)
 			SSshuttle.checkHostileEnvironment()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Rewrite some texts that break immersion

![Screenshot 2021-05-29 002749](https://user-images.githubusercontent.com/59653547/120017245-3b34db80-c018-11eb-98d3-377af63ba5c0.png)
![Screenshot 2021-05-29 002832](https://user-images.githubusercontent.com/59653547/120017253-40922600-c018-11eb-91f0-6b51cc395760.png)
![Screenshot 2021-05-29 004841](https://user-images.githubusercontent.com/59653547/120017390-6a4b4d00-c018-11eb-8a49-ccbe8dbd9cb0.png)
![Screenshot 2021-05-29 005140](https://user-images.githubusercontent.com/59653547/120017413-6fa89780-c018-11eb-89ef-cea97f26e246.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Better immersion. Remove references with no place in the setting (e.g. Central Command, deep space, Monster Reporting Division)

## Changelog
:cl:
tweak: Remove reference to deep space when mob is catatonic
tweak: Rewrite train announcements by removing references to Central Command
tweak: Rewrite monster wave announcement by removing references to Monster Reporting Division
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
