### PR TITLE
One last Ranger Pins and Pistols

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -364,7 +364,8 @@
 						"asterixcodix",
 						"panzer1944",
 						"purplepineapple",
-						"edisnij")
+						"edisnij",
+						"pisshole")
 	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
 
 /datum/gear/donator/ranger357
@@ -461,7 +462,8 @@
 						"akforeplay",
 						"rangerbust",
 						"kirshbia",
-						"arkadec")
+						"arkadec",
+						"pisshole")
 	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
 
 /datum/gear/donator/zirilliuniform


### PR DESCRIPTION
## About The Pull Request

This PR adds the last rangers pins and pistols. This was the final whitelist approved from the forums.

## Why It's Good For The Game

This adds the last ranger that was approved on the forums so now they dont have to ahelp for there pistol and pins.

## Changelog
:cl:
add: simply adds another ckey to the list of ranger pins and pistols.
/:cl:

