### PR TITLE
Replaces Auto-5s in NCR Army Loadout

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -201,7 +201,7 @@ Lieutenant
 		/obj/item/melee/classic_baton/telescopic=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
 		/obj/item/binoculars=1
-		)	
+		)
 /datum/outfit/job/ncr/f13lieutenant/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
@@ -460,7 +460,7 @@ Corporal
 //Assault
 /datum/outfit/loadout/corpcqb
 	name = "Assault"
-	l_hand = /obj/item/gun/ballistic/shotgun/automatic/combat/auto5
+	l_hand = /obj/item/gun/ballistic/shotgun/lever
 	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/mantle
 	belt = /obj/item/storage/belt/military/NCR_Bandolier
 	backpack_contents = list(
@@ -495,7 +495,7 @@ Combat Engineer
 	gloves			= /obj/item/clothing/gloves/color/latex/nitrile
 	accessory		= /obj/item/clothing/accessory/armband/med/ncr
 	suit_store		= /obj/item/gun/ballistic/automatic/service
-	l_hand			= /obj/item/storage/firstaid/regular	
+	l_hand			= /obj/item/storage/firstaid/regular
 	mask 			= /obj/item/clothing/mask/surgical
 	backpack_contents = list(
 		/obj/item/storage/survivalkit_aid_adv=1, \
@@ -618,7 +618,7 @@ Trooper
 //Assault
 /datum/outfit/loadout/troopcqb
 	name = "Assault"
-	l_hand = /obj/item/gun/ballistic/shotgun/automatic/combat/auto5
+	l_hand = /obj/item/gun/ballistic/shotgun/hunting
 	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/reinforced
 	belt = /obj/item/storage/belt/military/NCR_Bandolier
 	backpack_contents = list(

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -395,7 +395,7 @@ Sergeant
 //Assault
 /datum/outfit/loadout/sercqb
 	name = "Assault"
-	l_hand = /obj/item/gun/ballistic/shotgun/automatic/combat/auto5
+	l_hand = /obj/item/gun/ballistic/shotgun/lever
 	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/mantle/reinforced
 	belt = 	/obj/item/storage/belt/military/NCR_Bandolier
 	backpack_contents = list(
@@ -460,7 +460,7 @@ Corporal
 //Assault
 /datum/outfit/loadout/corpcqb
 	name = "Assault"
-	l_hand = /obj/item/gun/ballistic/shotgun/lever
+	l_hand = /obj/item/gun/ballistic/shotgun/hunting
 	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/mantle
 	belt = /obj/item/storage/belt/military/NCR_Bandolier
 	backpack_contents = list(


### PR DESCRIPTION
## About The Pull Request

Removes Auto5 shotgun from trooper and corporal loadouts; trooper and corporal get hunting-shotties, sergeant gets the slightly better lever action.

## Why It's Good For The Game

Automatic shotguns being given to troopers, corporals AND sergeants was a mild issue since only Veteran Legion get auto-5s and all others get non-automatic shotguns. This should act as balance to this while not harming NCR much with this change. Troopers and corporals will get a hunting shotgun, sergeants a lever action and their ranger counterparts who get auto-5s are left unchanged so Veteran legion and rangers remain on-par equipment wise.

## Changelog
:cl:
balance: Replaced all auto-5s in NCR army with either hunting shotguns or lever action shotguns.
/:cl: