### PR TITLE
Small Flamethrower Balance Fix

### DIFF
--- a/modular_citadel/code/modules/projectiles/guns/ballistic/flamethrower.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/flamethrower.dm
@@ -10,6 +10,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_HUGE
 	slowdown = 1
+	item_flags = SLOWS_WHILE_IN_HAND
 	var/obj/item/gun/ballistic/m2flamethrower/gun
 	var/armed = 0 //whether the gun is attached, 0 is attached, 1 is the gun is wielded.
 	var/overheat = 0


### PR DESCRIPTION
## About The Pull Request

Basically realized you can carry the flamethrower backpack in hand and it would not slow you down like it would upon wearing it. So - to fix that, I just added one small wittle change to the code that should give you the slowdown while holding it in general.

## Why It's Good For The Game

Prevents someone from powergaming/abusing slowdown to keep the balance of the flamethrower reasonable.

## Changelog
:cl:
fix: Fixes slowdown aboose.
/:cl:
