### PR TITLE
Armor Buff for BOS

### DIFF
--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -655,20 +655,20 @@
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood
 	name = "brotherhood armor"
-	desc = "(VI) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Knights. It bears a red stripe."
+	desc = "(VII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Knights. It bears a red stripe."
 	icon_state = "brotherhood_armor_knight"
 	item_state = "brotherhood_armor_knight"
-	armor = list("tier" = 6, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	armor = list("tier" = 7, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/senior
 	name = "brotherhood star knight armor"
-	desc = "(VI) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Star Knights. It bears a silver stripe."
+	desc = "(VII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Star Knights. It bears a silver stripe."
 	icon_state = "brotherhood_armor_senior"
 	item_state = "brotherhood_armor_senior"
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/captain
 	name = "brotherhood head knight armor"
-	desc = "(VII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Head Knights. It bears golden embroidery."
+	desc = "(VIII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Head Knights. It bears golden embroidery."
 	icon_state = "brotherhood_armor_captain"
 	item_state = "brotherhood_armor_captain"
 	armor = list("tier" = 7, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
@@ -689,15 +689,15 @@
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/scout
 	name = "brotherhood scout armor"
-	desc = "(V) A superior combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a red stripe."
+	desc = "(VI) A superior combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a red stripe."
 	icon_state = "brotherhood_scout_knight"
 	item_state = "brotherhood_scout_knight"
-	armor = list("tier" = 5, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	armor = list("tier" = 6, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 	slowdown = -0.1
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/scout/senior
 	name = "brotherhood star knight scout armor"
-	desc = "(V) A superior combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a silver stripe."
+	desc = "(VI) A superior combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a silver stripe."
 	icon_state = "brotherhood_scout_senior"
 	item_state = "brotherhood_scout_senior"
 

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -823,8 +823,8 @@ Knight
 	title = "Knight"
 	flag = F13KNIGHT
 	faction = "BOS"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 3
+	spawn_positions = 3
 	description = " You are the Brotherhood Knight, the veritable lifeblood of your organization. You are a versatile and adaptably trained person: from your primary duties of weapon & armor repair to basic combat, survival and stealth skills, the only thing you lack is proper experience. You are also in charge of Initiates."
 	forbids = "TheBrotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -823,8 +823,8 @@ Knight
 	title = "Knight"
 	flag = F13KNIGHT
 	faction = "BOS"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 4
+	spawn_positions = 4
 	description = " You are the Brotherhood Knight, the veritable lifeblood of your organization. You are a versatile and adaptably trained person: from your primary duties of weapon & armor repair to basic combat, survival and stealth skills, the only thing you lack is proper experience. You are also in charge of Initiates."
 	forbids = "TheBrotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."


### PR DESCRIPTION
## About The Pull Request

Since VTCC has tier-7 armor for its security personnel yet BOS were told to nerf ours in the past I've buffed our armor back up to be on-par due to dispute over it. Alternative was nerfing VTCC armor down to tier 6 but I was told buff ours instead so - here.

![image](https://user-images.githubusercontent.com/47883419/128644494-4626c060-cbc7-48fe-8922-76d5ef4e6ed4.png)
bet

## Why It's Good For The Game

Puts BOS Knight armors back to where they were pre-nerf since Vault did not wish to change theirs down a tier to be on-par with reinforced combat armor. Seethe.

What is the unhealthy part is we love this PRs like buffing NCR armor, buffing Legion armor, buffing faction armor constantly as a back and forth instead of accepting faction armors should be mid-tier at best and not upper tiers but allow them to use crafting to take wasteland armor and improve it. But that'll probably never happen so we're back to this TDM balance cycle where you fuck anyone with lower armor.

## Changelog
:cl:
balance: Restores old Knight armor values.
balance: Removes the one extra slot we got in exchange for our armor nerf. As if our server has the pop to ever fill the knight slots anyway.
/:cl: