### PR TITLE
Fixes Hydra

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -138,7 +138,7 @@
 
 /datum/crafting_recipe/hydra
 	name = "Hydra"
-	result = /obj/item/reagent_containers/spray/hydra
+	result = /obj/item/reagent_containers/pill/patch/hydra
 	reqs = list(/datum/reagent/consumable/nuka_cola = 10,
 				/obj/item/reagent_containers/food/snacks/grown/fungus = 4,
 				/obj/item/reagent_containers/food/snacks/grown/broc = 3,

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -24,7 +24,7 @@
 	/obj/item/reagent_containers/pill/buffout,
 	/obj/item/reagent_containers/pill/cateye,
 	/obj/item/reagent_containers/pill/patch/jet,
-	/obj/item/reagent_containers/spray/hydra
+	/obj/item/reagent_containers/pill/patch/hydra
 	)
 
 	var/static/radial_examine = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_examine")

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -434,7 +434,7 @@
 	/obj/item/reagent_containers/pill/buffout,
 	/obj/item/reagent_containers/pill/cateye,
 	/obj/item/reagent_containers/pill/patch/jet,
-	/obj/item/reagent_containers/spray/hydra
+	/obj/item/reagent_containers/pill/patch/hydra
 	)
 
 

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -84,3 +84,11 @@
 	icon = 'icons/obj/syringe.dmi'
 	icon_state = "med-x"
 	item_state = "med-x"
+
+/obj/item/reagent_containers/pill/patch/hydra
+	name = "hydra bottle"
+	desc = "A large bottle containing a blend of incredients; an incredible stimulant."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "hydra"
+	self_delay = 10
+	list_reagents = list(/datum/reagent/medicine/hydra = 10)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -333,12 +333,3 @@
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	volume = 100
 	list_reagents = list(/datum/reagent/toxin/plantbgone = 100)
-
-//Chem/Drug
-/obj/item/reagent_containers/spray/hydra
-	name = "hydra bottle"
-	desc = "A large bottle containing a blend of incredients; an incredible stimulant."
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "hydra"
-	volume = 15
-	list_reagents = list(/datum/reagent/medicine/hydra = 15)


### PR DESCRIPTION
## About The Pull Request

Makes Hydra into patches with lower delay than regular patches and makes it ungrindable instead of being unusable sprayer that can be abused

## Why It's Good For The Game

Drugs

## Changelog
:cl:
tweak: Turned Hydra into a patch
/:cl: