### PR TITLE
Legion Crafting Fix - Again

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -22,8 +22,8 @@
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legioncombathelmet)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legioncombatarmormk2)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legioncombathelmetmk2)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/cateye)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/hydra)
+/*	H.mind.teach_crafting_recipe(/datum/crafting_recipe/cateye)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/hydra)*/ //I have no clue how to fucking fix this, it keeps breaking legion crafting yet should code-wise works and compiles fine.
 
 /datum/outfit/job/CaesarsLegion/Legionnaire
 	belt = 			/obj/item/storage/belt/military/assault/legion

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -302,6 +302,7 @@
 	fire_sound = 'sound/weapons/gunshot.ogg'
 	automatic_burst_overlay = FALSE
 	can_suppress = FALSE
+	untinkerable = TRUE
 	burst_size = 1
 	semi_auto = TRUE
 	pin = /obj/item/firing_pin/implant/pindicate
@@ -1064,6 +1065,7 @@
 	automatic_burst_overlay = FALSE
 	//automatic = 0
 	semi_auto = TRUE
+	untinkerable = TRUE
 
 /obj/item/gun/ballistic/automatic/m1919
 	name = "Browning M1919"
@@ -1425,6 +1427,7 @@
 	//automatic = 1
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+	untinkerable = TRUE
 
 /obj/item/gun/ballistic/automatic/shotgun/caws
 	name = "H&K CAWS"
@@ -1438,6 +1441,7 @@
 	//automatic = 1
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+	untinkerable = TRUE
 
 /obj/item/gun/ballistic/automatic/m2a1
 	name = "Browning M2A1"


### PR DESCRIPTION
## About The Pull Request

Apparently these still don't work despite changes to medical menu that let me craft the drugs using chem-books. When made unique for legion it causes a crafting-menu crash.

I give up on this though, someone else can figure it out. 

Apparently breachers are under automatics instead of with the other auto-shotguns because it's mag-fed and coding was lazy I guess. So I fixed an oversight.

## Why It's Good For The Game

Fixes legion crashing. Again. And fixes an abuse of breacher shotguns being tinkerable.

## Changelog
:cl:
fixes: Legion crafting crash.
fixes: Breachers being tinkerable.
/:cl: