### PR TITLE
Grand Tinkering Quality of Life Fix

### DIFF
--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -59,6 +59,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	item_flags = NEEDS_PERMIT //doesn't slow you down
 	fire_delay = 3
+	untinkerable = TRUE
 //	distro = 1
 	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot
 

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -1022,6 +1022,7 @@
 
 /obj/item
 	var/tinkered = 0
+	var/untinkerable = FALSE
 
 /obj/item/experimental/proc/reroll(obj/item/W, mob/user)
 	var/obj/item/item = W.type
@@ -1032,19 +1033,7 @@
 	to_chat(user,"You destroy the item in the process.")
 
 /obj/item/experimental/proc/gun(obj/item/W, mob/user)
-	if(istype(W,/obj/item/gun/ballistic/automatic/shotgun))
-		to_chat(usr, "You can't improve [W.name]...")
-		return
-	if (istype(W,/obj/item/gun/ballistic/revolver/doublebarrel))
-		to_chat(usr, "You can't improve [W.name]...")
-		return
-	if (istype(W,/obj/item/gun/ballistic/revolver/shotgunrevolver))
-		to_chat(usr, "You can't improve [W.name]...")
-		return
-	if (istype(W,/obj/item/gun/ballistic/revolver/ballisticfist))
-		to_chat(usr, "You can't improve [W.name]...")
-		return
-	if(istype(W,/obj/item/gun/ballistic/m2flamethrower))
+	if(W.untinkerable == TRUE)
 		to_chat(usr, "You can't improve [W.name]...")
 		return
 	var/obj/item/gun/ballistic/B = W

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1188,7 +1188,7 @@
 	fire_sound = 'sound/f13weapons/varmint_rifle.ogg'
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
-	extra_damage = 4
+	extra_damage = 2
 	extra_penetration = 0.08
 	automatic_burst_overlay = FALSE
 	//automatic = 1

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -288,6 +288,7 @@
 	force = 10
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
+	untinkerable = TRUE
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
 	sawn_desc = "Omar's coming!"
 	obj_flags = UNIQUE_RENAME
@@ -342,6 +343,7 @@
 	unique_reskin = null
 //	projectile_damage_multiplier = 0.9
 	var/slung = FALSE
+	untinkerable = TRUE
 
 /obj/item/gun/ballistic/revolver/doublebarrel/improvised/attackby(obj/item/A, mob/user, params)
 	..()
@@ -374,6 +376,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	sawn_off = TRUE
 	slot_flags = ITEM_SLOT_BELT
+	untinkerable = TRUE
 
 
 /obj/item/gun/ballistic/revolver/reverse //Fires directly at its user... unless the user is a clown, of course.
@@ -635,6 +638,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	weapon_weight = WEAPON_LIGHT
 	spread = 40
+	untinkerable = TRUE
 
 /obj/item/gun/ballistic/revolver/needler
 	name = "needler pistol"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -14,6 +14,7 @@
 	spawnwithmagazine = TRUE
 	var/pump_sound = 'sound/weapons/shotgunpump.ogg'
 	fire_sound = 'sound/f13weapons/shotgun.ogg'
+	untinkerable = TRUE //fuck you no tinkering shotguns, you dirty powergamer
 
 /obj/item/gun/ballistic/shotgun/process_chamber(mob/living/user, empty_chamber = 0)
 	return ..() //changed argument value
@@ -507,6 +508,7 @@
 	scope_x_offset = 4
 	scope_y_offset = 12
 	pump_sound = 'sound/weapons/boltpump.ogg'
+	untinkerable = FALSE
 
 /obj/item/gun/ballistic/shotgun/remington/attackby(obj/item/A, mob/user, params)
 	..()
@@ -623,6 +625,7 @@
 	scope_x_offset = 12
 	scope_y_offset = 23
 	pump_sound = 'sound/weapons/boltpump.ogg'
+	untinkerable = FALSE
 
 /obj/item/gun/ballistic/revolver/widowmaker
 	name = "winchester widowmaker"
@@ -636,6 +639,7 @@
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 1
 	fire_sound = 'sound/f13weapons/max_sawn_off.ogg'
+	untinkerable = TRUE
 
 /obj/item/gun/ballistic/revolver/widowmaker/attackby(obj/item/A, mob/user, params)
 	..()
@@ -669,6 +673,7 @@
 	can_suppress = TRUE
 	suppressor_x_offset = 25
 	suppressor_y_offset = 30
+	untinkerable = FALSE
 
 /obj/item/gun/ballistic/shotgun/lasmusket
 	name = "Laser musket"
@@ -696,6 +701,7 @@
 	fire_sound = 'sound/f13weapons/lasmusket_fire.ogg'
 	pump_sound = 'sound/f13weapons/lasmusket_crank.ogg'
 	equipsound = 'sound/f13weapons/equipsounds/aep7equip.ogg'
+	untinkerable = FALSE
 
 /obj/item/gun/ballistic/shotgun/plasmacaster
 	name = "Plasma musket"
@@ -722,3 +728,4 @@
 	fire_sound = 'sound/f13weapons/lasmusket_fire.ogg'
 	pump_sound = 'sound/f13weapons/lasmusket_crank.ogg'
 	equipsound = 'sound/f13weapons/equipsounds/aep7equip.ogg'
+	untinkerable = FALSE

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -379,12 +379,14 @@
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+	untinkerable = FALSE
 
 /obj/item/gun/energy/laser/scatter/baby
 	name = "tribeam laser carbine"
 	desc = "A cut down version of the tribeam laser rifle."
 	icon_state = "tricar"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter/baby)
+	untinkerable = FALSE
 
 /obj/item/gun/energy/laser/plasma
 	name ="plasma rifle"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -379,14 +379,14 @@
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
-	untinkerable = FALSE
+	untinkerable = TRUE
 
 /obj/item/gun/energy/laser/scatter/baby
 	name = "tribeam laser carbine"
 	desc = "A cut down version of the tribeam laser rifle."
 	icon_state = "tricar"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter/baby)
-	untinkerable = FALSE
+	untinkerable = TRUE
 
 /obj/item/gun/energy/laser/plasma
 	name ="plasma rifle"

--- a/modular_citadel/code/modules/projectiles/guns/ballistic/flamethrower.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/flamethrower.dm
@@ -111,6 +111,7 @@
 	fire_sound = 'sound/weapons/flamethrower.ogg'
 	mag_type = /obj/item/ammo_box/magazine/internal/m2flamethrower
 	casing_ejector = FALSE
+	untinkerable = TRUE
 	item_flags = SLOWS_WHILE_IN_HAND
 	var/obj/item/m2flamethrowertank/ammo_pack
 


### PR DESCRIPTION
## About The Pull Request

Basically did a change Fortune 13 did in where they stopped adding specific path exceptions to tinkering and instead added a variable in its place where I can put 'untinkerable = TRUE' and 'untinkerable = FALSE' if needed (True to stop tinkering, False to override ability to not tinker - ex making it so certain bolt actions can be tinkered)

## Why It's Good For The Game

Basically a small quality of life fix that will help coders make guns tinkerable or not tinkerable easier without adding a new exception to the list every single time they want to make a gun untinkerable.

## Changelog
:cl:
add: Added the ability to tinker a /few/ bolt-action rifles to keep them somewhat viable for longer. (KAR, Mosin, Improvised Mosin, etc)
balance: Edited M1 Carbine's extra damage to be reduced by 2; balances the gun a lot and fixes tinkering issues with it.
tweak: Adjusts how tinkering exceptions work.
/:cl: