### PR TITLE
Tribal Crafting and LT Platecarrier.

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_forge.dm
+++ b/code/datums/components/crafting/recipes/recipes_forge.dm
@@ -64,6 +64,7 @@
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
+	always_availible = FALSE
 
 /datum/crafting_recipe/survival
 	name = "Survival Knife"
@@ -518,6 +519,7 @@
 	tools = list(TOOL_FORGE)
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
+	always_availible = FALSE
 
 /datum/crafting_recipe/lighttribe
 	name = "Light Tribal Armor"
@@ -528,6 +530,7 @@
 	tools = list(TOOL_FORGE)
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
+	always_availible = FALSE
 
 /*
 /datum/crafting_recipe/plate

--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -146,3 +146,12 @@
 			/obj/item/shovel/spade = 1)
 	result = /obj/item/shovel/serrated
 	category = CAT_PRIMAL
+
+/datum/crafting_recipe/tribalshield
+	name = "Tribal Brahmin Shield"
+	always_availible = FALSE
+	reqs = list(
+			/obj/item/stack/sheet/mineral/wood = 10,
+			/obj/item/stack/sheet/animalhide/brahmin = 2)
+	result = /obj/item/shield/tribal
+	category = CAT_PRIMAL

--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -218,6 +218,7 @@
 
 /datum/crafting_recipe/warclub
 	name = "Carve Wooden Warclub"
+	always_availible = FALSE
 	result = /obj/item/claymore/machete/warclub
 	time = 80
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 10,
@@ -275,6 +276,7 @@
 
 /datum/crafting_recipe/warmace
 	name = "Carve Wooden Warmace"
+	always_availible = FALSE
 	result = /obj/item/twohanded/sledgehammer/warmace
 	time = 100
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 20,
@@ -303,6 +305,7 @@
 
 /datum/crafting_recipe/arrowap
 	name = "Sturdy Arrow"
+	always_availible = FALSE
 	result = /obj/item/ammo_casing/caseless/arrow/ap
 	time = 40
 	reqs = list(/obj/item/stack/rods = 2,
@@ -313,6 +316,7 @@
 
 /datum/crafting_recipe/arrowpoison
 	name = "Poison Arrow"
+	always_availible = FALSE
 	result = /obj/item/ammo_casing/caseless/arrow/poison
 	time = 30
 	reqs = list(/obj/item/ammo_casing/caseless/arrow = 1,
@@ -323,6 +327,7 @@
 
 /datum/crafting_recipe/arrowburn
 	name = "Burn Posion Arrow"
+	always_availible = FALSE
 	result = /obj/item/ammo_casing/caseless/arrow/burning
 	time = 30
 	reqs = list(/obj/item/ammo_casing/caseless/arrow = 1,

--- a/code/game/objects/items/modkit.dm
+++ b/code/game/objects/items/modkit.dm
@@ -208,7 +208,7 @@
 	result_item = /obj/item/clothing/suit/armor/f13/legion/venator/ursus
 
 /obj/item/modkit/harebellscout
-	name = "Harebell scout beret"
+	name = "Harebell scout beret modkit"
 	target_items = list(/obj/item/clothing/head/beret/ncr_recon_ranger, /obj/item/clothing/head/beret/ncr_scout)
 	result_item = /obj/item/clothing/head/beret/tina_beret
 
@@ -221,6 +221,11 @@
 	name = "Hooded recon modkit"
 	target_items = list(/obj/item/clothing/suit/toggle/armor/f13/rangerrecon)
 	result_item = /obj/item/clothing/suit/hooded/f13/hooded_recon
+
+/obj/item/modkit/lieutenantplatecarrier
+	name = "Lieutenant platecarrier modkit"
+	target_items = list(/obj/item/clothing/suit/armor/f13/ncrarmor/lieutenant)
+	result_item = /obj/item/clothing/suit/armor/f13/ncrarmor/lieutenant/ltcarrier
 
 //Crusader Pistol Modkits
 /obj/item/modkit/crusader_10mm

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -523,13 +523,19 @@ obj/item/shield/riot/bullet_proof
 		to_chat(user, "<span class='notice'>[src] can now be concealed.</span>")
 	add_fingerprint(user)
 
-/obj/item/shield/riot/tribal
+/obj/item/shield/tribal
 	name = "tribal shield"
 	desc = "An oval shaped shield made of strong wood and brahmin skin."
 	icon_state = "btribal"
 	item_state = "btribal"
+	force = 20
+	throwforce = 5
+	throw_speed = 2
+	throw_range = 3
+	block_chance = 40
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/shield/riot/tribal/nightstalker
 	name = "nightstalker shield"

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -368,6 +368,13 @@
 	item_state = "ncr_lt_armour"
 	armor = list("tier" = 7, "energy" = 20, "bomb" = 50, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
+/obj/item/clothing/suit/armor/f13/ncrarmor/lieutenant/ltcarrier
+	name = "Lieutenant Plate Carrier"
+	desc = "(VII) A lightened version of the NCR officers vest that has reinforced with a light ceramic plate in an overlayed plate carrier."
+	icon_state = "lt_pc"
+	item_state = "lt_pc"
+	armor = list("tier" = 7, "energy" = 20, "bomb" = 50, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+
 /obj/item/clothing/suit/armor/f13/ncrarmor/scout
 	name = "NCR light infantry armor"
 	desc = "(V) A specialized variant of the standard NCR armor given to light infantrymen."
@@ -433,6 +440,7 @@
 	desc = "(VII) A special issue NCR officer's armour with an added thick overcoat for protection from the elements."
 	icon_state = "ncr_officer_coat"
 	item_state = "ncr_officer_coat"
+
 
 //NCR Ranger
 /obj/item/clothing/suit/toggle/armor/f13/rangerrecon
@@ -873,9 +881,3 @@
 	item_state = "remnant"
 	armor = list("tier" = 6, "energy" = 75, "bomb" = 70, "bio" = 80, "rad" = 80, "fire" = 80, "acid" = 50)
 
-/obj/item/clothing/suit/armor/f13/ncrarmor/Ltcarrier
-	name = "Lieutenant Plate Carrier"
-	desc = "(VII) A lightened version of the NCR officers vest that has reinforced with a light ceramic plate in an overlayed plate carrier."
-	icon_state = "lt_pc"
-	item_state = "lt_pc"
-	armor = list("tier" = 7, "energy" = 20, "bomb" = 50, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)

--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -26,6 +26,15 @@
 	ADD_TRAIT(H, TRAIT_TRAPPER, src)
 	ADD_TRAIT(H, TRAIT_MACHINE_SPIRITS, src)
 	H.grant_language(/datum/language/wayfarer)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/heavytribe)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/lighttribe)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ritual)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalshield)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/warclub)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/warmace)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/arrowap)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/arrowpoison)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/arrowburn)
 
 /*
 Tribal Chief

--- a/modular_citadel/code/modules/client/loadout/kits.dm
+++ b/modular_citadel/code/modules/client/loadout/kits.dm
@@ -248,6 +248,7 @@
 //Jack Torres - karlov
 /obj/item/storage/box/large/custom_kit/jacktorres/PopulateContents()
 	new /obj/item/clothing/head/helmet/f13/boonie_hat(src)
+	new /obj/item/modkit/lieutenantplatecarrier(src)
 
 //Alice Dakota - muhsollini
 /obj/item/storage/box/large/custom_kit/alicedakota/PopulateContents()


### PR DESCRIPTION
## About The Pull Request


This PR adds tribe crafting and takes items from the main crafting and puts them under wayfarer tribals only such as the arrows and tribal armors and even some weaponry that is meant for tribals and adds the shield to the crafting menu as it has the same stats as the legion shield and this pr also fixes Lieutenant platecarrier by organizing under the NCR category under of faction armor and adds modkit and adds the modkit to the person who requested it and added it into the game, the character said anyone can really be used by anyone if requested so it is a semi custom item for the player and can be used down the line.
This was tested before hand, so it shouldnt crash tribal crafting menu and should be 100% good to go.

## Why It's Good For The Game

This PR adds tribal stuff for only the tribals and makes them where it is only craftable by the tribals. Also this fixes the LT platecarrier and adds the modkit for the person who requested it so more flavor for them.

## Changelog
:cl:
adds: tweaks and adds code for tribal crafting things only, so this includes our unique shield.
tweaks: lieutenant platecarry into the right spot and adds code to make it into a modkit.
/:cl:

