### PR TITLE
Wells, plants and vending machines

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -6214,11 +6214,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"dLg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/kink,
-/turf/open/floor/wood/f13/old,
-/area/f13/city)
 "dLl" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
@@ -60883,7 +60878,7 @@ fyf
 diP
 fyf
 kEh
-dLg
+uSz
 eTJ
 ghE
 ahK

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -238,3 +238,9 @@
 /obj/structure/ladder/unbreakable/binary/unlinked //Crew gets to complete one
 	id = "unlinked_binary"
 	area_to_place = null
+
+/obj/structure/ladder/unbreakable/well
+	name = "ladder"
+	desc = "A dried up well with a sturdy metal ladder heading down."
+	icon = 'icons/obj/Ritas.dmi'
+	icon_state = "wellwheel"

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -47,6 +47,7 @@
 	/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
 	/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
 	/obj/item/reagent_containers/food/snacks/grown/wheat))
+	grind_results = list(/datum/reagent/cellulose = 0.05, /datum/reagent/oxygen = 0.05)
 
 /obj/item/grown/log/attackby(obj/item/W, mob/user, params)
 	if(W.sharpness)


### PR DESCRIPTION
## About The Pull Request

Adding in an actually ladder well structure so someone can fix the ladder well in the city properly. No matter what I try, I can't seem to fix the ladders in the city.

Let's people grind tower caps to obtain the reagents inside, which should help Tribal and Legion players in fixing brain damage and traumas.

Removes the kinkmate from the city bar.

## Why It's Good For The Game

This means that Tribal and Legion players aren't being shafted whenever they take too much brain damage, as it makes it easier for them to fix brain damage with an easier source of oxygen (mannitol, neurine and mentats), and cellulose (mentats).

Provides someone else with a structure that should work for fixing the ladder well in the middle of the city without causing errors. I can't seem to fix the ladders myself no matter what I've tried, but more power to them if someone else can. 

No more people running around with bodypillows, auto-surgeons containing sexual organs, etc.

## Changelog
:cl:
add: a ladder well structure
del: removed the kinkmate from the city bar
tweak: towercaps so they can actually be ground down
/:cl: