### PR TITLE
5.56 Crusader and BoS PA

### DIFF
--- a/code/game/objects/items/modkit.dm
+++ b/code/game/objects/items/modkit.dm
@@ -204,7 +204,7 @@
 						/obj/item/gun/energy/laser/crusader,
 						/obj/item/gun/energy/plasma/crusader
 	)
-	result_item = /obj/item/gun/ballistic/automatic/pistol/crusader_rifle
+	result_item = /obj/item/gun/ballistic/automatic/pistol/crusader_rifle_ncr
 
 /obj/item/modkit/crusader_laser
 	name = "crusader pistol laser conversion kit"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -130,7 +130,7 @@ Head Paladin
 	uniform = 		/obj/item/clothing/under/f13/bos/bodysuit/paladin
 	accessory = 	/obj/item/clothing/accessory/bos/sentinel
 	glasses =       /obj/item/clothing/glasses/night
-	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/t60
+	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/t60/bos
 	belt =			/obj/item/storage/belt/military/assault
 	head = 			/obj/item/clothing/head/helmet/f13/power_armor/t60
 	mask =			/obj/item/clothing/mask/gas/sechailer/swat
@@ -384,7 +384,7 @@ Star Paladin
 /datum/outfit/job/bos/f13seniorpaladin
 	name = "Star Paladin"
 	jobtype = /datum/job/bos/f13seniorpaladin
-	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/t51b
+	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/t51b/bos
 	head = 			/obj/item/clothing/head/helmet/f13/power_armor/t51b
 	glasses =       /obj/item/clothing/glasses/night
 	accessory = 	/obj/item/clothing/accessory/bos/seniorpaladin
@@ -466,7 +466,7 @@ Paladin
 /datum/outfit/job/bos/f13paladin
 	name = "Paladin"
 	jobtype = /datum/job/bos/f13paladin
-	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/t45d
+	suit = 			/obj/item/clothing/suit/armor/f13/power_armor/t45d/bos
 	head = 			/obj/item/clothing/head/helmet/f13/power_armor/t45d
 	glasses=		/obj/item/clothing/glasses/meson
 	uniform = 		/obj/item/clothing/under/f13/bos/bodysuit/paladin


### PR DESCRIPTION
## About The Pull Request

Gives paladins their colored PA and makes the 5.56 kit actually give you 5.56 crusader

## Why It's Good For The Game

More faction identification and actual functional weapon

## Changelog
:cl:
add: Paladin spawn with their new colored PAs
fix: 5.56 modkit giving you caseless instead of 5.56 crusader
/:cl: