### PR TITLE
Wastefood, Rainbow Bunch, Kudzu changes

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -96,6 +96,7 @@
 #define CAT_SANDWICH	"Sandwiches"
 #define CAT_SOUP	"Soups"
 #define CAT_SPAGHETTI	"Spaghettis"
+#define CAT_WASTEFOOD "Wastefood"
 #define CAT_ICE	"Frozen"
 #define CAT_MEDICAL "Medical"
 #define CAT_BOTTLE "Bottling"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
@@ -88,7 +88,7 @@
 	result = /obj/item/reagent_containers/food/snacks/f13/squirrelstew
 	category = CAT_FOOD
 	subcategory = CAT_WASTEFOOD
-
+/*
 /datum/crafting_recipe/food/pemmican
 	name = "pemmican"
 	reqs = list(
@@ -120,7 +120,7 @@
 	result = /obj/item/reagent_containers/food/snacks/tatofries
 	category = CAT_FOOD
 	subcategory = CAT_WASTEFOOD
-
+*/
 /datum/crafting_recipe/food/mirelurkstew
 	name = "Mirelurk Stew"
 	reqs = list(

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -41,13 +41,13 @@
 	investigate_log("was planted by [key_name(user)] at [AREACOORD(user)]", INVESTIGATE_BOTANY)
 	new /datum/spacevine_controller(get_turf(user), mutations, potency, production)
 	qdel(src)
-
+/*
 /obj/item/seeds/kudzu/attack_self(mob/user)
 	user.visible_message("<span class='danger'>[user] begins throwing seeds on the ground...</span>")
 	if(do_after(user, 50, needhand = TRUE, target = user.drop_location(), progress = TRUE))
 		plant(user)
 		to_chat(user, "<span class='notice'>You plant the kudzu. You monster.</span>")
-
+*/
 /obj/item/seeds/kudzu/get_analyzer_text()
 	var/text = ..()
 	var/text_string = ""

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -33,6 +33,7 @@
 					/obj/item/seeds/potato = 3,
 					/obj/item/seeds/poppy = 3,
 					/obj/item/seeds/pumpkin = 3,
+					/obj/item/seeds/rainbow_bunch = 3,
 					/obj/item/seeds/replicapod = 3,
 					/obj/item/seeds/wheat/rice = 3,
 					/obj/item/seeds/soya = 3,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2218,6 +2218,7 @@
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_seafood.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_soup.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_spaghetti.dm"
+#include "code\modules\food_and_drinks\recipes\tablecraft\recipes_wastefood.dm"
 #include "code\modules\games\cas.dm"
 #include "code\modules\games\unum.dm"
 #include "code\modules\holiday\easter.dm"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Wastefood is now craftable after a long time of waiting, but was done rather rudimentary.
- New define for Wastefood to compliment Wastefood craftability.
- Some removal of certain recipies that were no longer worked (tallow, pemmican, crunchy mutfruit, tato fries)
- Rainbow Bunches now spawn in the Megaseed once more.
- Kudzu can no longer be planted, but can still be grown and used for sushi food.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's readding stuff that should've been in for quite some time, religated to other parts and forgotten about. The Kudzu was used primarily for griefing and although it is with a heavy heart I finally remove this, it's done so that less people will have to needlessly be griefed. Rainbow Bunches should've also been in the seed vendor.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Wastefood recipes back in now.
add: Rainbow Bunches back in.
del: Commented out the ability to plant Kudzu seeds on tiles - now you can only grow them for food stuff.
code: New define - CAT_WASTEFOOD = Wastefood.
code: Had to comment out a few foodtypes as they currently lack the pathways (Crunchy Mutfruit, Tato Fries, Tallow, Pemmican)
code: Server will now load in recipes_wastefood.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
