### PR TITLE
Thanos snap

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -82,8 +82,9 @@
 /turf/open/floor/wood,
 /area/f13/vault)
 "afn" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/floor/plasteel/freezer,
+/obj/structure/chair/wood,
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/f13/wood,
 /area/f13/bunker)
 "afv" = (
 /obj/structure/flora/grass/jungle,
@@ -2810,9 +2811,11 @@
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
 "efY" = (
-/mob/living/simple_animal/hostile/raider/thief,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/remains/human,
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "egw" = (
 /obj/machinery/newscaster/security_unit{
@@ -2982,12 +2985,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/vault)
 "eqB" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old"
-	},
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
+/mob/living/simple_animal/hostile/handy/sentrybot/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "eqF" = (
@@ -3063,12 +3063,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
-"exz" = (
-/mob/living/simple_animal/hostile/handy/nsb,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtysolid"
-	},
-/area/f13/bunker)
 "exO" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -3280,7 +3274,6 @@
 	dir = 2;
 	icon_state = "rwindow"
 	},
-/mob/living/simple_animal/hostile/raider/tribal,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -3334,7 +3327,6 @@
 /obj/machinery/light/broken{
 	dir = 1
 	},
-/mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "eWr" = (
@@ -3530,15 +3522,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"fjq" = (
-/obj/effect/decal/remains/human,
-/mob/living/simple_animal/hostile/deathclaw{
-	obj_damage = 500
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/bunker)
 "fjt" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -3792,7 +3775,6 @@
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
 	},
-/mob/living/simple_animal/hostile/raider,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
@@ -4621,12 +4603,6 @@
 /obj/item/stamp/denied,
 /turf/open/floor/plasteel/neutral,
 /area/f13/vault)
-"gMc" = (
-/mob/living/simple_animal/hostile/deathclaw/mother,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "gNy" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall/r_wall/f13vault{
@@ -6568,12 +6544,6 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/f13/vault)
-"jyS" = (
-/mob/living/simple_animal/hostile/deathclaw/mother,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/bunker)
 "jzn" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/underground/cave)
@@ -7352,11 +7322,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"kFR" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
 "kGC" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -7947,12 +7912,6 @@
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
-	},
-/area/f13/bunker)
-"lAt" = (
-/mob/living/simple_animal/hostile/handy/gutsy/nsb,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
 "lBd" = (
@@ -10893,12 +10852,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"pEa" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
 "pEA" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/caution,
@@ -12339,10 +12292,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
-"rHt" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/floor/f13/wood,
-/area/f13/bunker)
 "rIK" = (
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -13225,12 +13174,6 @@
 	},
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
-"tqu" = (
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/bunker)
 "trf" = (
 /obj/structure/chair{
 	dir = 1
@@ -13539,7 +13482,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
 "tMJ" = (
-/mob/living/simple_animal/hostile/raider,
+/mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
@@ -14801,12 +14744,6 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/bunker)
-"vHO" = (
-/obj/structure/window/reinforced/spawner,
-/mob/living/simple_animal/hostile/raider/tribal,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "vId" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
@@ -15037,13 +14974,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"vYc" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
 "vYm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16460,14 +16390,6 @@
 	},
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
-"xRF" = (
-/mob/living/simple_animal/hostile/deathclaw{
-	obj_damage = 500
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/bunker)
 "xSr" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/darkpurple/side{
@@ -49479,7 +49401,7 @@ heT
 heT
 heT
 nOA
-kFR
+pdR
 pba
 bsh
 pVj
@@ -66008,7 +65930,7 @@ dnG
 aAq
 gQs
 man
-xRF
+rdj
 cIT
 cIT
 cIT
@@ -67028,8 +66950,8 @@ heT
 aUx
 eVd
 nmg
-kRy
-fjq
+nmg
+xPY
 nmg
 nmg
 apt
@@ -67284,11 +67206,11 @@ apt
 heT
 aUx
 hVx
-jyS
+uXT
 bDl
 psO
-gQm
-gMc
+efY
+nmg
 nmg
 ueX
 xPY
@@ -67555,7 +67477,7 @@ acL
 sur
 iEb
 fWv
-sFw
+cyH
 lbv
 kCd
 aUx
@@ -68309,7 +68231,7 @@ xXn
 xXn
 qLo
 xXn
-efY
+gpZ
 aUx
 gpZ
 apt
@@ -68325,7 +68247,7 @@ rnG
 sjp
 sjp
 wTw
-sFw
+sur
 rnG
 sur
 aUx
@@ -68568,8 +68490,8 @@ xXn
 xXn
 wbX
 wxh
-byR
-byR
+wbX
+wbX
 wfT
 apt
 eQd
@@ -68816,7 +68738,7 @@ aUx
 aUx
 ocx
 gpZ
-byR
+wbX
 krr
 wbX
 sWe
@@ -68826,7 +68748,7 @@ wbX
 rhx
 aUx
 cPK
-trQ
+wbX
 trQ
 haZ
 apt
@@ -69082,9 +69004,9 @@ xLK
 osR
 wbX
 aUx
-ced
+wbX
 idv
-byR
+wbX
 uRQ
 hHr
 heT
@@ -69093,7 +69015,7 @@ tfI
 tfI
 vAD
 jaG
-sFw
+sur
 hRG
 iLp
 sur
@@ -69329,7 +69251,7 @@ heT
 heT
 heT
 aWe
-vUB
+oFH
 kgE
 dRA
 omX
@@ -69588,7 +69510,7 @@ heT
 aWe
 uwS
 oFH
-afn
+oFH
 eKM
 yeH
 ocx
@@ -69610,7 +69532,7 @@ uXT
 kRy
 fFV
 kRy
-lAt
+uXT
 bjT
 hdb
 vwp
@@ -70123,7 +70045,7 @@ xoz
 kRy
 uXT
 bjT
-nmg
+eqB
 kRy
 iiY
 kRy
@@ -70634,7 +70556,7 @@ jNs
 iOW
 yhv
 exO
-exz
+nsZ
 azq
 azq
 jrx
@@ -70897,7 +70819,7 @@ azq
 aUx
 azq
 azq
-eqB
+gPv
 aUx
 heT
 heT
@@ -71139,7 +71061,7 @@ wbX
 wbX
 dVq
 rJG
-rHt
+sST
 bqQ
 sST
 aWe
@@ -71409,7 +71331,7 @@ jNs
 pvh
 nsZ
 aUx
-giL
+jNs
 txP
 xUI
 aUx
@@ -72681,7 +72603,7 @@ wbX
 ced
 sIn
 ikx
-wew
+afn
 haD
 nCC
 aWe
@@ -73188,13 +73110,13 @@ ujy
 hzL
 fds
 sST
-tqu
+nNk
 aUx
 gpZ
 xXn
 wbX
 ocx
-yeA
+sST
 ikx
 sST
 sST
@@ -73959,7 +73881,7 @@ dVq
 okX
 kML
 aPs
-pEa
+kML
 aUx
 aUx
 rpz
@@ -74228,7 +74150,7 @@ fwh
 wbX
 wbX
 wbX
-qCB
+wbX
 aZK
 wbX
 wbX
@@ -74475,10 +74397,10 @@ kML
 ocx
 tMY
 wbX
-wPp
+wvo
 wPp
 wvo
-wbX
+rhx
 wbX
 dVq
 sgc
@@ -74736,7 +74658,7 @@ gAr
 umi
 umi
 gpZ
-byR
+wbX
 ocx
 aUx
 aUx
@@ -74754,7 +74676,7 @@ ayp
 wbX
 xXn
 wbX
-byR
+wbX
 aUx
 heT
 heT
@@ -75234,9 +75156,9 @@ gSq
 xXn
 fCY
 iiK
-qCB
 wbX
-osR
+wbX
+wbX
 fLs
 wbX
 wbX
@@ -75487,12 +75409,12 @@ aUx
 aUx
 pmS
 nYd
-wlK
+wbX
 xLK
 wbX
 iiK
 wbX
-wbX
+rhx
 wbX
 lXh
 dXo
@@ -75745,7 +75667,7 @@ nBH
 lgr
 aWe
 pnZ
-wbX
+wlK
 nbb
 aWe
 wbX
@@ -75778,7 +75700,7 @@ aUx
 aUx
 aUx
 aUx
-ckX
+wbX
 xXn
 mZe
 wbX
@@ -76003,7 +75925,7 @@ xXn
 wxh
 jGC
 xXn
-ced
+wbX
 rnE
 wbX
 wbX
@@ -76019,9 +75941,9 @@ byR
 wbX
 tXJ
 wvo
-tXJ
+wvo
 wbX
-ced
+wbX
 aWe
 bQv
 wbX
@@ -76786,7 +76708,7 @@ xXn
 xLK
 wxh
 xXn
-oqc
+xXn
 dVq
 gpZ
 wbX
@@ -77034,7 +76956,7 @@ sBO
 oAS
 iiK
 xXn
-wbX
+osR
 uUS
 aWe
 gpZ
@@ -77047,7 +76969,7 @@ iPO
 aUx
 sWe
 wbX
-byR
+wbX
 aWe
 epm
 aUx
@@ -77806,7 +77728,7 @@ ujt
 dVq
 wbX
 xXn
-osR
+wbX
 ocx
 ttz
 wbX
@@ -77820,7 +77742,7 @@ rhx
 wbX
 xXn
 lKA
-hTO
+iZA
 tYD
 iZA
 iZA
@@ -78061,7 +77983,7 @@ gvJ
 ckX
 wgN
 aWe
-ckX
+wbX
 xXn
 xXn
 aWe
@@ -78325,7 +78247,7 @@ aUx
 xXn
 wbX
 wbX
-ckX
+wbX
 ocx
 ppS
 mwa
@@ -78334,7 +78256,7 @@ ced
 wbX
 wbX
 vbG
-vYc
+iZA
 jHW
 iZA
 xNg
@@ -78841,7 +78763,7 @@ xXn
 xLK
 wbX
 aUx
-vHO
+vSR
 vsf
 ocx
 gpZ
@@ -79118,7 +79040,7 @@ dVq
 pJH
 jHW
 aUn
-qYV
+jHW
 jHW
 ocx
 heT
@@ -79619,7 +79541,7 @@ heT
 heT
 heT
 aWe
-qYV
+jHW
 pJH
 iZA
 iZA
@@ -79886,7 +79808,7 @@ jHW
 bMZ
 iZA
 iZA
-vpw
+jHW
 jHW
 jHW
 pJH

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -12790,10 +12790,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
-"irF" = (
-/obj/structure/nest/mirelurk,
-/turf/open/water,
-/area/f13/caves)
 "irI" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
@@ -13625,7 +13621,6 @@
 /area/f13/village)
 "iOD" = (
 /obj/structure/chair/stool/retro/tan,
-/mob/living/simple_animal/hostile/raider,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "iOF" = (
@@ -14149,11 +14144,6 @@
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/brotherhood)
-"jeV" = (
-/obj/structure/barricade/sandbags,
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "jeX" = (
 /obj/structure/chair/office,
 /turf/open/floor/f13/wood,
@@ -25840,11 +25830,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/building)
-"qOp" = (
-/mob/living/simple_animal/hostile/mirelurk/baby,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
 "qOA" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -26533,14 +26518,6 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
-"rlX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/raider/ranged,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/f13/caves)
 "rnc" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed"
@@ -56141,7 +56118,7 @@ ssm
 fyf
 pcG
 hDQ
-hDQ
+uRJ
 uRJ
 uRJ
 uRJ
@@ -68134,7 +68111,7 @@ fyf
 fyf
 gcK
 oFp
-rlX
+qik
 vnj
 xgZ
 gpC
@@ -85397,7 +85374,7 @@ mTd
 iEp
 icW
 icW
-qOp
+icW
 icW
 iEp
 mTd
@@ -85912,7 +85889,7 @@ mTd
 vfU
 icW
 icW
-qOp
+icW
 iOM
 ggK
 gcK
@@ -86693,7 +86670,7 @@ ggK
 ggK
 mTd
 iOM
-jci
+ggK
 gcK
 gcK
 gcK
@@ -86913,7 +86890,7 @@ gcK
 gcK
 ktB
 gcK
-aeg
+ggK
 asI
 ggK
 asI
@@ -86944,7 +86921,7 @@ gcK
 gcK
 gcK
 mTd
-jci
+ggK
 ggK
 ggK
 ggK
@@ -88992,10 +88969,10 @@ csk
 csk
 fwu
 csk
-qyJ
 csk
 csk
-irF
+csk
+csk
 fwu
 hBr
 gcK
@@ -89238,7 +89215,7 @@ qyJ
 csk
 fzl
 ggK
-aeg
+ggK
 dfR
 irI
 irI
@@ -92497,7 +92474,7 @@ ees
 fsm
 ubd
 fyf
-jeV
+jxH
 jxH
 fyf
 fyf
@@ -93998,7 +93975,7 @@ fyf
 fyf
 fyf
 fyf
-nPu
+fyf
 fyf
 fyf
 fyf

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -6730,6 +6730,12 @@
 /obj/item/clothing/head/helmet/roman/fake,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gNX" = (
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/clinic)
 "gNZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -7615,6 +7621,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"hJR" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "hJV" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18195,7 +18205,6 @@
 /area/f13/tunnel)
 "sIN" = (
 /obj/effect/decal/cleanable/cobweb,
-/mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sJm" = (
@@ -20442,7 +20451,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vCk" = (
-/mob/living/simple_animal/hostile/deathclaw,
+/mob/living/simple_animal/hostile/deathclaw/mother,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vCF" = (
@@ -21508,7 +21517,6 @@
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibtorso"
 	},
-/mob/living/simple_animal/hostile/deathclaw,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xhd" = (
@@ -26662,7 +26670,7 @@ dJw
 nsw
 dOx
 xIF
-xVW
+xIF
 wvi
 xIF
 oEC
@@ -26921,7 +26929,7 @@ rMk
 xIF
 xIF
 rKy
-nsw
+xIF
 okO
 dZF
 eLE
@@ -28718,7 +28726,7 @@ ise
 iSA
 mxI
 ise
-hOT
+bcN
 lVt
 lVt
 bcN
@@ -28729,17 +28737,17 @@ hOT
 eUk
 bcN
 tRS
-hOT
+bcN
 eUk
 bcN
 tRS
 hOT
 oOE
 bcN
-hOT
 bcN
 bcN
-hOT
+bcN
+bcN
 siF
 bcN
 eUk
@@ -28994,7 +29002,7 @@ bcN
 bcN
 bcN
 bcN
-bcN
+gNX
 bcN
 bcN
 bcN
@@ -31842,7 +31850,7 @@ lnr
 lnr
 bAD
 lnr
-voG
+lnr
 lnr
 voG
 uoO
@@ -32349,7 +32357,7 @@ uoO
 uoO
 voG
 lnr
-voG
+lnr
 lnr
 lnr
 lnr
@@ -34651,7 +34659,7 @@ uoO
 uoO
 uoO
 iRU
-xMx
+rjz
 rjz
 ybf
 uoO
@@ -35409,7 +35417,7 @@ jfU
 jfU
 wtp
 jfU
-kNK
+jfU
 jfU
 jfU
 jfU
@@ -37460,7 +37468,7 @@ uoO
 uoO
 jfU
 jfU
-kNK
+jfU
 jfU
 jfU
 jfU
@@ -49810,7 +49818,7 @@ hkn
 hkn
 gzK
 gyl
-vCk
+hkn
 xCd
 mDq
 eLE
@@ -50067,7 +50075,7 @@ rkH
 mDq
 mDq
 xop
-hkn
+vCk
 oHE
 mDq
 eLE
@@ -58610,9 +58618,9 @@ nBk
 nBk
 nBk
 nBk
+hJR
 nBk
 nBk
-mSD
 nBk
 nBk
 nBk
@@ -58871,7 +58879,7 @@ nBk
 nBk
 nBk
 nBk
-nBk
+hJR
 nBk
 nBk
 nBk
@@ -59922,7 +59930,7 @@ nBk
 nBk
 nBk
 nBk
-mSD
+nBk
 tur
 tur
 tur
@@ -60586,7 +60594,7 @@ tur
 uoO
 uoO
 icd
-iOr
+lnr
 lnr
 qTb
 lnr
@@ -61882,7 +61890,7 @@ tur
 tur
 tur
 dxj
-yfe
+dxj
 dxj
 cxb
 dxj
@@ -62251,7 +62259,7 @@ aBb
 aBb
 kBo
 lnr
-pXa
+lnr
 aBb
 aBb
 aBb
@@ -63291,7 +63299,7 @@ aBb
 aBb
 lnr
 lnr
-pXa
+lnr
 aBb
 aBb
 aBb
@@ -64309,7 +64317,7 @@ aBb
 aBb
 aBb
 lnr
-pXa
+lnr
 lnr
 aBb
 lnr
@@ -64326,7 +64334,7 @@ aBb
 aBb
 lnr
 aBb
-pXa
+lnr
 lnr
 vCe
 lnr
@@ -65861,7 +65869,7 @@ lnr
 aBb
 uHU
 lnr
-pXa
+lnr
 aBb
 aBb
 aBb
@@ -66364,7 +66372,7 @@ aBb
 lnr
 aBb
 aBb
-pXa
+lnr
 lnr
 lnr
 ofm
@@ -67152,7 +67160,7 @@ aBb
 pXa
 lnr
 lnr
-pXa
+lnr
 aBb
 aBb
 uoO
@@ -67895,7 +67903,7 @@ uoO
 tur
 mRT
 nBk
-mSD
+nBk
 miI
 tur
 uoO
@@ -72767,7 +72775,7 @@ kFo
 wrJ
 cIi
 tnp
-tjI
+cvb
 cvb
 mFJ
 cvb
@@ -73536,7 +73544,7 @@ djc
 iwu
 wrJ
 iIu
-ubN
+wrJ
 tnp
 cvb
 cvb
@@ -74060,7 +74068,7 @@ coX
 wrJ
 kkq
 cAf
-ubN
+wrJ
 wrJ
 bjp
 tnp

--- a/_maps/map_files/templates/dungeons/north_bunker_1.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_1.dmm
@@ -66,7 +66,6 @@
 	dir = 8;
 	light_color = "#d8b1b1"
 	},
-/mob/living/simple_animal/hostile/handy,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -141,12 +140,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
-"eN" = (
-/mob/living/simple_animal/hostile/centaur,
-/turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg2"
 	},
 /area/f13/bunker)
 "fe" = (
@@ -539,8 +532,8 @@
 	},
 /area/f13/bunker)
 "qA" = (
-/obj/structure/chair,
 /obj/effect/decal/remains/human,
+/obj/structure/chair/office/light,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -598,12 +591,6 @@
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
-	},
-/area/f13/bunker)
-"tJ" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg3"
 	},
 /area/f13/bunker)
 "tM" = (
@@ -734,7 +721,7 @@
 	},
 /area/f13/bunker)
 "wU" = (
-/obj/structure/chair{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/barber{
@@ -811,10 +798,6 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
 	},
-/area/f13/bunker)
-"zw" = (
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/plating,
 /area/f13/bunker)
 "zJ" = (
 /obj/structure/closet,
@@ -1125,7 +1108,6 @@
 "IT" = (
 /obj/effect/decal/remains/human,
 /obj/item/flashlight/flare/torch,
-/mob/living/simple_animal/hostile/radscorpion,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg2"
 	},
@@ -1160,12 +1142,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
-"JF" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
 	},
 /area/f13/bunker)
 "Kk" = (
@@ -2068,7 +2044,7 @@ Rl
 xG
 En
 vO
-zw
+vO
 Kk
 xG
 Rl
@@ -2083,7 +2059,7 @@ Rl
 Rl
 Rl
 Eg
-nW
+tQ
 tQ
 tQ
 wD
@@ -2127,7 +2103,7 @@ tQ
 mb
 tQ
 tQ
-nW
+tQ
 tQ
 tQ
 tQ
@@ -2332,7 +2308,7 @@ nV
 RD
 xG
 fe
-QJ
+XM
 xG
 gv
 lS
@@ -2393,7 +2369,7 @@ Rl
 Rl
 Eg
 PH
-PH
+XM
 Eg
 xG
 xG
@@ -2658,7 +2634,7 @@ Rl
 xG
 Zg
 DZ
-QJ
+XM
 XM
 Jv
 xG
@@ -2702,10 +2678,10 @@ wU
 xG
 op
 lS
-pz
+XM
 xG
 FR
-XM
+QJ
 dE
 xG
 Rl
@@ -2738,12 +2714,12 @@ XM
 Bw
 XM
 qJ
-pz
+XM
 XM
 Bw
 qJ
 XM
-pz
+XM
 XM
 xG
 Rl
@@ -2847,7 +2823,7 @@ rr
 XM
 xG
 gv
-QJ
+XM
 sy
 Wj
 qN
@@ -2855,7 +2831,7 @@ Zp
 op
 XM
 pq
-XM
+QJ
 XM
 fH
 Bw
@@ -2885,14 +2861,14 @@ oP
 XM
 qJ
 XM
-QJ
 XM
+TZ
 XM
 DA
 uu
 sy
 Bw
-pz
+XM
 XM
 XM
 XM
@@ -3162,7 +3138,7 @@ pQ
 xG
 XM
 XM
-pz
+XM
 Od
 PW
 PW
@@ -3269,7 +3245,7 @@ lH
 lU
 By
 oh
-oh
+Bo
 gA
 EG
 oh
@@ -3303,7 +3279,7 @@ Rl
 Xc
 xG
 gA
-eN
+dV
 oh
 Pw
 rG
@@ -3385,7 +3361,7 @@ lU
 oh
 tM
 gA
-JF
+oh
 ud
 jf
 qu
@@ -3504,7 +3480,7 @@ ti
 xG
 ZV
 gA
-tJ
+lU
 xG
 xG
 xG
@@ -3779,9 +3755,9 @@ oh
 gA
 xG
 pS
-Bo
 oh
-Bo
+oh
+oh
 vt
 xG
 Rl
@@ -3852,7 +3828,7 @@ Rl
 xG
 pP
 oh
-oh
+tx
 xG
 dj
 tx
@@ -3930,9 +3906,9 @@ HB
 wh
 lU
 xG
-gl
-dV
 oh
+dV
+tx
 Rl
 Rl
 xG

--- a/_maps/map_files/templates/dungeons/north_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_2.dmm
@@ -259,7 +259,8 @@
 	},
 /area/f13/bunker)
 "fy" = (
-/mob/living/simple_animal/hostile/cazador/young,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/fireant,
 /turf/open/floor/grass,
 /area/f13/bunker)
 "fB" = (
@@ -336,8 +337,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "gA" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/mob/living/simple_animal/hostile/cazador/young,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/giantant,
 /turf/open/floor/grass,
 /area/f13/bunker)
 "gB" = (
@@ -567,7 +568,6 @@
 	},
 /area/f13/bunker)
 "mc" = (
-/mob/living/simple_animal/hostile/poison/giant_spider,
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
@@ -628,16 +628,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/grass,
-/area/f13/bunker)
-"nm" = (
-/mob/living/simple_animal/hostile/handy{
-	faction = list("hostile","goodboy")
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
 /area/f13/bunker)
 "nr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -1007,11 +997,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"wb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/fireant,
-/turf/open/floor/grass,
-/area/f13/bunker)
 "we" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/barber{
@@ -1219,14 +1204,6 @@
 /area/f13/bunker)
 "AE" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
-"AF" = (
-/mob/living/simple_animal/hostile/poison/giant_spider,
-/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -1716,21 +1693,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"KK" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
 "KN" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/grass,
 /area/f13/bunker)
 "KO" = (
-/mob/living/simple_animal/hostile/alien,
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
@@ -2016,15 +1983,6 @@
 /obj/item/surgical_drapes,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker)
-"PH" = (
-/mob/living/simple_animal/hostile/handy/gutsy{
-	faction = list("hostile","goodboy")
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
 /area/f13/bunker)
 "PO" = (
 /obj/item/storage/trash_stack,
@@ -2476,7 +2434,6 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "Zg" = (
-/mob/living/simple_animal/hostile/radscorpion/black,
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -3503,7 +3460,7 @@ ns
 XM
 XM
 XM
-PH
+XM
 yr
 kj
 BR
@@ -3539,7 +3496,7 @@ SP
 TU
 XM
 XM
-nm
+Bw
 XM
 XM
 XM
@@ -3566,7 +3523,7 @@ xG
 Zg
 xJ
 XN
-dD
+kj
 Ra
 kj
 XM
@@ -3638,9 +3595,9 @@ Rl
 Rl
 xG
 HC
-RB
 oj
-RB
+oj
+oj
 xG
 XM
 Bw
@@ -3792,7 +3749,7 @@ xG
 KO
 go
 go
-DM
+go
 xG
 OR
 cQ
@@ -3902,19 +3859,19 @@ Rl
 xG
 XM
 vH
-dD
+kj
 bB
 XM
 Sa
 XM
 fW
-fj
+XM
 XM
 XN
 pI
 XM
 xf
-KK
+XN
 yr
 Vf
 fj
@@ -4063,7 +4020,7 @@ xG
 nU
 Pp
 XM
-jX
+XM
 JN
 Fp
 xG
@@ -4339,7 +4296,7 @@ QE
 kj
 yS
 Bw
-AF
+Bw
 XM
 Ra
 LG
@@ -4408,7 +4365,7 @@ XM
 MJ
 kj
 ti
-fy
+nu
 nu
 nu
 nu
@@ -4510,7 +4467,7 @@ Rl
 Rl
 Rl
 xG
-ZP
+fy
 ey
 ZP
 FK
@@ -4587,8 +4544,8 @@ Rl
 Rl
 xG
 ZP
-wb
 ZP
+gA
 pR
 ZP
 fC
@@ -4599,7 +4556,7 @@ Ra
 Ra
 ti
 nu
-fy
+nu
 QJ
 Ed
 nu
@@ -4683,7 +4640,7 @@ nu
 nu
 Om
 ny
-gA
+Vx
 nu
 xG
 Rl
@@ -4950,7 +4907,7 @@ mC
 Px
 go
 go
-TH
+oj
 oj
 xG
 Rl
@@ -5043,7 +5000,7 @@ Rl
 Rl
 xG
 oj
-RB
+oj
 bP
 go
 iJ
@@ -5164,7 +5121,7 @@ XO
 RB
 oh
 oh
-RB
+oj
 oh
 XO
 Rl

--- a/_maps/map_files/templates/dungeons/north_sewer_1.dmm
+++ b/_maps/map_files/templates/dungeons/north_sewer_1.dmm
@@ -54,10 +54,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw,
-/turf/open/floor/plating/tunnel,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
 /area/f13/tunnel)
 "dY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -128,12 +128,11 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
 	},
-/mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "gM" = (
-/mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/neutral,
 /area/f13/tunnel)
 "hx" = (
@@ -349,7 +348,6 @@
 	brightness = 3;
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/f13/tunnel)
@@ -378,8 +376,8 @@
 	},
 /area/f13/tunnel)
 "pS" = (
-/mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8
 	},
