### PR TITLE
Fix to Surface Side BOS Medbay

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -20396,19 +20396,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"moA" = (
-/obj/structure/chair{
-	dir = 8;
-	icon_state = "chair"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/simple_door/bunker,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/brotherhood)
 "moD" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -37878,8 +37865,6 @@
 	},
 /area/f13/city)
 "xeo" = (
-/obj/structure/table/optable,
-/obj/structure/table/optable,
 /obj/structure/table/optable,
 /obj/machinery/iv_drip{
 	pixel_x = -7;
@@ -73816,7 +73801,7 @@ xwk
 bXl
 bXl
 bXl
-moA
+jWe
 los
 los
 los


### PR DESCRIPTION
## About The Pull Request

Got rid of the 3 surgery tables extra that prevent you from being able to climb yourself onto the table. Also got rid of the chair in the door and the 'map merge conflict' marker.

## Why It's Good For The Game

As stated above. Seems to be a mapping issue we've had since the surface-side to bunker was reworked.

## Changelog
:cl:
fixes: Errors in BOS surface map.
/:cl:
