### PR TITLE
NCR loadout pistols for officers

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -818,7 +818,6 @@
 /obj/item/storage/belt/holster/ncr_officer/PopulateContents()
 	new /obj/item/gun/ballistic/automatic/pistol/m1911/custom(src)
 	new /obj/item/ammo_box/magazine/m45(src)
-	new /obj/item/ammo_box/magazine/m45(src)
 
 /obj/item/storage/belt/holster/med_lt/PopulateContents()
 	new /obj/item/gun/ballistic/revolver/thatgun(src)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -815,6 +815,11 @@
 	new /obj/item/ammo_box/magazine/m9mm(src)
 	new /obj/item/ammo_box/magazine/m9mm(src)
 
+/obj/item/storage/belt/holster/ncr_officer/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/pistol/m1911/custom(src)
+	new /obj/item/ammo_box/magazine/m45(src)
+	new /obj/item/ammo_box/magazine/m45(src)
+
 /obj/item/storage/belt/holster/med_lt/PopulateContents()
 	new /obj/item/gun/ballistic/revolver/thatgun(src)
 	new /obj/item/ammo_box/a556/stripper(src)

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -64,6 +64,7 @@ Colonel
 	head 		= /obj/item/clothing/head/helmet/f13/power_armor/t45d/sierra
 	belt        = /obj/item/storage/belt/military/assault/ncr/crossbelt
 	glasses 	= /obj/item/clothing/glasses/sunglasses/big
+	neck		= /obj/item/storage/belt/holster/ncr_officer
 	suit_store  = /obj/item/gun/ballistic/automatic/marksman
 	gloves      = /obj/item/clothing/gloves/f13/leather
 	suit 		= /obj/item/clothing/suit/armor/f13/power_armor/t45d/sierra
@@ -115,7 +116,7 @@ Captain
 	accessory 	= /obj/item/clothing/accessory/ncr/CPT
 	suit 		= /obj/item/clothing/suit/armor/f13/ncrarmor/captain
 	glasses 	= /obj/item/clothing/glasses/sunglasses/big
-	neck 		= /obj/item/storage/belt/holster
+	neck 		= /obj/item/storage/belt/holster/ncr_officer
 	ears = 		/obj/item/radio/headset/headset_ncr_com
 	backpack_contents = list(
 		/obj/item/kitchen/knife/combat=1, \
@@ -200,7 +201,7 @@ Lieutenant
 		/obj/item/kitchen/knife/combat=1, \
 		/obj/item/melee/classic_baton/telescopic=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
-		/obj/item/binoculars=1, \
+		/obj/item/binoculars=1
 		)
 /datum/outfit/job/ncr/f13lieutenant/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -188,7 +188,7 @@ Lieutenant
 	shoes 		= /obj/item/clothing/shoes/f13/military/ncr_officer_boots
 	accessory 	= /obj/item/clothing/accessory/ncr/LT1
 	head 		= /obj/item/clothing/head/beret/ncr_lt
-	neck 		= /obj/item/storage/belt/holster/ncr
+	neck 		= /obj/item/storage/belt/holster/ncr_officer
 	glasses 	= /obj/item/clothing/glasses/sunglasses/big
 	gloves 		= /obj/item/clothing/gloves/f13/leather
 	ears 		= /obj/item/radio/headset/headset_ncr_com
@@ -200,7 +200,7 @@ Lieutenant
 		/obj/item/kitchen/knife/combat=1, \
 		/obj/item/melee/classic_baton/telescopic=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
-		/obj/item/binoculars=1
+		/obj/item/binoculars=1, \
 		)
 /datum/outfit/job/ncr/f13lieutenant/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -309,7 +309,7 @@ Sergeant First Class
 	shoes 			= /obj/item/clothing/shoes/f13/military/ncr
 	accessory 		= /obj/item/clothing/accessory/ncr/FSGT
 	glasses 		= /obj/item/clothing/glasses/sunglasses/big
-	neck 			= /obj/item/storage/belt/holster/ncr
+	neck 			= /obj/item/storage/belt/holster/ncr_officer
 	ears 			= /obj/item/radio/headset/headset_ncr_com
 	suit 			= /obj/item/clothing/suit/armor/f13/ncrarmor/mantle/reinforced
 	head 			= /obj/item/clothing/head/f13/ncr


### PR DESCRIPTION
## About The Pull Request

9mms were nerfed into the ground awhile ago and the NCR LT starts with a 9mm as well as the rest of NCR while the medical officer gets a 5.56 revolver - for some reason.

Instead I've shoved the First Sergeant and LT with an M1911 and a mag for it.

## Why It's Good For The Game

Adds a new holster variant for the highest ranking enlisted and the the officer ranks within NCR to allow them a better sidearm - as other factions have much better spawn side-arms to them than the NCR. 9mms suck.

## Changelog
:cl:
add: Adds new NCR Officer holster option.
balance: Gives said holster to first sergeant, LT and other officers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
