### PR TITLE
Fixes Custom Trail Rangers

### DIFF
--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -804,7 +804,7 @@ obj/item/clothing/suit/armor/f13/exile/cust0m
 	icon_state = "ranger_cloak"
 	item_state = "ranger_cloak"
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0) //Same armor as trail ranger gear
-	slowdown = -0.14 //Same speed buff as trail ranger gear
+	slowdown = -0.2 //Same speed buff as trail ranger gear
 
 /obj/item/clothing/suit/armor/f13/herbertranger //Armor wise, it's reskinned raider armor.
 	name = "weathered desert ranger armor"

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -460,12 +460,12 @@
 	slowdown = -0.2
 
 /obj/item/clothing/suit/armor/f13/tina_jacket
-	name = "Trail Coat"
+	name = "trail coat"
 	desc = "A dark red ranger's trenchcoat, replete with a belt and a trail ranger scarf dyed the color of harebells. It smells a little like flowers, lemon juice and gunpowder."
 	icon_state = "tina_jacket"
 	item_state = "tina_jacket"
 	armor = list("tier" = 4, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
-	slowdown = -0.14
+	slowdown = -0.2
 
 /obj/item/clothing/suit/armor/f13/modif_r_vest
 	name = "subdued ranger vest"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Trail ranger gear was recently buffed to have a -0.2 speed var rather than -0.14. This adds the same change to the custom loadouts for other trail rangers.

## Why It's Good For The Game

Balance.

## Changelog
:cl:
fix: Custom trail rangers now have the same stats as regular trail rangers
spellcheck: Fixed a grammatical error in Tina's ranger gear
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
