### PR TITLE
AK Fix and Powerfist fix

### DIFF
--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -7,7 +7,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
 	attack_verb = list("whacked", "fisted", "power-punched")
-	force = 30
+	force = 40
 	armour_penetration = 0.5
 	throwforce = 10
 	throw_range = 7

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -872,6 +872,9 @@
 	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'
 	burst_size = 2
 	fire_delay = 3
+	can_attachments = TRUE
+	can_scope = FALSE
+	can_bayonet = FALSE
 	spread = 10
 	extra_damage = 2
 	suppressor_state = "suppressor"


### PR DESCRIPTION
## About The Pull Request

Type 93 was using legacy code and couldn't take attachments despite supposed to being able to.

Powerfist lost 10 of his damage on accident when changing its .dm path. Fixed this.

## Why It's Good For The Game

Unintended changes by me prior.

## Changelog
:cl:
fixes: Powerfist and Type-93
/:cl: