### PR TITLE
Modkits for Talon and Marked Patrol and two more loadouts

### DIFF
--- a/code/game/objects/items/modkit.dm
+++ b/code/game/objects/items/modkit.dm
@@ -177,6 +177,16 @@
 	name = "P08 luger modkit"
 	target_items = list(/obj/item/gun/ballistic/automatic/pistol/ninemil)
 	result_item = /obj/item/gun/ballistic/automatic/pistol/ninemil/luger
+	
+/obj/item/modkit/talon
+	name = "Talon armor modkit"
+	target_items = list(/obj/item/clothing/suit/armor/f13/raider)
+	result_item = /obj/item/clothing/suit/armor/f13/talon
+
+/obj/item/modkit/markedmen
+	name = "Marked patrol modkit"
+	target_items = list(/obj/item/clothing/suit/armor/f13/raider)
+	result_item = /obj/item/clothing/suit/armor/f13/marked_patrol
 
 //Crusader Pistol Modkits
 /obj/item/modkit/crusader_10mm

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -245,6 +245,16 @@
 	name = "Aaron Cooper's belongings"
 	path = /obj/item/storage/box/large/custom_kit/aaroncooper
 	ckeywhitelist = list("wilsonmann55")
+	
+/datum/gear/donator/kits/traniooccisorluti
+	name = "Tranio Occisor Luti's belongings"
+	path = /obj/item/storage/box/large/custom_kit/traniooccisorluti
+	ckeywhitelist = list("spaceanglo")
+	
+/datum/gear/donator/kits/gravestalon
+	name = "Grave's belongings"
+	path = /obj/item/storage/box/large/custom_kit/gravestalon
+	ckeywhitelist = list("pisshole")
 
 //////////////////////////////
 ///Ranger items start here.///

--- a/modular_citadel/code/modules/client/loadout/kits.dm
+++ b/modular_citadel/code/modules/client/loadout/kits.dm
@@ -224,24 +224,24 @@
 
 //KC - croike
 /obj/item/storage/box/large/custom_kit/kc/PopulateContents()
-	new /obj/item/clothing/suit/armor/f13/talon(src)
+	new /obj/item/modkit/talon(src)
 	
 //Tech - grongo
 /obj/item/storage/box/large/custom_kit/tech/PopulateContents()
-	new /obj/item/clothing/suit/armor/f13/talon(src)
+	new /obj/item/modkit/talon(src)
 	
 //Nova - novaskelly
 /obj/item/storage/box/large/custom_kit/nova/PopulateContents()
-	new /obj/item/clothing/suit/armor/f13/talon(src)
+	new /obj/item/modkit/talon(src)
 	new /obj/item/clothing/accessory/armband/med(src)
 
 //Smokes - lordyanex
 /obj/item/storage/box/large/custom_kit/smokes/PopulateContents()
-	new /obj/item/clothing/suit/armor/f13/talon(src)
+	new /obj/item/modkit/talon(src)
 	
 //Marcy - landoorando
 /obj/item/storage/box/large/custom_kit/marcy/PopulateContents()
-	new /obj/item/clothing/suit/armor/f13/marked_patrol(src)
+	new /obj/item/modkit/markedmen(src)
 	
 //Jack Torres - karlov
 /obj/item/storage/box/large/custom_kit/jacktorres/PopulateContents()
@@ -259,4 +259,11 @@
 /obj/item/storage/box/large/custom_kit/aaroncooper/PopulateContents()
 	new /obj/item/clothing/suit/toggle/labcoat/f13/wanderer/drive(src)
 	
+//Tranio Occisor Luti - spaceanglo	
+/obj/item/storage/box/large/custom_kit/traniooccisorluti/PopulateContents()
+	new /obj/item/clothing/gloves/f13/blacksmith
+	new /obj/item/clothing/mask/bandana/skull
 	
+//Graves - pisshole
+/obj/item/storage/box/large/custom_kit/gravestalon/PopulateContents()
+	new /obj/item/modkit/talon(src)


### PR DESCRIPTION
## About The Pull Request
Modkits are apart of the custom loadout process and needed to be apart of loadouts which is the process of the loadouts before hand having the responsibility of it making sure it stays the same again.


## Why It's Good For The Game

Modkits are good and these are sadly the ones that I should of done before hand and instead of giving them the armor on the start, you can apply these on the raider armors to make them as your special armor.

## Changelog
:cl:
add: two more loadouts, which include Tranio Occisor Luti and Graves belongs and adds two new modkits which talon and marked patrol.
/:cl:

