### PR TITLE
Medical Rebalance and Plant Changes

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -42,27 +42,27 @@
 /datum/crafting_recipe/healpowder
 	name = "Healing powder"
 	result = /obj/item/reagent_containers/pill/patch/healingpowder
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 3,
-				/obj/item/reagent_containers/food/snacks/grown/xander = 3)
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 2,
+				/obj/item/reagent_containers/food/snacks/grown/xander = 2)
 	time = 35
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/healpoultice
 	name = "Healing poultice"
 	result = /obj/item/reagent_containers/pill/patch/healpoultice
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 2,
-				/obj/item/reagent_containers/food/snacks/grown/xander = 2,
-				/obj/item/reagent_containers/food/snacks/grown/feracactus = 2,
-				/obj/item/reagent_containers/food/snacks/grown/fungus = 2,
-				/obj/item/reagent_containers/food/snacks/grown/pungafruit = 2)
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 1,
+				/obj/item/reagent_containers/food/snacks/grown/xander = 1,
+				/obj/item/reagent_containers/food/snacks/grown/feracactus = 1,
+				/obj/item/reagent_containers/food/snacks/grown/fungus = 1,
+				/obj/item/reagent_containers/food/snacks/grown/pungafruit = 1)
 	time = 45
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/stimpak
 	name = "Stimpak"
 	result = /obj/item/reagent_containers/hypospray/medipen/stimpak
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 4,
-				/obj/item/reagent_containers/food/snacks/grown/xander = 4,
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 2,
+				/obj/item/reagent_containers/food/snacks/grown/xander = 2,
 				/obj/item/reagent_containers/syringe = 1)
 	tools = list(TOOL_WORKBENCH)
 	time = 45

--- a/code/modules/fallout/obj/food_and_drinks/wastefood.dm
+++ b/code/modules/fallout/obj/food_and_drinks/wastefood.dm
@@ -34,7 +34,7 @@
 	id = /datum/reagent/consumable/ethanol/spiritcleanser
 	results = list(/datum/reagent/consumable/ethanol/spiritcleanser = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/pungajuice = 1, /datum/reagent/consumable/ethanol/daturatea = 1)
-	
+
 /////PLANTS Fallout 13///////
 
 /obj/item/seeds/buffalogourd
@@ -380,7 +380,7 @@
 	icon_dead = "punga-dead"
 	icon_harvest = "punga-harvest"
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list(/datum/reagent/medicine/charcoal = 0.1, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/medicine/radaway = 0.05)
+	reagents_add = list(/datum/reagent/medicine/charcoal = 0.1, /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/pungafruit
 	seed = /obj/item/seeds/punga
@@ -586,7 +586,7 @@
 	yield = 6
 	potency = 20
 	growthstages = 2
-	reagents_add = list(/datum/reagent/medicine/charcoal = 0.05, /datum/reagent/medicine/mutadone = 0.05)
+	reagents_add = list(/datum/reagent/medicine/radaway = 0.10, /datum/reagent/medicine/mutadone = 0.05)
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 
 /obj/item/reagent_containers/food/snacks/grown/fungus


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stim and Powder changes that were made months ago only really affected wastelanders. Factions still mass produce healing supplies and the nerf has not worked. All it currently does is make the game more grind, So this PR reverts those crafting changes. Lets give some power back to wastelanders.

Also moving Radaway production to fungus makes fungus legion medicine for Rads, while leaving Punga the plant cure for toxins as currently The charcoal in Punga purges the rad away from your system. 


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
tweak: Moved Radaway production to Cave Fungus. 
balance: Decreased the Cost of Stims and Poltice by half
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
