### PR TITLE
Economy balance + Misc mapping changes

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -189,12 +189,6 @@
 "anY" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 10
 	},
@@ -933,6 +927,7 @@
 /obj/effect/decal/waste{
 	icon_state = "goo8"
 	},
+/obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating/f13/inside/mountain,
 /area/f13/underground/cave)
 "bwT" = (
@@ -9706,16 +9701,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"obO" = (
-/obj/structure/rack,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/obj/item/storage/fancy/ammobox/lethalshot,
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/bunker)
 "ocx" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/r_wall/rust,
@@ -14995,8 +14980,6 @@
 /obj/structure/table,
 /obj/item/stamp/hos,
 /obj/item/gun/ballistic/shotgun/trench,
-/obj/item/storage/fancy/ammobox/beanbag,
-/obj/item/storage/fancy/ammobox/beanbag,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
 "wbe" = (
@@ -16274,7 +16257,6 @@
 /obj/item/clothing/gloves/color/captain,
 /obj/item/clothing/head/caphat/parade,
 /obj/item/clothing/neck/cloak/cap,
-/obj/item/clothing/suit/armor/vest/capcarapace/alt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -18452,7 +18434,7 @@ sBg
 jPK
 jPK
 jPK
-obO
+pIl
 wYe
 kRy
 wYe

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -3209,7 +3209,7 @@
 /area/f13/building)
 "bHr" = (
 /obj/structure/ladder/unbreakable{
-	icon_state = "manhole_open";
+	height = 2;
 	id = "VC6"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9100,7 +9100,7 @@
 	dir = 8
 	},
 /obj/structure/ladder/unbreakable{
-	icon_state = "manhole_open";
+	height = 2;
 	id = "VC5"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -10406,7 +10406,7 @@
 /area/f13/building)
 "gqf" = (
 /obj/structure/ladder/unbreakable{
-	icon_state = "manhole_open";
+	height = 2;
 	id = "VC7"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10423,9 +10423,10 @@
 /area/f13/tunnel)
 "gqE" = (
 /obj/structure/ladder/unbreakable{
-	desc = "A normal wasteland well with a ladder inside.";
+	desc = "A ladder hidden inside a well.";
+	height = 2;
 	id = "VC4";
-	name = "ladder well";
+	name = "well ladder";
 	pixel_x = -18
 	},
 /obj/structure/sink/well{
@@ -15274,6 +15275,7 @@
 /area/f13/village)
 "jbR" = (
 /obj/structure/ladder/unbreakable{
+	height = 2;
 	icon_state = "manhole_open";
 	id = "VC3"
 	},
@@ -23412,9 +23414,7 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "orB" = (
-/obj/machinery/mineral/wasteland_trader/general{
-	icon_state = "trade_idle"
-	},
+/obj/machinery/mineral/wasteland_vendor/clothing,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
 "orZ" = (
@@ -24503,13 +24503,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
-"pcA" = (
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/mineral/wasteland_trader/general{
-	icon_state = "trade_idle"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "pcG" = (
 /turf/closed/wall/f13/store,
 /area/f13/village)
@@ -34180,6 +34173,7 @@
 /area/f13/wasteland)
 "uSo" = (
 /obj/structure/ladder/unbreakable{
+	height = 2;
 	icon_state = "manhole_open";
 	id = "VC2"
 	},
@@ -39760,6 +39754,7 @@
 /area/f13/tunnel)
 "yip" = (
 /obj/structure/ladder/unbreakable{
+	height = 2;
 	icon_state = "manhole_open";
 	id = "VC1"
 	},
@@ -93183,7 +93178,7 @@ lDS
 mjL
 pim
 hNc
-pcA
+tbw
 ggK
 pCy
 sYX

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -10422,15 +10422,10 @@
 	},
 /area/f13/tunnel)
 "gqE" = (
-/obj/structure/ladder/unbreakable{
-	desc = "A ladder hidden inside a well.";
-	height = 2;
+/obj/structure/ladder/unbreakable/well{
 	id = "VC4";
-	name = "well ladder";
+	name = "ladder well";
 	pixel_x = -18
-	},
-/obj/structure/sink/well{
-	pixel_x = -15
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -85651,7 +85651,7 @@ ktB
 ktB
 ktB
 ktB
-gcK
+ktB
 gcK
 gcK
 gcK

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -13627,7 +13627,6 @@
 "nts" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	icon_state = "ladder10";
 	id = "VC1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17143,7 +17142,6 @@
 "qLa" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	icon_state = "ladder10";
 	id = "VC2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -21411,7 +21409,6 @@
 "vgo" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	icon_state = "ladder10";
 	id = "FOA1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -23026,7 +23023,6 @@
 "xmS" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	icon_state = "ladder10";
 	id = "VC4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -23104,7 +23100,6 @@
 "xqU" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	icon_state = "ladder10";
 	id = "VC5"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -23133,7 +23128,6 @@
 "xwT" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	icon_state = "ladder10";
 	id = "VC3"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,

--- a/_maps/map_files/templates/dungeons/north_bunker_1.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_1.dmm
@@ -129,7 +129,6 @@
 /area/f13/bunker)
 "eI" = (
 /obj/structure/table,
-/obj/item/reagent_containers/syringe/medx,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -514,6 +513,10 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/bunker)
+"qn" = (
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "qu" = (
 /obj/effect/decal/waste,
@@ -2059,7 +2062,7 @@ Rl
 Rl
 Rl
 Eg
-tQ
+qn
 tQ
 tQ
 wD

--- a/_maps/map_files/templates/dungeons/north_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_2.dmm
@@ -2459,6 +2459,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"Zs" = (
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "Zu" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cola_float,
@@ -2822,7 +2826,7 @@ Qe
 go
 xS
 nf
-oj
+Zs
 xG
 Rl
 Rl

--- a/_maps/map_files/templates/dungeons/north_sewer_1.dmm
+++ b/_maps/map_files/templates/dungeons/north_sewer_1.dmm
@@ -668,6 +668,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"Fc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "Fx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2597,7 +2602,7 @@ lM
 Rj
 zs
 BQ
-ZL
+Fc
 BH
 BH
 QU

--- a/_maps/map_files/templates/dungeons/north_sewer_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_sewer_2.dmm
@@ -405,6 +405,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/tunnel)
+"ho" = (
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/handy/assaultron/nsb,
@@ -4806,7 +4810,7 @@ ga
 BH
 BH
 BH
-sR
+ho
 sR
 cA
 sR

--- a/_maps/map_files/templates/dungeons/oasis_bunker_1.dmm
+++ b/_maps/map_files/templates/dungeons/oasis_bunker_1.dmm
@@ -279,13 +279,10 @@
 	},
 /area/f13/radiation)
 "hD" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/syringe/medx,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker)
+/obj/structure/spider/stickyweb,
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "iC" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel{
@@ -631,7 +628,6 @@
 /area/f13/bunker)
 "tx" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/syringe/medx,
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
@@ -1855,7 +1851,7 @@ pf
 "}
 (8,1,1) = {"
 wR
-Xj
+hD
 OZ
 jc
 iK
@@ -2710,7 +2706,7 @@ bp
 NX
 mm
 xw
-hD
+SS
 bp
 bp
 bp

--- a/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
@@ -2684,11 +2684,11 @@
 	},
 /area/f13/bunker)
 "Vt" = (
-/obj/structure/simple_door/bunker,
-/obj/machinery/door/poddoor{
-	id = 69
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
 	},
-/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "Vu" = (
 /obj/structure/table,
@@ -2928,9 +2928,6 @@
 /area/f13/bunker)
 "Yp" = (
 /obj/structure/table,
-/obj/machinery/button/door{
-	id = 69
-	},
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
@@ -3652,7 +3649,7 @@ Hy
 kj
 kj
 kj
-kj
+Zs
 kj
 Zs
 rW
@@ -3694,7 +3691,7 @@ Hy
 kj
 kj
 kj
-kj
+Zs
 kj
 kj
 kj
@@ -4328,7 +4325,7 @@ Xu
 Xu
 Xu
 Xu
-SM
+Vt
 rW
 Zs
 Zs
@@ -4532,7 +4529,7 @@ rW
 rW
 oo
 Xu
-Vt
+oo
 oo
 Xu
 SD
@@ -4574,7 +4571,7 @@ rW
 Zs
 Zs
 Zs
-Xu
+oo
 Xu
 vy
 Xu

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -211,8 +211,6 @@ GLOBAL_LIST_INIT(trash_chem, list(
 GLOBAL_LIST_INIT(trash_craft, list(
 	/obj/item/crafting/duct_tape = 5,
 	/obj/item/crafting/abraxo = 5,
-	/obj/item/crafting/reloader = 5,
-	/obj/item/crafting/lunchbox = 5,
 	/obj/item/stack/crafting/metalparts/three = 5,
 	/obj/item/stack/crafting/electronicparts/three = 5,
 	/obj/item/stack/crafting/goodparts = 5
@@ -228,9 +226,18 @@ GLOBAL_LIST_INIT(trash_gun, list(
 ))
 
 GLOBAL_LIST_INIT(trash_money, list(
-	/obj/item/stack/f13Cash/random/low = 140,
-	/obj/item/stack/f13Cash/random/med = 80,
-	/obj/item/stack/f13Cash/random/high = 40
+	/obj/item/stack/f13Cash/random/low = 10,
+	/obj/item/stack/f13Cash/random/med = 20,
+	/obj/item/stack/f13Cash/random/high = 5,
+	/obj/item/stack/f13Cash/random/ncr/med = 10,
+	/obj/item/stack/f13Cash/random/ncr/med = 20,
+	/obj/item/stack/f13Cash/random/ncr/high = 5,
+	/obj/item/stack/f13Cash/random/denarius/low = 10,
+	/obj/item/stack/f13Cash/random/denarius/med = 20,
+	/obj/item/stack/f13Cash/random/denarius/high = 5,
+	/obj/item/stack/f13Cash/random/aureus/low = 5,
+	/obj/item/stack/f13Cash/random/aureus/med = 10,
+	/obj/item/stack/f13Cash/random/aureus/high = 5
 ))
 
 GLOBAL_LIST_INIT(trash_tool, list(
@@ -275,6 +282,8 @@ GLOBAL_LIST_INIT(trash_misc, list(
 	/obj/item/light/bulb = 5,
 	/obj/item/reagent_containers/syringe = 5,
 	/obj/item/restraints/handcuffs = 5,
+	/obj/item/crafting/reloader = 5,
+	/obj/item/crafting/lunchbox = 5,
 	/obj/item/kitchen/knife/butcher = 5,
 	/obj/item/toy/crayon/spraycan = 5
 ))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes all wasteland trading vendors and instead rebalances the caps gained from trash piles, making a medium amount of caps way more likely and a high amount of caps slightly more likely. You also get all types of money from trash piles now. 


Mapping:
Adds abandoned crate spawners to the end of all major dungeons, because they add a fun minigame and some unique loot. Fixes cog city ladder sprites. Removes some mob skipping on the surface and in Oasis bunker 2.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Forces factions to go out if they want to have money, stopping inflation of the economy with leather + mining.

Mapping changes because they are fun and help with cheese.

## Changelog
:cl:
add: abandoned crates are back
del: trading point vendors
balance: trash money loot table
fix: ladders
fix: ladder well??!?!?!
fix: mob skipping
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