@@ -556,21 +554,22 @@
 	},
 /area/f13/tunnel)
 "zs" = (
-/mob/living/simple_animal/hostile/deathclaw,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw/legendary{
+	bare_wound_bonus = 10;
+	health = 1250;
+	melee_damage_lower = 85;
+	melee_damage_upper = 90;
+	name = "Alpha Deathclaw";
+	speed = -1.25;
+	wound_bonus = 10
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "zE" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/grimy,
-/area/f13/tunnel)
-"zV" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/mob/living/simple_animal/hostile/centaur,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "Aw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1251,7 +1250,7 @@ Rj
 EK
 Qs
 LK
-zV
+nz
 Vv
 Zk
 iY
@@ -1741,7 +1740,7 @@ Rj
 SK
 Rj
 CJ
-EK
+Be
 Cf
 kz
 iY
@@ -1774,7 +1773,7 @@ AS
 Kr
 iY
 Rj
-Jh
+Rj
 Rj
 iY
 Qs
@@ -2077,7 +2076,7 @@ iY
 pi
 sw
 sw
-gM
+sw
 Or
 sw
 sw
@@ -2113,9 +2112,9 @@ kE
 QU
 iY
 pJ
-lm
-TD
 pS
+TD
+lm
 lm
 lm
 QF
@@ -2234,7 +2233,7 @@ IZ
 bS
 iY
 Qs
-Be
+Rj
 Qs
 Rj
 Rj
@@ -2302,7 +2301,7 @@ BH
 (32,1,1) = {"
 QU
 iY
-Fx
+dP
 Kr
 iY
 iY
@@ -2557,7 +2556,7 @@ Ev
 ZL
 Rj
 Rj
-dP
+Aw
 tO
 iY
 BH
@@ -2596,7 +2595,7 @@ ZL
 Rj
 lM
 Rj
-Rj
+zs
 BQ
 ZL
 BH
@@ -2852,7 +2851,7 @@ LU
 BH
 BH
 LU
-HI
+LU
 LU
 BH
 QU
@@ -2977,7 +2976,7 @@ qz
 LU
 LU
 qz
-zs
+qz
 BH
 BH
 QU

--- a/_maps/map_files/templates/dungeons/north_sewer_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_sewer_2.dmm
@@ -106,6 +106,7 @@
 "cb" = (
 /obj/effect/decal/fakelattice,
 /obj/item/ammo_casing/shotgun/improvised,
+/mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -213,10 +214,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/radiation)
-"dx" = (
-/mob/living/simple_animal/hostile/handy/protectron/nsb,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
 "dL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_master/advanced,
@@ -710,7 +707,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/generic,
-/mob/living/simple_animal/hostile/handy/gutsy/nsb,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "nC" = (
@@ -928,11 +924,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/radiation)
-"rE" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "rM" = (
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -1046,14 +1037,6 @@
 	icon_state = "floor7-old"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
-"uw" = (
-/obj/effect/decal/fakelattice,
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/raider/tribal,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
 /area/f13/bunker)
 "uz" = (
 /obj/machinery/door/airlock/grunge,
@@ -1352,7 +1335,6 @@
 	},
 /area/f13/bunker)
 "yP" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
 	},
@@ -1785,11 +1767,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"Hz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/raider/baseball,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
 "HE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -2054,13 +2031,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"LR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/raider/tribal,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker)
 "LZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -2193,11 +2163,6 @@
 "PI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"Qd" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/deathclaw,
-/turf/open/water,
-/area/f13/caves)
 "Qh" = (
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/inside/subway,
@@ -2478,7 +2443,6 @@
 /area/f13/tunnel)
 "Vd" = (
 /obj/item/fishingrod,
-/mob/living/simple_animal/hostile/raider/thief,
 /turf/open/water,
 /area/f13/tunnel)
 "Vp" = (
@@ -2539,10 +2503,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"Wj" = (
-/mob/living/simple_animal/hostile/deathclaw,
-/turf/open/water,
-/area/f13/caves)
 "WG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2568,10 +2528,6 @@
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/water,
-/area/f13/tunnel)
-"Xi" = (
-/mob/living/simple_animal/hostile/raider/biker,
-/turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "Xn" = (
 /obj/structure/decoration/rag{
@@ -2749,8 +2705,6 @@
 /area/f13/radiation)
 "ZZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 
@@ -3024,7 +2978,7 @@ qz
 QU
 mn
 QG
-wv
+ZN
 oq
 mn
 mn
@@ -3680,7 +3634,7 @@ Sx
 yP
 Tq
 Tq
-Xi
+kE
 kE
 wI
 wI
@@ -3867,7 +3821,7 @@ kI
 hc
 XE
 vS
-xJ
+PI
 sT
 Yn
 Yn
@@ -3902,7 +3856,7 @@ Tq
 If
 RZ
 Yn
-ee
+pC
 pC
 CN
 aK
@@ -3948,7 +3902,7 @@ PI
 Yn
 po
 WO
-LR
+vf
 mn
 QU
 BH
@@ -4064,7 +4018,7 @@ XJ
 ts
 kO
 bl
-uw
+vB
 Wi
 vc
 ki
@@ -4138,7 +4092,7 @@ DI
 PI
 Yn
 zz
-ee
+pC
 Et
 gM
 Yn
@@ -4204,7 +4158,7 @@ QU
 Xo
 QO
 he
-Ko
+Tq
 fV
 PI
 pC
@@ -4228,7 +4182,7 @@ Yn
 yI
 wx
 tG
-rE
+pC
 RU
 Ni
 Yn
@@ -4327,7 +4281,7 @@ PI
 pC
 dp
 vB
-Hz
+ZZ
 zo
 jr
 RK
@@ -4409,7 +4363,7 @@ dc
 YP
 Pr
 PI
-He
+PI
 sF
 LZ
 uO
@@ -4447,7 +4401,7 @@ ZB
 pC
 ck
 dc
-Pr
+PI
 PI
 RF
 PI
@@ -4473,10 +4427,10 @@ yk
 fG
 ld
 Sx
-QN
+Tq
 Sx
 Tq
-If
+Sx
 ik
 YP
 LG
@@ -4584,7 +4538,7 @@ BH
 Vw
 Jf
 vw
-dx
+SD
 gI
 vw
 vw
@@ -4823,7 +4777,7 @@ sR
 sR
 lP
 DD
-Wj
+DD
 DD
 DD
 DD
@@ -4869,7 +4823,7 @@ DD
 DD
 cA
 sR
-Qd
+lP
 DD
 sR
 sR

--- a/_maps/map_files/templates/dungeons/oasis_bunker_1.dmm
+++ b/_maps/map_files/templates/dungeons/oasis_bunker_1.dmm
@@ -598,7 +598,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "sz" = (
-/obj/structure/nest/ghoul,
+/mob/living/simple_animal/hostile/ghoul/glowing{
+	faction = list("hostile")
+	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "sI" = (
@@ -862,9 +864,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "AK" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/radscorpion,
-/turf/open/indestructible/ground/inside/mountain,
+/mob/living/simple_animal/hostile/radscorpion/black,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/bunker)
 "BS" = (
 /obj/structure/barricade/wooden,
@@ -892,7 +896,6 @@
 /obj/structure/sign/warning/radiation{
 	pixel_y = -30
 	},
-/mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -1013,9 +1016,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
 "HI" = (
-/obj/effect/spawner/lootdrop/trash,
-/mob/living/simple_animal/hostile/radscorpion,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/bunker)
 "HJ" = (
 /obj/machinery/autolathe,
@@ -1447,12 +1455,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "UM" = (
-/obj/effect/decal/remains/human,
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "UW" = (
 /obj/machinery/light/small,
@@ -1511,14 +1515,6 @@
 "Yu" = (
 /obj/structure/rack,
 /obj/item/tank/internals/anesthetic,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
-"YN" = (
-/obj/machinery/light/small,
-/mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -1768,7 +1764,7 @@ pW
 pW
 NJ
 NJ
-Uq
+UM
 Qi
 Oh
 pf
@@ -1945,7 +1941,7 @@ Kz
 wR
 Xj
 Gw
-jc
+OZ
 Hu
 yC
 VE
@@ -2187,8 +2183,8 @@ pW
 pf
 pf
 pf
-au
-YN
+HI
+HQ
 pf
 Kz
 Kz
@@ -2248,7 +2244,7 @@ Kz
 Kz
 pf
 KA
-AK
+yQ
 pj
 pf
 Kz
@@ -2291,7 +2287,7 @@ Kz
 pW
 pT
 NJ
-HI
+KA
 pW
 Kz
 Kz
@@ -2692,7 +2688,7 @@ Kz
 Kz
 pf
 bp
-FQ
+bp
 pf
 Kz
 Kz
@@ -2710,13 +2706,13 @@ xN
 Ec
 wR
 jh
-UM
+bp
 NX
 mm
 xw
 hD
 bp
-gJ
+bp
 bp
 th
 oN
@@ -2934,17 +2930,17 @@ au
 fm
 bp
 bp
-gZ
+bp
 bp
 BX
 bp
 bp
 Uq
-FQ
+bp
 pW
 pW
 bp
-FQ
+bp
 pf
 Kz
 Kz
@@ -3015,8 +3011,8 @@ gJ
 bp
 BX
 bp
+AK
 bp
-gZ
 xv
 NX
 cW
@@ -3042,7 +3038,7 @@ Kz
 Kz
 bp
 gZ
-gZ
+bp
 bp
 BX
 bp

--- a/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
@@ -1249,10 +1249,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"xs" = (
-/mob/living/simple_animal/hostile/handy/assaultron,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/bunker)
 "xu" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/barber{
@@ -1626,11 +1622,6 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker)
-"Dc" = (
-/mob/living/simple_animal/hostile/handy/assaultron,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "De" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -3095,7 +3086,7 @@ Zs
 rW
 fg
 fg
-Dc
+fg
 rW
 lN
 oF
@@ -3139,7 +3130,7 @@ WI
 fg
 PN
 rW
-xs
+oF
 fg
 rJ
 rW


### PR DESCRIPTION
## About The Pull Request

At the request of sir corbo I have thanos snapped the mobs in every location but focused on the crowded raider areas and anywhere there is infighting. 
Some adjustments have been made so two smaller mobs would be replaced with one bigger one and the sorts - though a lot were also just removed. 

## Why It's Good For The Game

This is a mappers attempt to improve on the lag caused by npcs, this change is fully fixable if we find it unbalances things too much but I think it will just make it more fun. 

## Changelog
:cl:
add: A few stronger mobs in bunkers 
del: A lot of weaker mobs
del: Quite a few nests 
/:cl:

