### PR TITLE
Legion Cateye/Hydra Fix

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -145,6 +145,7 @@
 				/obj/item/reagent_containers/food/snacks/grown/feracactus = 2)
 	time = 40
 	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
 	always_availible = FALSE
 
 /datum/crafting_recipe/cateye
@@ -156,6 +157,7 @@
 				/obj/item/reagent_containers/food/snacks/grown/feracactus = 2)
 	time = 20
 	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
 	always_availible = FALSE
 
 /datum/crafting_recipe/buffout

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -22,8 +22,8 @@
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legioncombathelmet)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legioncombatarmormk2)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legioncombathelmetmk2)
-/*	H.mind.teach_crafting_recipe(/datum/crafting_recipe/cateye)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/hydra)*/ //I have no clue how to fucking fix this, it keeps breaking legion crafting yet should code-wise works and compiles fine.
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/cateye)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/hydra)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire
 	belt = 			/obj/item/storage/belt/military/assault/legion


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Attempted fix of the Cateye/Hydra to be craftable by legion players within the game
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
They've been added before and broke the menu, this fix is an attempt to make them work without breaking the legion crafting menu
## Changelog
fix: Attempted to fix the code to make them work
code: It had seemed like the code would be flawless on it, but when I was looking at the crafting menu for the two recipes, they lacked a category specification. I think this is what broke the crafting UI to begin with. I tested it. This works as intended now. Good to go.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
