### PR TITLE
Silos and Dispensers, Followers and Matrices, Doors and Buttons

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -7950,7 +7950,9 @@
 /area/f13/building)
 "eRU" = (
 /obj/structure/grille,
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = "office"
+	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/city)
@@ -8614,10 +8616,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/city)
 "fjC" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
+/obj/machinery/chem_master/advanced,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -10546,7 +10545,9 @@
 	},
 /area/f13/village)
 "gtY" = (
-/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large/styptic,
+/obj/item/reagent_containers/glass/beaker/large/styptic,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -11764,9 +11765,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/city)
 "hft" = (
-/obj/machinery/door/airlock/research,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
-/area/f13/city)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "hfz" = (
 /obj/machinery/computer/arcade,
 /obj/effect/decal/cleanable/dirt,
@@ -15058,13 +15064,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "iVE" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large/styptic,
-/obj/item/reagent_containers/glass/beaker/large/styptic,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "office"
 	},
-/area/f13/followers)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/city)
 "iVW" = (
 /obj/structure/sink{
 	dir = 8
@@ -15744,7 +15750,7 @@
 	},
 /area/f13/wasteland)
 "jrX" = (
-/obj/machinery/chem_master,
+/obj/machinery/chem_heater,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -26789,6 +26795,7 @@
 	pixel_x = 30;
 	pixel_y = -3
 	},
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/followers)
 "qvH" = (
@@ -42142,7 +42149,7 @@ gcK
 bRq
 jeX
 cPZ
-cPZ
+hft
 fjC
 grj
 cPZ
@@ -42911,11 +42918,11 @@ gcK
 gcK
 gcK
 vDd
-jrX
 eUQ
-iVE
-fmX
 gtY
+cPZ
+fmX
+cPZ
 hxn
 jrX
 vDd
@@ -48089,7 +48096,7 @@ sfi
 sfi
 mgo
 agi
-eRU
+iVE
 ufP
 koD
 unI
@@ -48346,7 +48353,7 @@ owq
 owq
 mgo
 fdn
-eRU
+iVE
 xZu
 koD
 unI
@@ -56581,7 +56588,7 @@ gRf
 xWT
 xWT
 tiG
-hft
+tiG
 xWT
 xWT
 ydH

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -17023,10 +17023,6 @@
 	},
 /turf/closed/wall/rust,
 /area/f13/caves)
-"kiF" = (
-/obj/machinery/ore_silo,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/city)
 "kiK" = (
 /obj/structure/decoration/sign{
 	desc = "It's a portrait of a person you don't know anything about.";
@@ -52471,7 +52467,7 @@ brH
 yas
 aVU
 hct
-kiF
+kNu
 kNu
 vWd
 brH

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2129,6 +2129,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bZx" = (
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/f13/followers)
 "caQ" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -6324,17 +6332,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/brotherhood/offices1st)
-"fTt" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/followers)
 "fUn" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -6823,6 +6820,9 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"gtR" = (
+/turf/closed/wall/f13/wood/interior,
+/area/f13/followers)
 "gtY" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7027,6 +7027,14 @@
 	},
 /turf/closed/wall,
 /area/f13/tcoms)
+"gIh" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/f13/followersadministrator,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/f13/followers)
 "gIy" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
@@ -7308,12 +7316,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "reddirtyfull"
-	},
+/turf/closed/wall/f13/wood/interior,
 /area/f13/followers)
 "gWK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12627,6 +12630,13 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"mxg" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/f13/followers)
 "mxh" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/recon,
@@ -14869,6 +14879,11 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"ozT" = (
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/f13/followers)
 "oAt" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood,
@@ -14913,6 +14928,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"oDD" = (
+/turf/closed/indestructible/f13/matrix,
+/area/f13/followers)
 "oEt" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/spacevine{
@@ -16752,6 +16770,14 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"qrh" = (
+/obj/structure/table,
+/obj/item/paper_bin/carbon,
+/obj/item/pen/fountain,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/f13/followers)
 "qrJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18802,6 +18828,12 @@
 "seP" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/f13/brotherhood/rnd)
+"seW" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/followers)
 "sfi" = (
 /obj/effect/landmark/start/f13/scribe,
 /obj/effect/decal/cleanable/dirt,
@@ -19220,11 +19252,10 @@
 	},
 /area/f13/brotherhood/leisure)
 "sCQ" = (
-/obj/structure/chair/comfy/black,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/start/f13/followersadministrator,
+/obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
 /area/f13/followers)
 "sDo" = (
@@ -20554,6 +20585,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "ulr" = (
@@ -24136,12 +24170,12 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aHw
+aHw
+aHw
+aHw
+aHw
+aHw
 aHw
 aHw
 aHw
@@ -24393,12 +24427,12 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aHw
+xOw
+mxg
+bZx
+ozT
+tFr
 aHw
 uwt
 veq
@@ -24650,12 +24684,12 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+aHw
+gIh
+qrh
+bZx
+ozT
+tFr
 aHw
 xCs
 vgo
@@ -24907,13 +24941,13 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 aHw
+xOw
+ozT
+ozT
+ozT
+xOw
+seW
 dEy
 dEy
 aHw
@@ -25414,11 +25448,11 @@ aHw
 eom
 fmf
 fkv
-fTt
+gWc
 fbD
 fmf
 fkv
-fTt
+gWc
 epZ
 fmf
 fkv
@@ -25671,11 +25705,11 @@ aHw
 epH
 fbD
 fbD
-fTt
+gWc
 epH
 fbD
 fbD
-fTt
+gWc
 fNr
 fbD
 fbD
@@ -25928,11 +25962,11 @@ aHw
 epZ
 fbD
 fbD
-fTt
+gWc
 epZ
 fbD
 eom
-fTt
+gWc
 fbD
 fbD
 eom
@@ -26692,7 +26726,7 @@ uoO
 uoO
 uoO
 uoO
-aHw
+oDD
 dEy
 dEy
 dEy
@@ -27470,7 +27504,7 @@ aHw
 eom
 fbD
 epZ
-fTt
+gtR
 eom
 fbD
 epZ
@@ -27727,7 +27761,7 @@ aHw
 fbD
 fbD
 fNr
-fTt
+gWc
 fbD
 fbD
 fNr
@@ -27984,7 +28018,7 @@ aHw
 fkv
 fAs
 fbD
-fTt
+gWc
 fkv
 fAs
 fbD

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -16060,7 +16060,6 @@
 	},
 /area/f13/tunnel)
 "pLl" = (
-/obj/machinery/ore_silo,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -536,8 +536,8 @@
 /datum/job/vtcc/f13innkeeper
 	title = "Innkeeper"
 	flag = F13INNKEEPER
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the Merchant."
 	description = "Yours is a simple life, pouring pints and renting rooms out for the masses. Those hungry mouths are buying food somewhere, and it's your job to fill them with whatever food you can prepare. It's a simple life, but a rewarding one. Ownership means you have the legal rulings over your area of operations, what has been told by you for the visitors. What goes within the walls of the bar is subject to your rulings, so long as it coincides with laws and rulings made by officials and the Security forces."
 


### PR DESCRIPTION
## About The Pull Request

Due to the nature of the silos, you can't unlink a machine from the silos in the code itself. These things have caused _far_ too many issues to be left in. Fixes the button in the Alderman's office to actually open the window shutters. Fixes the lack of an access requirement on one of the doors in the lab. Gives the Follower LP an actual office, and provides them with a matrix tile and an old-world refinery, instead of a pair of chem masters.

## Why It's Good For The Game

Less BoS/VC conflict over the dumbest things in history

## Changelog
:cl:
add: FLP Office
del: Ore Silos from the map
tweak: Followers chem setup
fix: Lab Door access
fix: Alderman window button
/:cl: