### PR TITLE
Gives 'Quack Doctor' outlaws intermediate surgery.

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -459,7 +459,7 @@ Outlaw
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/ec=3,
 		/obj/item/switchblade=1,
-		/obj/item/book/granter/trait/chemistry=1,
+		/obj/item/book/granter/trait/midsurgery=1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 4,
 		/obj/item/reagent_containers/medspray/synthflesh = 2
 		)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR switches the Quack Doctor chem book for an intermediate surgery book, allowing Outlaw Doctors to perform more advanced surgeries like facial reconstruction. At the moment, there is nothing setting apart an outlaw doc from a wastelander with minor surgery.

## Why It's Good For The Game

Gives outlaws a little more reason to choose the medical route for their gimmicks. Actually makes the Quack Doctor loadout useful and not almost useless.

## Changelog
:cl:
balance: Quack Doctor outlaw now starts with intermediate surgery instead of a chemistry book.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
