### PR TITLE
Deathclaw Cloak, Warmace and Tribal Anvil Balance

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -22,16 +22,6 @@
 				/obj/item/stack/sheet/sinew = 1)
 	category = CAT_PRIMAL
 
-/datum/crafting_recipe/goliathcloak
-	name = "Goliath Cloak"
-	result = /obj/item/clothing/suit/hooded/cloak/goliath
-	time = 50
-	reqs = list(/obj/item/stack/sheet/leather = 2,
-				/obj/item/stack/sheet/sinew = 2,
-				/obj/item/stack/sheet/animalhide/goliath_hide = 2) //it takes 4 goliaths to make 1 cloak if the plates are skinned
-	category = CAT_PRIMAL
-	always_availible = FALSE
-
 /datum/crafting_recipe/drakecloak
 	name = "Ash Drake Armour"
 	result = /obj/item/clothing/suit/hooded/cloak/drake

--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -273,17 +273,14 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_WASTELAND
 
-/*
 /datum/crafting_recipe/warmace
 	name = "Carve Wooden Warmace"
 	result = /obj/item/twohanded/sledgehammer/warmace
 	time = 100
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 10,
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 20,
 				/obj/item/stack/sheet/cloth = 3)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_PRIMAL
-	subcategory = CAT_TRIBAL_WEAPONS
-*/
 
 /datum/crafting_recipe/training_machete
 	name = "training machete"

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -324,7 +324,7 @@
 	name = "deathclaw cloak"
 	icon_state = "clawsuitcloak"
 	desc = "(V) A staunch, practical cloak made out of sinew and skin from the fearsome deathclaw."
-	armor = list("tier" = 5, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
+	armor = list("tier" = 5, "energy" = 20, "bomb" = 40, "bio" = 30, "rad" = 10, "fire" = 60, "acid" = 20)
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/goliath
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 
@@ -332,7 +332,7 @@
 	name = "deathclaw cloak hood"
 	icon_state = "clawheadcloak"
 	desc = "(V) A protective & concealing hood."
-	armor = list("tier" = 5, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
+	armor = list("tier" = 5, "energy" = 15, "bomb" = 25, "bio" = 0, "rad" = 10, "fire" = 60, "acid" = 20)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
 
 /obj/item/clothing/suit/hooded/parka/medical

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -291,8 +291,8 @@
 /obj/structure/anvil/obtainable/basic
 	name = "anvil"
 	desc = "An anvil. It's got wheels bolted to the bottom."
-	anvilquality = 0
-	itemqualitymax = 6
+	anvilquality = 1
+	itemqualitymax = 8
 
 /obj/structure/anvil/obtainable/ratvar
 	name = "brass anvil"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR actually balances the Deathclaw Cloak, Warmace and Tribal Anvil. This was a big balance change that people wanted to change the Deathclaw cloak balance and this PR does it and makes the thing craftable again and same goes with the warmace. Warmace is up to 20 and 3 cloth due to balancing but it will be fine. Removed old recipe for goliath cloak which is not needed anymore gone.

## Why It's Good For The Game

Deathclaw cloak readded and was requested by the community a few times to add it back and balance it for everyone to craft and now it will be. Tribal Anvil was messed up and was doing weaker compared to sandstone anvil and now it will be buffed a bit to caught up to it. Warmace is readded because it is another tribal weapon that should of been readded and now it will be.

## Changelog
:cl:
tweak: Balances Deathclaw cloak, anvil and warmace. 
/:cl:

