### PR TITLE
Bunker updates (bos and dungeons)

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -3441,7 +3441,15 @@
 	},
 /area/f13/building)
 "bQI" = (
-/obj/item/flag/bos,
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "NW";
+	move_me = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9;
+	icon_state = "warningline_red"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "bQL" = (
@@ -4991,14 +4999,17 @@
 	},
 /area/f13/building)
 "cZQ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "SW";
+	move_me = 1
 	},
-/obj/effect/landmark/start/f13/ncrheavytrooper,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10;
+	icon_state = "warningline_red"
 	},
-/area/f13/ncr)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood)
 "cZW" = (
 /obj/machinery/vending/cola/random,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5405,9 +5416,14 @@
 	},
 /area/f13/village)
 "dlB" = (
-/obj/structure/car/rubbish1,
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = -6
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "dlI" = (
 /obj/structure/table,
@@ -6181,15 +6197,7 @@
 	},
 /area/f13/wasteland)
 "dIW" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "SW";
-	move_me = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5;
-	icon_state = "warningline_red"
-	},
+/obj/item/flag/bos,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
 "dJg" = (
@@ -7212,14 +7220,9 @@
 	},
 /area/f13/caves)
 "eva" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/landmark/start/f13/ncrheavytrooper,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/ncr)
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "evs" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -15841,9 +15844,12 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
 "jvC" = (
-/obj/structure/flora/junglebush,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+	dir = 4;
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "jvT" = (
@@ -19767,8 +19773,10 @@
 	},
 /area/f13/wasteland)
 "lRJ" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "lRT" = (
 /obj/structure/flora/tree/tall{
@@ -27389,17 +27397,12 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "qOR" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "NW";
-	move_me = 1
+/obj/structure/flora/junglebush,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
-	icon_state = "warningline_red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood)
+/area/f13/wasteland)
 "qOV" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -28331,11 +28334,9 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/village)
 "rvO" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/car/rubbish1,
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rvT" = (
 /obj/effect/decal/cleanable/dirt{
@@ -29413,8 +29414,8 @@
 	pixel_x = -11;
 	pixel_y = 8
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "sif" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -31935,14 +31936,6 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"tDE" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "tDH" = (
 /obj/structure/debris/v4,
 /obj/effect/decal/cleanable/dirt,
@@ -37314,16 +37307,6 @@
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wPz" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = -6
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "wPE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -39859,10 +39842,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
-"ylJ" = (
-/obj/effect/landmark/start/f13/libritor,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "ylP" = (
 /obj/structure/fence{
 	dir = 1
@@ -43012,9 +42991,9 @@ kzs
 xGv
 dsn
 wSn
-eva
+sed
 tXt
-cZQ
+kzs
 wSn
 jGz
 wSn
@@ -70743,7 +70722,7 @@ iFI
 bQI
 jQH
 fMu
-bQI
+cZQ
 iFI
 gcK
 gcK
@@ -70998,7 +70977,7 @@ gcK
 gcK
 iFI
 fMu
-qOR
+fMu
 dIW
 fMu
 iFI
@@ -71256,7 +71235,7 @@ gcK
 iFI
 fMu
 fMu
-fMu
+dIW
 fMu
 iFI
 gcK
@@ -76683,7 +76662,7 @@ jem
 gcK
 gcK
 ktB
-ktB
+gcK
 gcK
 gcK
 gcK
@@ -77198,7 +77177,7 @@ gcK
 gcK
 gcK
 ktB
-ktB
+gcK
 gcK
 gcK
 gcK
@@ -77451,16 +77430,16 @@ qPL
 qPL
 qPL
 jem
-pEv
 gcK
-gcK
-gcK
+ktB
 ktB
 gcK
 gcK
 gcK
 gcK
 gcK
+gbL
+gbL
 gcK
 gcK
 fyf
@@ -77708,16 +77687,16 @@ qPL
 qPL
 qRr
 jem
-pEv
-pEv
-gcK
 gcK
 ktB
-ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gbL
-gbL
-gcK
 gcK
 gcK
 gcK
@@ -77948,9 +77927,9 @@ mvv
 bpD
 fyf
 vaA
-mGC
-mGC
-mGC
+vaA
+vaA
+vaA
 vaA
 jem
 jem
@@ -77965,17 +77944,17 @@ keK
 jem
 jem
 jem
-xQL
-pEv
-pEv
-gcK
 gcK
 ktB
 gcK
 gcK
-gbL
-gbL
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
 gcK
 gcK
 gcK
@@ -78205,9 +78184,9 @@ mvv
 doX
 cWG
 cWG
-hwJ
-hwJ
-hwJ
+cWG
+cWG
+cWG
 cWG
 cWG
 bnY
@@ -78220,20 +78199,20 @@ cWG
 cWG
 cWG
 cWG
-bnY
-cWG
-cWG
-wDc
-pEv
-gcK
+jvC
 gcK
 gcK
 ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
-gcK
-gcK
 gcK
 gcK
 gts
@@ -78462,9 +78441,6 @@ mvv
 mvv
 mvv
 mvv
-bwq
-bwq
-bwq
 mvv
 mvv
 mvv
@@ -78481,15 +78457,18 @@ mvv
 mvv
 mvv
 bpD
+gcK
+ktB
+ktB
+gcK
+fyf
 fyf
 uHT
 gcK
 gcK
-ktB
-ktB
 gcK
-gbL
-gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -78719,9 +78698,6 @@ mvv
 mvv
 mvv
 mvv
-bwq
-bwq
-bwq
 mvv
 mvv
 mvv
@@ -78738,6 +78714,11 @@ mvv
 mvv
 mvv
 bpD
+gcK
+ktB
+gcK
+gcK
+fyf
 fyf
 sim
 gcK
@@ -78745,8 +78726,6 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gbL
 gbL
 gcK
 gcK
@@ -78976,9 +78955,6 @@ mvv
 mvv
 mvv
 mvv
-bwq
-bwq
-bwq
 mvv
 mvv
 mvv
@@ -78995,19 +78971,22 @@ mvv
 mvv
 mvv
 bpD
+ktB
+gcK
+gcK
+ktB
+fyf
 fyf
 dDC
 fyf
 sim
 gcK
 gcK
-ktB
-ktB
+gcK
 gcK
 gbL
+gcK
 gbL
-gcK
-gcK
 gcK
 gcK
 gcK
@@ -79233,9 +79212,6 @@ mfD
 mfD
 mfD
 mfD
-kXK
-kXK
-kXK
 mfD
 mfD
 mfD
@@ -79247,11 +79223,16 @@ mfD
 mfD
 mfD
 mfD
-xGH
-mvv
-mvv
-mvv
-bpD
+mfD
+mfD
+mfD
+mfD
+hCg
+gcK
+gcK
+ktB
+fyf
+fyf
 fyf
 fyf
 sim
@@ -79259,14 +79240,12 @@ dDC
 gcK
 gcK
 gcK
-ktB
-ktB
-gbL
+gcK
 gbL
 gbL
 gcK
 gcK
-gcK
+gbL
 gcK
 gcK
 fyf
@@ -79490,9 +79469,9 @@ pMI
 pWx
 fyf
 vaA
-mGC
-mGC
-mGC
+vaA
+vaA
+vaA
 vaA
 jWO
 fyf
@@ -79504,11 +79483,13 @@ fyf
 fyf
 fyf
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
+fyf
+gcK
+ktB
+ktB
+gcK
+fyf
+fyf
 fyf
 uHT
 fyf
@@ -79517,14 +79498,12 @@ dDC
 gcK
 gcK
 gcK
-ktB
-ktB
 gbL
 gbL
 gcK
 gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 fyf
@@ -79761,27 +79740,27 @@ gCh
 fyf
 fyf
 fyf
-tBN
-mvv
-mvv
-mvv
-bpD
 fyf
-fyf
-fyf
-uHT
-fyf
-uHT
-gcK
-gcK
 gcK
 ktB
 gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+uHT
+fyf
+uHT
+gcK
+gcK
+gcK
 gbL
 gbL
 gcK
-gcK
-gcK
+gbL
+gbL
 gcK
 gcK
 fyf
@@ -80018,11 +79997,13 @@ fyf
 fyf
 fyf
 fyf
-tBN
-mvv
-mvv
-mvv
-doX
+fyf
+gcK
+ktB
+gcK
+qOV
+cWG
+cWG
 cWG
 cWG
 cWG
@@ -80032,13 +80013,11 @@ dDC
 uHT
 gcK
 gcK
-ktB
-gcK
 gbL
 gbL
 gcK
 gcK
-gcK
+gbL
 gcK
 gcK
 fyf
@@ -80275,9 +80254,11 @@ fyf
 fyf
 rsE
 fyf
+gcK
+gcK
+ktB
+pEv
 tBN
-mvv
-mvv
 mvv
 mvv
 mvv
@@ -80288,8 +80269,6 @@ fyf
 fyf
 fyf
 gcK
-gcK
-ktB
 gcK
 gcK
 gbL
@@ -80532,27 +80511,27 @@ fyf
 fyf
 fyf
 shF
-tBN
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-mvv
-wPz
-fyf
-dlB
-gcK
-gcK
-gcK
 ktB
+ktB
+gcK
+pEv
+lRJ
+mvv
+mvv
+mvv
+mvv
+mvv
+dlB
+fyf
+rvO
+gcK
+gcK
 gcK
 gcK
 gcK
 gbL
 gcK
-gcK
+gbL
 gcK
 gcK
 gcK
@@ -80787,12 +80766,14 @@ gcK
 gcK
 dhD
 fyf
-fyf
+eva
+gcK
+ktB
+gcK
+gcK
+gcK
 lRJ
-tBN
 mvv
-mvv
-tlj
 mvv
 mvv
 mvv
@@ -80803,13 +80784,11 @@ fyf
 gcK
 gcK
 gcK
-ktB
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+gbL
 gcK
 gcK
 gcK
@@ -81046,27 +81025,27 @@ gcK
 gcK
 gcK
 gcK
-nlO
-mfD
-mfD
-mfD
-xGH
+gcK
+ktB
+gcK
+gcK
+lRJ
 mvv
 mvv
 mvv
-bpD
+mvv
+aBH
+hCg
 dDC
 gcK
 gcK
 gcK
 gcK
-ktB
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+gbL
 gcK
 gcK
 gcK
@@ -81304,24 +81283,24 @@ jem
 jem
 gcK
 gcK
+ktB
+ktB
+ktB
 gcK
-fFu
-dhD
-jvC
 ykC
+gwk
 ykC
-ykC
-bpD
+qOR
+hCg
+fyf
 fyf
 gcK
 gcK
 gcK
-ktB
-ktB
 gcK
 gcK
 gcK
-gcK
+gbL
 gcK
 gcK
 gcK
@@ -81563,17 +81542,17 @@ gcK
 gcK
 gcK
 gcK
-mcN
-mcN
+vaA
+vaA
 tAx
-rvO
+mvv
 tKx
 mcN
 mcN
 gcK
 gcK
 gcK
-ktB
+gcK
 gcK
 gcK
 gcK
@@ -81822,9 +81801,9 @@ gcK
 gcK
 gcK
 vaA
-gcK
-gcK
-gcK
+bcM
+bcM
+bcM
 vaA
 gcK
 gcK
@@ -82079,9 +82058,9 @@ gcK
 ktB
 ktB
 vaA
-ktB
-ktB
-ktB
+bcM
+bcM
+bcM
 vaA
 gcK
 gcK
@@ -82336,9 +82315,9 @@ ktB
 ktB
 vaA
 qZy
-gcK
-gcK
-gcK
+bcM
+bcM
+bcM
 qZy
 mcN
 fyf
@@ -82594,7 +82573,7 @@ vaA
 vaA
 jCc
 tKx
-tDE
+mvv
 cCL
 bpD
 fyf
@@ -96149,7 +96128,7 @@ hom
 gMi
 dUv
 sEC
-ylJ
+xNm
 hom
 dJE
 mQz
@@ -96663,7 +96642,7 @@ rgS
 sge
 dUv
 sEC
-ylJ
+xNm
 hom
 hom
 apu

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1317,6 +1317,13 @@
 /obj/item/papercutter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"biP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "engine"
+	},
+/area/f13/brotherhood/mining)
 "bje" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -2827,6 +2834,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
+"cyX" = (
+/obj/structure/flora/junglebush/large,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cza" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -8199,6 +8210,7 @@
 	dir = 1;
 	name = "shower drain"
 	},
+/obj/structure/curtain,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whiterustysolid"
 	},
@@ -8595,9 +8607,6 @@
 /area/f13/brotherhood/offices1st)
 "hCG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
 /obj/machinery/light/fo13colored/Aqua{
 	critical_machine = 1;
 	dir = 8;
@@ -10567,6 +10576,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"jtq" = (
+/obj/structure/nest/mirelurk,
+/turf/open/water,
+/area/f13/caves)
 "jtD" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 30;
@@ -12286,14 +12299,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "kXA" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/leisure)
 "kZo" = (
 /obj/item/trash/tray,
 /obj/item/trash/f13/dog,
@@ -13410,11 +13419,15 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "mhc" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
+	pixel_x = -10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/leisure)
 "mhD" = (
 /obj/structure/toilet{
 	dir = 8
@@ -14939,10 +14952,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nCP" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "nCY" = (
 /obj/structure/table/reinforced,
@@ -15319,6 +15332,7 @@
 	dir = 1;
 	name = "shower drain"
 	},
+/obj/structure/curtain,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whiterustysolid"
 	},
@@ -15406,6 +15420,7 @@
 	dir = 1;
 	name = "shower drain"
 	},
+/obj/structure/curtain,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whiterustysolid"
 	},
@@ -15668,9 +15683,11 @@
 /turf/closed/wall,
 /area/f13/tunnel)
 "oef" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/leisure)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "oeS" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17491,10 +17508,13 @@
 /turf/open/floor/plating/rust,
 /area/f13/tunnel)
 "pDU" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/item/clothing/under/misc/bathrobe,
 /obj/item/clothing/under/misc/bathrobe,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whiterustysolid"
+	},
 /area/f13/brotherhood/offices2nd)
 "pDW" = (
 /obj/structure/rack,
@@ -20577,7 +20597,7 @@
 	},
 /area/f13/tunnel)
 "rZw" = (
-/mob/living/simple_animal/hostile/radroach,
+/obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rZF" = (
@@ -23023,6 +23043,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"uhu" = (
+/turf/open/water,
+/area/f13/caves)
 "uhw" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light/small,
@@ -25399,15 +25422,9 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "wiT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	pixel_x = -10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/leisure)
+/mob/living/simple_animal/hostile/poison/giant_spider,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wiX" = (
 /obj/structure/sign/poster/prewar/poster73,
 /turf/closed/wall/r_wall,
@@ -26132,6 +26149,10 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"wVW" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wWc" = (
 /obj/structure/sink{
 	dir = 4;
@@ -73606,7 +73627,7 @@ uoO
 uoO
 uoO
 aoj
-xVz
+rZw
 xVz
 xVz
 uoO
@@ -73863,9 +73884,9 @@ uoO
 uoO
 uoO
 aoj
+rZw
 xVz
-xVz
-xVz
+rZw
 aoj
 aoj
 uoO
@@ -74122,7 +74143,7 @@ uoO
 aoj
 aoj
 aoj
-xVz
+rZw
 aoj
 aoj
 uoO
@@ -74891,8 +74912,8 @@ uoO
 uoO
 uoO
 aoj
+wiT
 xVz
-uiV
 aoj
 uoO
 uoO
@@ -75148,9 +75169,9 @@ uoO
 uoO
 uoO
 aoj
-xVz
-xVz
 rZw
+xVz
+xVz
 uoO
 uoO
 uoO
@@ -75405,8 +75426,8 @@ uoO
 uoO
 uoO
 uoO
-rZw
 xVz
+rZw
 xVz
 uoO
 uoO
@@ -76435,8 +76456,8 @@ uoO
 aoj
 aoj
 aoj
-xVz
-xVz
+wiT
+rZw
 uoO
 uoO
 uoO
@@ -76692,7 +76713,7 @@ uoO
 uoO
 uoO
 uoO
-xVz
+rZw
 xVz
 uoO
 uoO
@@ -76949,8 +76970,8 @@ uoO
 uoO
 uoO
 uoO
-xVz
-xVz
+rZw
+rZw
 aoj
 aoj
 uoO
@@ -81523,8 +81544,8 @@ saw
 saw
 saw
 saw
-kOv
-wiT
+saw
+saw
 jZH
 rjJ
 gUJ
@@ -81780,8 +81801,8 @@ saw
 saw
 khW
 jZH
-cLD
-cLD
+kOv
+mhc
 jZH
 kgu
 gUJ
@@ -82294,8 +82315,8 @@ saw
 saw
 eez
 jZH
-ouk
-ouk
+cLD
+cLD
 jZH
 kGH
 gUJ
@@ -82551,8 +82572,8 @@ saw
 saw
 muV
 jZH
-oef
-saw
+ouk
+ouk
 jZH
 wwy
 gUJ
@@ -82808,7 +82829,7 @@ saw
 saw
 khW
 jZH
-saw
+kXA
 saw
 jZH
 jCM
@@ -83359,8 +83380,8 @@ wac
 wac
 vYw
 oHY
+gul
 pDU
-tca
 tca
 tca
 xNs
@@ -83898,12 +83919,12 @@ xhA
 sll
 xhA
 xmk
-hZE
+twE
 twE
 ogl
 ogl
 ogl
-cyU
+twE
 xmk
 qkC
 aNY
@@ -84155,12 +84176,12 @@ xhA
 sll
 xhA
 xmk
-twE
+hZE
 twE
 ogl
 ogl
 ogl
-twE
+cyU
 xmk
 dNP
 gpq
@@ -84412,7 +84433,7 @@ xhA
 nkS
 xhA
 xmk
-xmk
+twE
 twE
 ogl
 ogl
@@ -84668,8 +84689,8 @@ rUF
 xhA
 vcT
 xhA
-xhA
 xmk
+twE
 twE
 bES
 twE
@@ -84912,7 +84933,7 @@ qCm
 xhA
 xhA
 xhA
-xhA
+pqC
 qWx
 qWx
 vni
@@ -84925,7 +84946,7 @@ xhA
 xhA
 sll
 xhA
-xhA
+xmk
 xmk
 pYq
 xmk
@@ -85918,7 +85939,7 @@ vYw
 vYw
 vYw
 vYw
-kXA
+jWb
 xSi
 xSi
 usN
@@ -86175,8 +86196,8 @@ gEZ
 gEZ
 gEZ
 gEZ
-nCP
 gEZ
+jlu
 gEZ
 gEZ
 gEZ
@@ -86432,7 +86453,7 @@ tlG
 uET
 uQm
 gEZ
-mrV
+nCP
 cOE
 mTF
 xYu
@@ -87460,8 +87481,8 @@ gHh
 gHh
 ckK
 gEZ
+oef
 mrV
-mhc
 mTF
 xYu
 xYu
@@ -87777,7 +87798,7 @@ aoj
 aoj
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 aoj
@@ -89572,16 +89593,16 @@ uAc
 uAc
 xVz
 xVz
-xVz
-xVz
+vOo
+cyX
 uoO
 uoO
 uoO
 aoj
 aoj
+mED
 uoO
-uoO
-uoO
+wVW
 uoO
 aoj
 aoj
@@ -89829,16 +89850,16 @@ uAc
 uAc
 xVz
 xVz
-xVz
-xVz
-xVz
+uhu
+uhu
+wVW
+mED
 uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
+mED
+uhu
+uhu
+vOo
+cyX
 uoO
 uoO
 uoO
@@ -90087,15 +90108,15 @@ uAc
 xVz
 xVz
 xVz
-xVz
-xVz
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
+uhu
+uhu
+uhu
+uhu
+uhu
+uhu
+uhu
+jtq
+mED
 uoO
 uoO
 uoO
@@ -90344,14 +90365,14 @@ uAc
 vOo
 xVz
 xVz
-xVz
-aoj
-aoj
-uoO
-uoO
-uoO
-uoO
-uoO
+uhu
+uhu
+uhu
+uhu
+uhu
+uhu
+rEl
+mED
 uoO
 uoO
 uoO
@@ -90602,9 +90623,17 @@ xVz
 xVz
 xVz
 xVz
+vOo
+uhu
+uhu
+vOo
+wVW
+uoO
+uoO
+uoO
+uoO
 aoj
 aoj
-aoj
 uoO
 uoO
 uoO
@@ -90613,14 +90642,6 @@ uoO
 uoO
 aoj
 aoj
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
-uoO
 uoO
 uoO
 uoO
@@ -90859,23 +90880,23 @@ xVz
 xVz
 xVz
 xVz
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
+xVz
+xVz
+mED
 aoj
 uoO
 uoO
 uoO
+aoj
+aoj
+aoj
+aoj
 uoO
 uoO
 uoO
+uoO
+uoO
+aoj
 uoO
 uoO
 uoO
@@ -91116,23 +91137,23 @@ xVz
 xVz
 xVz
 xVz
-uoO
-aoj
-aoj
-aoj
-uoO
-uoO
-uoO
-aoj
-aoj
-aoj
-aoj
-uoO
-uoO
+xVz
 uoO
 uoO
 aoj
 uoO
+uoO
+uoO
+aoj
+aoj
+aoj
+aoj
+uoO
+uoO
+uoO
+uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -91875,7 +91896,7 @@ otj
 gFU
 qQq
 aXF
-qQq
+biP
 jpl
 mAv
 eXD
@@ -91899,7 +91920,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -92156,7 +92177,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO
@@ -92413,8 +92434,8 @@ uoO
 uoO
 uoO
 uoO
-uoO
-uoO
+aoj
+aoj
 uoO
 uoO
 uoO
@@ -92669,7 +92690,7 @@ uoO
 uoO
 uoO
 uoO
-uoO
+aoj
 uoO
 uoO
 uoO

--- a/_maps/map_files/templates/dungeons/north_sewer_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_sewer_2.dmm
@@ -1118,7 +1118,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "vj" = (
-/mob/living/simple_animal/hostile/raider/thief,
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
 	},
@@ -1197,10 +1196,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "vS" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/biker,
+/mob/living/simple_animal/hostile/raider/legendary,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
+/area/f13/tunnel)
 "wm" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13{
@@ -1357,9 +1355,14 @@
 	},
 /area/f13/radiation)
 "yW" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/assaultron/nsb,
-/turf/open/indestructible/ground/inside/mountain,
+/mob/living/simple_animal/hostile/handy/sentrybot{
+	color = "#FFFF00";
+	harm_intent_damage = 10;
+	health = 400;
+	name = "legendary sentry bot";
+	obj_damage = 100
+	},
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "yY" = (
 /obj/item/storage/trash_stack,
@@ -1790,11 +1793,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"If" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "Ik" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/crumpled,
@@ -1810,7 +1808,6 @@
 /area/f13/bunker)
 "IL" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/abomhorror/nsb,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -2268,13 +2265,9 @@
 /area/f13/bunker)
 "Ry" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/thief,
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"RF" = (
-/mob/living/simple_animal/hostile/handy/sentrybot/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "RH" = (
 /obj/item/paper,
 /obj/item/paper/crumpled,
@@ -2517,10 +2510,6 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"WY" = (
-/obj/structure/nest/deathclaw,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "Xa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
@@ -2672,11 +2661,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ZB" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy/sentrybot/nsb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "ZF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -3824,7 +3808,7 @@ Tq
 kI
 hc
 XE
-vS
+pC
 PI
 sT
 Yn
@@ -3857,7 +3841,7 @@ QU
 Xo
 Xo
 Tq
-If
+Sx
 RZ
 Yn
 pC
@@ -4129,7 +4113,7 @@ PI
 pC
 BW
 Et
-ee
+pC
 lZ
 Xa
 Gs
@@ -4393,21 +4377,21 @@ wI
 zi
 mi
 Tq
-cW
+Sx
 Gp
-Gx
+Sx
 Tq
 oO
 Nf
 pC
 pC
-ZB
+pC
 pC
 ck
 dc
 PI
 PI
-RF
+PI
 PI
 PI
 KA
@@ -4433,7 +4417,7 @@ ld
 Sx
 Tq
 Sx
-Tq
+vS
 Sx
 ik
 YP
@@ -4442,7 +4426,7 @@ Jx
 pC
 ny
 dk
-Vw
+yW
 pC
 ka
 YG
@@ -4516,11 +4500,11 @@ WG
 Ed
 ck
 Jf
-yW
+WG
 WG
 ck
 en
-Ee
+ck
 vw
 KQ
 BH
@@ -4872,7 +4856,7 @@ BH
 cA
 ZF
 cA
-WY
+sR
 BH
 QU
 BH

--- a/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
@@ -93,8 +93,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/mob/living/simple_animal/hostile/ghoul/coldferal,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "bK" = (
@@ -113,6 +113,13 @@
 /area/f13/bunker)
 "bZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ch" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "ci" = (
 /obj/effect/decal/cleanable/dirt,
@@ -238,12 +245,8 @@
 	},
 /area/f13/bunker)
 "eg" = (
-/mob/living/simple_animal/hostile/supermutant/legendary,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/obj/structure/mirror,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "ek" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/larva,
@@ -280,13 +283,10 @@
 	},
 /area/f13/bunker)
 "eB" = (
-/mob/living/simple_animal/hostile/alien{
-	faction = list("ghoul")
-	},
+/mob/living/simple_animal/hostile/ghoul/frozenreaver,
 /turf/open/floor/padded,
 /area/f13/bunker)
 "eN" = (
-/obj/item/lipstick/random,
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plating/tunnel,
@@ -463,12 +463,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "hL" = (
-/obj/structure/bed/pod,
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
+/mob/living/simple_animal/hostile/ghoul/coldferal,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "hT" = (
 /obj/structure/wreck/trash/one_barrel,
@@ -542,6 +538,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
+/mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jj" = (
@@ -703,7 +700,7 @@
 /area/f13/bunker)
 "ml" = (
 /obj/structure/sign/poster/contraband/pinup_ride,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "mo" = (
 /obj/effect/decal/cleanable/blood/splatter/xeno,
@@ -724,9 +721,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"mT" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/underground/cave)
 "nb" = (
 /obj/structure/wreck/trash/one_barrel,
 /turf/open/floor/plasteel/barber{
@@ -744,12 +738,11 @@
 	},
 /area/f13/bunker)
 "ni" = (
-/obj/structure/chair/stool/retro,
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/legendary{
+	faction = list("hostile","ghoul")
 	},
+/turf/open/floor/plating,
 /area/f13/bunker)
 "nj" = (
 /obj/structure/table/reinforced,
@@ -809,7 +802,6 @@
 /area/f13/bunker)
 "ol" = (
 /obj/effect/decal/cleanable/blood/gibs/human/lizard/limb,
-/obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -821,9 +813,6 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker)
-"oo" = (
-/turf/closed/indestructible/rock,
 /area/f13/bunker)
 "oz" = (
 /mob/living/simple_animal/hostile/handy/assaultron,
@@ -851,9 +840,11 @@
 	},
 /area/f13/bunker)
 "oQ" = (
-/obj/structure/nest/deathclaw,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/coldferal,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
 "oV" = (
@@ -909,6 +900,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"qi" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron{
+	color = "#FFFF00";
+	harm_intent_damage = 10;
+	health = 600;
+	melee_damage_lower = 60;
+	melee_damage_upper = 75;
+	name = "legendary assaultron";
+	obj_damage = 80
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qn" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 8
@@ -925,12 +929,16 @@
 /area/f13/bunker)
 "qG" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "qZ" = (
-/mob/living/simple_animal/hostile/gecko,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer,
+/mob/living/simple_animal/hostile/ghoul/legendary{
+	faction = list("hostile","ghoul")
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/bunker)
 "rj" = (
 /obj/structure/wreck/trash/one_barrel,
@@ -1008,6 +1016,13 @@
 	},
 /turf/open/floor/engine,
 /area/f13/radiation)
+"sn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "ss" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/engine,
@@ -1020,13 +1035,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "sI" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
 "sV" = (
@@ -1160,7 +1173,7 @@
 /area/f13/bunker)
 "vy" = (
 /obj/effect/decal/cleanable/blood,
-/turf/closed/mineral/random/low_chance,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "vB" = (
 /obj/structure/chair/stool/retro,
@@ -1231,7 +1244,14 @@
 /area/f13/bunker)
 "wy" = (
 /obj/structure/sign/poster/contraband/pinup_funk,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
+"wH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "wR" = (
 /obj/structure/timeddoor,
@@ -1466,7 +1486,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
-/mob/living/simple_animal/hostile/supermutant,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -1495,6 +1514,7 @@
 "Bh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/melee/chainofcommand/tailwhip,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -1553,7 +1573,7 @@
 /area/f13/bunker)
 "Ce" = (
 /obj/machinery/computer/security/telescreen/entertainment,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "Cp" = (
 /mob/living/simple_animal/hostile/handy,
@@ -1631,8 +1651,12 @@
 	},
 /area/f13/bunker)
 "Dg" = (
-/mob/living/simple_animal/hostile/supermutant/rangedmutant,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/bunker)
 "Di" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1653,21 +1677,16 @@
 	},
 /area/f13/bunker)
 "DJ" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/structure/chair/office/light,
+/mob/living/simple_animal/hostile/ghoul/coldferal,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/supermutant/nightkin,
-/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "DM" = (
-/obj/machinery/vending/autodrobe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "DO" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -1679,7 +1698,10 @@
 /area/f13/bunker)
 "DQ" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/closed/mineral/random/low_chance,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/bunker)
 "DV" = (
 /mob/living/simple_animal/hostile/ghoul/soldier/armored,
@@ -1714,7 +1736,7 @@
 /area/f13/bunker)
 "Ek" = (
 /obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "En" = (
 /obj/structure/table,
@@ -1796,11 +1818,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "Fe" = (
-/mob/living/simple_animal/hostile/deathclaw/mother,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "Ff" = (
 /obj/structure/urinal,
@@ -1875,7 +1894,7 @@
 /area/f13/bunker)
 "GL" = (
 /obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "GR" = (
 /obj/structure/camera_assembly,
@@ -1911,12 +1930,8 @@
 	},
 /area/f13/radiation)
 "Ho" = (
-/mob/living/simple_animal/hostile/gecko,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/obj/structure/timeddoor,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "Hy" = (
 /turf/closed/mineral/random/low_chance,
@@ -1991,13 +2006,18 @@
 	},
 /area/f13/bunker)
 "JI" = (
-/obj/item/reagent_containers/rag/towel/random,
 /obj/structure/table,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "JM" = (
-/mob/living/simple_animal/hostile/supermutant,
+/obj/machinery/door/poddoor{
+	armor = list("melee" = 5000, "bullet" = 10000, "laser" = 10000, "energy" = 10000, "bomb" = 5000, "bio" = 10000, "rad" = 10000, "fire" = 10000, "acid" = 7000);
+	desc = "An extremely heavy duty blast door that opens mechanically.";
+	id = bunkeelee;
+	max_integrity = 6000000
+	},
+/obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -2045,6 +2065,7 @@
 	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/coldferal,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -2124,6 +2145,7 @@
 "Mq" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
@@ -2248,9 +2270,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "Op" = (
-/mob/living/simple_animal/hostile/supermutant,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/mob/living/simple_animal/hostile/handy/sentrybot{
+	color = "#FFFF00";
+	harm_intent_damage = 10;
+	health = 400;
+	name = "legendary sentry bot";
+	obj_damage = 100
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "Os" = (
 /obj/docking_port/stationary{
@@ -2333,18 +2362,26 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"Qb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "Qh" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "Ql" = (
-/obj/structure/nest/ghoul,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/obj/structure/closet/crate/secure/weapon,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "Qn" = (
@@ -2442,6 +2479,13 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"Sk" = (
+/obj/item/circuitboard/machine/cyborgrecharger,
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "Sm" = (
 /obj/structure/closet,
 /obj/item/clothing/glasses/hud/security/sunglasses,
@@ -2504,6 +2548,21 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"SY" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/securitron{
+	color = "#FFFF00";
+	harm_intent_damage = 10;
+	health = 350;
+	melee_damage_lower = 50;
+	melee_damage_upper = 60;
+	name = "Legendary Securitron";
+	speed = 1.2
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "Ta" = (
 /obj/structure/grille/broken,
 /mob/living/simple_animal/hostile/stalker,
@@ -2518,12 +2577,24 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"To" = (
-/mob/living/simple_animal/hostile/stalkeryoung,
-/obj/effect/decal/cleanable/dirt,
+"Tm" = (
+/mob/living/simple_animal/hostile/handy/assaultron{
+	color = "#FFFF00";
+	harm_intent_damage = 10;
+	health = 600;
+	melee_damage_lower = 60;
+	melee_damage_upper = 75;
+	name = "legendary assaultron";
+	obj_damage = 80
+	},
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
+/area/f13/bunker)
+"To" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "Ts" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -2664,10 +2735,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "Vb" = (
-/mob/living/simple_animal/hostile/deathclaw/mother,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "Vi" = (
@@ -2731,6 +2803,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"VN" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "VU" = (
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -2743,18 +2819,28 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "Wq" = (
-/mob/living/simple_animal/hostile/supermutant,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "Wr" = (
 /obj/item/circuitboard/machine/smartfridge,
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/engine,
 /area/f13/radiation)
+"Ws" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/sentrybot{
+	color = "#FFFF00";
+	harm_intent_damage = 10;
+	health = 400;
+	name = "legendary sentry bot";
+	obj_damage = 100
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "Wy" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
@@ -2764,13 +2850,9 @@
 	},
 /area/f13/bunker)
 "WA" = (
-/mob/living/simple_animal/hostile/alien{
-	faction = list("ghoul")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/mob/living/simple_animal/hostile/handy/robobrain,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "WB" = (
@@ -2784,6 +2866,21 @@
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"WN" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron{
+	color = "#FFFF00";
+	harm_intent_damage = 10;
+	health = 600;
+	melee_damage_lower = 60;
+	melee_damage_upper = 75;
+	name = "legendary assaultron";
+	obj_damage = 80
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "WO" = (
 /obj/structure/sink{
@@ -2832,8 +2929,10 @@
 	},
 /area/f13/bunker)
 "Xc" = (
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "Xe" = (
 /obj/machinery/shower{
@@ -2870,14 +2969,13 @@
 /area/f13/bunker)
 "Xs" = (
 /obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/hostile/deathclaw/mother,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
 "Xu" = (
-/turf/closed/mineral/random/low_chance,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "Xz" = (
 /mob/living/simple_animal/hostile/rat,
@@ -2904,6 +3002,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"XM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharge_station,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "XQ" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -2922,12 +3027,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "Ym" = (
-/mob/living/simple_animal/hostile/supermutant,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "Yp" = (
 /obj/structure/table,
+/obj/machinery/button{
+	id = bunkeelee
+	},
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
@@ -2996,15 +3105,15 @@ Zs
 Zs
 Zs
 Zs
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
 Zs
 Zs
 Zs
@@ -3038,7 +3147,7 @@ Zs
 Zs
 Zs
 Zs
-rW
+Xu
 aS
 uP
 ui
@@ -3046,7 +3155,7 @@ rW
 Kd
 Zn
 ui
-rW
+Xu
 Zs
 Zs
 Zs
@@ -3080,7 +3189,7 @@ Zs
 Zs
 Zs
 Zs
-rW
+Xu
 fg
 fg
 fg
@@ -3088,7 +3197,7 @@ rW
 lN
 oF
 fg
-rW
+Xu
 Zs
 Zs
 Zs
@@ -3122,7 +3231,7 @@ Zs
 Zs
 Zs
 Zs
-rW
+Xu
 WI
 fg
 PN
@@ -3130,12 +3239,12 @@ rW
 oF
 fg
 rJ
-rW
-rW
-rW
-rW
-rW
-rW
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
 Zs
 Zs
 Zs
@@ -3164,7 +3273,7 @@ Zs
 Zs
 Zs
 Zs
-rW
+Xu
 oE
 cI
 oE
@@ -3177,13 +3286,13 @@ WB
 VU
 xR
 Tg
-rW
+Xu
 wy
-rW
-rW
+Xu
+Xu
 Ek
-rW
-rW
+Xu
+Xu
 Zs
 Zs
 Zs
@@ -3206,7 +3315,7 @@ Zs
 Zs
 Zs
 Zs
-rW
+Xu
 Ev
 FB
 jd
@@ -3225,7 +3334,7 @@ uf
 yx
 zK
 HC
-rW
+Xu
 Zs
 Zs
 Zs
@@ -3248,7 +3357,7 @@ Zs
 Zs
 Zs
 Zs
-rW
+Xu
 Zz
 Un
 uf
@@ -3284,13 +3393,13 @@ Zs
 Zs
 "}
 (8,1,1) = {"
-rW
-rW
-rW
-rW
+Xu
+Xu
+Xu
+Xu
 Zs
 Zs
-rW
+Xu
 Ev
 Ev
 zc
@@ -3309,7 +3418,7 @@ Ev
 iT
 Ev
 jd
-rW
+Xu
 Zs
 Zs
 Zs
@@ -3326,13 +3435,13 @@ Zs
 Zs
 "}
 (9,1,1) = {"
-rW
+Xu
 Ec
 SD
 GL
 Zs
 Zs
-rW
+Xu
 Ev
 uf
 zp
@@ -3351,29 +3460,29 @@ zu
 uf
 XD
 Ev
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-Zs
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
 Zs
 Zs
 "}
 (10,1,1) = {"
-Eo
+eg
 TC
 at
-rW
-rW
-rW
+Xu
+Xu
+Xu
 Ce
 Jo
 Jo
@@ -3404,13 +3513,13 @@ Cw
 ya
 CZ
 zW
-rW
-Zs
+Qh
+Xu
 Zs
 Zs
 "}
 (11,1,1) = {"
-rW
+Xu
 YF
 rW
 rW
@@ -3425,7 +3534,7 @@ Oo
 rW
 cy
 cy
-DJ
+cy
 TN
 uf
 uf
@@ -3446,8 +3555,8 @@ rj
 gG
 PS
 As
-rW
-rW
+Qh
+Xu
 Zs
 Zs
 "}
@@ -3458,11 +3567,11 @@ cw
 BJ
 rW
 VM
-Op
+uf
 jd
 iS
 VM
-Op
+uf
 Ev
 rW
 xU
@@ -3488,16 +3597,16 @@ Ez
 gR
 SD
 Qu
-rW
-rW
+Qh
+Xu
 Zs
 Zs
 "}
 (13,1,1) = {"
-rW
+Xu
 AH
 Xa
-To
+SD
 rW
 gh
 uf
@@ -3530,13 +3639,13 @@ SD
 Gl
 ya
 Cb
-DM
-rW
+yq
+Xu
 Zs
 Zs
 "}
 (14,1,1) = {"
-rW
+Xu
 MJ
 EW
 sV
@@ -3573,19 +3682,19 @@ EG
 MB
 hZ
 ya
-rW
+Xu
 Zs
 Zs
 "}
 (15,1,1) = {"
-rW
+Xu
 oN
 rW
 rW
 rW
 rW
 Ev
-Dg
+Ev
 Ev
 Ri
 uf
@@ -3615,12 +3724,12 @@ eN
 JI
 hT
 aA
-rW
+Xu
 Zs
 Zs
 "}
 (16,1,1) = {"
-rW
+Xu
 CN
 Qv
 Ta
@@ -3645,24 +3754,24 @@ qn
 Wr
 um
 dx
-Hy
+aJ
 kj
 kj
 kj
-Zs
 kj
-Zs
+kj
+kj
 rW
 Eo
 rW
 rW
-aq
-rW
+VN
+Xu
 Zs
 Zs
 "}
 (17,1,1) = {"
-rW
+Xu
 CI
 lp
 EL
@@ -3687,24 +3796,24 @@ xQ
 mo
 DY
 KP
-Hy
-kj
-kj
-kj
-Zs
+aJ
 kj
 kj
 kj
 kj
 kj
+kj
+rW
+Tm
+Qh
 Mq
 SM
-rW
+Xu
 Zs
 Zs
 "}
 (18,1,1) = {"
-rW
+Xu
 SU
 wk
 yo
@@ -3729,24 +3838,24 @@ AN
 PH
 PH
 Hy
-Hy
-kj
-kj
-kj
-Zs
+aJ
 kj
 kj
 kj
 kj
 kj
+kj
+rW
+Qh
+Qh
 IL
 Qh
-rW
+Xu
 Zs
 Zs
 "}
 (19,1,1) = {"
-rW
+Xu
 Qh
 NM
 SD
@@ -3771,24 +3880,24 @@ nS
 ME
 SN
 Hy
-Hy
+aJ
 kj
 kj
 kj
 Zs
 rW
 rW
-kj
-kj
 rW
-Fe
+Qh
+Qh
 SD
-rW
+WN
+Xu
 Zs
 Zs
 "}
 (20,1,1) = {"
-rW
+Xu
 Ro
 VA
 jj
@@ -3813,24 +3922,24 @@ IQ
 ci
 DY
 fR
-Hy
+aJ
 kj
 kj
 Zs
 Zs
 rW
 yZ
-yq
+qi
 CE
 tY
 ex
 Bh
-rW
+Xu
 Zs
 Zs
 "}
 (21,1,1) = {"
-rW
+Xu
 rW
 rW
 rW
@@ -3855,7 +3964,7 @@ Ts
 FM
 PH
 sl
-Hy
+aJ
 kj
 Zs
 Zs
@@ -3864,22 +3973,22 @@ rW
 Im
 lj
 SD
-SD
+wH
 SM
-rW
-rW
+SD
+Xu
 Zs
 Zs
 "}
 (22,1,1) = {"
-rW
+Xu
 Fq
-Xc
+bZ
 bZ
 fV
 rW
 bK
-lp
+oQ
 rW
 ET
 lp
@@ -3897,35 +4006,35 @@ AN
 PH
 oG
 ek
-Hy
+aJ
 kj
 Zs
 rW
 rW
 rW
 rW
+Xc
+sn
 rW
-SD
-Qh
-rW
-rW
-Zs
+Xu
+Xu
+Xu
 Zs
 Zs
 "}
 (23,1,1) = {"
-rW
-bZ
+Xu
+hL
 fP
 cs
 XC
 rW
-Wq
+lp
 BD
 rW
 Cv
-BD
-WA
+fy
+lp
 rW
 Bb
 Ny
@@ -3939,7 +4048,7 @@ Vx
 Ud
 Hy
 Hy
-Hy
+aJ
 Zs
 Zs
 rW
@@ -3949,20 +4058,20 @@ SD
 CR
 Xs
 Qh
-rW
+Xu
 Zs
 Zs
 Zs
 Zs
 "}
 (24,1,1) = {"
-rW
+Xu
 Rn
 qa
 Rq
 FY
 Xq
-BD
+qZ
 Wy
 Ff
 BD
@@ -3981,28 +4090,28 @@ Pb
 NJ
 Vy
 Jp
-Hy
+aJ
 Zs
 Zs
 rW
-Qh
+Op
 aX
 Qh
-SD
+ch
 el
 nD
-rW
+Xu
 Zs
 Zs
 Zs
 Zs
 "}
 (25,1,1) = {"
-rW
+Xu
 bZ
 nE
 RC
-Ym
+FY
 rW
 BD
 lp
@@ -4019,31 +4128,31 @@ ZS
 rW
 rW
 rW
+DM
+DM
+DM
+DM
+DM
 Ua
 Ua
-Ua
-Ua
-Ua
-Ua
-Ua
-Ua
+Ho
 RO
 SD
 SD
 SD
-SD
-rW
-rW
+Ws
+Xu
+Xu
 Zs
 Zs
 Zs
 Zs
 "}
 (26,1,1) = {"
-rW
+Xu
 fD
 MW
-FY
+ni
 Mp
 rW
 BD
@@ -4068,13 +4177,13 @@ An
 An
 An
 An
-Ua
-tY
-oQ
+Ho
+Ql
+Qh
 mQ
 Lk
-hL
-rW
+SD
+Xu
 Zs
 Zs
 Zs
@@ -4082,7 +4191,7 @@ Zs
 Zs
 "}
 (27,1,1) = {"
-rW
+Xu
 rW
 rW
 rW
@@ -4110,13 +4219,13 @@ WP
 WP
 WP
 An
-Ua
-AH
-SM
+Ho
+To
+Qb
+VN
 rW
 rW
-rW
-rW
+Xu
 Zs
 Zs
 Zs
@@ -4124,7 +4233,7 @@ Zs
 Zs
 "}
 (28,1,1) = {"
-rW
+Xu
 qA
 lp
 EP
@@ -4134,15 +4243,15 @@ lp
 ky
 rW
 lp
-lp
-Ql
+Dg
+TL
 Wy
 KN
 lp
 lp
 lp
 lp
-lp
+Dg
 lp
 rW
 Ua
@@ -4152,13 +4261,13 @@ WP
 WP
 WP
 An
-Ua
-SD
+Ho
+Vb
 Uw
 SG
-sI
+SD
 on
-rW
+Xu
 Zs
 Zs
 Zs
@@ -4166,14 +4275,14 @@ Zs
 Zs
 "}
 (29,1,1) = {"
-rW
+Xu
 ky
 vB
-ni
+cT
 BD
 rW
 lp
-eg
+lp
 rW
 rW
 Xq
@@ -4194,13 +4303,13 @@ WP
 Os
 WP
 An
-Ua
-SG
+Ho
+Wq
 SD
 SM
-Vb
+RO
 CZ
-rW
+Xu
 Zs
 Zs
 Zs
@@ -4208,13 +4317,13 @@ Zs
 Zs
 "}
 (30,1,1) = {"
-rW
-ni
+Xu
+cT
 pH
 pH
 TZ
 rW
-lp
+oQ
 BD
 rW
 BD
@@ -4236,13 +4345,13 @@ eo
 eo
 ZN
 An
-Ua
-Xu
+Ho
+WA
 SG
 cx
 VA
-RO
-rW
+XM
+Xu
 Zs
 Zs
 Zs
@@ -4250,7 +4359,7 @@ Zs
 Zs
 "}
 (31,1,1) = {"
-rW
+Xu
 TB
 di
 pH
@@ -4278,13 +4387,13 @@ gW
 gW
 gW
 wR
-Ua
-Xu
-Xu
-Xu
-NA
+Ho
 Qh
-rW
+Qh
+Qh
+NA
+Sk
+Xu
 Zs
 Zs
 Zs
@@ -4292,7 +4401,7 @@ Zs
 Zs
 "}
 (32,1,1) = {"
-rW
+Xu
 GB
 En
 nx
@@ -4302,7 +4411,7 @@ lp
 oV
 rW
 BD
-BA
+DJ
 En
 pb
 vS
@@ -4319,14 +4428,14 @@ lp
 SL
 lp
 TL
+BD
 Xu
-oo
-Xu
-Xu
-Xu
-Xu
+Qh
+SG
+Qh
+WA
 Vt
-rW
+Xu
 Zs
 Zs
 Zs
@@ -4334,13 +4443,13 @@ Zs
 Zs
 "}
 (33,1,1) = {"
-rW
+Xu
 cT
 Qa
 aB
 dB
 rW
-lp
+sI
 rW
 rW
 rW
@@ -4362,13 +4471,13 @@ lp
 lp
 tS
 DQ
-oo
 Xu
-Xu
-Xu
+Xc
+VN
 rW
 rW
 rW
+Xu
 Zs
 Zs
 Zs
@@ -4376,7 +4485,7 @@ Zs
 Zs
 "}
 (34,1,1) = {"
-rW
+Xu
 bK
 vB
 vB
@@ -4403,9 +4512,9 @@ CT
 dS
 NZ
 CT
+BD
 Xu
-oo
-Xu
+Qh
 SD
 rW
 Zs
@@ -4418,7 +4527,7 @@ Zs
 Zs
 "}
 (35,1,1) = {"
-rW
+Xu
 lp
 BD
 De
@@ -4446,8 +4555,8 @@ AK
 yB
 Wy
 BD
-oo
 Xu
+SG
 Ah
 rW
 Zs
@@ -4460,13 +4569,13 @@ Zs
 Zs
 "}
 (36,1,1) = {"
-rW
+Xu
 AX
 Vu
 En
 En
 rW
-Wq
+lp
 rW
 Zs
 rW
@@ -4485,12 +4594,12 @@ rW
 lp
 CT
 sg
-Xu
+BD
 lp
 lp
-oo
-Xu
-SD
+JM
+SG
+SY
 rW
 rW
 Zs
@@ -4502,10 +4611,10 @@ Zs
 Zs
 "}
 (37,1,1) = {"
-rW
+Xu
 Cv
-Ho
 lp
+oQ
 lp
 rW
 lp
@@ -4525,13 +4634,13 @@ vG
 Dx
 rW
 Xq
-rW
-rW
-oo
 Xu
-oo
-oo
 Xu
+Xu
+Xu
+Fe
+Xu
+SG
 SD
 Yp
 rW
@@ -4544,7 +4653,7 @@ Zs
 Zs
 "}
 (38,1,1) = {"
-rW
+Xu
 TD
 ky
 OE
@@ -4566,15 +4675,15 @@ lp
 Mf
 bn
 rW
-JM
+BD
+Xu
+Zs
+Zs
+Zs
+Zs
 rW
-Zs
-Zs
-Zs
-oo
-Xu
 vy
-Xu
+SG
 iU
 rW
 Zs
@@ -4586,7 +4695,7 @@ Zs
 Zs
 "}
 (39,1,1) = {"
-rW
+Xu
 kx
 Xo
 pZ
@@ -4609,14 +4718,14 @@ Ub
 rW
 rW
 lp
+Xu
+Zs
+Zs
+Zs
+Zs
 rW
-Zs
-Zs
-Zs
-Xu
-Xu
-Xu
-Xu
+Ym
+SG
 NM
 rW
 Zs
@@ -4628,7 +4737,7 @@ Zs
 Zs
 "}
 (40,1,1) = {"
-rW
+Xu
 rW
 rW
 lt
@@ -4638,7 +4747,7 @@ Cv
 ZU
 BD
 Qv
-Wq
+lp
 lp
 lp
 lp
@@ -4651,16 +4760,16 @@ lp
 hI
 xz
 lp
+Xu
+Zs
+Zs
+Zs
+Zs
 rW
-Zs
-Zs
-Zs
-Xu
-Xu
-Xu
-Xu
-Xu
-Xu
+rW
+rW
+rW
+rW
 Zs
 Zs
 Zs
@@ -4670,17 +4779,17 @@ Zs
 Zs
 "}
 (41,1,1) = {"
-rW
+Xu
 uR
 Uz
-qZ
+uR
 rW
 rW
 BD
 lp
 lp
 lp
-lp
+oQ
 lp
 hG
 BD
@@ -4692,16 +4801,16 @@ BD
 BD
 lp
 lp
-lp
-rW
+oQ
+Xu
 Zs
 Zs
 Zs
 Zs
-Xu
-Xu
-Xu
-Xu
+Zs
+Zs
+Zs
+Zs
 Zs
 Zs
 Zs
@@ -4712,37 +4821,37 @@ Zs
 Zs
 "}
 (42,1,1) = {"
-rW
+Xu
 Tv
 xK
 Bk
-rW
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-Zs
-Zs
-Zs
-Zs
-Zs
 Xu
 Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Xu
+Zs
+Zs
+Zs
+Zs
+Zs
+Zs
+Zs
 Zs
 Zs
 Zs
@@ -4754,11 +4863,11 @@ Zs
 Zs
 "}
 (43,1,1) = {"
-rW
-rW
-rW
-rW
-rW
+Xu
+Xu
+Xu
+Xu
+Xu
 Zs
 Zs
 Zs


### PR DESCRIPTION
## About The Pull Request
Some requested bunker changes in my oasis bunker alt, removed the different types of mobs that had no reason to be there. Also removed claws and muties since we were told we rely too much on muties and claws. 
Those are replaced with more ghouls and new legendary bot variations. 
Also added back the ending blast door but made it indestructible. 

North sewer bunker 2 (the raiders) has been culled a bit, getting rid of a lot of raiders and adding a few extra legendaries. Also rid of a few bots to add a legendary one of those too. 
One of the claw nests is gone. 

Bos changes mostly minor moving walls over and shit. Also added river back with a mirelurk nest upon request, all changes have been seen by lms and are posted with screenshots in dev-general.
Cut the cars back out of the base to make it a bit prettier in that section since there was a lot of wasted space. 
Moved the ladders to be in the corners because whoever put them in the previous configuration should probably fall down a hole. 

## Why It's Good For The Game

Helps with lag, prettiness, and cohesiveness.

## Changelog
:cl:
add: Legendary sentry bot
add: Legendary assaultron
add: Legendary securitron
del: excess nests
tweak: bos mines
tweak: oasis bunker layout and mobs
balance: north sewer raiders
fix: ugly walls 
/:cl:

