### PR TITLE
Disables Sonic Jackhammer Instant R-Wall Penetrations & Destructions

### DIFF
--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -49,7 +49,7 @@
 		to_chat(M, "<span class='warning'>This wall is far too strong for you to destroy.</span>")
 	M.DelayNextAction()
 
-/turf/closed/wall/r_wall/try_destroy(obj/item/I, mob/user, turf/T)
+/*turf/closed/wall/r_wall/try_destroy(obj/item/I, mob/user, turf/T)
 	if(istype(I, /obj/item/pickaxe/drill/jackhammer))
 		to_chat(user, "<span class='notice'>You begin to smash though [src]...</span>")
 		if(do_after(user, 50, target = src))
@@ -60,7 +60,7 @@
 			dismantle_wall()
 			return TRUE
 	return FALSE
-
+*/
 /turf/closed/wall/r_wall/try_decon(obj/item/W, mob/user, turf/T)
 	//DECONSTRUCTION
 	switch(d_state)


### PR DESCRIPTION
disables jackhammers from penetrating reinforced walls. it's silly. stop it.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
disables jackhammers from penetrating reinforced walls. it's silly. stop it. This is mostly a Salt PR, I wouldn't mind it going up for a vote or something to get more feedback on it. It's just something that bugs me. Nobody should have this sort of power.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes an absolutely broken piece of equipment's brokenness without removing it outright.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Commented out the R-Wall penetration code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
