### PR TITLE
Tribal locks the overhaul bows.

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -338,6 +338,7 @@
 
 /datum/crafting_recipe/tribalwar/sturdybow
 	name = "Sturdy Bow"
+	always_availible = FALSE
 	result = /obj/item/gun/ballistic/automatic/sturdybow
 	time = 80
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 5,
@@ -348,6 +349,7 @@
 
 /datum/crafting_recipe/tribalwar/silverbow
 	name = "Silver Bow"
+	always_availible = FALSE
 	result = /obj/item/gun/ballistic/automatic/silverbow
 	time = 80
 	reqs = list(/obj/item/stack/sheet/mineral/silver = 10,
@@ -358,6 +360,7 @@
 
 /datum/crafting_recipe/tribalwar/bonebow
 	name = "Deathclaw Bow"
+	always_availible = FALSE
 	result = /obj/item/gun/ballistic/automatic/bonebow
 	time = 80
 	reqs = list(/obj/item/stack/sheet/animalhide/deathclaw = 6,

--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -35,6 +35,9 @@
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/arrowap)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/arrowpoison)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/arrowburn)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/sturdybow)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/silverbow)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/bonebow)
 
 /*
 Tribal Chief


### PR DESCRIPTION
## About The Pull Request

This PR is rather simple and it locks the new bows behind tribals.
This has been tested on a private server and should work does not crash the crafting menu..

## Why It's Good For The Game

This pr locks the new bows behind the tribal jobs.

## Changelog
:cl:
fix: Bows to be tribal locked.
/:cl:
