### PR TITLE
Separates Ranger Armors and Weapons

### DIFF
--- a/code/modules/fallout/obj/items.dm
+++ b/code/modules/fallout/obj/items.dm
@@ -51,7 +51,7 @@
 		for(var/new_type in chosen)
 			var/atom/movable/gun = new new_type(get_turf(src))
 			if(istype(gun, /obj/item/gun/))
-				to_chat(user, "You take your [gun] out of the case.")
+				to_chat(user, "You take [gun] out of the case.")
 		qdel(src)
 
 /obj/item/storage/backpack/duffelbag/marksman

--- a/code/modules/fallout/obj/items.dm
+++ b/code/modules/fallout/obj/items.dm
@@ -30,3 +30,67 @@
 				M.adjustFireLoss(-2)
 				M.adjustToxLoss(-2)
 				M.adjustOxyLoss(-2)
+
+
+/obj/item/guncase
+	name = "firearm case"
+	desc = "A briefcase containing a Ranger's perferred firearm."
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "secure"
+
+/obj/item/guncase/attack_self(mob/living/user)
+	var/list/weapons = list()
+	weapons["AR-15 Marksman Carbine"] = list(/obj/item/storage/backpack/duffelbag/marksman)
+	weapons["M1A1 Carbine"] = list(/obj/item/storage/backpack/duffelbag/m1a1)
+	weapons["M1 Garand Battle Rifle"] = list(/obj/item/storage/backpack/duffelbag/m1garand)
+	weapons["DKS Sniper Rifle"] = list(/obj/item/storage/backpack/duffelbag/sniper)
+	weapons["Browning Auto-5 Shotgun"] = list(/obj/item/storage/backpack/duffelbag/auto5)
+	var/choice = input(user,"Select your stored weapon.") as null|anything in weapons
+	if(src && choice)
+		var/list/chosen = weapons[choice]
+		for(var/new_type in chosen)
+			var/atom/movable/gun = new new_type(get_turf(src))
+			if(istype(gun, /obj/item/gun/))
+				to_chat(user, "You take your [gun] out of the case.")
+		qdel(src)
+
+/obj/item/storage/backpack/duffelbag/marksman
+
+/obj/item/storage/backpack/duffelbag/marksman/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/marksman(src)
+	new /obj/item/ammo_box/magazine/m556/rifle/assault(src)
+	new /obj/item/ammo_box/magazine/m556/rifle/assault(src)
+	new /obj/item/ammo_box/magazine/m556/rifle/assault(src)
+
+/obj/item/storage/backpack/duffelbag/m1a1
+
+/obj/item/storage/backpack/duffelbag/m1a1/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/m1carbine/compact(src)
+	new /obj/item/ammo_box/magazine/m10mm_adv/simple(src)
+	new /obj/item/ammo_box/magazine/m10mm_adv/simple(src)
+	new /obj/item/ammo_box/magazine/m10mm_adv/simple(src)
+
+/obj/item/storage/backpack/duffelbag/m1garand
+
+/obj/item/storage/backpack/duffelbag/m1garand/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/m1garand(src)
+	new /obj/item/ammo_box/magazine/garand308(src)
+	new /obj/item/ammo_box/magazine/garand308(src)
+	new /obj/item/ammo_box/magazine/garand308(src)
+	new /obj/item/attachments/scope(src)
+
+/obj/item/storage/backpack/duffelbag/auto5
+
+/obj/item/storage/backpack/duffelbag/auto5/PopulateContents()
+	new /obj/item/gun/ballistic/shotgun/automatic/combat/auto5(src)
+	new /obj/item/storage/fancy/ammobox/lethalshot(src)
+	new /obj/item/storage/fancy/ammobox/lethalshot(src)
+	new /obj/item/storage/fancy/ammobox/slugshot(src)
+
+/obj/item/storage/backpack/duffelbag/sniper
+
+/obj/item/storage/backpack/duffelbag/sniper/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/marksman/sniper(src)
+	new /obj/item/ammo_box/magazine/w308(src)
+	new /obj/item/ammo_box/magazine/w308(src)
+	new /obj/item/ammo_box/magazine/w308(src)

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -846,7 +846,6 @@ Veteran Ranger
 	/datum/outfit/loadout/rangerrecon,
 	/datum/outfit/loadout/rangertrail,
 	/datum/outfit/loadout/rangerpatrol,
-	/datum/outfit/loadout/rangerpatrolcqb,
 	/datum/outfit/loadout/rangermedic,
 	/datum/outfit/loadout/rangerengineer
 	)
@@ -884,10 +883,9 @@ Veteran Ranger
 	suit =	/obj/item/clothing/suit/toggle/armor/f13/rangerrecon
 	belt =	/obj/item/storage/belt/military/reconbandolier
 	head = /obj/item/clothing/head/helmet/f13/combat/swat
-	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
 	gloves = /obj/item/clothing/gloves/patrol
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/w308 = 3,
+		/obj/item/guncase = 1,
 		/obj/item/storage/survivalkit_aid=1
 	)
 
@@ -895,13 +893,11 @@ Veteran Ranger
 	name = "Trail Ranger"
 	suit =	/obj/item/clothing/suit/armor/f13/trailranger
 	belt =	/obj/item/storage/belt/military/NCR_Bandolier
-	suit_store = /obj/item/gun/ballistic/automatic/m1garand
 	gloves = /obj/item/clothing/gloves/patrol
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/garand308=3,
+		/obj/item/guncase = 1,
 		/obj/item/melee/classic_baton/telescopic=1,
-		/obj/item/storage/survivalkit_aid=1,
-		/obj/item/attachments/scope=1
+		/obj/item/storage/survivalkit_aid=1
 	)
 
 /datum/outfit/loadout/rangerpatrol
@@ -910,25 +906,9 @@ Veteran Ranger
 	head = /obj/item/clothing/head/f13/ranger
 	uniform = /obj/item/clothing/under/f13/ranger/patrol
 	belt =	/obj/item/storage/belt/military/assault/ncr
-	suit_store = /obj/item/gun/ballistic/automatic/marksman
 	gloves = /obj/item/clothing/gloves/patrol
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m556/rifle/assault = 3,
-		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
-		/obj/item/storage/survivalkit_aid = 1
-	)
-
-/datum/outfit/loadout/rangerpatrolcqb
-	name = "CQB Patrol Ranger"
-	suit = /obj/item/clothing/suit/armor/f13/combat/ncr_patrol
-	head = /obj/item/clothing/head/f13/ranger
-	uniform = /obj/item/clothing/under/f13/ranger/patrol
-	belt =	/obj/item/storage/belt/military/assault/ncr
-	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/auto5
-	gloves = /obj/item/clothing/gloves/patrol
-	backpack_contents = list(
-		/obj/item/storage/fancy/ammobox/lethalshot = 2,
-		/obj/item/storage/fancy/ammobox/slugshot = 1,
+		/obj/item/guncase = 1,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
 		/obj/item/storage/survivalkit_aid = 1
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Separates Ranger armor selection and weapon selection into two separate things. Each ranger armor can now be used separately of each weapon.

When spawning in as a ranger, you now choose your type as Trail, Recon, or Patrol. Your loadout spawns you a 'firearm case' which when opened gives you the choice between the regular ranger weapons: M1 garand, M1 carbine, sniper rifle, marksman carbine, and auto-5. 

The three base loadouts spawn with the 'firearm case'
![image](https://user-images.githubusercontent.com/67706292/125168810-3fa2f700-e175-11eb-8cac-375eec08d079.png)

When used in hand, you receive this menu.
![image](https://user-images.githubusercontent.com/67706292/125168838-58aba800-e175-11eb-83d1-2bafe83ee0d3.png)

When the weapon of choice is selected, you are given it in a bag.
![image](https://user-images.githubusercontent.com/67706292/125168850-66612d80-e175-11eb-93e4-5a91d1437261.png)


## Why It's Good For The Game

None of the weapons or armors have been modified. This just cleans up the loadout menu by removing the "CQB" loadout and giving rangers more customization rather than "recon must have sniper. patrol must have funny shotgun. trail must have ping rifle".

Checked with the NCR LMs and approved.

## Changelog
:cl:
add: Added firearm cases for ranger loadouts, allowing you to select a gun rather than have guns tied to armor selection.
del: Removed the CQB loadout since it was just copy pasted patrol ranger with a shotgun. You can select the weapon using the firearm case.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
