### PR TITLE
Adds Tinker kits and Inventions to the trading point

### DIFF
--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -14,7 +14,7 @@
 	var/expected_price = 0
 	var/list/prize_list = list()  //if you add something to this, please, for the love of god, sort it by price/type. use tabs and not spaces.
 
-	var/list/goods_list = list( /obj/item/stack/ore/diamond = 50,
+	var/list/goods_list = list( /obj/item/stack/ore/diamond = 25,
 								/obj/item/stack/ore/gold = 7,
 								/obj/item/stack/ore/silver = 2,
 								/obj/item/stack/ore/iron = 1,
@@ -54,7 +54,7 @@
 	dat += "Iron ore : 1.5 caps<br>"
 	dat += "Silver : 5 caps<br>"
 	dat += "Gold : 15 caps<br>"
-	dat += "Diamond : 50 caps<br>"
+	dat += "Diamond : 25 caps<br>"
 	dat += "Leather : 5 caps<br>"
 	dat += "Jet/Psycho/MedX : 5-15 caps<br>"
 	dat += "Inventions : 25 caps"

--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -14,15 +14,15 @@
 	var/expected_price = 0
 	var/list/prize_list = list()  //if you add something to this, please, for the love of god, sort it by price/type. use tabs and not spaces.
 
-	var/list/goods_list = list( /obj/item/stack/ore/diamond = 25,
+	var/list/goods_list = list( /obj/item/stack/ore/diamond = 50,
 								/obj/item/stack/ore/gold = 7,
 								/obj/item/stack/ore/silver = 2,
 								/obj/item/stack/ore/iron = 1,
 								/obj/item/stack/sheet/leather = 3,
 								/obj/item/reagent_containers/pill/patch/jet = 5,
 								/obj/item/reagent_containers/hypospray/medipen/psycho = 15,
-								/obj/item/reagent_containers/syringe/medx = 15
-								/obj/item/invention = 25
+								/obj/item/reagent_containers/syringe/medx = 15,
+								/obj/item/invention = 25,
 								/obj/item/experimental = 25
 								)
 

--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -14,7 +14,7 @@
 	var/expected_price = 0
 	var/list/prize_list = list()  //if you add something to this, please, for the love of god, sort it by price/type. use tabs and not spaces.
 
-	var/list/goods_list = list( /obj/item/stack/ore/diamond = 25,
+	var/list/goods_list = list( /obj/item/stack/ore/diamond = 50,
 								/obj/item/stack/ore/gold = 7,
 								/obj/item/stack/ore/silver = 2,
 								/obj/item/stack/ore/iron = 1,
@@ -22,6 +22,8 @@
 								/obj/item/reagent_containers/pill/patch/jet = 5,
 								/obj/item/reagent_containers/hypospray/medipen/psycho = 15,
 								/obj/item/reagent_containers/syringe/medx = 15
+								/obj/item/invention = 25
+								/obj/item/experimental = 25
 								)
 
 /obj/machinery/mineral/wasteland_trader/general
@@ -55,7 +57,8 @@
 	dat += "Diamond : 50 caps<br>"
 	dat += "Leather : 5 caps<br>"
 	dat += "Jet/Psycho/MedX : 5-15 caps<br>"
-	dat += ""
+	dat += "Inventions : 25 caps"
+	dat += "Tinker Kits : 25 caps"
 	dat += "</div>"
 
 	var/datum/browser/popup = new(user, "tradingvendor", "Trading point", 400, 500)

--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -54,7 +54,7 @@
 	dat += "Iron ore : 1.5 caps<br>"
 	dat += "Silver : 5 caps<br>"
 	dat += "Gold : 15 caps<br>"
-	dat += "Diamond : 25 caps<br>"
+	dat += "Diamond : 50 caps<br>"
 	dat += "Leather : 5 caps<br>"
 	dat += "Jet/Psycho/MedX : 5-15 caps<br>"
 	dat += "Inventions : 25 caps"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds tinker kits, and inventions to the trading point for 25 caps each aswell as adjusting diamonds to their proper listed price
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
salvage items become useless past V tier yet this makes a reason to still go out and scrap for them, aswell as diamonds being incorrectly priced
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Tweak: Diamonds are 50 caps as listed now
Add: tinker and invention kits to the trading point
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
