### PR TITLE
Fixed C-stims. Military Larpers copes.

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -7073,8 +7073,8 @@
 /area/f13/wasteland)
 "esj" = (
 /obj/structure/closet/cabinet,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /obj/effect/spawner/lootdrop/clothing_middle,
@@ -11135,7 +11135,7 @@
 /obj/item/pen,
 /obj/item/paper,
 /obj/item/pen,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gMZ" = (
@@ -19874,7 +19874,7 @@
 /area/f13/building)
 "lVa" = (
 /obj/structure/table,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -24703,7 +24703,7 @@
 /area/f13/village)
 "phz" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pig" = (
@@ -30312,7 +30312,7 @@
 	pixel_y = 15
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
@@ -31516,8 +31516,8 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/medspray/synthflesh,
 /obj/item/reagent_containers/medspray/synthflesh,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -31792,7 +31792,7 @@
 /area/f13/village)
 "txO" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -33291,7 +33291,7 @@
 /area/f13/wasteland)
 "urt" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "uru" = (
@@ -36227,7 +36227,7 @@
 "wgv" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wgO" = (

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -9463,8 +9463,8 @@
 /area/f13/ncr)
 "iSR" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -19175,7 +19175,7 @@
 /area/f13/sewer)
 "syv" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -21770,7 +21770,7 @@
 /area/f13/tunnel)
 "vEB" = (
 /obj/structure/table,
-/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/pill/patch/medx,
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -437,7 +437,7 @@ GLOBAL_LIST_INIT(loot_medical_drug, list(
 	/obj/item/reagent_containers/pill/patch/turbo,
 	/obj/item/reagent_containers/pill/patch/healingpowder,
 	/obj/item/reagent_containers/pill/stimulant,
-	/obj/item/reagent_containers/syringe/medx
+	/obj/item/reagent_containers/pill/patch/medx
 ))
 
 GLOBAL_LIST_INIT(loot_t1_melee, list(

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -124,7 +124,7 @@
 
 /datum/crafting_recipe/medx
 	name = "Med-X"
-	result = /obj/item/reagent_containers/syringe/medx
+	result = /obj/item/reagent_containers/pill/patch/medx
 	reqs = list(/obj/item/reagent_containers/syringe = 1,
 				/obj/item/reagent_containers/food/snacks/grown/pungafruit = 2,
 				/obj/item/reagent_containers/food/snacks/grown/datura = 2,
@@ -145,6 +145,7 @@
 				/obj/item/reagent_containers/food/snacks/grown/feracactus = 2)
 	time = 40
 	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
 	always_availible = FALSE
 
 /datum/crafting_recipe/cateye
@@ -156,6 +157,7 @@
 				/obj/item/reagent_containers/food/snacks/grown/feracactus = 2)
 	time = 20
 	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
 	always_availible = FALSE
 
 /datum/crafting_recipe/buffout

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -550,7 +550,7 @@
 				/obj/item/reagent_containers/pill/patch/turbo,
 				/obj/item/reagent_containers/pill/patch/healingpowder,
 				/obj/item/reagent_containers/pill/stimulant,
-				/obj/item/reagent_containers/syringe/medx,
+				/obj/item/reagent_containers/pill/patch/medx,
 				/obj/item/storage/pill_bottle/chem_tin/buffout
 				)
 /*	------------------------------------------------

--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -21,7 +21,7 @@
 								/obj/item/stack/sheet/leather = 3,
 								/obj/item/reagent_containers/pill/patch/jet = 5,
 								/obj/item/reagent_containers/hypospray/medipen/psycho = 15,
-								/obj/item/reagent_containers/syringe/medx = 15,
+								/obj/item/reagent_containers/pill/patch/medx = 10,
 								/obj/item/invention = 25,
 								/obj/item/experimental = 25
 								)

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -207,7 +207,7 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	reagent_state = LIQUID
 	color = "#6D6374"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
-	overdose_threshold = 11
+	overdose_threshold = 15
 	addiction_threshold = 6
 
 /datum/reagent/medicine/medx/on_mob_add(mob/living/carbon/human/M)

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -791,7 +791,7 @@
 /datum/outfit/loadout/addict
 	name = "Addict"
 	backpack_contents = list(
-	/obj/item/reagent_containers/syringe/medx=1,
+	/obj/item/reagent_containers/pill/patch/medx=1,
 	/obj/item/reagent_containers/pill/buffout = 2,
 	/obj/item/reagent_containers/pill/lsd = 2,
 	/obj/item/reagent_containers/pill/patch/jet = 2,

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -89,7 +89,7 @@ Great Khan
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs=1, \
 		/obj/item/reagent_containers/pill/patch/jet=2, \
-		/obj/item/reagent_containers/syringe/medx=1, \
+		/obj/item/reagent_containers/pill/patch/medx=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1)
 	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
 	suit_store = pick(

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -18,6 +18,14 @@
 	var/limit = 10
 	var/speed = 1
 	var/list/holdingitems
+	var/blacklistchems = list(
+	/obj/item/reagent_containers/pill/patch/turbo,
+	/obj/item/reagent_containers/pill/patch/medx,
+	/obj/item/reagent_containers/pill/buffout,
+	/obj/item/reagent_containers/pill/cateye,
+	/obj/item/reagent_containers/pill/patch/jet,
+	/obj/item/reagent_containers/spray/hydra
+	)
 
 	var/static/radial_examine = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_examine")
 	var/static/radial_eject = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_eject")
@@ -97,6 +105,9 @@
 
 	if(panel_open) //Can't insert objects when its screwed open
 		return TRUE
+
+	if (is_type_in_list(I, blacklistchems))
+		return
 
 	if (istype(I, /obj/item/reagent_containers) && !(I.item_flags & ABSTRACT) && I.is_open_container())
 		var/obj/item/reagent_containers/B = I

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -428,6 +428,15 @@
 	spillable = TRUE
 	var/obj/item/grinded
 	var/mortar_mode = MORTAR_JUICE
+	var/blacklistchems = list(
+	/obj/item/reagent_containers/pill/patch/turbo,
+	/obj/item/reagent_containers/pill/patch/medx,
+	/obj/item/reagent_containers/pill/buffout,
+	/obj/item/reagent_containers/pill/cateye,
+	/obj/item/reagent_containers/pill/patch/jet,
+	/obj/item/reagent_containers/spray/hydra
+	)
+
 
 /obj/item/reagent_containers/glass/mortar/examine(mob/user)
 	. = ..()
@@ -445,6 +454,10 @@
 		to_chat(user, "<span class='notice'>You decide to hold [src] differently to [mortar_mode == MORTAR_JUICE ? "juice the harvest" : "grind the harvest"].</span>")
 
 /obj/item/reagent_containers/glass/mortar/attackby(obj/item/I, mob/living/carbon/human/user)
+
+	if (is_type_in_list(I, blacklistchems))
+		return
+
 	..()
 	if(istype(I,/obj/item/pestle))
 		if(grinded)

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -76,3 +76,11 @@
 	list_reagents = null
 	icon_state = "bandaid_healingpowder"
 	self_delay = 0
+
+/obj/item/reagent_containers/pill/patch/medx
+	name = "syringe (med-x)"
+	desc = "Contains Med-X, a powerful analgesic drug that increases the user's damage resistance. Highly addictive, and prolonged presence in the body comes with severe side effects."
+	list_reagents = list(/datum/reagent/medicine/medx = 10)
+	icon = 'icons/obj/syringe.dmi'
+	icon_state = "medipen"
+	item_state = "medipen"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -362,8 +362,3 @@
 	desc = "A non-harmful dart that can administer medication from a range. Once it hits a patient, using its smart nanofilter technology only medicines contained within the dart are administered to the patient. Additonally, due to capillary action, injection of chemicals past the overdose limit is prevented. Has an extended volume capacity thanks to bluespace foam."
 	amount_per_transfer_from_this = 50
 	volume = 50
-
-/obj/item/reagent_containers/syringe/medx
-	name = "syringe (med-x)"
-	desc = "Contains Med-X, a powerful analgesic drug that increases the user's damage resistance. Highly addictive, and prolonged presence in the body comes with severe side effects."
-	list_reagents = list(/datum/reagent/medicine/medx = 15)


### PR DESCRIPTION
makes certain chemicals ungrindable or untransferable to Stims

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
D.A.R.E to be drug free
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes balance issues of combining multiple chems that should never have been combined in the first place.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Turned Med-x into a patch from a syringe.
balance: Made Several Chemicals ungrindable and untransferable 
fix: Removes Combat stimulant mixes from Stimpaks
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
