### PR TITLE
rubber 5.56 ammo

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -42,6 +42,10 @@
 	name = "5.56 match bullet casing"
 	projectile_type = /obj/item/projectile/bullet/a556/match
 
+/obj/item/ammo_casing/a556/rubber
+	name = "5.56 rubber bullet casing"
+	projectile_type = /obj/item/projectile/bullet/a556/rubber
+
 /obj/item/ammo_casing/a556/sport //.223
 	name = ".223 bullet casing"
 	desc = "A .223 bullet casing."

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -564,6 +564,11 @@
 	ammo_type = /obj/item/ammo_casing/a556/match
 	custom_materials = list(/datum/material/iron = 28000, /datum/material/blackpowder = 3500)
 
+/obj/item/ammo_box/a556/rubber
+	name = "ammo box (5.56 rubber)"
+	ammo_type = /obj/item/ammo_casing/a556/rubber
+	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1500)
+
 /obj/item/ammo_box/a556/sport
 	name = "ammo box (.223)"
 	ammo_type = /obj/item/ammo_casing/a556/sport

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -68,6 +68,11 @@
 	bare_wound_bonus = -18
 	pixels_per_second = TILES_TO_PIXELS(20)
 
+/obj/item/projectile/bullet/a556/rubber
+	name = "5.56 rubber bullet"
+	damage = 5
+	stamina = 38
+
 /obj/item/projectile/bullet/a556/sport
 	name = ".223 FMJ bullet"
 	damage = 28

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -269,6 +269,13 @@
 	build_path = /obj/item/ammo_box/a556/jhp
 	category = list("initial", "Basic Ammo")
 
+/datum/design/ammolathe/a556rubber
+	name = "5.56 rubber ammo box"
+	id = "a556rubber"
+	materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1500)
+	build_path = /obj/item/ammo_box/a556/rubber
+	category = list("initial", "Basic Ammo")
+
 /datum/design/ammolathe/magnumshot
 	name = "magnum buckshot shotgun box"
 	id = "magnumshot"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds rubber 5.56 ammo for non lethal takedowns and training purposes. It's slightly weaker than a regular beanbag and costs the same as FMJ to make

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows more RP scenarios.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: rubber 5.56 ammo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
