### PR TITLE
Fixes bug that prevents PA from getting slowed down by EMPs

### DIFF
--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -263,15 +263,20 @@
 		return
 	if(emped == 0)
 		if(ismob(loc))
+			var/mob/living/L = loc
 			to_chat(loc, "<span class='warning'>Warning: electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
 			slowdown += 30
 			armor = armor.modifyRating(linemelee = -75, linebullet = -75, linelaser = -75)
 			emped = 1
+			if(istype(L))
+				L.update_equipment_speed_mods()
 			spawn(50) //5 seconds of being slow and weak
 				to_chat(loc, "<span class='warning'>Armor power reroute successful. All systems operational.</span>")
 				slowdown -= 30
 				armor = armor.modifyRating(linemelee = 75, linebullet = 75, linelaser = 75)
 				emped = 0
+				if(istype(L))
+					L.update_equipment_speed_mods()
 
 /obj/item/clothing/suit/armor/f13/power_armor/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
 	if(check_armor_penetration(object) <= 0.15 && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))


### PR DESCRIPTION
I'm banned off here and code for somewhere else but we noticed that your PA slowdown from EMPs is broken. This is a port of the fix that's already on there.

Basically, whenever you change slowdown on worn equipment you need to call that proc to update it, or it doesn't work. In testing we noticed that EMPs didnt properly slowdown power armor because it lacked that. All this change does is call the proc to update the slowdown.

this bug has been in your code for over  1 year and 3 months. In order to track down when the bug originated, I had to go back to the old repo since this has existed before the rebase. It was introduced in [this](https://github.com/judgex/desertrose/commit/34123b7e196ea0f07c1e6335faa596eac4499670#diff-888e0037deac19795de7b40dea3de528fc3915f0ebf93d66dd476307f25f0edb) PR by Celyne, on April 3rd 2020.


:P
