### PR TITLE
Slight changes/buff to salvaging components

### DIFF
--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -941,7 +941,6 @@
 	Loot = list(/obj/item/stack/crafting/metalparts/five,
 				/obj/item/stack/ore/blackpowder/two,
 				/obj/item/stack/crafting/electronicparts/three,
-				/obj/item/stack/ore/lead/,
 				/obj/item/stack/sheet/metal/ten,
 				/obj/item/stack/sheet/cloth/five,
 				/obj/item/stack/sheet/leather/five,

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -941,11 +941,10 @@
 	Loot = list(/obj/item/stack/crafting/metalparts/five,
 				/obj/item/stack/ore/blackpowder/two,
 				/obj/item/stack/crafting/electronicparts/three,
-				/obj/item/stack/sheet/lead/five,
+				/obj/item/stack/ore/lead/,
 				/obj/item/stack/sheet/metal/ten,
 				/obj/item/stack/sheet/cloth/five,
 				/obj/item/stack/sheet/leather/five,
-				/obj/item/scrap/research,
 				/obj/item/stock_parts/cell/ammo/ec,
 				/obj/item/stack/crafting/goodparts
 				)
@@ -985,11 +984,12 @@
 				/obj/item/advanced_crafting_components/receiver,
 				/obj/item/advanced_crafting_components/assembly,
 				/obj/item/advanced_crafting_components/alloys,
+				/obj/item/advanced_crafting_components/flux,
+				/obj/item/advanced_crafting_components/lenses,
 				/obj/item/reagent_containers/hypospray/medipen/stimpak,
 				/obj/item/weldingtool/advanced,
 				/obj/item/stock_parts/cell/ammo/mfc,
-				/obj/item/stock_parts/cell/ammo/ecp,
-				/obj/item/megaphone)
+				/obj/item/stock_parts/cell/ammo/ecp,)
 
 /obj/item/experimental
 	name = "Experimental component"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes three unused loot drops from low salvage and high salvage that being the megaphone, strange object, lead being removed for being entirely useless and high tier with crafting supplies
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
refined lead cannot be used for what appears to be anything according to mentors i have asked and some code-digging making it an empty drop aswell as the megaphone being near-non sensical aswell as unused by a vast portion of the playerbase and the research object a redundancy with the advanced 10k blueprint
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add:flux and lens to advanced pre-war salvage
del:megaphone, lead, 2k object drops
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
