### PR TITLE
Seethe Cope R82 and PA fix PR

### DIFF
--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -7,8 +7,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
 	attack_verb = list("whacked", "fisted", "power-punched")
-	force = 40
-	armour_penetration = 50
+	force = 50
+	armour_penetration = 0.8
 	throwforce = 10
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -1,21 +1,39 @@
 /obj/item/melee/powerfist
-	name = "power-fist"
-	desc = "A metal gauntlet with a piston-powered ram ontop for that extra 'ompfh' in your punch."
+	name = "powerfist"
+	desc = "A metal gauntlet with a piston-powered ram on top for that extra 'oomph' in your punch."
 	icon_state = "powerfist"
 	item_state = "powerfist"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
-	item_flags = NEEDS_PERMIT | NO_COMBAT_MODE_FORCE_MODIFIER //To avoid ambushing and oneshotting healthy crewmembers on force setting 3.
 	attack_verb = list("whacked", "fisted", "power-punched")
-	force = 20
+	force = 40
+	armour_penetration = 50
 	throwforce = 10
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
-	resistance_flags = FIRE_PROOF
-	attack_speed = CLICK_CD_MELEE * 1.5
-	var/fisto_setting = 1
+
+/obj/item/melee/goliath //Workaround to the gas issue with the powerfist. No idea why it works.
+	name = "Goliath"
+	desc = "Armored gauntlet with a piston-powered ram, this one is a experimental one captured and named by the Legion."
+	icon_state = "goliath"
+	item_state = "goliath"
+	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	flags_1 = CONDUCT_1
+	attack_verb = list("whacked", "fisted", "power-punched")
+	force = 40
+	armour_penetration = 0.95
+	throwforce = 20
+	throw_range = 7
+	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
+
+
+/*	var/fisto_setting = 1
 	var/gasperfist = 3
 	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
 
@@ -112,4 +130,4 @@
 	var/weight = getweight(user, STAM_COST_ATTACK_MOB_MULT)
 	if(weight)
 		user.adjustStaminaLossBuffered(weight)
-	return TRUE
+	return TRUE*/

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -15,24 +15,6 @@
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
 
-/obj/item/melee/goliath //Workaround to the gas issue with the powerfist. No idea why it works.
-	name = "Goliath"
-	desc = "Armored gauntlet with a piston-powered ram, this one is a experimental one captured and named by the Legion."
-	icon_state = "goliath"
-	item_state = "goliath"
-	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	flags_1 = CONDUCT_1
-	attack_verb = list("whacked", "fisted", "power-punched")
-	force = 40
-	armour_penetration = 0.95
-	throwforce = 20
-	throw_range = 7
-	w_class = WEIGHT_CLASS_NORMAL
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
-
-
 /*	var/fisto_setting = 1
 	var/gasperfist = 3
 	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -12,6 +12,7 @@
 	throwforce = 10
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
+	resistance_flags = FIRE_PROOF
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
 

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -433,7 +433,7 @@
 	item_state = "r_gear_rig"
 	armor = list("tier" = 5, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 	slowdown = -0.1
-	
+
 /obj/item/clothing/suit/armor/f13/ncr_trenchcloak
 	name = "ranger trenchcloak"
 	desc = "(V) A cloak worn by Rangers of the New California Republic. Often seen on trail rangers or scouts, this cloak provides ample protection from the deserts harsh sunlight during the hours spent in the field and from the elements."
@@ -456,7 +456,7 @@
 	icon_state = "cowboyrang"
 	item_state = "cowboyrang"
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
-	slowdown = -0.14
+	slowdown = -0.20
 
 /obj/item/clothing/suit/armor/f13/modif_r_vest
 	name = "subdued ranger vest"

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -456,7 +456,7 @@
 	icon_state = "cowboyrang"
 	item_state = "cowboyrang"
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
-	slowdown = -0.20
+	slowdown = -0.14
 
 /obj/item/clothing/suit/armor/f13/modif_r_vest
 	name = "subdued ranger vest"

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -1038,6 +1038,9 @@
 	if (istype(W,/obj/item/gun/ballistic/revolver/doublebarrel))
 		to_chat(usr, "You can't improve [W.name]...")
 		return
+	if (istype(W,/obj/item/gun/ballistic/revolver/shotgunrevolver))
+		to_chat(usr, "You can't improve [W.name]...")
+		return
 	var/obj/item/gun/ballistic/B = W
 
 	var/dmgmod = rand(-10,10)

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -1041,6 +1041,9 @@
 	if (istype(W,/obj/item/gun/ballistic/revolver/shotgunrevolver))
 		to_chat(usr, "You can't improve [W.name]...")
 		return
+	if (istype(W,/obj/item/gun/ballistic/revolver/ballisticfist))
+		to_chat(usr, "You can't improve [W.name]...")
+		return
 	var/obj/item/gun/ballistic/B = W
 
 	var/dmgmod = rand(-10,10)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -688,7 +688,7 @@
 	automatic_burst_overlay = TRUE
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	semi_auto = TRUE
-	burst_shot_delay = 2.2 //Was 2 before.
+	burst_shot_delay = 3.0 //Was 2.2 before.
 	can_suppress = TRUE
 	can_automatic = TRUE
 	can_scope = TRUE


### PR DESCRIPTION
## About The Pull Request

i fixed it

## Why It's Good For The Game

**R82** can fire stupidly fast on full-auto as fast as a mini-gun with reduction to fire-delay via tinkering. Needed to have a slower fire rate due to this on bust mode with an autosear. Otherwise it outweighs _any_ gun.

**Powerfist** system was unfair and broken. Went back to legacy powerfist code. Oxygen canisters are near impossible to obtain as a waster if you find a powerfist or make one through inventing. Not to mention if you just set the canister to max output you can one-hit most people in under tier-5 armor into hard crit.

**Revolver Shotgun** could be tinkered and i hate how we have shotguns in the revolver path because that's what causes this - no more 20 damage per projectile from a shotgun thank you please 

## Changelog
:cl:
tweak: R82 fixed cope
tweak: Powerfist revert to legacy for its fix seethe
fix: fuck revolvers, fixed revolver shotgun being tinkerable
/:cl: