### PR TITLE
Ranger CQC/Krav Removal

### DIFF
--- a/code/__DEFINES/melee.dm
+++ b/code/__DEFINES/melee.dm
@@ -9,4 +9,4 @@
 #define MARTIALART_CQC "CQC"
 #define MARTIALART_PLASMAFIST "plasma fist"
 #define MARTIALART_RISINGBASS "rising bass"
-#define MARTIALART_RANGERTAKEDOWN "ranger takedown"
+//#define MARTIALART_RANGERTAKEDOWN "ranger takedown"

--- a/code/datums/martial/rangertakedown.dm
+++ b/code/datums/martial/rangertakedown.dm
@@ -1,4 +1,4 @@
-/datum/martial_art/rangertakedown
+/*/datum/martial_art/rangertakedown
 	name = "Ranger Takedown"
 	id = MARTIALART_RANGERTAKEDOWN
 	var/datum/action/ranger_takedown/rangertakedown = new/datum/action/ranger_takedown()
@@ -69,3 +69,4 @@
 	D.DefaultCombatKnockdown(rand(10,30)) //Due to the defensive nature of the move, it shouldn't be longer than putting on a pair of cuffs. (30)
 	log_combat(A, D, "sweeped (Ranger Takedown)")
 	return TRUE
+*/

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -766,8 +766,8 @@ Veteran Ranger
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_LIGHT_STEP, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
-	var/datum/martial_art/rangertakedown/RT = new
-	RT.teach(H)
+	//var/datum/martial_art/rangertakedown/RT = new
+	//RT.teach(H)
 
 /datum/outfit/job/ncr/f13vetranger
 	name = "NCR Veteran Ranger"
@@ -840,8 +840,8 @@ Veteran Ranger
 	ADD_TRAIT(H, TRAIT_LIGHT_STEP, src)
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
-	var/datum/martial_art/rangertakedown/RT = new
-	RT.teach(H)
+	//var/datum/martial_art/rangertakedown/RT = new
+	//RT.teach(H)
 
 /datum/outfit/job/ncr/f13ranger
 	name = "NCR Ranger"

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -49,7 +49,7 @@
 			return // removes bullet disemboweling
 		if(BODY_ZONE_HEAD)
 			return // removed any chance of decap from bullets.
-				return
+
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
 	if(!affecting?.dismemberable || affecting.get_damage() < (affecting.max_damage - P.dismemberment))
 		return

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -48,7 +48,8 @@
 		if(BODY_ZONE_CHEST)
 			return // removes bullet disemboweling
 		if(BODY_ZONE_HEAD)
-			return // removed any chance of decap from bullets.
+			if(head) // No decap unless head is slot is empty
+				return
 
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
 	if(!affecting?.dismemberable || affecting.get_damage() < (affecting.max_damage - P.dismemberment))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -48,7 +48,7 @@
 		if(BODY_ZONE_CHEST)
 			return // removes bullet disemboweling
 		if(BODY_ZONE_HEAD)
-			if(head) // No decap unless head is slot is empty
+			return // removed any chance of decap from bullets.
 				return
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
 	if(!affecting?.dismemberable || affecting.get_damage() < (affecting.max_damage - P.dismemberment))

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -39,9 +39,8 @@
 	scars_covered_by_clothes = FALSE
 
 /obj/item/bodypart/head/can_dismember(obj/item/I)
-	// Can't decap people alive or with some kind of headgear less headaches for staff.
-	if(owner && (owner.stat != DEAD || owner.head))
-		return FALSE
+	// Can't decap at all anymore because even accidental decaps can get you noted. So remove the mechanic.
+	return FALSE
 	return ..()
 
 /obj/item/bodypart/head/drop_organs(mob/user)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -39,8 +39,9 @@
 	scars_covered_by_clothes = FALSE
 
 /obj/item/bodypart/head/can_dismember(obj/item/I)
-	// Can't decap at all anymore because even accidental decaps can get you noted. So remove the mechanic entirely.
-	return ..()
+	// Can't decap people alive or with some kind of headgear less headaches for staff.
+	if(owner && (owner.stat != DEAD || owner.head))
+		return FALSE
 
 /obj/item/bodypart/head/drop_organs(mob/user)
 	var/turf/T = get_turf(src)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -40,7 +40,6 @@
 
 /obj/item/bodypart/head/can_dismember(obj/item/I)
 	// Can't decap at all anymore because even accidental decaps can get you noted. So remove the mechanic entirely.
-	return FALSE
 	return ..()
 
 /obj/item/bodypart/head/drop_organs(mob/user)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -39,7 +39,7 @@
 	scars_covered_by_clothes = FALSE
 
 /obj/item/bodypart/head/can_dismember(obj/item/I)
-	// Can't decap at all anymore because even accidental decaps can get you noted. So remove the mechanic.
+	// Can't decap at all anymore because even accidental decaps can get you noted. So remove the mechanic entirely.
 	return FALSE
 	return ..()
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -628,7 +628,6 @@
 #include "code\datums\martial\mushpunch.dm"
 #include "code\datums\martial\plasma_fist.dm"
 #include "code\datums\martial\psychotic_brawl.dm"
-#include "code\datums\martial\rangertakedown.dm"
 #include "code\datums\martial\rising_bass.dm"
 #include "code\datums\martial\sleeping_carp.dm"
 #include "code\datums\martial\wrestling.dm"


### PR DESCRIPTION
## About The Pull Request

Despite being told ranger CQC does not instant stun/knockdown, it does - in one hit! Stunbatons were removed from BOS and I was told all instant-stun based mechanics were removed purposefully. So, this mechanic should be removed as well.

## Why It's Good For The Game

Removes Ranger CQC due to instant-stunlock used from what other players even stated only during hostage-taking or jail to get out of consequences with an instant-stun. NCR LMs themselves have described it as "Only being used during memes and prison breaks"

## Changelog
:cl:
removes: Ranger takedown.
/:cl: