### PR TITLE
Fixes Legion Crafting Issue

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -22,8 +22,8 @@
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legioncombathelmet)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legioncombatarmormk2)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legioncombathelmetmk2)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/cateye)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/hydra)
+	/*H.mind.teach_crafting_recipe(/datum/crafting_recipe/cateye)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/hydra)*/
 
 /datum/outfit/job/CaesarsLegion/Legionnaire
 	belt = 			/obj/item/storage/belt/military/assault/legion


### PR DESCRIPTION
## About The Pull Request

Disabled the two lines that caused Legion to be unable to use crafting screen. Attempted to make two chems only craftable by Legion - but apparently the game doesn't like that very much.

## Why It's Good For The Game

Fixes Legion being able to use crafting screen.

## Changelog
:cl:
fixes: Legion crafting menu issue.
/:cl:
