### PR TITLE
MKUltra only by Admin, PPSH/UZI scope removal, Custom loadout

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -554,7 +554,7 @@
 	can_suppress = FALSE
 	can_attachments = TRUE
 	extra_damage = -4
-	can_scope = TRUE
+	can_scope = FALSE
 	scope_state = "AEP7_scope"
 	scope_x_offset = 9
 	scope_y_offset = 21
@@ -573,7 +573,7 @@
 	burst_shot_delay = 2
 	can_suppress = TRUE
 	can_attachments = TRUE
-	can_scope = TRUE
+	can_scope = FALSE
 	scope_state = "AEP7_scope"
 	scope_x_offset = 9
 	scope_y_offset = 21

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -300,6 +300,11 @@
 	name = "Marine's belongings"
 	path = /obj/item/storage/box/large/custom_kit/marinetalon
 	ckeywhitelist = list("saintsfan3324")
+	
+/datum/gear/donator/kits/flagstaff
+	name = "Flagstaff's belongings"
+	path = /obj/item/storage/box/large/custom_kit/flagstaff
+	ckeywhitelist = list"("landoorando")
 
 //////////////////////////////
 ///Ranger items start here.///

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -304,7 +304,7 @@
 /datum/gear/donator/kits/flagstaff
 	name = "Flagstaff's belongings"
 	path = /obj/item/storage/box/large/custom_kit/flagstaff
-	ckeywhitelist = list"("landoorando")
+	ckeywhitelist = list("landoorando")
 
 //////////////////////////////
 ///Ranger items start here.///

--- a/modular_citadel/code/modules/client/loadout/kits.dm
+++ b/modular_citadel/code/modules/client/loadout/kits.dm
@@ -310,4 +310,6 @@
 /obj/item/storage/box/large/custom_kit/marinetalon/PopulateContents()
 	new /obj/item/modkit/talon(src)
 
-	
+//Flagstaff - landoorando
+/obj/item/storage/box/large/custom_kit/flagstaff/PopulateContents()
+	new /obj/item/clothing/mask/rat/flagstaff()

--- a/modular_citadel/code/modules/client/loadout/kits.dm
+++ b/modular_citadel/code/modules/client/loadout/kits.dm
@@ -312,4 +312,4 @@
 
 //Flagstaff - landoorando
 /obj/item/storage/box/large/custom_kit/flagstaff/PopulateContents()
-	new /obj/item/clothing/mask/rat/flagstaff()
+	new /obj/item/clothing/mask/rat/flagstaff(src)

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -280,8 +280,8 @@
 	name = "MKUltra"
 	id = /datum/reagent/fermi/enthrall
 	results = list(/datum/reagent/fermi/enthrall = 5)
-	required_reagents = list(/datum/reagent/consumable/coco = 1, /datum/reagent/bluespace = 1, /datum/reagent/toxin/mindbreaker = 1, /datum/reagent/medicine/psicodine = 1, /datum/reagent/drug/happiness = 1)
-	required_catalysts = list(/datum/reagent/blood = 1)
+	//required_reagents = list(/datum/reagent/consumable/coco = 1, /datum/reagent/bluespace = 1, /datum/reagent/toxin/mindbreaker = 1, /datum/reagent/medicine/psicodine = 1, /datum/reagent/drug/happiness = 1)
+	//required_catalysts = list(/datum/reagent/blood = 1)
 	mix_message = "the reaction gives off a burgundy plume of smoke!"
 	//FermiChem vars:
 	OptimalTempMin 			= 780


### PR DESCRIPTION
## About The Pull Request

This PR removes MKUltra from player making it but keeps MKUltra in the code just the recipe being gone. This was requested by staff. This PR also removes Uzi and PPsh being able to equipped with scopes now, you cannot. Adds Rando o Danos Loadout for there outlaw.

## Why It's Good For The Game

This is good for the game as MKUltra will not be crafted by player means and so you wont get someone trying to gas a full faction with MKUltra. This is also good for the game as it removes uzi and ppsh scopes. Adds flagstaffs belongs.

## Changelog
:cl:
tweak: tweaks code for MKUltra to be only admin spawned only, also tweaks the code for uzi and ppsh to not have scopes anymore.
add: Flagstaffs loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
