### PR TITLE
Cog City loadouts

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -7012,6 +7012,13 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/city)
+"edR" = (
+/obj/machinery/cell_charger,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "edZ" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -29875,6 +29882,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/effect/turf_decal/bot,
+/obj/item/stack/ore/blackpowder/five,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -32221,6 +32229,16 @@
 /obj/item/picket_sign,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sZx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "sZA" = (
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/outside/desert,
@@ -37086,6 +37104,9 @@
 "vIE" = (
 /obj/machinery/autolathe/ammo,
 /obj/effect/turf_decal/bot,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -56404,7 +56425,7 @@ xLh
 oep
 xLh
 xLh
-xLh
+sZx
 xLh
 cCE
 wOj
@@ -56661,7 +56682,7 @@ tHn
 qAL
 qGv
 xLh
-xLh
+edR
 xLh
 oyS
 wOj

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -5129,6 +5129,25 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"cWW" = (
+/obj/effect/turf_decal/bot,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/ammo_box/tube/c4570,
+/obj/item/ammo_box/tube/c4570,
+/obj/item/ammo_box/tube/c4570,
+/obj/item/ammo_box/tube/c4570,
+/obj/item/ammo_box/tube/c4570,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "cXh" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/radio/intercom{
@@ -5419,17 +5438,19 @@
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
 	},
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/turf_decal/bot,
+/obj/item/ammo_box/magazine/m10mm_adv,
+/obj/item/ammo_box/magazine/m10mm_adv,
+/obj/item/ammo_box/magazine/m10mm_adv,
+/obj/item/ammo_box/magazine/m10mm_adv,
+/obj/item/ammo_box/magazine/m10mm_adv,
+/obj/item/ammo_box/magazine/m10mm_adv,
+/obj/item/ammo_box/magazine/m10mm_adv/ext,
+/obj/item/ammo_box/magazine/m10mm_adv/ext,
+/obj/item/ammo_box/magazine/m10mm_adv/ext,
+/obj/item/ammo_box/magazine/m10mm_adv/ext,
+/obj/item/ammo_box/magazine/m10mm_adv/ext,
+/obj/item/ammo_box/magazine/m10mm_adv/ext,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -55907,7 +55928,7 @@ sfB
 wOj
 umk
 xLh
-xIP
+cWW
 qAL
 mBC
 xLh

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -46,6 +46,7 @@
 /obj/machinery/door/unpowered/wooddoor{
 	autoclose = 1;
 	max_integrity = 300;
+	name = "Khan Khamp";
 	obj_integrity = 300;
 	req_access_txt = "125"
 	},
@@ -134,9 +135,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
 "aar" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 5
+	},
+/obj/item/clothing/head/helmet/f13/brahmincowboyhat,
+/obj/item/clothing/shoes/f13/military/cowboy,
+/obj/item/clothing/suit/armor/f13/rustedcowboy,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "aat" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -185,12 +192,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "aaB" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/closed/wall/f13/tentwall,
+/area/f13/caves)
 "aaC" = (
 /obj/structure/rack,
 /obj/item/storage/bag/plants,
@@ -443,7 +446,10 @@
 /area/f13/legion)
 "abh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/barred,
+/obj/structure/simple_door/metal/barred{
+	name = "Forge";
+	req_access_txt = "123"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "abi" = (
@@ -471,7 +477,10 @@
 /area/f13/legion)
 "abm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/wood,
+/obj/structure/simple_door/wood{
+	name = "Armory";
+	req_access_txt = "123"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "abn" = (
@@ -693,12 +702,8 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "aep" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -811,6 +816,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"ahv" = (
+/obj/machinery/vending/cola/space_up,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "ahK" = (
 /obj/structure/table/wood/settler,
 /obj/structure/mirror{
@@ -869,9 +882,10 @@
 	},
 /area/f13/building)
 "ajN" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/tree/jungle,
-/turf/open/floor/grass,
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2left"
+	},
 /area/f13/wasteland)
 "ajO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -913,9 +927,6 @@
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "red"
-	},
-/obj/item/flag/vtcc/highvhills{
-	name = "Cog City Flag"
 	},
 /turf/open/floor/grass,
 /area/f13/wasteland)
@@ -1126,6 +1137,12 @@
 "apL" = (
 /turf/open/floor/plasteel/stairs/medium,
 /area/f13/city)
+"aqr" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aqD" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
@@ -1198,10 +1215,7 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "asF" = (
 /obj/structure/window/fulltile/house,
@@ -1224,6 +1238,13 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
+"atI" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "atL" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/desert,
@@ -1256,9 +1277,7 @@
 	icon_state = "post_wood"
 	},
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "auw" = (
 /obj/item/flag/vtcc/highvhills{
@@ -1631,15 +1650,6 @@
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"aIi" = (
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/caves)
 "aIS" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1671,6 +1681,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"aKq" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aKs" = (
 /obj/item/clothing/shoes/sneakers/black,
 /turf/open/floor/f13/wood,
@@ -1729,6 +1745,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"aMo" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aMp" = (
 /obj/structure/closet,
 /turf/open/floor/plasteel/barber{
@@ -1780,6 +1801,12 @@
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aOp" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland)
 "aOE" = (
 /obj/structure/displaycase,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -1842,12 +1869,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "aPL" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
+/obj/structure/closet,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/vending/wallmed{
-	pixel_x = -30
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -1949,10 +1975,7 @@
 	dir = 1
 	},
 /obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "aUl" = (
 /obj/structure/fence,
@@ -2058,6 +2081,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aWP" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/obj/effect/landmark/start/f13/townsecscout,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "aXi" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -2146,6 +2178,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"aYS" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "aYV" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2239,6 +2276,13 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
+"bct" = (
+/obj/structure/simple_door/metal/fence{
+	name = "Legion Gate";
+	req_access_txt = 123
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "bcx" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -2315,6 +2359,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/city)
+"beO" = (
+/obj/structure/fluff/railing,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "bfu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
@@ -2365,6 +2417,11 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"bhU" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "bia" = (
 /obj/structure/fence,
@@ -2502,6 +2559,13 @@
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
+"bma" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
@@ -2647,10 +2711,7 @@
 /area/f13/farm)
 "boO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "bpc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2719,9 +2780,9 @@
 	},
 /area/f13/ncr)
 "bqy" = (
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
+/obj/structure/stone_tile/slab/cracked,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "bqB" = (
@@ -2792,6 +2853,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/brotherhood)
+"buv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "buD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -2831,6 +2900,13 @@
 /obj/machinery/recharger,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bvn" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "bvs" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3070,6 +3146,13 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bCe" = (
+/obj/structure/chair/sofa/corp/left,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "bCG" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -3303,6 +3386,7 @@
 	},
 /area/f13/building)
 "bLb" = (
+/obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate"
 	},
@@ -3390,6 +3474,13 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland)
+"bOS" = (
+/obj/effect/decal/marking,
+/obj/structure/junk/locker,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
 "bPd" = (
@@ -3498,6 +3589,13 @@
 /obj/structure/sign/poster/prewar/poster91,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"bSi" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "bSR" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -3543,6 +3641,20 @@
 	icon_state = "dirt"
 	},
 /area/f13/caves)
+"bTE" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
+"bUV" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/item/trash/chips,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "bVq" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -3668,6 +3780,10 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
+"caX" = (
+/obj/structure/campfire/stove,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "cbf" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/road{
@@ -3833,6 +3949,12 @@
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"cjP" = (
+/obj/structure/simple_door/wood{
+	req_access_txt = "123"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "cjS" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
@@ -4079,6 +4201,19 @@
 /obj/item/pet_carrier,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cqP" = (
+/obj/structure/wreck/trash/one_tire,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
+	},
+/area/f13/wasteland)
+"crd" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "crp" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
@@ -4268,6 +4403,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"cwM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
+	},
+/area/f13/building)
 "cxy" = (
 /obj/machinery/power/solar,
 /obj/structure/cable{
@@ -4387,6 +4528,22 @@
 "cCi" = (
 /turf/open/floor/carpet,
 /area/f13/city)
+"cCE" = (
+/obj/machinery/camera/autoname{
+	dir = 1;
+	network = list("Vault")
+	},
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/pda/security,
+/obj/item/pda/security,
+/obj/item/pda/security,
+/obj/item/pda/security,
+/obj/item/pda/security,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "cCL" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/rock/pile/largejungle,
@@ -4397,12 +4554,34 @@
 /mob/living/simple_animal/hostile/raider/thief,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"cDf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"cDE" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "cFe" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"cFg" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "cFY" = (
 /obj/structure/grille,
 /obj/effect/spawner/structure/window/reinforced,
@@ -4512,6 +4691,14 @@
 /obj/structure/closet,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"cGZ" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland)
 "cHk" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/ruins{
@@ -4561,6 +4748,7 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
+/obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "cJi" = (
@@ -4685,9 +4873,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "cOU" = (
-/obj/structure/sink/puddle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
+/obj/structure/sign/poster/prewar/poster71,
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
+"cOV" = (
+/obj/item/reagent_containers/glass/bucket/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/city)
 "cOZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/start/f13/innkeeper,
@@ -4741,9 +4933,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "cQC" = (
-/obj/structure/reagent_dispensers/compostbin,
+/obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
+/area/f13/caves)
 "cQU" = (
 /obj/machinery/smartfridge/drying_rack,
 /obj/machinery/light/small,
@@ -4753,6 +4945,13 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"cRo" = (
+/obj/effect/decal/marking,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "cRM" = (
 /obj/structure/debris/v3,
 /obj/structure/flora/rock/jungle,
@@ -4921,6 +5120,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"cWV" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "cXh" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/radio/intercom{
@@ -4960,6 +5168,11 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/wasteland)
+"cYH" = (
+/obj/structure/fluff/railing/corner,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "cYL" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -5016,6 +5229,10 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"daa" = (
+/obj/structure/simple_door/wood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "dau" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plastic/fifty,
@@ -5107,6 +5324,13 @@
 "dbO" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"dbP" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "dbY" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -5192,16 +5416,20 @@
 	},
 /area/f13/caves)
 "dfx" = (
-/obj/structure/table,
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 4
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -5;
-	pixel_y = 3
-	},
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -5226,6 +5454,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"dgr" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "dgt" = (
 /obj/machinery/light{
 	dir = 1
@@ -5260,9 +5495,9 @@
 	},
 /area/f13/farm)
 "dgK" = (
-/obj/effect/landmark/start/f13/shaman,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
+/obj/structure/simple_door/tent,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "dgS" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/ketchup,
@@ -5299,6 +5534,13 @@
 /area/f13/bar)
 "dit" = (
 /turf/closed/wall/f13/supermart,
+/area/f13/building)
+"diu" = (
+/obj/item/trash/sosjerky,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "diw" = (
 /obj/machinery/hydroponics/soil,
@@ -5337,11 +5579,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "diT" = (
-/obj/effect/landmark/start/f13/townsecscout,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "diU" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/grown/corn,
@@ -5391,7 +5633,8 @@
 /area/f13/building)
 "dkp" = (
 /obj/structure/simple_door/wood{
-	name = "Decanii Office"
+	name = "Decanii Office";
+	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -5532,6 +5775,15 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/tunnel)
+"doy" = (
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "doB" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood{
@@ -5748,12 +6000,8 @@
 	},
 /area/f13/building)
 "dup" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "dux" = (
 /obj/effect/decal/cleanable/oil,
@@ -5896,6 +6144,7 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
+/obj/effect/landmark/start/f13/townsec,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -5945,22 +6194,15 @@
 	},
 /area/f13/wasteland)
 "dzE" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/smelling_salts/wayfarer,
-/obj/item/smelling_salts/wayfarer,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "dzQ" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
 	name = "village gate"
 	},
 /obj/structure/stone_tile/slab/cracked,
-/obj/structure/spacevine{
-	name = "vines"
-	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "dAg" = (
@@ -6100,9 +6342,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "dDK" = (
-/obj/structure/legion_extractor,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
+/area/f13/caves)
 "dEw" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -6110,8 +6354,8 @@
 /area/f13/bar)
 "dEB" = (
 /obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetbrown"
+/obj/item/bedsheet/purple{
+	color = "#450159"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
@@ -6140,6 +6384,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"dFK" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "dFQ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
@@ -6386,6 +6637,12 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
+"dPa" = (
+/obj/machinery/vending/snack,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland)
 "dPe" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/wood,
@@ -6396,6 +6653,13 @@
 /obj/item/reagent_containers/food/snacks/burger/superbite,
 /turf/open/floor/plasteel/blue,
 /area/f13/city)
+"dPJ" = (
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "dQf" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -6418,6 +6682,12 @@
 /area/f13/brotherhood)
 "dRo" = (
 /obj/structure/simple_door/metal/fence,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"dRw" = (
+/obj/structure/sign/poster/contraband/starkist{
+	pixel_y = -32
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "dRI" = (
@@ -6457,19 +6727,31 @@
 	},
 /area/f13/building)
 "dTn" = (
-/obj/structure/stone_tile/surrounding_tile,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/f13/wasteland)
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dTp" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "dTv" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"dTK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/city)
 "dTT" = (
 /obj/structure/fence{
 	dir = 8
@@ -6529,9 +6811,11 @@
 	},
 /area/f13/wasteland)
 "dWt" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dWH" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
@@ -6579,6 +6863,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/city)
+"dYq" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2"
+	},
+/area/f13/wasteland)
 "dYS" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -6604,6 +6894,19 @@
 /obj/item/stack/f13Cash/random/ncr/low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dZl" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "dZE" = (
 /obj/structure/fireplace,
 /turf/open/floor/carpet/black,
@@ -6625,6 +6928,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"ear" = (
+/obj/structure/lamp_post{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "eaA" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -6734,6 +7045,14 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/followers)
+"efZ" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "egn" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -6756,10 +7075,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "egU" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
+/obj/structure/bonfire,
+/obj/item/stack/rods/ten,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
+"ehm" = (
+/obj/structure/tires,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
 /area/f13/wasteland)
 "ehx" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -6877,6 +7202,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ejo" = (
+/obj/structure/fence,
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ejp" = (
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/f13/wood{
@@ -6953,6 +7285,11 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/village)
+"eml" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "emn" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7120,7 +7457,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "erS" = (
-/obj/structure/closet,
+/obj/structure/table,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/machinery/button/door{
+	id = "Brig Lockdown";
+	name = "brig lockdown button";
+	pixel_x = 32
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -7131,15 +7476,9 @@
 	},
 /area/f13/wasteland)
 "esj" = (
-/obj/structure/closet/cabinet,
-/obj/item/reagent_containers/pill/patch/medx,
-/obj/item/reagent_containers/pill/patch/medx,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/obj/effect/spawner/lootdrop/clothing_middle,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/stone_tile/block/cracked,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "esD" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/hardhat,
@@ -7409,7 +7748,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eBu" = (
-/obj/structure/table/wood/fancy/royalblack,
+/obj/structure/table/wood/fancy/purple,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "eBM" = (
@@ -7459,6 +7798,23 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"eDn" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 5
+	},
+/obj/item/clothing/head/f13/cowboy,
+/obj/item/clothing/shoes/f13/military/cowboy,
+/obj/item/clothing/suit/armor/f13/rustedcowboy,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"eDv" = (
+/obj/structure/simple_door/wood{
+	name = "Medicus";
+	req_access_txt = "123"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/legion)
 "eDx" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -7472,7 +7828,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/village)
 "eDT" = (
 /obj/structure/sign/poster/contraband/have_a_puff{
 	pixel_x = -31
@@ -7595,10 +7951,6 @@
 /area/f13/ncr)
 "eGX" = (
 /obj/structure/sign/poster/prewar/poster92,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = 30;
-	pixel_y = -3
-	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "eHj" = (
@@ -7633,13 +7985,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/tunnel)
-"eHW" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/item/storage/box/cups,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/city)
 "eIC" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7652,6 +7997,13 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"eIY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
 "eJa" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -7683,6 +8035,19 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
+"eJH" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"eJI" = (
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "eJN" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -7883,6 +8248,13 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"ePA" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/brews,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "ePI" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/wood/house,
@@ -8105,13 +8477,9 @@
 	},
 /area/f13/wasteland)
 "eUD" = (
-/obj/machinery/button/door{
-	id = "Marshal's Office";
-	pixel_x = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/item/reagent_containers/glass/rag,
+/obj/item/reagent_containers/glass/bucket/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "eUI" = (
 /obj/structure/rack,
@@ -8499,9 +8867,13 @@
 	},
 /area/f13/village)
 "ffs" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
 	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ffv" = (
 /obj/structure/flora/tree/jungle/small,
@@ -8684,6 +9056,13 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"fjW" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerouter"
+	},
+/area/f13/wasteland)
 "fjY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -8713,6 +9092,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"flf" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland)
 "flu" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Merchant's mansion";
@@ -8726,10 +9111,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "flP" = (
 /obj/machinery/light{
@@ -8909,6 +9291,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fqD" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "fqL" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -8955,22 +9343,27 @@
 /area/f13/village)
 "frH" = (
 /obj/structure/flora/junglebush/large,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "frK" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
-"frY" = (
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+"frQ" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/item/flag/vtcc/highvhills{
+	name = "Cog City Flag"
 	},
+/turf/open/floor/grass,
 /area/f13/wasteland)
+"frY" = (
+/obj/machinery/door/airlock/vault{
+	name = "Outer Jail Entrance";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/city)
 "fsl" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9034,10 +9427,7 @@
 "ftH" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/flora/ausbushes/leafybush,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "ftL" = (
 /obj/effect/decal/cleanable/dirt{
@@ -9113,6 +9503,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/city)
+"fvu" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fvz" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2bottom"
@@ -9204,6 +9598,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"fzf" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 5;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "fzl" = (
 /obj/structure/lattice/catwalk,
 /turf/open/water,
@@ -9212,13 +9613,7 @@
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
 	},
-/obj/structure/barricade/wooden/strong{
-	obj_integrity = 500
-	},
 /obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "fzM" = (
@@ -9244,6 +9639,27 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/village)
+"fAf" = (
+/obj/structure/rack,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "fAt" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -9289,6 +9705,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"fAW" = (
+/obj/item/trash/f13/blamco_large,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "fAX" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/grass,
@@ -9363,6 +9786,15 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"fCW" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3"
+	},
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "fDi" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/f13/wood,
@@ -9455,6 +9887,10 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fHf" = (
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "fHx" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_bl,
@@ -9473,6 +9909,13 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/building)
+"fIE" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "fIF" = (
 /obj/machinery/light{
@@ -9518,18 +9961,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
-"fKq" = (
-/obj/structure/table,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/city)
 "fKt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/snooker{
@@ -9537,6 +9968,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/city)
+"fKC" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "fKN" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9678,6 +10118,15 @@
 /obj/item/twohanded/spear,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"fQq" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "fQr" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -9688,27 +10137,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fQt" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/donut/blumpkin{
-	pixel_x = -6;
-	pixel_y = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
 	},
-/obj/item/reagent_containers/food/snacks/donut/blumpkin{
-	pixel_x = 6;
-	pixel_y = 7
-	},
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "fQu" = (
-/obj/machinery/hydroponics/soil{
-	mutmod = 2;
-	name = "ancient mutated soil"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "fQz" = (
 /obj/structure/table/wood/poker{
 	name = "felt table"
@@ -9729,6 +10168,11 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"fQX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "fQY" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light/small{
@@ -9793,12 +10237,11 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "fTx" = (
+/obj/structure/barricade/wooden/strong,
 /obj/structure/curtain{
-	color = "#845f58"
+	color = "#450159"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "fTz" = (
 /obj/structure/window/fulltile/ruins{
@@ -9874,10 +10317,7 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "fXj" = (
 /obj/structure/rack,
@@ -10239,9 +10679,8 @@
 /area/f13/ncr)
 "gjB" = (
 /obj/structure/car/rubbish1,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
 "gjC" = (
@@ -10266,16 +10705,9 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/village)
 "gke" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bucket/wood,
-/obj/item/shovel/spade,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/ambrosia,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "gkh" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -10367,6 +10799,7 @@
 /area/f13/village)
 "goK" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
+/obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "goO" = (
@@ -10474,6 +10907,13 @@
 /obj/effect/landmark/observer_start,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gqG" = (
+/obj/item/trash/can,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "grc" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10573,6 +11013,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"gtl" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "gtn" = (
 /obj/structure/mirelurkegg,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10749,6 +11203,14 @@
 /obj/item/reagent_containers/pill/patch/healpoultice,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"gxD" = (
+/obj/structure/bed,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/bedsheet/brown,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gxO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -10891,10 +11353,7 @@
 /area/f13/caves)
 "gBZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "gCb" = (
 /obj/structure/closet/crate/miningcar,
@@ -10928,17 +11387,52 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "gCS" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/structure/rack,
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot,
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/night,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -11005,13 +11499,8 @@
 	},
 /area/f13/wasteland)
 "gEY" = (
-/obj/structure/simple_door/house{
-	icon_state = "room"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/obj/structure/closet,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "gFn" = (
 /obj/effect/landmark/start/f13/slave,
@@ -11151,6 +11640,13 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/city)
+"gLE" = (
+/obj/item/storage/bag/trash,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "gLH" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -11206,10 +11702,7 @@
 	icon_state = "post_wood"
 	},
 /obj/structure/flora/ausbushes/palebush,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "gNe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11273,6 +11766,16 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"gOV" = (
+/obj/structure/rack,
+/obj/item/storage/bag/plants,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/machinery/light/small/broken,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gPd" = (
 /obj/item/storage/fancy/rollingpapers,
 /obj/item/storage/fancy/rollingpapers,
@@ -11294,6 +11797,13 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"gPA" = (
+/obj/structure/chair/comfy/plywood{
+	dir = 1
+	},
+/obj/item/fishingrod,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gPI" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -11398,6 +11908,21 @@
 /obj/item/clothing/suit/armor/f13/tribe_armor,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"gRr" = (
+/obj/structure/fence,
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
+"gRy" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "gSf" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -11465,10 +11990,7 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/stone_tile/block/cracked,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "gVd" = (
 /obj/structure/sink{
@@ -11489,7 +12011,7 @@
 /area/f13/wasteland)
 "gVt" = (
 /obj/structure/curtain{
-	color = "#845f58"
+	color = "#450159"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -11527,10 +12049,7 @@
 "gXh" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/stone_tile/block/cracked,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "gXm" = (
 /obj/structure/barricade/sandbags,
@@ -11629,19 +12148,21 @@
 "gYI" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/stone_tile/block/cracked,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "gYZ" = (
-/obj/structure/lamp_post{
-	dir = 8
+/obj/machinery/door/poddoor/shutters{
+	id = "Brig Lockdown";
+	name = "lockdown shutters"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright2"
+/obj/machinery/door/airlock/command/glass{
+	name = "Inner Jail Entrance";
+	req_one_access_txt = "134"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "gZd" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/flora/ausbushes/genericbush,
@@ -11660,9 +12181,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "gZE" = (
-/obj/machinery/chem_master/primitive,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "gZN" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -11694,7 +12215,10 @@
 /area/f13/caves)
 "haP" = (
 /obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
+	},
 /area/f13/wasteland)
 "hbm" = (
 /turf/closed/wall/f13/wood/house,
@@ -11981,12 +12505,13 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "hjO" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/closet,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/grass,
-/area/f13/wasteland)
+/area/f13/city)
 "hjW" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/cleanable/dirt,
@@ -12126,12 +12651,17 @@
 	},
 /area/f13/wasteland)
 "hpm" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/storage/fancy/egg_box,
+/obj/structure/decoration/clock{
+	pixel_y = 30
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hpx" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell{
@@ -12149,8 +12679,8 @@
 	},
 /area/f13/building)
 "hpG" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/chair/bench,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "hpH" = (
@@ -12197,32 +12727,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"hqC" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
-/obj/item/storage/belt/military/assault,
-/obj/item/clothing/suit/armor/f13/combat/swat,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/head/helmet/f13/combat/swat,
-/obj/item/clothing/glasses/legiongoggles,
-/obj/structure/window/reinforced,
-/obj/item/grenade/chem_grenade/teargas,
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	req_access_txt = "1"
-	},
-/obj/item/grenade/flashbang,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/city)
 "hqL" = (
-/obj/structure/spirit_board,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/village)
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/structure/fence/end/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "hqP" = (
 /obj/item/kirbyplants/random{
 	pixel_y = 8
@@ -12239,9 +12750,7 @@
 /area/f13/ncr)
 "hrb" = (
 /obj/structure/flora/ausbushes/genericbush,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "hrx" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -12707,11 +13216,8 @@
 	},
 /area/f13/village)
 "hEx" = (
-/obj/item/clothing/under/rank/security/officer/skirt,
-/obj/item/clothing/under/rank/security/officer/skirt,
-/obj/item/clothing/under/rank/security/officer/skirt,
-/obj/item/clothing/under/rank/security/officer/skirt,
-/obj/structure/rack,
+/obj/structure/table,
+/obj/item/storage/box/deputy_badges,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -12734,11 +13240,24 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"hFu" = (
+/obj/structure/simple_door/wood{
+	name = "Medicus";
+	req_access_txt = "123"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "hFM" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"hFP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/building)
 "hFW" = (
 /obj/structure/chair/pew/left{
@@ -12954,6 +13473,11 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
+"hMb" = (
+/obj/structure/closet/cabinet,
+/obj/item/instrument/guitar,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hMe" = (
 /obj/effect/mine/stun,
 /obj/effect/decal/cleanable/dirt,
@@ -12971,6 +13495,7 @@
 "hMz" = (
 /obj/structure/stone_tile/surrounding/burnt,
 /obj/structure/stone_tile/center,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "hMI" = (
@@ -13010,6 +13535,10 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"hNz" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "hNL" = (
 /obj/structure/table/wood/fancy,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -13038,19 +13567,6 @@
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
-"hOC" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = -30
-	},
-/obj/structure/table,
-/obj/item/storage/box/evidence,
-/obj/item/storage/box/evidence,
-/obj/item/book/manual/wiki/detective,
-/obj/item/cartridge/detective,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/city)
 "hOJ" = (
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
@@ -13066,15 +13582,14 @@
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/city)
 "hQh" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/guncase,
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/item/flag/vtcc/highvhills{
-	name = "Cog City Flag"
-	},
-/turf/open/floor/grass,
-/area/f13/wasteland)
+/area/f13/city)
 "hQr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerturn"
@@ -13631,6 +14146,7 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
+/obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "ieU" = (
@@ -13873,6 +14389,25 @@
 	icon_state = "horizontaltopbordertop2"
 	},
 /area/f13/caves)
+"imp" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"imr" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ims" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/wasteland)
@@ -14009,7 +14544,7 @@
 	pixel_y = -2
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/village)
 "iqZ" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -14100,6 +14635,13 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"itu" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "itJ" = (
@@ -14221,8 +14763,15 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "iyo" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
+/obj/structure/table,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -14266,16 +14815,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"izj" = (
+/obj/structure/bonfire,
+/obj/item/stack/rods/ten,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
+"izs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "izB" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/glass/mortar{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pestle{
-	pixel_x = 5;
-	pixel_y = -3
-	},
+/obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "izR" = (
@@ -14345,14 +14895,7 @@
 	},
 /area/f13/building)
 "iBT" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
+/obj/structure/chair/sofa/corp,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -14719,6 +15262,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/tunnel)
+"iMJ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iMV" = (
 /obj/effect/turf_decal{
 	dir = 1
@@ -15002,9 +15555,7 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "iRT" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
+/obj/structure/sink/puddle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "iSj" = (
@@ -15019,6 +15570,12 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"iSw" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2"
+	},
+/area/f13/wasteland)
 "iSV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner{
@@ -15124,6 +15681,10 @@
 /obj/structure/sign/poster/prewar/poster82,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"iXW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iXX" = (
 /obj/structure/rack,
 /obj/item/clothing/neck/tie,
@@ -15139,10 +15700,7 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "iYs" = (
 /obj/structure/bed/mattress{
@@ -15184,6 +15742,16 @@
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"iZy" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "iZL" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/blueyellow,
@@ -15194,10 +15762,7 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "iZV" = (
 /obj/machinery/light{
@@ -15214,8 +15779,16 @@
 	},
 /area/f13/wasteland)
 "jaf" = (
+/obj/item/reagent_containers/food/snacks/donut/blumpkin{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/donut/blumpkin{
+	pixel_x = -6;
+	pixel_y = 1
+	},
 /obj/structure/table,
-/obj/item/storage/box/deputy_badges,
+/obj/item/storage/box/cups,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -15384,16 +15957,6 @@
 "jem" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
-"jex" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser/aer9,
-/obj/item/gun/energy/laser/aer9,
-/obj/item/gun/energy/laser/aer9,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/city)
 "jeO" = (
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/wood/house/broken,
@@ -15492,6 +16055,13 @@
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jhH" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "jix" = (
 /obj/machinery/autolathe/constructionlathe,
 /obj/machinery/light{
@@ -15574,10 +16144,7 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "jlT" = (
 /obj/machinery/light/small{
@@ -15625,6 +16192,15 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"jmO" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "jmZ" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -15772,6 +16348,17 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"jsa" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
+"jsc" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "jsP" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -15814,6 +16401,12 @@
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"juy" = (
+/obj/structure/fence/cut/medium{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "juC" = (
 /obj/structure/decoration/vent{
 	pixel_x = -7;
@@ -15977,23 +16570,10 @@
 	},
 /area/f13/wasteland)
 "jyI" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/gloves/f13/military,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/structure/displaycase,
+/obj/item/gun/ballistic/revolver/lucky37{
+	pixel_x = 3
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -16021,14 +16601,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "jzN" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
+/turf/closed/wall/f13/wood/house,
+/area/f13/wasteland)
 "jAf" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16059,13 +16633,6 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jBB" = (
-/obj/structure/table,
-/obj/item/detective_scanner,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/city)
 "jBH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16105,6 +16672,9 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"jDd" = (
+/turf/closed/wall/mineral/iron,
+/area/f13/caves)
 "jDk" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16170,6 +16740,13 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"jGp" = (
+/obj/structure/closet,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jGz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16185,6 +16762,11 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"jHj" = (
+/obj/structure/chair/bench,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "jHF" = (
 /obj/structure/chair,
 /turf/open/floor/f13/wood{
@@ -16303,6 +16885,10 @@
 "jMj" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/radiation)
+"jMy" = (
+/obj/machinery/door/unpowered/wooddoor,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jMz" = (
 /obj/structure/table/wood/fancy,
 /obj/item/restraints/handcuffs,
@@ -16395,6 +16981,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"jQx" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/cans,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "jQy" = (
 /obj/item/radio/intercom{
 	frequency = 1891;
@@ -16501,6 +17094,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"jTb" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jTq" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
@@ -16728,9 +17326,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jZM" = (
-/obj/structure/bed/dogbed,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/fence/wooden{
+	dir = 4;
+	icon_state = "post_wood"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kas" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -16738,6 +17339,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"kav" = (
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
 "kaI" = (
 /obj/machinery/door/poddoor/preopen{
 	id = 61
@@ -16769,6 +17376,12 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"kbN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "kbQ" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/wood/f13/carpet,
@@ -17107,10 +17720,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "kkV" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	termtag = "Secret"
+/obj/machinery/door/airlock/command/glass{
+	name = "Processing Lockers";
+	req_one_access_txt = "134"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -17459,6 +18071,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"kwo" = (
+/obj/structure/wreck/trash/secway,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "kws" = (
 /obj/structure/decoration/vent,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -17486,6 +18103,12 @@
 	obj_integrity = 500
 	},
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
+"kwT" = (
+/obj/structure/wreck/trash/one_barrel,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
 /area/f13/wasteland)
 "kwU" = (
 /obj/structure/chair/sofa/corp/right,
@@ -17533,6 +18156,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"kxP" = (
+/obj/structure/car/rubbish2,
+/obj/structure/tires,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "kyc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17643,6 +18273,12 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
+/area/f13/wasteland)
+"kBo" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain3"
+	},
 /area/f13/wasteland)
 "kBr" = (
 /obj/structure/rack,
@@ -17769,8 +18405,13 @@
 	},
 /area/f13/caves)
 "kEh" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/smelling_salts/wayfarer,
+/obj/item/smelling_salts/wayfarer,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
 "kEi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -17826,9 +18467,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kFn" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/structure/bed/mattress{
-	icon_state = "mattress4"
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/glass/mortar{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pestle{
+	pixel_x = 5;
+	pixel_y = -3
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
@@ -17844,6 +18490,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
+"kFS" = (
+/obj/machinery/door/unpowered/wooddoor,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "kFX" = (
 /obj/structure/reagent_dispensers/barrel/dangerous{
 	anchored = 1
@@ -17908,9 +18560,20 @@
 /obj/item/instrument/trumpet,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"kIy" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "kIZ" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"kJp" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
 /area/f13/wasteland)
 "kJu" = (
 /obj/structure/anvil/obtainable/basic,
@@ -18091,7 +18754,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kQb" = (
-/obj/structure/chair/sofa/corp/left,
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Secret"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -18150,6 +18817,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"kSu" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/shoes/workboots/mining,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kSv" = (
 /obj/effect/landmark/start/f13/alderman,
 /turf/open/floor/wood/f13/carpet,
@@ -19012,6 +19684,12 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
+"ltS" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ltZ" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -19231,8 +19909,10 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
 "lzV" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "lzW" = (
@@ -19395,17 +20075,14 @@
 	},
 /area/f13/building)
 "lDR" = (
-/obj/structure/table/wood/settler,
-/obj/item/kitchen/knife,
-/obj/item/hatchet,
-/obj/item/wirecutters{
-	icon_state = "cutters"
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
 	},
-/obj/item/lighter,
-/obj/item/screwdriver/nuke,
-/obj/item/crowbar/crude,
-/obj/item/hemostat/tribal,
-/obj/item/retractor/tribal,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "lDS" = (
@@ -19420,13 +20097,15 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/bar)
-"lEV" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+"lES" = (
+/obj/structure/lamp_post{
+	pixel_x = -15
 	},
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "lFf" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/f13/wood{
@@ -19487,12 +20166,6 @@
 	id = "exteriorgate";
 	name = "Exterior door button";
 	pixel_x = -6;
-	pixel_y = 32
-	},
-/obj/machinery/button/door{
-	id = "interiorgate";
-	name = "Interior door button";
-	pixel_x = 6;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -19613,6 +20286,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"lMd" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "lMn" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/autolathe/ammo,
@@ -19650,6 +20328,10 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"lNn" = (
+/obj/structure/window/fulltile/wood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "lNA" = (
 /obj/machinery/light{
 	dir = 8;
@@ -19662,6 +20344,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"lNT" = (
+/obj/structure/chair/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lOi" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -19792,9 +20478,10 @@
 	},
 /area/f13/wasteland)
 "lRW" = (
-/obj/structure/window/fulltile/wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "lRX" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
@@ -19871,6 +20558,12 @@
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/store,
 /area/f13/building)
+"lUo" = (
+/obj/structure/table/wood,
+/obj/item/phone,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lUv" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small{
@@ -19907,6 +20600,15 @@
 /obj/item/clothing/under/f13/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lWi" = (
+/obj/structure/sign/poster/contraband/space_cola{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "lWj" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19957,10 +20659,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "lZl" = (
 /obj/effect/turf_decal/stripes/white/box,
@@ -19981,7 +20680,17 @@
 "lZn" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/village)
+"lZK" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/reagent_containers/pill/patch/medx,
+/obj/item/reagent_containers/pill/patch/medx,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lZP" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -20082,6 +20791,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/followers)
+"mdf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
 "mdv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood{
@@ -20130,10 +20845,22 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"meT" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "meU" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/followers)
+"meW" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mfj" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/ruins{
@@ -20205,13 +20932,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "mgu" = (
-/obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/key,
-/obj/item/key,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
+/obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "mgz" = (
@@ -20294,6 +21016,13 @@
 	icon_state = "rubble"
 	},
 /area/f13/village)
+"mjD" = (
+/obj/structure/closet,
+/obj/item/reagent_containers/pill/patch/turbo,
+/obj/item/reagent_containers/pill/patch/turbo,
+/obj/item/reagent_containers/pill/patch/turbo,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mjJ" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/dice,
@@ -20324,6 +21053,14 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/city)
+"mlw" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "mlD" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper_bin,
@@ -20464,6 +21201,20 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"mpV" = (
+/obj/structure/table/wood/settler,
+/obj/item/retractor/tribal,
+/obj/item/hemostat/tribal,
+/obj/item/crowbar/crude,
+/obj/item/lighter,
+/obj/item/kitchen/knife,
+/obj/item/hatchet,
+/obj/item/wirecutters{
+	icon_state = "cutters"
+	},
+/obj/item/screwdriver/nuke,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
 "mqs" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
@@ -20515,6 +21266,7 @@
 /area/f13/ncr)
 "mrL" = (
 /obj/effect/turf_decal,
+/obj/machinery/door/airlock/command/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "mrY" = (
@@ -20592,6 +21344,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/city)
+"mui" = (
+/obj/machinery/vending/cigarette,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "muk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -20612,6 +21370,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"muR" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "muT" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop3"
@@ -20683,6 +21450,11 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mxj" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "mxO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20696,6 +21468,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mxU" = (
+/obj/structure/wreck/trash/secway,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "myh" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -20725,10 +21503,20 @@
 	icon_state = "gib6-old";
 	pixel_x = 8
 	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 30;
+	pixel_y = -3
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"mzS" = (
+/obj/structure/wreck/trash/bus_door,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland)
 "mzY" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -20771,6 +21559,25 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/closet{
+	anchored = 1
+	},
+/obj/item/clothing/under/rank/security/officer/skirt,
+/obj/item/clothing/under/rank/security/officer/skirt,
+/obj/item/clothing/under/rank/security/officer/skirt,
+/obj/item/clothing/under/rank/security/officer/skirt,
+/obj/item/clothing/under/rank/security/officer/skirt,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -20875,10 +21682,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "mGO" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/landmark/start/f13/marshal,
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/city)
 "mGZ" = (
 /obj/structure/closet/crate/bin,
@@ -20936,6 +21746,21 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"mIz" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/storage/box/teargas,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
+"mIU" = (
+/obj/structure/simple_door/interior,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "mJf" = (
 /obj/structure/chair{
 	dir = 4
@@ -20950,13 +21775,6 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
-"mJX" = (
-/obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/caves)
 "mKe" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -21008,14 +21826,6 @@
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"mLo" = (
-/obj/structure/destructible/tribal_torch/lit,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/caves)
 "mLr" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -21045,13 +21855,18 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
 "mML" = (
-/obj/machinery/door/airlock/command/glass{
-	req_one_access_txt = "62"
+/obj/effect/landmark/start/f13/townsecscout,
+/obj/structure/chair/f13chair1{
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/city)
+"mMO" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mMS" = (
 /obj/structure/vaultdoor{
 	name = "vault 113 door";
@@ -21207,6 +22022,14 @@
 /obj/machinery/grill,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"mSC" = (
+/obj/structure/sign/poster/contraband/space_up{
+	pixel_y = -32
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermainbottom"
+	},
+/area/f13/wasteland)
 "mSD" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/f13{
@@ -21278,11 +22101,10 @@
 	},
 /area/f13/wasteland)
 "mUB" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/caves)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "mUO" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21335,6 +22157,11 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"mVx" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mVE" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -21395,6 +22222,14 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
+"mYa" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "mYi" = (
 /obj/structure/fence{
 	dir = 4
@@ -21722,10 +22557,7 @@
 "nhY" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "nij" = (
 /obj/structure/filingcabinet,
@@ -21756,6 +22588,7 @@
 "njS" = (
 /obj/structure/fence/corner/wooden,
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "nkp" = (
@@ -21800,11 +22633,8 @@
 	},
 /area/f13/building)
 "nlD" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "interiorgate"
-	},
 /obj/effect/turf_decal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/wall/r_wall,
 /area/f13/city)
 "nlN" = (
 /obj/structure/window/fulltile/wood_window,
@@ -21861,6 +22691,17 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"nnW" = (
+/obj/structure/simple_door/wood{
+	name = "Armory";
+	req_access_txt = "123"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/legion)
+"nof" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "noo" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -21905,11 +22746,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nqU" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/obj/machinery/hydroponics/soil{
+	mutmod = 0;
+	name = "ancient fertile soil";
+	yieldmod = 1.3
 	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
+"nrr" = (
+/obj/structure/rack,
+/obj/item/storage/bag/plants,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/clothing/gloves/botanic_leather,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "nrw" = (
 /obj/structure/displaycase,
@@ -21979,6 +22831,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"ntN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ntS" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -22388,14 +23247,12 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
+/obj/structure/flora/rock/jungle,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "nLr" = (
 /obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "nLL" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -22453,6 +23310,17 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nNM" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "nNU" = (
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -22637,6 +23505,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nTa" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland)
 "nTe" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -22759,6 +23633,18 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nWB" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2bottom"
+	},
+/area/f13/wasteland)
+"nXk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "nYI" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/folder/blue,
@@ -22872,6 +23758,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"obX" = (
+/obj/structure/wreck/trash/autoshaft,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "oco" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -22909,6 +23801,13 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"ode" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "odh" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -22967,7 +23866,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/legion)
 "oep" = (
-/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "Marshal's Office"
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Marshal's office";
+	req_one_access_txt = "134"
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -23042,6 +23947,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ohm" = (
+/obj/machinery/vending/wallmed{
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "ohx" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -23090,6 +24004,13 @@
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/tunnel)
+"ojI" = (
+/obj/item/trash/f13/steak,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "ojU" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -23189,6 +24110,20 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/brotherhood)
+"omR" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"omW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
 "one" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick/jade,
@@ -23233,10 +24168,8 @@
 /obj/structure/fence/corner/wooden{
 	dir = 1
 	},
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "onQ" = (
 /obj/structure/table,
@@ -23371,6 +24304,10 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"oqD" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oqE" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
@@ -23381,6 +24318,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/followers)
+"oqH" = (
+/obj/item/trash/raisins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "oqU" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/destructible/tribal_torch/lit,
@@ -23466,6 +24410,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"ouc" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "ouS" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13{
@@ -23601,6 +24551,14 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"oyS" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/box/flashbangs,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "ozh" = (
 /obj/item/tank/internals/anesthetic,
 /obj/item/tank/internals/anesthetic,
@@ -23653,6 +24611,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/city)
+"oBf" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "oBQ" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23743,10 +24707,7 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "oFp" = (
 /obj/structure/decoration/vent/rusty,
@@ -24033,7 +24994,17 @@
 /turf/open/floor/circuit/f13_blue,
 /area/f13/city)
 "oMA" = (
-/obj/structure/chair/office/dark,
+/obj/machinery/button/door{
+	id = "Marshal's Office";
+	pixel_x = 32;
+	pixel_y = 6
+	},
+/obj/machinery/button/door{
+	id = "Brig Lockdown";
+	name = "brig lockdown button";
+	pixel_x = 32;
+	pixel_y = -6
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -24058,6 +25029,19 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"oNa" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland)
+"oNz" = (
+/obj/item/trash/f13/blamco,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "oNC" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood{
@@ -24086,10 +25070,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "oNZ" = (
 /obj/effect/decal/remains/human,
@@ -24098,6 +25079,14 @@
 /obj/item/clothing/head/helmet/f13/raidercombathelmet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oOF" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "oON" = (
 /obj/machinery/plantgenes,
 /turf/open/floor/wood/f13,
@@ -24343,6 +25332,13 @@
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"oWW" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "oXd" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -24369,6 +25365,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"oXw" = (
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/obj/structure/simple_door/wood{
+	name = "Medicus";
+	req_access_txt = "123"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"oXM" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/landmark/start/f13/townsecscout,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "oYb" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/legion)
@@ -24419,6 +25434,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/caves)
+"pae" = (
+/obj/item/trash/f13/dandyapples,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "par" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -24447,11 +25469,24 @@
 	},
 /turf/open/floor/plating,
 /area/f13/village)
+"pbk" = (
+/obj/item/trash/f13/borscht,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "pbr" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"pbQ" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pbX" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
@@ -24482,6 +25517,11 @@
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"pcu" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "pcG" = (
 /turf/closed/wall/f13/store,
 /area/f13/village)
@@ -24517,29 +25557,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "pdy" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	network = list("Vault")
-	},
-/obj/structure/rack,
-/obj/item/clothing/under/f13/vault,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/belt/security,
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/assembly/flash/handheld,
-/obj/item/restraints/handcuffs,
-/obj/item/gun/ballistic/automatic/pistol/n99,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/head/helmet/riot/vaultsec,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/effect/turf_decal/bot,
+/obj/structure/chair/sofa/corp/left,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -24768,6 +25789,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"pkh" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderlefttop"
+	},
+/area/f13/wasteland)
 "pku" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib6-old";
@@ -24775,6 +25802,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"plg" = (
+/obj/structure/spirit_board,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
+"pll" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "plq" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermainleft"
@@ -24809,6 +25846,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"pnr" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "pnw" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
@@ -24873,6 +25917,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"poW" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
 "poX" = (
 /obj/structure/sink{
 	dir = 1;
@@ -24989,9 +26039,7 @@
 "prc" = (
 /obj/structure/fence/corner/wooden,
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "prs" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -25007,6 +26055,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"prC" = (
+/obj/structure/table/reinforced,
+/obj/item/phone,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "prF" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -25016,7 +26070,8 @@
 /area/f13/wasteland)
 "prG" = (
 /obj/structure/simple_door/wood{
-	name = "Centuriae Office"
+	name = "Centuriae Office";
+	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -25116,6 +26171,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/city)
+"puN" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "puP" = (
 /obj/structure/rack,
 /obj/item/seeds/cannabis,
@@ -25188,6 +26250,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"pxg" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pxw" = (
 /obj/structure/fence/pole_b,
 /obj/structure/table/wood/settler,
@@ -25322,10 +26389,7 @@
 	faction = list("neutral");
 	name = "Sniffs-The-Earth"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pBv" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25363,6 +26427,12 @@
 /obj/machinery/microwave,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"pCt" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "pCy" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -25371,16 +26441,26 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pCM" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Marshal's office"
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -5;
+	pixel_y = 10
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "Marshal's Office"
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/item/export/bottle/tequila{
+	pixel_y = 6
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/city)
+"pDa" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "pDd" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -25489,6 +26569,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"pGb" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
+"pGs" = (
+/obj/item/trash/f13/cram_large,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "pHc" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/chem_dispenser/drinks,
@@ -25632,6 +26725,15 @@
 /obj/item/hatchet,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"pKS" = (
+/obj/machinery/light/small,
+/obj/structure/rack,
+/obj/item/storage/bag/plants,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pKY" = (
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25673,6 +26775,12 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/tunnel)
+"pMc" = (
+/obj/machinery/vending/cola/space_up,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland)
 "pMh" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
@@ -25752,6 +26860,18 @@
 /obj/item/paper_bin,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/legion)
+"pOi" = (
+/obj/structure/table/wood,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/pestspray,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pOw" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -25791,14 +26911,6 @@
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"pPX" = (
-/obj/structure/destructible/tribal_torch/lit,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
 /area/f13/caves)
 "pQx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26363,6 +27475,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"qio" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "qip" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -26454,6 +27571,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qkJ" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qkO" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26702,10 +27825,8 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qsX" = (
 /obj/structure/table/reinforced,
@@ -26725,10 +27846,7 @@
 "quG" = (
 /obj/structure/fence/corner/wooden,
 /obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "quP" = (
 /obj/structure/disposalpipe/segment{
@@ -26944,14 +28062,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "qAL" = (
-/obj/structure/table,
-/obj/item/storage/box/handcuffs{
-	pixel_x = 9;
-	pixel_y = 5
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = -6;
-	pixel_y = 2
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters{
+	id = "Marshal's Office"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -27011,6 +28125,10 @@
 /obj/item/clothing/head/festive,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qDn" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qDs" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13/wood,
@@ -27092,7 +28210,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
 "qGv" = (
-/obj/machinery/workbench,
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -27263,6 +28394,11 @@
 /obj/effect/mine/stun,
 /turf/open/floor/plating,
 /area/f13/caves)
+"qLu" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qLC" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag,
@@ -27692,6 +28828,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"qXG" = (
+/obj/structure/fence/corner/wooden,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "qYr" = (
 /obj/machinery/chem_master/primitive,
 /turf/open/floor/f13/wood,
@@ -27721,6 +28863,13 @@
 	dir = 4
 	},
 /area/f13/village)
+"rae" = (
+/obj/item/trash/f13/yumyum,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "ram" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -27766,6 +28915,15 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"rbB" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "rbF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
@@ -27873,6 +29031,13 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"reN" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "rfP" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/barber{
@@ -27884,7 +29049,6 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
 	},
-/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "rgC" = (
@@ -27894,12 +29058,11 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/city)
 "rgR" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/grass,
-/area/f13/wasteland)
+/area/f13/city)
 "rgS" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -27985,17 +29148,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "ric" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
+/obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -28010,6 +29163,14 @@
 /obj/structure/sign/poster/contraband/pinup_couch,
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar)
+"riI" = (
+/obj/structure/table/greyscale,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "riP" = (
 /obj/effect/landmark/start/f13/hunter,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -28054,6 +29215,12 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
+"rkz" = (
+/obj/structure/curtain{
+	color = "#450159"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
 "rkC" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -28140,6 +29307,13 @@
 /obj/machinery/reagentgrinder/constructed,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/city)
+"rmY" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "rnc" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed"
@@ -28156,6 +29330,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
+/area/f13/wasteland)
+"rnt" = (
+/obj/structure/fence,
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rnu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28206,6 +29385,7 @@
 "rpn" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "rpu" = (
@@ -28249,7 +29429,16 @@
 /turf/open/water,
 /area/f13/brotherhood)
 "rrx" = (
-/obj/effect/landmark/start/f13/marshal,
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1;
+	name = "night vision goggles crate"
+	},
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -28272,9 +29461,8 @@
 	icon_state = "post_wood"
 	},
 /obj/structure/flora/ausbushes/pointybush,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "rss" = (
 /obj/structure/barricade/wooden/strong,
@@ -28284,6 +29472,13 @@
 "rsE" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"rsJ" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
 /area/f13/wasteland)
 "rtl" = (
 /turf/open/indestructible/ground/outside/ruins{
@@ -28366,6 +29561,10 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"rxb" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "rxn" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -28539,6 +29738,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"rDF" = (
+/obj/effect/decal/marking,
+/obj/structure/wreck/trash/autoshaft,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "rEc" = (
 /obj/structure/bed,
 /obj/effect/decal/remains{
@@ -28571,6 +29777,13 @@
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"rEw" = (
+/obj/item/trash/energybar,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "rEA" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/instacoffee{
@@ -28636,6 +29849,13 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"rHR" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rHS" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/item/storage/box/drinkingglasses,
@@ -28651,8 +29871,10 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "rIK" = (
-/obj/machinery/vending/nukacolavendfull,
-/obj/machinery/light,
+/obj/machinery/workbench,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -28661,6 +29883,16 @@
 /obj/structure/cross,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"rJm" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
+"rJo" = (
+/obj/structure/window/fulltile/house,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "rJT" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -28797,8 +30029,8 @@
 /area/f13/building)
 "rOm" = (
 /obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetbrown"
+/obj/item/bedsheet/purple{
+	color = "#450159"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
@@ -28915,6 +30147,13 @@
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
+"rRG" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "rRJ" = (
@@ -29113,6 +30352,7 @@
 	name = "vines"
 	},
 /obj/structure/destructible/tribal_torch/lit,
+/obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate"
 	},
@@ -29233,6 +30473,11 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"sdB" = (
+/obj/structure/simple_door/brokenglass,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "sdG" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -29511,24 +30756,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "sjY" = (
-/obj/structure/rack,
-/obj/item/clothing/under/f13/vault,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/belt/security,
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/assembly/flash/handheld,
-/obj/item/restraints/handcuffs,
-/obj/item/gun/ballistic/automatic/pistol/n99,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/head/helmet/riot/vaultsec,
-/obj/item/clothing/glasses/sunglasses,
-/obj/effect/spawner/lootdrop/armory_contraband,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -29544,10 +30774,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "skj" = (
-/obj/structure/dresser,
-/obj/item/warpaint_bowl{
-	pixel_y = 11
-	},
+/obj/effect/landmark/start/f13/shaman,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "skD" = (
@@ -29702,16 +30929,6 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"snQ" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/obj/machinery/door/poddoor/shutters{
-	id = "Marshal's Office"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/city)
 "snR" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -29747,6 +30964,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"soE" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
+"soS" = (
+/obj/structure/rack,
+/obj/item/storage/bag/plants,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "soY" = (
 /obj/structure/fence{
 	dir = 4
@@ -30091,6 +31321,13 @@
 /obj/item/storage/bag/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"szV" = (
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sAe" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -30150,6 +31387,11 @@
 /obj/machinery/workbench,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"sBB" = (
+/obj/item/trash/candy,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "sBQ" = (
 /mob/living/simple_animal/hostile/gecko,
@@ -30211,11 +31453,10 @@
 	},
 /area/f13/wasteland)
 "sDc" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
+/obj/structure/chair/bench,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
 /area/f13/wasteland)
 "sDj" = (
 /obj/structure/fence/corner{
@@ -30271,6 +31512,14 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"sEI" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/soap/deluxe,
+/obj/structure/decoration/vent,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sEY" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -30290,12 +31539,22 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/followers)
+"sGb" = (
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "sGm" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
+"sGo" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain3"
 	},
 /area/f13/wasteland)
 "sGG" = (
@@ -30335,6 +31594,13 @@
 	icon_state = "verticalinnermainbottom"
 	},
 /area/f13/wasteland)
+"sHL" = (
+/obj/item/trash/f13/sugarbombs,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "sHO" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /obj/effect/decal/remains/human,
@@ -30493,6 +31759,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"sMx" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "sMz" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -30634,6 +31907,12 @@
 /obj/item/pen/fountain,
 /turf/open/floor/wood,
 /area/f13/village)
+"sQJ" = (
+/obj/structure/table/reinforced,
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "sQX" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
@@ -30649,6 +31928,12 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bar)
+"sRL" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
+	},
+/area/f13/wasteland)
 "sRV" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
@@ -30866,6 +32151,12 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"sXq" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "sXy" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -30900,6 +32191,13 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
+"sYr" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "sYF" = (
@@ -30997,9 +32295,9 @@
 /area/f13/building)
 "tbg" = (
 /obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/turf/open/indestructible/ground/outside/road{
+	dir = 1;
+	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
 "tbq" = (
@@ -31034,6 +32332,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"tcn" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "tcp" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -31062,6 +32367,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
+"tdd" = (
+/obj/machinery/smartfridge/bottlerack/alchemy_rack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
 "tdn" = (
 /obj/machinery/door/unpowered/wooddoor{
 	name = "Commanding Officer"
@@ -31070,6 +32379,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ncr)
+"tdu" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "tdv" = (
 /obj/structure/chair/booth{
 	dir = 1
@@ -31247,14 +32561,11 @@
 	},
 /area/f13/legion)
 "tiy" = (
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/effect/turf_decal/bot,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Secret"
+	},
+/obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -31311,6 +32622,16 @@
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"tky" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/taperecorder,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "tkO" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13{
@@ -31413,10 +32734,7 @@
 	icon_state = "post_wood"
 	},
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "tmH" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
@@ -31435,6 +32753,13 @@
 /obj/effect/landmark/start/f13/genghis,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"tod" = (
+/obj/structure/car,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "tom" = (
 /obj/structure/toilet{
 	dir = 1
@@ -31447,9 +32772,7 @@
 	icon_state = "post_wood"
 	},
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "toy" = (
 /obj/structure/tires,
@@ -31502,6 +32825,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"tpt" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "tpA" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -31582,6 +32912,11 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"trY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/mattress,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tsj" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -31735,7 +33070,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "twP" = (
-/obj/structure/billboard/cola/pristine,
+/obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "twY" = (
@@ -31758,6 +33093,10 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
+/area/f13/wasteland)
+"txv" = (
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "txC" = (
 /obj/item/wrench,
@@ -31806,6 +33145,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
+"tyM" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "tyQ" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -31912,6 +33258,15 @@
 	icon_state = "verticalrightborderleft2top"
 	},
 /area/f13/wasteland)
+"tCJ" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "tCQ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/dirt{
@@ -31919,6 +33274,12 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/ncr)
+"tCU" = (
+/obj/structure/table/wood,
+/obj/item/shovel,
+/obj/item/shovel,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tCW" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -32011,8 +33372,9 @@
 	},
 /area/f13/caves)
 "tFK" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "armory"
+/obj/machinery/door/airlock/vault{
+	name = "Armory";
+	req_one_access_txt = "134"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -32098,7 +33460,9 @@
 	},
 /area/f13/brotherhood)
 "tHn" = (
-/obj/effect/landmark/start/f13/townsec,
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -32226,10 +33590,8 @@
 /area/f13/followers)
 "tKU" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "tKZ" = (
 /turf/closed/wall/f13/wood/house/broken,
@@ -32358,8 +33720,9 @@
 	},
 /area/f13/wasteland)
 "tPA" = (
+/obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/village)
 "tQk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/glass/bucket{
@@ -32403,6 +33766,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"tRb" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "tRc" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -32410,16 +33782,13 @@
 	},
 /area/f13/wasteland)
 "tRX" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/remains/human,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
+/obj/structure/rack,
+/obj/item/storage/bag/plants,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/plant_analyzer,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
 "tRY" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -32427,6 +33796,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tSc" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "tSd" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -32477,6 +33851,13 @@
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/city)
+"tTR" = (
+/obj/item/trash/f13/porknbeans,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "tTV" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/bars,
@@ -32616,12 +33997,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"tWu" = (
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
+"tWe" = (
+/obj/effect/spawner/lootdrop/ammo,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"tWu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/city)
 "tWv" = (
 /obj/structure/bed/mattress/pregame,
 /obj/item/clothing/head/fedora,
@@ -32707,6 +34093,11 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_l,
 /area/f13/caves)
+"tZi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tZI" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards,
@@ -32745,6 +34136,13 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"ubi" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ubj" = (
 /obj/structure/closet/cabinet/anchored,
 /turf/open/floor/carpet{
@@ -33009,6 +34407,13 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
+"ujr" = (
+/obj/item/trash/f13/bubblegum_large,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "ujC" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/muzzle,
@@ -33052,6 +34457,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"ulx" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "ulC" = (
 /obj/structure/lattice,
 /obj/structure/spacevine{
@@ -33090,6 +34501,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
+"umf" = (
+/obj/effect/decal/marking,
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "umi" = (
 /turf/closed/wall/f13/store{
 	desc = "A pre-War wall made of solid concrete.";
@@ -33097,10 +34515,7 @@
 	},
 /area/f13/city)
 "umk" = (
-/obj/structure/guncase,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot,
+/obj/structure/chair/sofa/corp/right,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -33551,6 +34966,11 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/village)
+"uzp" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uzs" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor2-old"
@@ -33599,6 +35019,22 @@
 /obj/structure/car,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"uAY" = (
+/obj/effect/landmark/start/f13/townsecscout,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
+"uBm" = (
+/obj/item/mop,
+/obj/structure/mopbucket,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "uBx" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_br,
@@ -33618,8 +35054,10 @@
 	},
 /area/f13/wasteland)
 "uCn" = (
-/obj/machinery/door/airlock/vault{
-	name = "jail"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
@@ -33645,6 +35083,10 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"uDt" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "uDw" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -34043,6 +35485,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"uOO" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "uOQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -34200,6 +35651,13 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood)
+"uTh" = (
+/obj/structure/simple_door/metal/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "uTn" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -34384,6 +35842,13 @@
 "uXj" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"uXy" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "uXU" = (
 /obj/structure/table/wood,
 /obj/item/papercutter,
@@ -34418,7 +35883,8 @@
 /area/f13/village)
 "uYs" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "gatehouse"
+	name = "Gatehouse";
+	req_one_access_txt = "134"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
@@ -34453,7 +35919,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "uYH" = (
-/obj/machinery/autolathe/ammo,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/f13/townsec,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -34814,10 +36283,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/pointybush,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vjO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -34899,6 +36365,12 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"vnf" = (
+/obj/structure/tires/two,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "vnj" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -34933,11 +36405,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/farm)
-"vpa" = (
-/obj/structure/chair/office,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
 "vpx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -34981,9 +36448,26 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "vrc" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/storage/box/handcuffs{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/structure/table,
+/obj/item/storage/box/evidence{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/city)
 "vrg" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -35055,6 +36539,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vtB" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "vtH" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
@@ -35086,13 +36579,11 @@
 	},
 /area/f13/building)
 "vvc" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Secret"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "vvi" = (
@@ -35144,6 +36635,13 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"vwW" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vxb" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2"
@@ -35197,6 +36695,14 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vzi" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2top"
+	},
+/area/f13/wasteland)
 "vzk" = (
 /obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt{
@@ -35391,15 +36897,20 @@
 "vEo" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "vEw" = (
 /obj/item/chair/stool/retro,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vEM" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2bottom"
+	},
+/area/f13/wasteland)
 "vFn" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood{
@@ -35573,22 +37084,7 @@
 	},
 /area/f13/building)
 "vIE" = (
-/obj/structure/rack,
-/obj/item/clothing/under/f13/vault,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/belt/security,
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/assembly/flash/handheld,
-/obj/item/restraints/handcuffs,
-/obj/item/gun/ballistic/automatic/pistol/n99,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/head/helmet/riot/vaultsec,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
+/obj/machinery/autolathe/ammo,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -35657,6 +37153,13 @@
 	icon_state = "horizontalbottomborderbottom2right"
 	},
 /area/f13/wasteland)
+"vMg" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "vMh" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -35761,6 +37264,12 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
+"vOP" = (
+/obj/structure/fence/cut/large{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "vPz" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/floor/plasteel/barber{
@@ -35775,6 +37284,14 @@
 	},
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"vPG" = (
+/obj/structure/lamp_post{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
 /area/f13/wasteland)
 "vPN" = (
 /obj/structure/decoration/rag{
@@ -35829,27 +37346,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vQU" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/machinery/vending/wallmed{
+	pixel_y = 23
 	},
-/obj/structure/rack,
-/obj/item/clothing/under/f13/vault,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/belt/security,
-/obj/item/melee/classic_baton/telescopic,
-/obj/item/assembly/flash/handheld,
-/obj/item/restraints/handcuffs,
-/obj/item/gun/ballistic/automatic/pistol/n99,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/ammo_box/magazine/m10mm_adv/simple,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/head/helmet/riot/vaultsec,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -35911,6 +37411,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood)
+"vSP" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "vTa" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -35920,6 +37430,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/city)
+"vTj" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"vTk" = (
+/obj/item/trash/f13/fancylads,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "vTr" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick,
@@ -35990,6 +37517,7 @@
 "vVU" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "vWd" = (
@@ -36091,10 +37619,7 @@
 "vYT" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/flora/junglebush,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "vYX" = (
 /obj/machinery/light/small,
@@ -36301,6 +37826,13 @@
 /obj/structure/grille/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"wjk" = (
+/obj/structure/table/wood,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wjl" = (
 /obj/structure/sign/poster/ncr/keep_to_myself,
 /turf/closed/wall/f13/store,
@@ -36325,17 +37857,8 @@
 	},
 /area/f13/followers)
 "wjy" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 9;
-	pixel_y = 10
-	},
-/obj/item/export/bottle/tequila{
-	pixel_y = 6
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -36392,10 +37915,7 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "wkH" = (
 /obj/machinery/light/small{
@@ -36436,18 +37956,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wnv" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/bean,
-/obj/item/ammo_box/shotgun/bean,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
+/obj/machinery/light,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -36615,7 +38124,7 @@
 /area/f13/wasteland)
 "wsJ" = (
 /obj/structure/fence/corner{
-	dir = 9
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -36686,6 +38195,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"wvR" = (
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "wvU" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	dir = 5;
@@ -36730,8 +38245,23 @@
 /turf/open/floor/circuit/f13_blue,
 /area/f13/city)
 "wxB" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/city)
 "wxI" = (
 /obj/structure/closet/cabinet,
@@ -36771,6 +38301,13 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"wyt" = (
+/obj/machinery/chem_master/primitive,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
 "wyI" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -36791,6 +38328,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"wzk" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housebase"
+	},
+/area/f13/building)
 "wzm" = (
 /mob/living/simple_animal/hostile/wolf/playable/shepherd{
 	desc = "Legion mongrels are dogs owned and bred by the Houndmasters of Caesar's Legion. Mongrels are mainly used in combat and scouting missions by the Legion.";
@@ -36915,6 +38459,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"wCg" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/f13/wasteland)
 "wCu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -37060,6 +38609,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"wHn" = (
+/obj/structure/simple_door/wood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
 "wHu" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -37129,6 +38682,10 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"wKS" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wKU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -37229,6 +38786,11 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
+"wNS" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wOb" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -37344,6 +38906,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"wQD" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "wQR" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -37428,6 +38994,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"wSx" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wSC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -37439,20 +39010,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "wSP" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
-/obj/item/storage/belt/military/assault,
-/obj/item/clothing/suit/armor/f13/combat/swat,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/head/helmet/f13/combat/swat,
-/obj/item/clothing/glasses/legiongoggles,
-/obj/structure/window/reinforced,
-/obj/item/grenade/chem_grenade/teargas,
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	req_access_txt = "1"
+/obj/machinery/autolathe,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/grenade/flashbang,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -37493,9 +39055,9 @@
 	},
 /area/f13/ncr)
 "wUv" = (
-/obj/structure/car/rubbish1,
+/obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/building)
 "wUL" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/tree/jungle/small,
@@ -37559,6 +39121,15 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"wWe" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Security";
+	req_one_access_txt = "134"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/city)
 "wWh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/pusher,
@@ -37686,6 +39257,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xax" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "xay" = (
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -37728,11 +39313,9 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/city)
 "xbA" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "xbK" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -37794,6 +39377,13 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/village)
+"xcv" = (
+/obj/structure/car/rubbish2,
+/obj/structure/wreck/trash/one_tire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "xcQ" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/combat{
@@ -37950,6 +39540,11 @@
 /obj/item/storage/backpack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xga" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "xgk" = (
 /obj/effect/landmark/start/f13/venator,
 /turf/open/floor/carpet/black,
@@ -37976,10 +39571,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xgC" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xgI" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -38118,6 +39714,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"xkY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "xlb" = (
 /obj/structure/sink/well{
 	pixel_x = -15
@@ -38125,13 +39725,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xll" = (
-/obj/structure/fence{
+/obj/structure/fence/corner/wooden{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outermaincornerouter"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/grass,
 /area/f13/wasteland)
 "xlA" = (
 /obj/structure/chair/wood{
@@ -38536,6 +40135,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
+"xwr" = (
+/obj/structure/sign/poster/contraband/red_rum{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "xws" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -38685,6 +40293,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"xCY" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
 "xDA" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/f13{
@@ -38870,9 +40483,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xIP" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
-	},
+/obj/structure/closet,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -39016,10 +40628,15 @@
 	},
 /area/f13/village)
 "xMz" = (
-/obj/structure/bed/old,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
+"xMB" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "xMN" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -39029,12 +40646,8 @@
 	},
 /area/f13/building)
 "xMP" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland)
+/turf/closed/mineral/random/low_chance,
+/area/f13/village)
 "xNd" = (
 /obj/structure/wreck/bus/orange,
 /turf/open/indestructible/ground/outside/road{
@@ -39070,6 +40683,12 @@
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"xOM" = (
+/obj/structure/closet/crate/bin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "xOR" = (
 /obj/machinery/hydroponics/soil{
 	mutmod = 0;
@@ -39079,9 +40698,6 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xOZ" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
@@ -39148,6 +40764,13 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"xRa" = (
+/obj/item/trash/f13/crisps,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "xRk" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -39177,6 +40800,9 @@
 "xSa" = (
 /obj/structure/bed/oldalt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "xSm" = (
@@ -39210,6 +40836,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"xTk" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xTn" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -39293,6 +40926,13 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
+"xVe" = (
+/obj/structure/dresser,
+/obj/item/warpaint_bowl{
+	pixel_y = 11
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/village)
 "xVu" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/farm)
@@ -39557,6 +41197,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"ydf" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ydm" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -39720,6 +41371,12 @@
 /obj/structure/campfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"yic" = (
+/obj/structure/fence/corner{
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "yip" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -39826,9 +41483,7 @@
 /obj/structure/stone_tile/block/cracked{
 	dir = 5
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "yld" = (
 /obj/machinery/light,
@@ -40496,7 +42151,7 @@ xZu
 gcK
 gwi
 vDe
-xaG
+gke
 trF
 hJz
 trF
@@ -41785,7 +43440,7 @@ nKX
 trF
 hJz
 trF
-bcM
+xbA
 gwi
 gbL
 gcK
@@ -43844,12 +45499,12 @@ dXQ
 cos
 mvv
 rjE
-rjE
+dTv
 ggK
 xKr
 ggK
 gcK
-gcK
+gbL
 gbL
 gbL
 gbL
@@ -44106,7 +45761,7 @@ mvv
 ggK
 gfY
 gbL
-gcK
+gbL
 gbL
 gbL
 gbL
@@ -44363,7 +46018,7 @@ rjE
 ggK
 ggK
 ggK
-gcK
+gbL
 gbL
 gbL
 gbL
@@ -44620,12 +46275,12 @@ rjE
 ggK
 gcK
 gcK
-gcK
 gbL
-gbL
-gbL
-gbL
-gbL
+ktB
+ktB
+ktB
+ktB
+ktB
 gbL
 gbL
 gcK
@@ -44868,7 +46523,7 @@ rjE
 mvv
 mvv
 mvv
-rjE
+dTv
 dWR
 rjE
 rjE
@@ -44877,13 +46532,13 @@ rjE
 gcK
 gcK
 gbL
+ktB
 gbL
 gbL
 gbL
 gbL
 gbL
-gbL
-gbL
+ktB
 gbL
 gcK
 gcK
@@ -45130,10 +46785,10 @@ rjE
 rjE
 rjE
 mvv
-rjE
+dTv
 gcK
 gcK
-gbL
+ktB
 gbL
 gbL
 ggK
@@ -45141,7 +46796,7 @@ asI
 xzn
 gbL
 gbL
-gbL
+ktB
 gbL
 gcK
 ktB
@@ -45378,7 +47033,7 @@ lwj
 cNc
 uXj
 dZK
-rjE
+fQu
 rjE
 rjE
 rjE
@@ -45390,7 +47045,7 @@ mvv
 rjE
 gcK
 gcK
-gbL
+ktB
 gbL
 lmk
 ggK
@@ -45399,7 +47054,7 @@ sVl
 sVl
 gbL
 gbL
-gbL
+ktB
 gcK
 ktB
 gbL
@@ -45630,8 +47285,8 @@ qFk
 qFk
 qFk
 sLr
-tBN
-bpD
+mvv
+rjE
 rbF
 uXj
 uXj
@@ -45647,7 +47302,7 @@ dZK
 mvv
 gcK
 gcK
-gbL
+ktB
 gbL
 ggK
 ggK
@@ -45657,7 +47312,7 @@ sVl
 vhY
 gbL
 gbL
-gcK
+ktB
 ktB
 gbL
 gbL
@@ -45887,8 +47542,8 @@ gcK
 gcK
 gcK
 gcK
-tBN
-bpD
+mvv
+mvv
 ish
 gaV
 ebl
@@ -45904,7 +47559,7 @@ uXj
 dZK
 gcK
 gcK
-gbL
+ktB
 gbL
 asI
 jcb
@@ -46144,24 +47799,24 @@ qFk
 qFk
 qFk
 sLr
-tBN
-bpD
+rjE
+mvv
 ekW
 qFk
 qFk
-utT
-utT
+fTx
+fTx
 qFk
 qFk
 xZu
-xGH
+xgC
 lwj
 lwj
 uXj
 uXj
 gcK
 gcK
-gbL
+ktB
 gbL
 gbL
 asI
@@ -46401,8 +48056,8 @@ bnn
 otr
 uKq
 sLr
-dgB
-bpD
+qNM
+mvv
 ish
 qFk
 uke
@@ -46419,8 +48074,8 @@ uXj
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
+ktB
 gbL
 gbL
 gbL
@@ -46659,7 +48314,7 @@ otr
 otr
 qLC
 mvv
-bpD
+rjE
 xZu
 qFk
 eKM
@@ -46678,8 +48333,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
+ktB
 gbL
 gbL
 sVl
@@ -46915,8 +48570,8 @@ fpv
 iAU
 otr
 sLr
-xGH
-bpD
+mvv
+mvv
 ish
 qFk
 eCK
@@ -47157,23 +48812,23 @@ fyf
 gcK
 gcK
 gcK
-gcK
 ktB
-gcK
-ktB
-gcK
-gcK
-ktB
-gcK
-gcK
+qFk
+qFk
+qFk
+qFk
+qFk
+qFk
+qFk
+qFk
 qFk
 qFk
 qFk
 qFk
 qFk
 sLr
-tBN
-bpD
+mvv
+dTv
 ish
 qFk
 qFk
@@ -47414,23 +49069,23 @@ fyf
 gcK
 gcK
 gcK
-gcK
 ktB
-gcK
-ktB
-gcK
-ktB
-ktB
-ktB
-gcK
+qFk
+izB
+otr
+otr
+otr
+otr
+tRX
+qFk
 gcK
 gcK
 gcK
 gcK
 gcK
 cIL
-tBN
-bpD
+mvv
+mvv
 xZu
 qFk
 uPU
@@ -47671,23 +49326,23 @@ hAC
 fyf
 gcK
 gcK
-gcK
-gcK
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+qFk
+iRT
+otr
+otr
+otr
+otr
+otr
+qFk
 gcK
 gcK
 gcK
 gcK
 gcK
 bzm
-tBN
-bpD
+mvv
+rjE
 ish
 qFk
 uSI
@@ -47928,23 +49583,23 @@ wDc
 fyf
 fyf
 gcK
-gcK
-gcK
+ktB
+qFk
+jsa
+nqU
+nqU
+qFk
+qFk
+rkz
 qFk
 qFk
 qFk
 qFk
 qFk
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+qFk
 gTD
-tBN
-bpD
+mwO
+mvv
 gTD
 qFk
 eDx
@@ -48185,23 +49840,23 @@ bpD
 fyf
 fyf
 gcK
-gcK
 ktB
 qFk
-xqy
-fQu
-fQu
+otr
+nqU
+nqU
 qFk
+tdd
+otr
+wyt
+fpv
 qFk
-qFk
-qFk
+hna
+xVe
 qFk
 gcK
-gcK
-gcK
-gcK
-ggK
-ggK
+cQC
+dWt
 gcK
 qFk
 uSI
@@ -48443,22 +50098,22 @@ fyf
 gcK
 gcK
 gcK
-gcK
 qFk
-cOU
-otr
-otr
-iRT
+qFk
+qFk
+qFk
+qFk
+tdd
 otr
 otr
 kFn
 qFk
+otr
+otr
+qFk
 gcK
-gcK
-gcK
-gcK
-ggK
-ggK
+dDK
+cQC
 gcK
 qFk
 uPU
@@ -48700,22 +50355,22 @@ fyf
 gcK
 gcK
 ktB
-gcK
-qFk
-cQC
-dDK
-gke
+sLr
+kEh
+otr
+otr
 qFk
 otr
 otr
-gZE
+otr
+fpv
 qFk
-gcK
-gcK
-gcK
+otr
+aQa
+qFk
 cLP
-ggK
-ggK
+dTn
+esj
 ggK
 qiN
 qFk
@@ -48957,33 +50612,33 @@ fyf
 gcK
 gcK
 ktB
-gcK
-qFk
-qFk
-qFk
-qFk
-qFk
-xqy
-otr
+sLr
 lDR
+otr
+otr
+rkz
+otr
+otr
+otr
+otr
+wHn
+otr
+dEB
 qFk
-gcK
-gcK
-gcK
 gTD
 ggK
-ggK
-ggK
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-cWG
-wDc
+cQC
+ffs
+rjE
+mvv
+mvv
+mvv
+mvv
+rjE
+mvv
+mvv
+mvv
+fQX
 dZK
 lqV
 uXj
@@ -49214,33 +50869,33 @@ gcK
 gcK
 gcK
 ktB
-gcK
+sLr
+mpV
+otr
+otr
 qFk
-dzE
-izB
-hna
+tPA
+otr
+otr
+otr
 qFk
 qFk
-iRT
 qFk
 qFk
 gcK
 gcK
-gcK
-gcK
-gcK
-ggK
-ggK
-mfD
-xGH
-aBH
-mfD
-mfD
-mfD
-mfD
-mfD
-xGH
-bpD
+dDK
+cQC
+mvv
+mvv
+mvv
+mwO
+mvv
+mvv
+mvv
+mwO
+rjE
+mvv
 wYa
 uXj
 uXj
@@ -49470,37 +51125,37 @@ fyf
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
 qFk
-dgK
-otr
-otr
-hTs
-otr
-otr
 qFk
-gcK
-gcK
-gcK
-gTD
+qFk
+qFk
+qFk
+qFk
+rkz
+rkz
+qFk
+qFk
+xMP
+xMP
+qiN
 gcK
 gcK
 gcK
 gcK
 qiN
-tBN
-bpD
+mvv
+mvv
 rtK
 uXj
 uXj
 ffv
-qHH
-tBN
-bpD
+xll
+mwO
+mvv
 ufP
 rbF
-rbF
+tSc
 goK
 sLr
 bPf
@@ -49727,13 +51382,13 @@ fyf
 gcK
 gcK
 gcK
-gcK
 ktB
 qFk
-dEB
-aep
-skj
-qFk
+otr
+xqy
+otr
+otr
+bnn
 otr
 otr
 pJQ
@@ -49746,15 +51401,15 @@ uRJ
 jxq
 dRT
 rss
-tBN
-bpD
+mvv
+mvv
 uXj
 lqV
 uXj
 uXj
 kAN
-tBN
-bpD
+mwO
+mvv
 rbF
 ish
 ish
@@ -49985,14 +51640,14 @@ gcK
 gcK
 gcK
 ktB
-gcK
 qFk
-qFk
-qFk
-qFk
-xqy
+eBu
+eBu
 otr
 otr
+iAU
+iAU
+iAU
 sLr
 ttU
 uRJ
@@ -50003,15 +51658,15 @@ fyX
 fyX
 uRJ
 unW
-tBN
-bpD
+mvv
+mvv
 xZu
 uXj
 kCH
 uXj
 njS
-tBN
-bpD
+mvv
+rjE
 ish
 sLr
 bPf
@@ -50125,9 +51780,9 @@ bMI
 rbF
 eoI
 uQx
-hQh
+bMI
 rbF
-rHT
+frQ
 koD
 unI
 rHT
@@ -50242,12 +51897,12 @@ gcK
 gcK
 ktB
 gcK
-gcK
 qFk
-xqy
+eBu
 otr
 otr
 otr
+iAU
 iAU
 iAU
 sLr
@@ -50260,16 +51915,16 @@ bMg
 bMg
 uRJ
 nrV
-daU
-bpD
+rjE
+mwO
 eZT
 uXj
 ush
 vMQ
-ish
-tBN
-bpD
-ish
+eoI
+mvv
+mvv
+mvv
 wdT
 fjT
 vPY
@@ -50499,14 +52154,14 @@ gcK
 gcK
 ktB
 gcK
-gcK
 qFk
 eBu
 otr
+plg
+skj
 otr
 otr
-iAU
-iAU
+otr
 lZX
 uRJ
 jTq
@@ -50518,14 +52173,14 @@ uKu
 uRJ
 uRJ
 mvv
-bpD
+mvv
 ish
 uXj
 czl
 spu
 ish
-tBN
-bpD
+mvv
+mvv
 qkd
 mvj
 vPY
@@ -50756,12 +52411,12 @@ gcK
 gcK
 ktB
 gcK
-gcK
 qFk
 eBu
 otr
-hqL
 otr
+otr
+iAU
 iAU
 iAU
 sLr
@@ -50775,14 +52430,14 @@ uRJ
 uRJ
 qMi
 mvv
-bpD
+mwO
 uQx
 uXj
 uXj
 uXj
 qHH
-tBN
-bpD
+mwO
+mvv
 gfk
 pFh
 vPY
@@ -50890,7 +52545,7 @@ iMV
 ceN
 xGp
 gND
-mrL
+nlD
 xQQ
 ybI
 ybI
@@ -51013,12 +52668,12 @@ gcK
 gcK
 ktB
 gcK
-gcK
 qFk
+eBu
 eBu
 otr
 otr
-otr
+iAU
 iAU
 iAU
 may
@@ -51032,15 +52687,15 @@ uKu
 uRJ
 uRJ
 mvv
-bpD
+mvv
 kCH
 uXj
 uXj
 lqV
 alI
-tBN
-bpD
-gfk
+mvv
+mvv
+jHj
 xlE
 vPY
 vPY
@@ -51154,8 +52809,8 @@ rbF
 xZu
 rbF
 akn
-eoI
-rHT
+buv
+frQ
 koD
 unI
 uQx
@@ -51270,14 +52925,14 @@ gcK
 gcK
 gcK
 ktB
-gcK
 qFk
+otr
 xqy
 otr
 otr
 aep
-iAU
-iAU
+otr
+otr
 mkw
 uRJ
 uKu
@@ -51288,16 +52943,16 @@ bMg
 bMg
 uRJ
 sLr
-xGH
-bpD
+mwO
+mvv
 tTv
 uXj
 uXj
 dTp
-njS
-tBN
-bpD
-ish
+kAN
+mvv
+mwO
+ufP
 xlE
 cWy
 vKC
@@ -51411,7 +53066,7 @@ cFY
 cFY
 cFY
 wOj
-rbF
+wOj
 xZu
 koD
 unI
@@ -51527,7 +53182,7 @@ fyf
 gcK
 ktB
 gcK
-gcK
+qFk
 qFk
 qFk
 qFk
@@ -51545,15 +53200,15 @@ mvJ
 dkW
 uRJ
 unW
-tBN
-bpD
+mwO
+mvv
 wYa
 uQx
-eoI
-nVu
-wYa
-nlO
-hCg
+hpG
+lRW
+qXG
+mvv
+rjE
 xZu
 dLB
 rbr
@@ -51649,14 +53304,14 @@ uMZ
 rbe
 erY
 erY
-erY
-kaM
-sgz
-sgz
-kjQ
-kaM
-qoS
-fvz
+wSC
+jZE
+jZE
+jZE
+jZE
+jZE
+jZE
+jZE
 iNR
 prs
 gus
@@ -51665,10 +53320,10 @@ prs
 prs
 uYs
 xLh
-xLh
+tiy
 lhN
+kQb
 wOj
-eoI
 rbF
 koD
 unI
@@ -51785,7 +53440,7 @@ gcK
 ktB
 gcK
 ktB
-ktB
+gcK
 gcK
 qFk
 aha
@@ -51802,10 +53457,10 @@ uRJ
 uRJ
 dRT
 dLB
-daU
+mvv
 pBp
-cWG
-cWG
+mwO
+mvv
 vjL
 ish
 eoI
@@ -51906,15 +53561,15 @@ cWB
 qJR
 erY
 erY
-wSC
-dNT
-gQv
-gQv
-dNT
-gYZ
-gQv
-jZE
-iNR
+bfu
+sfB
+sfB
+sfB
+sfB
+sfB
+sfB
+sfB
+sfB
 vLe
 iue
 bVq
@@ -51922,11 +53577,11 @@ lrq
 scW
 wOj
 xLh
-xLh
-lhN
+uYH
+ucw
+uYH
 wOj
 eoI
-dyS
 koD
 unI
 rbF
@@ -52063,8 +53718,8 @@ mvv
 gPT
 gPT
 gPT
-sgn
-rbF
+jZM
+mUB
 ish
 rbF
 ish
@@ -52163,14 +53818,14 @@ unI
 uMZ
 erY
 erY
-bfu
-tWu
+ajN
 sfB
-sfB
-sfB
-sfB
-sfB
-sfB
+fQt
+uCn
+cOV
+tpN
+cOV
+dTK
 sfB
 wOj
 wOj
@@ -52180,10 +53835,10 @@ wOj
 wOj
 xLh
 xLh
-rIK
+xLh
+xLh
 wOj
-hjO
-ufP
+reN
 koD
 unI
 eoI
@@ -52320,8 +53975,8 @@ mvv
 mvv
 mvv
 mvv
-sgn
-gfk
+jZM
+sDc
 ish
 ish
 xZu
@@ -52421,25 +54076,25 @@ uMZ
 dFQ
 dFQ
 sBk
-gdY
 sfB
-mgu
+xOZ
+xOZ
 prs
 tpN
 prs
-xFv
+prs
 sfB
-wOj
+hjO
 xIP
 aPL
-eHW
-snQ
-xLh
-xLh
-xLh
-xLh
+xIP
+xIP
 wOj
-eoI
+aWP
+mML
+xLh
+wnv
+wOj
 rHT
 koD
 unI
@@ -52578,7 +54233,7 @@ xOR
 xOR
 xOR
 tmv
-hpG
+gfk
 ish
 nVu
 ish
@@ -52678,25 +54333,25 @@ uMZ
 erY
 sOD
 oKA
-uaf
 sfB
-vpa
-prs
-wxB
-prs
-prs
+mgu
+dup
+tpN
+tpN
+dup
+mgu
 sfB
+xLh
+xLh
+xLh
+xLh
+xLh
 wOj
-kQb
+tky
+ucw
 xLh
 xLh
-pCM
-xLh
-xLh
-xLh
-xLh
-mML
-ees
+wWe
 ees
 sVF
 unI
@@ -52786,9 +54441,9 @@ unI
 hbW
 mmK
 apk
-fLc
-sJw
-rRR
+koD
+uaf
+nPX
 fyf
 fyf
 fyf
@@ -52835,11 +54490,11 @@ mvv
 mvv
 mvv
 quG
-ish
+rbF
 ish
 rbF
 ish
-tTv
+wCg
 jfD
 qFk
 qFk
@@ -52935,25 +54590,25 @@ uMZ
 erY
 sOD
 oKA
-cam
 sfB
-mGO
+xOZ
 prs
-tpN
+prs
+prs
 prs
 xMz
 sfB
 wOj
-dup
+wOj
+kkV
+wOj
+wOj
+wOj
+oXM
+uAY
 xLh
 xLh
-snQ
-xLh
-xLh
-xLh
-xLh
-mML
-ybI
+wWe
 ybI
 nkp
 sIf
@@ -53043,9 +54698,9 @@ pBv
 box
 erY
 erY
-aJb
-tUb
-pfl
+koD
+uaf
+nPX
 fyf
 fyf
 fyf
@@ -53091,7 +54746,7 @@ mvv
 mvv
 xlb
 mvv
-bpD
+mwO
 rgA
 rPj
 ttP
@@ -53106,11 +54761,11 @@ cos
 cos
 cos
 cos
-mTd
-mTd
-tPA
-tPA
-mTd
+qFk
+qFk
+otr
+otr
+qFk
 gcK
 gcK
 gcK
@@ -53192,26 +54847,26 @@ uMZ
 erY
 sOD
 sBk
-bFJ
-uCn
+frY
+xOZ
 prs
 prs
-tpN
-tpN
-tpN
-sfB
-wOj
+prs
+prs
+prs
+gYZ
 xLh
-kkV
+xLh
+xLh
 wjy
-snQ
 xLh
 xLh
-oMA
-fQt
+xLh
+xLh
+xLh
+wnv
 wOj
-rbF
-rHT
+sGb
 koD
 nPg
 ybI
@@ -53300,9 +54955,9 @@ ajD
 lSD
 erY
 erY
-sgz
-ehN
-pfl
+koD
+uaf
+nPX
 qOV
 wDc
 fyf
@@ -53348,7 +55003,7 @@ mvv
 mvv
 mvv
 mvv
-bpD
+mvv
 eKF
 vVU
 eKF
@@ -53365,8 +55020,8 @@ kEA
 cos
 ktB
 gcK
-tPA
-tPA
+otr
+otr
 gcK
 ktB
 gcK
@@ -53449,25 +55104,25 @@ qnS
 dFQ
 sOD
 wwM
-bFJ
 sfB
-mGO
-prs
+mgu
+dup
 tpN
-prs
-prs
+tpN
+dup
+tpN
 sfB
-wOj
+hQh
 xLh
-rrx
-ucw
-snQ
+xLh
+xLh
+xLh
 xLh
 xLh
 dyH
 ucw
+dyH
 wOj
-uQx
 eoI
 koD
 unI
@@ -53557,9 +55212,9 @@ ajD
 hbW
 erY
 erY
-kaM
-kaM
-pfl
+koD
+uaf
+nPX
 nlO
 hCg
 fyf
@@ -53606,7 +55261,7 @@ xOR
 xOR
 xOR
 aUj
-dTn
+vDy
 ish
 stK
 eKF
@@ -53621,9 +55276,9 @@ sQA
 hWm
 cos
 ktB
-hwC
-tPA
-tPA
+gcK
+otr
+otr
 gcK
 ktB
 gcK
@@ -53706,26 +55361,26 @@ dXy
 erY
 sOD
 koD
-uCW
 sfB
-vrc
+xOZ
 prs
-wxB
+prs
+tpN
 prs
 xOZ
 sfB
-wOj
+iyo
 erS
-eUD
-jaf
-snQ
 xLh
+jaf
+rgR
+ric
 xLh
 veC
 lhN
+veC
 wOj
-sMk
-rbF
+dbP
 koD
 unI
 pRk
@@ -53814,9 +55469,9 @@ ofX
 hbW
 dFQ
 gmX
-geM
-ees
-ubd
+koD
+uaf
+nPX
 fyf
 fyf
 fyf
@@ -53878,9 +55533,9 @@ gyy
 kDf
 cos
 ktB
-hwC
+gcK
 lZn
-tPA
+otr
 gcK
 ktB
 gcK
@@ -53962,18 +55617,18 @@ ofX
 rQh
 erY
 nJc
-koD
-uaf
+diT
 sfB
+tWu
 vvc
-prs
+eUD
 tpN
 xFv
 xSa
 sfB
 wOj
 wOj
-wOj
+oep
 wOj
 wOj
 wOj
@@ -53981,7 +55636,7 @@ tFK
 wOj
 wOj
 wOj
-xZu
+wOj
 ufP
 koD
 unI
@@ -54127,18 +55782,18 @@ eKF
 prF
 pPF
 gCQ
-mJX
+nLr
 vhY
 vhY
 sVl
 aPm
 gyy
 cos
-lPT
-lPT
-tPA
-tPA
-mTd
+qFk
+qFk
+otr
+otr
+qFk
 gcK
 gcK
 gcK
@@ -54220,7 +55875,7 @@ uMZ
 erY
 rbe
 koD
-frY
+sfB
 sfB
 sfB
 sfB
@@ -54231,14 +55886,14 @@ sfB
 wOj
 umk
 xLh
-jBB
-hOC
+xIP
+qAL
 mBC
 xLh
-mBC
-jex
+vrc
+ohm
+wxB
 wOj
-rbF
 eoI
 koD
 unI
@@ -54329,7 +55984,7 @@ hbW
 cdc
 snB
 koD
-bFJ
+uaf
 nPX
 fyf
 fyf
@@ -54372,10 +56027,10 @@ wsq
 uRJ
 qYr
 iWc
+mwO
 mvv
 mvv
 mvv
-aBH
 qsK
 ish
 uQx
@@ -54391,11 +56046,11 @@ sVl
 ueT
 vhY
 cos
-lPT
-egU
-tPA
-tPA
-mTd
+qFk
+bnn
+otr
+otr
+qFk
 gcK
 gcK
 gcK
@@ -54486,17 +56141,17 @@ yaT
 yaT
 sfB
 wOj
-umk
-xLh
-tHn
+iBT
 xLh
 xLh
-diT
+qAL
+rrx
 xLh
-iyo
+xLh
+xLh
+dZl
 wOj
-sMk
-rHT
+bSi
 koD
 unI
 uQx
@@ -54630,9 +56285,9 @@ uRJ
 dRT
 sLr
 qFk
-xGH
-aBH
-hCg
+mvv
+mvv
+mwO
 cUd
 ish
 ish
@@ -54643,16 +56298,16 @@ akA
 iZT
 fZo
 jlF
-mUB
+bcM
 ueT
 azo
 dpA
 cos
-lPT
-tPA
-tPA
-tPA
-lPT
+qFk
+otr
+otr
+otr
+qFk
 gcK
 gcK
 gcK
@@ -54745,14 +56400,14 @@ sfB
 wOj
 pdy
 xLh
-tHn
-oep
-uYH
-diT
 xLh
-tiy
+oep
+xLh
+xLh
+xLh
+xLh
+cCE
 wOj
-uQx
 rbF
 koD
 unI
@@ -54891,7 +56546,7 @@ uRJ
 uRJ
 kxH
 qFk
-eoI
+eFQ
 jcQ
 mvv
 jcQ
@@ -54901,15 +56556,15 @@ gYI
 oNR
 dXQ
 lYt
-mLo
+nhY
 vhY
 aPm
 cos
-lPT
+qFk
 iqX
 eDL
 eDL
-lPT
+qFk
 gcK
 gcK
 gcK
@@ -55000,16 +56655,16 @@ pMZ
 xUW
 sfB
 wOj
-vQU
 xLh
 tHn
-fKq
+tHn
+qAL
 qGv
-diT
 xLh
-wnv
+xLh
+xLh
+oyS
 wOj
-ajN
 xZu
 koD
 sIf
@@ -55142,7 +56797,7 @@ uRJ
 uRJ
 uRJ
 uRJ
-fTx
+jMN
 uRJ
 uRJ
 uRJ
@@ -55162,11 +56817,11 @@ gXh
 xvM
 vhY
 cos
-lPT
-lPT
+qFk
+qFk
 kwR
 kwR
-lPT
+qFk
 gcK
 gcK
 gcK
@@ -55257,16 +56912,16 @@ vBO
 fZm
 sfB
 wOj
-vIE
-xLh
-tHn
+vQU
+kQb
+pCM
 qAL
 dfx
-diT
 xLh
-iBT
+xLh
+xLh
+mIz
 wOj
-ufP
 rHT
 koD
 nPg
@@ -55399,7 +57054,7 @@ uRJ
 uRJ
 uRJ
 uRJ
-gVt
+uRJ
 uRJ
 uRJ
 uRJ
@@ -55413,7 +57068,7 @@ ish
 cos
 fGh
 nhY
-aIi
+oNR
 dXQ
 gBZ
 sVl
@@ -55515,16 +57170,16 @@ oON
 sfB
 wOj
 sjY
+mGO
+ucw
+qAL
 xLh
 xLh
 xLh
 xLh
-xLh
-xLh
-ric
+gtl
 wOj
-sMk
-uQx
+suR
 koD
 unI
 rHT
@@ -55664,7 +57319,7 @@ iWc
 qFk
 umT
 ish
-eoI
+fqD
 ish
 fAX
 pwZ
@@ -55772,15 +57427,15 @@ cQU
 sfB
 wOj
 jyI
-xLh
+oMA
 hEx
-hqC
+qAL
 wSP
-wSP
-wSP
+rIK
+vIE
 gCS
+fAf
 wOj
-uQx
 rbF
 koD
 unI
@@ -56037,8 +57692,8 @@ wOj
 wOj
 wOj
 wOj
-rgR
-eoI
+wOj
+bvn
 koD
 unI
 eoI
@@ -57469,7 +59124,7 @@ gcK
 pwZ
 mYm
 gje
-pPX
+vEo
 oNR
 dwp
 gUF
@@ -57728,7 +59383,7 @@ sVl
 sVl
 ueT
 tKU
-aIi
+sXq
 dXQ
 asm
 cos
@@ -57982,12 +59637,12 @@ gcK
 gcK
 cos
 sVl
-ffs
+bcM
 iYe
 xzn
-lEV
+nLr
 oNR
-dXQ
+soE
 dzQ
 tBN
 mvv
@@ -59029,7 +60684,7 @@ gcK
 gcK
 kGc
 ajD
-idu
+qnS
 idu
 idu
 idu
@@ -59286,7 +60941,7 @@ fyf
 fyf
 kGc
 ajD
-ehN
+dXy
 rbe
 ehN
 ehN
@@ -59543,9 +61198,9 @@ fyf
 fyf
 kGc
 ajD
-kaM
-kaM
-kaM
+dXy
+erY
+erY
 akU
 fvz
 kaM
@@ -59799,11 +61454,11 @@ fyf
 fyf
 fyf
 kGc
-sIf
-ees
-ees
-ees
-ees
+ajD
+dXy
+erY
+erY
+geM
 gQv
 fsm
 fsm
@@ -60055,13 +61710,13 @@ fyf
 fyf
 fyf
 fyf
-nJW
-ptf
-ptf
-ptf
-ptf
-ptf
-ptf
+kGc
+ajD
+dXy
+erY
+cdc
+bfu
+sUX
 ptf
 ptf
 ptf
@@ -60111,7 +61766,7 @@ fyf
 fyf
 fyf
 fyf
-kEh
+xhd
 gKG
 uSz
 uSz
@@ -60312,13 +61967,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-dDC
-fyf
-fyf
-fyf
-fyf
+kGc
+ajD
+lPu
+cdc
+gWo
+hzb
+edA
 fyf
 fyf
 fyf
@@ -60368,7 +62023,7 @@ fyf
 fyf
 fyf
 fyf
-kEh
+xhd
 uSz
 uSz
 uSz
@@ -60569,11 +62224,11 @@ fyf
 fyf
 fyf
 lWZ
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+ajD
+dXy
+gWo
+uit
 fyf
 fyf
 fyf
@@ -60625,7 +62280,7 @@ fyf
 fyf
 fyf
 fyf
-kEh
+xhd
 uSz
 xsD
 uSz
@@ -60826,13 +62481,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+ajD
+dXy
+pfl
+hWk
+oCi
+bEw
 fyf
 fyf
 fyf
@@ -60882,7 +62537,7 @@ fyf
 fyf
 diP
 fyf
-kEh
+xhd
 uSz
 eTJ
 ghE
@@ -61083,13 +62738,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+ajD
+dXy
+pfl
+hCs
+sBk
+dMW
 fyf
 fyf
 fyf
@@ -61139,7 +62794,7 @@ fyf
 fyf
 wrg
 fyf
-kEh
+xhd
 xhd
 xhd
 xhd
@@ -61340,13 +62995,13 @@ sND
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+nJW
+rAt
+grp
+uit
+hCs
+sBk
+dMW
 fyf
 fyf
 fyf
@@ -61600,10 +63255,10 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
+hWk
+rkr
+sBk
+dMW
 fyf
 fyf
 fyf
@@ -61854,13 +63509,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gSt
+noK
+eHB
+rkr
+rbe
+wwM
+dMW
 fyf
 fyf
 sND
@@ -62111,13 +63766,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+ajD
+dXy
+wGJ
+cdc
+koD
+dMW
 fyf
 fyf
 fyf
@@ -62162,26 +63817,26 @@ apk
 apk
 koD
 dMW
-vxC
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xbA
-xll
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
+pMI
 rAt
 grp
 wKo
@@ -62368,13 +64023,13 @@ hAC
 fyf
 fyf
 fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+ajD
+dXy
+tPy
+cdc
+koD
+dMW
 fyf
 fyf
 fyf
@@ -62420,23 +64075,23 @@ ubg
 koD
 dMW
 fyf
+uqa
+uqa
+uqa
+sYX
 fyf
 fyf
 fyf
 fyf
+uqa
+uqa
+sYX
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+sYX
+uqa
+sYX
+sYX
 fyf
 dxJ
 fyf
@@ -62625,13 +64280,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-hAC
+kGc
+ajD
+dXy
+cdc
+cdc
+bfu
+dMW
 fyf
 fyf
 fyf
@@ -62673,27 +64328,27 @@ kGc
 unI
 uMZ
 erY
-gmX
+erY
 koD
 dMW
 fyf
+uqa
+wzk
+ubi
+uqa
 fyf
+sYX
+uqa
+uqa
+uqa
+eIY
+uqa
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uqa
+wzk
+kbN
+tZi
+kIy
 fyf
 fyf
 fyf
@@ -62882,13 +64537,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
+kGc
+ajD
+dXy
+bJB
+bJB
+oKA
+dMW
 fyf
 fyf
 fyf
@@ -62926,39 +64581,39 @@ oJm
 sYX
 fyf
 fyf
-nJW
-rAt
-grp
-wKo
+kGc
+unI
+uMZ
+erY
 erY
 koD
 dMW
 fyf
+uqa
+iXW
+mdf
+uqa
+fyf
+uqa
+omW
+iXW
+iXW
+iXW
+uqa
+fyf
+uqa
+hFP
+iXW
+mdf
+izs
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+tVV
+oCi
+eHB
+eHB
+oCi
+ssm
 fyf
 fyf
 fyf
@@ -63115,20 +64770,20 @@ fyf
 ibA
 fyf
 uey
-qOV
-cWG
-hpm
-cWG
-wDc
+fyf
+fyf
+jJb
 fyf
 fyf
 fyf
 fyf
 fyf
-tBN
-mvv
-mvv
-aBH
+fyf
+fyf
+nlO
+mfD
+mfD
+mfD
 hCg
 fyf
 fyf
@@ -63139,13 +64794,13 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+ajD
+rQh
+erY
+erY
+sBk
+dMW
 fyf
 fyf
 fyf
@@ -63183,39 +64838,39 @@ rpu
 sYX
 fyf
 fyf
-fyf
-fyf
-fyf
-mEL
-eMD
+kGc
+unI
+qnS
+erY
+erY
 koD
 dMW
 fyf
+uqa
+iXW
+cwM
+uqa
+fyf
+uqa
+iXW
+iXW
+kbN
+ntN
+sYX
+fyf
+uqa
+trY
+iXW
+izs
+wrg
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kdJ
+dXy
+erY
+erY
+oKA
+nPX
 dDC
 fyf
 fyf
@@ -63371,38 +65026,38 @@ bEw
 fyf
 fyf
 fyf
-qOV
-daU
-mvv
+igz
+igz
+igz
 haP
-wUv
-bpD
+dWZ
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+bEw
 fyf
 fyf
 fyf
 fyf
-fyf
-nlO
-mfD
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gSt
+igz
+igz
+igz
+igz
+igz
+igz
+hgX
+ofX
+uMZ
+erY
+erY
+sBk
+dMW
 fyf
 sND
 fyf
@@ -63440,39 +65095,39 @@ ccF
 sYX
 fyf
 fyf
+kGc
+unI
+dXy
+cdc
+erY
+koD
+dMW
+fyf
+uqa
+uXy
+sdB
+uqa
+fyf
+wQD
+daa
+uqa
+uXy
+uqa
+uqa
+fyf
+sYX
+uqa
+uqa
+kIy
 fyf
 fyf
-fyf
-fyf
-fyf
-hzb
-edA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+ajD
+dXy
+dFQ
+erY
+koD
+nPX
 fyf
 fyf
 fyf
@@ -63627,39 +65282,39 @@ sJw
 rRR
 fyf
 fyf
-fyf
-tBN
-mvv
-mvv
-aBH
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
+wIK
+sJw
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+sJw
+sJw
+sJw
+rRR
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+wIK
+sJw
+sJw
+sJw
+sJw
+sJw
+sJw
+sJw
+onk
+qnS
+cdc
+dFQ
+sBk
+dMW
 fyf
 fyf
 fyf
@@ -63697,41 +65352,41 @@ sYX
 sYX
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+dXy
+rbe
+tPy
+koD
+jkJ
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+hgX
+ofX
+dXy
+cdc
+erY
+koD
+nPX
 fyf
 gSt
-igz
-igz
 igz
 igz
 igz
@@ -63884,39 +65539,39 @@ aJb
 fJv
 fyf
 fyf
-fyf
-tBN
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCs
+cdc
+cdc
+cdc
+cdc
+cdc
+kjQ
+erY
+erY
+erY
+erY
+vMU
+hOl
+cdc
+pWN
+plq
+uPP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCs
+cdc
+hOl
+erY
+erY
+erY
+erY
+vMU
+cdc
+cdc
+rbe
+cdc
+sBk
+dMW
 fyf
 fyf
 fyf
@@ -63954,41 +65609,41 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+dXy
+erY
+erY
+fLc
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+onk
+rQh
+cdc
+erY
+fLc
+rRR
 fyf
 wIK
-hkW
-sTa
 sTa
 sJw
 ybI
@@ -63996,8 +65651,8 @@ ybI
 xbR
 sJw
 rRR
-tBN
-mvv
+wIK
+nkp
 dGL
 gcK
 gcK
@@ -64141,39 +65796,39 @@ kjQ
 pWN
 uPP
 fyf
-jJb
-nlO
-mfD
-mfD
-hCg
+pkh
+tPy
+cdc
+cdc
+cdc
+kjQ
+erY
+erY
+erY
+erY
+vMU
+hOl
+hOl
+cdc
+cdc
+tPy
+pWN
+uPP
 fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCs
+cdc
+tPy
+kjQ
+erY
+erY
+erY
+vMU
+tPy
+cdc
+cdc
+apk
+oKA
+dMW
 fyf
 fyf
 fyf
@@ -64209,53 +65864,53 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
 sND
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hCs
-rnx
-aJb
+kGc
+unI
+dXy
+ubg
+cdc
+cdc
+cdc
+cdc
+cdc
+cdc
+cdc
+cdc
+kjQ
+ehN
+hOl
+hOl
+hOl
+hOl
+hOl
+ehN
+ehN
+rbe
+ehN
+ehN
+ehN
+ehN
+vMU
+sgz
+sgz
+sgz
+sgz
+pWN
+uPP
+hWk
+rkr
 aJb
 aJb
 tUb
 idu
 hBN
 aJb
-fJv
-nlO
-xGH
-gVp
+pWN
+rkr
+koD
+cWV
 gcK
 gcK
 gcK
@@ -64397,40 +66052,40 @@ etI
 fvz
 gWo
 uit
-qOV
+fyf
 tbg
+tPy
+cdc
+kjQ
+erY
+erY
+erY
+erY
+erY
+erY
+vMU
+hOl
+cdc
+cdc
+cdc
+cdc
+tPy
+pfl
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hCs
+cdc
+rbe
+kjQ
+erY
+erY
+erY
+vMU
+cdc
+hOl
+hOl
+erY
+wwM
+dMW
 fyf
 fyf
 fyf
@@ -64459,7 +66114,6 @@ dMW
 fyf
 fyf
 fyf
-wrg
 fyf
 fyf
 fyf
@@ -64469,50 +66123,51 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-mEL
-wKo
+kdJ
+unI
+dXy
+tPy
+cdc
+cdc
+cdc
+cdc
+cdc
+cdc
+cdc
+cdc
+rbe
+ehN
+vMU
+sgz
+sgz
+sgz
+kjQ
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+vMU
+sgz
+rbe
+sgz
+sgz
+sgz
+dmL
+pfl
+hCs
 dmL
 sgz
 kjQ
 ehN
-fvz
+sgz
 hOl
 kjQ
-pWN
-uPP
-tBN
-mvv
+sgz
+sgz
+koD
+dMW
 fck
 fck
 fck
@@ -64651,43 +66306,43 @@ fsm
 krJ
 gQv
 jZE
-fsm
+gQv
 ubd
 fyf
-nlO
-hCg
-fyf
-fyf
-jJb
-qOV
+kGc
+muk
+dXy
+cdc
+wkd
+geM
 gjB
+ees
+ees
+ees
+ulx
+gQv
+krJ
+gQv
+gQv
+gQv
+gQv
+gQv
+ubd
 fyf
-fyf
-fyf
-rtR
-fyf
-toy
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
+ars
+gQv
+gQv
+gQv
+gQv
+gQv
+gQv
+gQv
+gQv
+gQv
+gQv
+jZE
+sVF
+dMW
 fyf
 fyf
 fyf
@@ -64714,62 +66369,62 @@ gmX
 koD
 dMW
 fyf
+ejo
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+uxC
+wEo
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rlN
+kdJ
+unI
+dXy
+cdc
+cdc
+cdc
+cdc
+cdc
+cdc
+cdc
+cdc
+cdc
+kjQ
+ehN
+vMU
+sgz
+rbe
+sgz
+kjQ
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+ehN
+vMU
+sgz
+sgz
+sgz
+sgz
+gWo
+uit
+mEL
 btW
 btW
 fvz
 qNB
 kaM
-kaM
-fvz
-gWo
-uit
-tBN
-mvv
+sgz
+sgz
+sgz
+sgz
+koD
+dMW
 dGL
 fck
 kIZ
@@ -64911,40 +66566,40 @@ uCW
 qGZ
 jMC
 fyf
+kGc
+unI
+iSw
+apk
+erY
+bfu
+sUX
+ptf
+ptf
+ptf
+ptf
+sMx
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+edA
 fyf
-fyf
-rtR
-uey
-fyf
-nlO
-hCg
-fyf
-fyf
-fyf
-fyf
-olZ
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+nJW
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+ptf
+edA
 fyf
 fyf
 fyf
@@ -64970,52 +66625,42 @@ dFQ
 gmX
 koD
 dMW
-fyf
-fyf
+sND
+thG
+twP
+qOV
+rRG
+wDc
 twP
 fyf
 fyf
+thG
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-ars
+ilu
+rAt
+grp
+eMD
+trd
+geM
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
+ees
 ees
 ees
 ees
@@ -65025,8 +66670,18 @@ ees
 ees
 ubd
 fyf
-nlO
-xGH
+sZA
+ars
+ees
+ees
+ees
+muk
+uMZ
+erY
+apk
+apk
+koD
+jkJ
 rFk
 mvv
 moo
@@ -65168,13 +66823,13 @@ trd
 jMC
 fyf
 fyf
-fyf
-hAC
-fyf
-mtL
-fyf
-fyf
-fyf
+kGc
+unI
+rQh
+tWe
+erY
+bfu
+dMW
 fyf
 fyf
 fyf
@@ -65228,51 +66883,41 @@ snB
 koD
 dMW
 fyf
+thG
+fyf
+tBN
+mvv
+bpD
+fyf
+fyf
+fyf
+thG
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nJW
+ilu
+hzb
+ptf
+gNA
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+crd
+ptf
 ptf
 ptf
 ptf
@@ -65283,11 +66928,21 @@ ptf
 edA
 fyf
 fyf
-nlO
-mfD
-mfD
-mfD
-mfD
+tcn
+ehm
+ptf
+gNA
+qDU
+qnS
+dFQ
+dFQ
+kjQ
+fLc
+vPG
+ybI
+ybI
+nkp
+rsJ
 mfD
 mfD
 xGH
@@ -65425,13 +67080,13 @@ gjP
 gjP
 gjP
 gjP
-uxC
-uxC
-fyf
-fyf
-fyf
-fyf
-uxC
+bma
+pGb
+erY
+erY
+gWo
+hzb
+fjW
 voV
 eJn
 eJn
@@ -65485,6 +67140,15 @@ snB
 koD
 dMW
 fyf
+thG
+twP
+tBN
+rjH
+bpD
+twP
+fyf
+fyf
+thG
 fyf
 fyf
 fyf
@@ -65494,57 +67158,48 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-qOV
-cWG
-wDc
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+dzf
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+unI
+dXy
+dmL
+sgz
+kjQ
+erY
+xcb
+rDF
+umf
+koD
+dMW
 fyf
 fyf
 nlO
@@ -65682,11 +67337,11 @@ pIV
 gvh
 fyX
 gjP
-fyf
-fyf
-fyf
-hAC
-fyf
+kdJ
+unI
+erY
+gWo
+uit
 fyf
 sZA
 taF
@@ -65742,57 +67397,15 @@ snB
 koD
 dMW
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
+thG
 fyf
 tBN
 mvv
 bpD
 fyf
 fyf
+rVr
+thG
 fyf
 fyf
 fyf
@@ -65802,6 +67415,48 @@ fyf
 fyf
 fyf
 fyf
+gts
+xga
+xkY
+prC
+xkY
+kwo
+gLE
+nXk
+pbk
+doy
+nXk
+pGs
+pnr
+gts
+bFJ
+sYX
+nNM
+uCO
+gxD
+vJb
+sYX
+nNM
+uCO
+gxD
+vJb
+sYX
+nNM
+uCO
+gxD
+vJb
+sYX
+unI
+rQh
+sgz
+rbe
+kjQ
+dFQ
+erY
+erY
+xuL
+koD
+dMW
 fyf
 fyf
 fyf
@@ -65939,10 +67594,10 @@ djK
 jTq
 cvH
 srw
-fyf
-fyf
-fyf
-fyf
+ilu
+rAt
+grp
+uit
 toy
 fyf
 fyf
@@ -65999,51 +67654,7 @@ apk
 koD
 dMW
 fyf
-dva
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+thG
 fyf
 tBN
 mvv
@@ -66051,6 +67662,7 @@ bpD
 fyf
 fyf
 fyf
+thG
 fyf
 fyf
 fyf
@@ -66059,6 +67671,49 @@ fyf
 fyf
 fyf
 fyf
+dRw
+gts
+ahv
+xkY
+sQJ
+xkY
+xkY
+nXk
+nXk
+jQx
+jQx
+jsc
+jQx
+jhH
+gts
+bFJ
+sYX
+dhC
+kFS
+rpu
+rpu
+sYX
+dhC
+kFS
+rpu
+rpu
+sYX
+dhC
+kFS
+rpu
+rpu
+sYX
+unI
+qnS
+apk
+apk
+wGJ
+rbe
+nWB
+erY
+vnf
+koD
+dMW
 fyf
 fyf
 fyf
@@ -66197,7 +67852,7 @@ tYJ
 hzK
 srw
 fyf
-uey
+fyf
 jxH
 jxH
 jxH
@@ -66256,66 +67911,66 @@ ubg
 koD
 dMW
 fyf
+uqa
+lNn
+uqa
+daa
+uqa
+uqa
+uqa
+uqa
+yic
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+tVV
+noK
+plq
+plq
+plq
+oCi
+ssm
+xCY
+tdu
+xkY
+bhU
+bTE
+bhU
+nXk
+ujr
+jsc
+jsc
+jsc
+jsc
+nXk
+gts
+bFJ
+sYX
+vTj
+uCO
+wjk
+iXW
+sYX
+vTj
+uCO
+wjk
+iXW
+sYX
+vTj
+uCO
+wjk
+iXW
+sYX
+unI
+dXy
+erY
+erY
+erY
+apk
+xcb
+xcb
+bOS
+koD
+dMW
 fyf
 fyf
 fyf
@@ -66513,66 +68168,66 @@ snB
 koD
 dMW
 fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+uqa
+bxl
+rpu
+rpu
+rpu
+jTb
+rpu
+lNn
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+ajD
+dXy
+cdc
+cdc
+sBk
+nPX
+xCY
+qio
+sBB
+xkY
+xkY
+xkY
+tTR
+jhH
+diu
+nXk
+pae
+oqH
+dPJ
+gts
+pll
+sYX
+rbB
+uCO
+xVZ
+iXW
+sYX
+rbB
+uCO
+xVZ
+iXW
+sYX
+rbB
+uCO
+xVZ
+iXW
+sYX
+rJm
+dXy
+erY
+sGo
+erY
+erY
+vnf
+erY
+kBo
+koD
+dMW
 fyf
 fyf
 fyf
@@ -66715,7 +68370,7 @@ tRc
 pWN
 qUv
 fyf
-uey
+fyf
 fyf
 taF
 fbq
@@ -66770,67 +68425,67 @@ dmL
 koD
 dMW
 fyf
-uey
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
 uqa
-lRW
+rpu
+rpu
+rpu
+rpu
+rpu
+rpu
 uqa
-itJ
-uqa
-uqa
-uqa
-uqa
-fyf
-fyf
-rVr
-fyf
-fyf
-fyf
-trW
-fyf
-fyf
+cWG
+cWG
+wDc
+kGc
+ofX
+dXy
+cdc
+tPy
+sBk
+mSC
+gts
+tpt
+cYH
+fIE
+fIE
+fIE
+nXk
+nXk
+ePA
+ePA
+ePA
+ePA
+nXk
+gts
+bFJ
+sYX
+sYX
+sYX
+sYX
+jMy
+sYX
+sYX
+sYX
+sYX
+jMy
+sYX
+sYX
+sYX
+sYX
+jMy
+sYX
+onk
+dYq
+erY
+erY
+erY
+erY
+erY
+erY
+erY
+koD
+dMW
+thG
 fyf
 fyf
 fyf
@@ -67027,67 +68682,67 @@ apk
 koD
 dMW
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-fyf
-dWt
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
+uqa
+itJ
+uqa
 uqa
 bxl
-jZM
 rpu
 rpu
-xgC
-rpu
-lRW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+daa
+mvv
+mvv
+bpD
+kGc
+unI
+dXy
+gWo
+wKo
+sBk
+eme
+gts
+xkY
+beO
+xkY
+vTk
+xkY
+nXk
+nXk
+jQx
+jQx
+jQx
+jQx
+sHL
+gts
+bFJ
+uPj
+aOp
+sgz
+sgz
+vMU
+sgz
+sgz
+cGZ
+kjQ
+erY
+sgz
+sgz
+vEM
+wGJ
+sgz
+sgz
+wGJ
+sgz
+erY
+erY
+erY
+erY
+cRo
+xcb
+xcb
+koD
+dMW
+juy
 fyf
 fyf
 fyf
@@ -67284,67 +68939,67 @@ erY
 koD
 dMW
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
+uqa
+rpu
+lZK
 uqa
 rpu
 rpu
 rpu
-rpu
-qfV
-rpu
 uqa
-cWG
-cWG
-wDc
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+xGH
+mvv
+bpD
+kGc
+unI
+dXy
+pWN
+rkr
+sBk
+cam
+gts
+gRy
+gts
+lMd
+gts
+gts
+cDE
+nXk
+nXk
+rEw
+ojI
+nXk
+ode
+gts
+bFJ
+uPj
+sgz
+sgz
+vMU
+sgz
+sgz
+dmL
+sgz
+kjQ
+erY
+sgz
+flf
+kjQ
+wGJ
+dmL
+sgz
+sgz
+sgz
+rbe
+erY
+erY
+erY
+fAt
+fAt
+fAt
+koD
+dMW
+thG
 fyf
 fyf
 oFP
@@ -67410,7 +69065,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+oFP
 gcK
 gcK
 gcK
@@ -67541,67 +69196,67 @@ gmX
 koD
 dMW
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
-uqa
-itJ
-uqa
 uqa
 bxl
+mVx
+uqa
 rpu
+tJe
 rpu
-itJ
-mvv
+lNn
+tBN
 mvv
 bpD
-fyf
-uHT
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+dXy
+bJB
+bJB
+wwM
+wvR
+kav
+ybI
+ybI
+ybI
+tyM
+gts
+xRa
+nXk
+jsc
+jsc
+jQx
+ePA
+xwr
+gts
+bFJ
+uPj
+dPa
+hOl
+vMU
+oNa
+flf
+sgz
+sgz
+kjQ
+erY
+sgz
+kjQ
+kjQ
+wGJ
+sgz
+sgz
+wGJ
+sgz
+erY
+erY
+erY
+erY
+oBf
+xcb
+xcb
+koD
+dMW
+vOP
 fyf
 fyf
 oFP
@@ -67666,9 +69321,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+oFP
+caX
+oFP
 gcK
 gcK
 fyf
@@ -67798,67 +69453,67 @@ gmX
 koD
 dMW
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
 uqa
-rpu
-esj
+lNn
 uqa
-rpu
-rpu
-rpu
 uqa
-xGH
+uqa
+uqa
+uqa
+uqa
+tBN
 mvv
 bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+rQh
+erY
+erY
+koD
+unI
+erY
+tod
+erY
+erY
+koD
+gts
+lWi
+nXk
+vMg
+vMg
+vMg
+vMg
+nXk
+gts
+bFJ
+uPj
+pMc
+hOl
+vMU
+sgz
+sgz
+kjQ
+erY
+erY
+nTa
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+muk
+rQh
+dFQ
+dFQ
+dFQ
+wGJ
+sRL
+kjQ
+eJI
+koD
+dMW
+thG
 fyf
 fyf
 oFP
@@ -67922,11 +69577,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-fyf
-gcK
-gcK
+oFP
+aar
+cbr
+eDn
+oFP
 gcK
 gcK
 fyf
@@ -68062,59 +69717,59 @@ fyf
 fyf
 fyf
 fyf
-sqA
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dTv
-uqa
-bxl
-lzV
-uqa
-rpu
-tJe
-rpu
-lRW
 tBN
 mvv
 bpD
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+uMZ
+erY
+erY
+koD
+unI
+erY
+erY
+erY
+erY
+koD
+gts
+oNz
+nXk
+rae
+nXk
+nXk
+bUV
+gqG
+gts
+bFJ
+uPj
+sgz
+sgz
+kjQ
+vMU
+dmL
+sgz
+kjQ
+erY
+hOl
+sYX
+qLu
+efZ
+lzV
+pMz
+sYX
+mui
+dXy
+sgz
+dmL
+sgz
+kjQ
+apk
+mxU
+kwT
+koD
+dMW
 oFP
 oFP
 oFP
@@ -68179,11 +69834,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-fyf
-fyf
-fyf
-gcK
+oFP
+cbr
+cbr
+cbr
+oFP
 gcK
 gcK
 fyf
@@ -68320,57 +69975,57 @@ fyf
 fyf
 fyf
 fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rVr
-uqa
-lRW
-uqa
-uqa
-uqa
-uqa
-uqa
-uqa
 tBN
 mvv
 bpD
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+uMZ
+erY
+erY
+koD
+unI
+xcb
+xcb
+erY
+erY
+poW
+gts
+pnr
+fAW
+ePA
+ePA
+ePA
+ePA
+nXk
+gts
+bFJ
+uPj
+sgz
+sgz
+kjQ
+vzi
+sgz
+sgz
+kjQ
+erY
+hOl
+sYX
+iXW
+iXW
+rpu
+rpu
+sYX
+xOM
+dXy
+sgz
+mzS
+sgz
+kjQ
+xcb
+xcb
+xcb
+koD
 oFP
 oFP
 tBB
@@ -68436,14 +70091,14 @@ dkg
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
-fyf
-fyf
+oFP
+wUv
+uqa
+wUv
+oFP
 gcK
 gcK
-fyf
+hqL
 fyf
 sYX
 rpu
@@ -68567,55 +70222,11 @@ lSD
 cdc
 snB
 koD
-dMW
-fyf
-fyf
-uey
-uey
+uSm
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-uey
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hNz
 fyf
 fyf
 fyf
@@ -68624,10 +70235,54 @@ fyf
 tBN
 mvv
 bpD
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+uMZ
+erY
+erY
+koD
+unI
+kJp
+erY
+erY
+erY
+koD
+gts
+nof
+nof
+nof
+nof
+nof
+nof
+mIU
+gts
+bFJ
+sYX
+sYX
+sYX
+jMy
+sYX
+jMy
+sYX
+sYX
+sYX
+kFS
+sYX
+tXK
+wNS
+rpu
+iXW
+acn
+erY
+dXy
+sgz
+sgz
+sgz
+kjQ
+obX
+erY
+kxP
+koD
 oFP
 nBC
 cIA
@@ -68828,50 +70483,6 @@ dMW
 fyf
 fyf
 fyf
-uey
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 fyf
 fyf
 fyf
@@ -68881,10 +70492,54 @@ fyf
 tBN
 mvv
 bpD
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+uMZ
+erY
+erY
+koD
+unI
+erY
+ouc
+erY
+erY
+koD
+gts
+iZy
+nXk
+nXk
+mIU
+nXk
+nXk
+nXk
+gts
+bFJ
+sYX
+dkj
+uCO
+iXW
+sYX
+iXW
+uCO
+dkj
+sYX
+cDf
+sYX
+sYX
+wSx
+lUo
+rpu
+sYX
+vtB
+dXy
+sgz
+sgz
+sgz
+dmL
+kjQ
+dmL
+erY
+koD
 oFP
 wER
 kDm
@@ -68952,13 +70607,13 @@ tFR
 pMI
 fyf
 fyf
-upX
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
+siJ
 tKZ
 skh
 rpu
@@ -69086,63 +70741,63 @@ fyf
 fyf
 fyf
 fyf
+hNz
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-ivi
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
+nlO
+mfD
+hCg
+kGc
+unI
+uMZ
+erY
+erY
+koD
+unI
+xcb
+umf
+erY
+erY
+koD
+gts
+xax
+oWW
+nXk
+nof
+vSP
+jhH
+nXk
+gts
+bFJ
+sYX
+kFS
+uCO
+iXW
+sYX
+iXW
+uCO
+kFS
+sYX
+cDf
+jmO
+sYX
+iMJ
+iXW
+rpu
+rJo
+unI
+dXy
+dmL
+sgz
+kjQ
+erY
+xcb
+xcb
+xcb
+koD
+dMW
 oFP
 oFP
 oFP
@@ -69211,7 +70866,7 @@ fyf
 fyf
 fyf
 fyf
-nPu
+tOH
 fyf
 fyf
 fyf
@@ -69351,56 +71006,56 @@ fyf
 qHZ
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+uMZ
+erY
+erY
+koD
+unI
+erY
+xcv
+erY
+erY
+koD
+gts
+muR
+nXk
+nXk
+nof
+bCe
+nXk
+nXk
+uOO
+bFJ
+sYX
+rpu
+rpu
+rpu
+sYX
+rpu
+rpu
+rpu
+sYX
+cDf
+jmO
+sYX
+sYX
+rpu
+rpu
+rJo
+unI
+rQh
+apk
+apk
+erY
+geM
+ear
+ees
+ees
+sVF
+dMW
+thG
 fyf
 fyf
 fyf
@@ -69466,11 +71121,11 @@ tFR
 pMI
 fyf
 fyf
+cTp
+wrg
+cTp
 fyf
 fyf
-fyf
-fyf
-trW
 fyf
 fyf
 sYX
@@ -69608,56 +71263,56 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-dWt
-fyf
-nlO
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+kGc
+unI
+uMZ
+erY
+erY
+koD
+unI
+erY
+erY
+erY
+erY
+koD
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+gts
+dzf
+sYX
+mVx
+vJb
+omR
+sYX
+mVx
+vJb
+omR
+sYX
+fQq
+cDf
+riI
+sYX
+pxg
+wSx
+rJo
+unI
+uMZ
+erY
+erY
+erY
+cJy
+sUX
+crd
+ptf
+ptf
+dgr
+juy
 fyf
 fyf
 fyf
@@ -69728,7 +71383,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+tOH
 fyf
 sYX
 sYX
@@ -69865,56 +71520,56 @@ igz
 igz
 igz
 igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
+hgX
+unI
+uMZ
+erY
+erY
+koD
+atI
+ees
+lES
+erY
+erY
+koD
+cqP
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+qyR
+bFJ
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+pGb
+uMZ
+dFQ
+dFQ
+dFQ
+oQa
+fzf
+feL
+feL
+feL
+feL
+gRr
 igz
 igz
 igz
@@ -69986,7 +71641,7 @@ fyf
 fyf
 fyf
 fyf
-upX
+fyf
 kdJ
 nPg
 sTa
@@ -70123,6 +71778,17 @@ ybI
 ybI
 ybI
 ybI
+onk
+uMZ
+ehN
+ehN
+fLc
+ybI
+ybI
+onk
+erY
+erY
+fLc
 ybI
 ybI
 ybI
@@ -70149,23 +71815,12 @@ ybI
 ybI
 ybI
 ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
-ybI
+onk
+box
+rbe
+cdc
+cdc
+fLc
 ybI
 ybI
 ybI
@@ -70236,11 +71891,11 @@ lyY
 fyf
 gcK
 gcK
-gcK
-fyf
-fyf
-fyf
-fyf
+aaB
+dgK
+dgK
+dgK
+lPT
 fyf
 fyf
 fyf
@@ -70381,16 +72036,16 @@ cdc
 idu
 idu
 idu
+ehN
+ehN
+ehN
+ehN
+idu
 hBN
 aJb
-tUb
-idu
-idu
-hBN
-aJb
-agr
-idu
-idu
+sCK
+erY
+erY
 idu
 hBN
 aJb
@@ -70418,9 +72073,9 @@ aJb
 agr
 idu
 idu
-idu
-hBN
-aJb
+hOl
+hOl
+hOl
 cdc
 idu
 idu
@@ -70493,11 +72148,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-fyf
-fyf
-fyf
+oFP
+dzE
+cbr
+cbr
+wUv
 fyf
 fyf
 tVV
@@ -70750,12 +72405,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+oFP
+dzE
+cbr
+cbr
+wUv
 fyf
-fyf
-fyf
-sND
 fyf
 ilu
 trd
@@ -71007,11 +72662,11 @@ gcK
 uIh
 gcK
 gcK
-gcK
-gcK
-fyf
-fyf
-fyf
+oFP
+egU
+cbr
+cbr
+wUv
 fyf
 fyf
 fyf
@@ -71265,10 +72920,10 @@ ggK
 gcK
 gcK
 gcK
-gcK
-gcK
-fyf
-fyf
+oFP
+gEY
+gZE
+wUv
 fyf
 fyf
 wXl
@@ -71391,7 +73046,7 @@ ptf
 ptf
 ptf
 ptf
-ptf
+rmY
 ptf
 ptf
 ptf
@@ -71523,9 +73178,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-fyf
-fyf
+oFP
+oFP
+oFP
 fyf
 tVV
 dfQ
@@ -71647,9 +73302,9 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
+qOV
+cWG
+wDc
 fyf
 fyf
 fyf
@@ -71904,14 +73559,14 @@ fyf
 fyf
 fyf
 fyf
+tBN
+mvv
+bpD
+thG
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+pSk
 kGc
 unI
 erY
@@ -72150,21 +73805,21 @@ fyf
 fyf
 fyf
 fyf
+pSk
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+szV
+szV
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+vug
+sYX
+sYX
 fyf
 fyf
 fyf
@@ -72409,19 +74064,19 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+exj
+exj
+rpu
+uCO
+hMb
+exj
+uCO
+uzp
+rpu
+rpu
+rpu
+sYX
 fyf
 fyf
 fyf
@@ -72666,19 +74321,19 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+rpu
+rpu
+rpu
+uCO
+rpu
+rpu
+uCO
+vJb
+xNQ
+rpu
+rpu
+sYX
 fyf
 fyf
 fyf
@@ -72923,19 +74578,19 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+rpu
+rpu
+vJb
+uCO
+rpu
+pbQ
+uCO
+uCO
+uCO
+uCO
+rpu
+sYX
 fyf
 fyf
 fyf
@@ -73161,7 +74816,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+pSk
 fyf
 fyf
 fyf
@@ -73180,19 +74835,19 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-sND
-fyf
+sYX
+rpu
+qkJ
+buO
+uCO
+rpu
+eml
+uCO
+nfp
+itu
+oeL
+rpu
+sYX
 fyf
 fyf
 fyf
@@ -73259,7 +74914,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+uHT
 fyf
 fyf
 fyf
@@ -73437,19 +75092,19 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-uey
-qOV
-cWG
+sYX
+rpu
+rkZ
+meT
+uCO
+sDp
+uCO
+uCO
 hpm
-cWG
-wDc
-fyf
-fyf
+rpu
+rpu
+rpu
+sYX
 fyf
 fyf
 fyf
@@ -73694,19 +75349,19 @@ fyf
 fyf
 fyf
 fyf
-fyf
-sND
-fyf
-fyf
-fyf
-qOV
-daU
-mvv
-haP
-wUv
-bpD
-fyf
-fyf
+sYX
+sDp
+uCO
+uCO
+uCO
+rpu
+rpu
+ods
+rpu
+rpu
+pbQ
+pbQ
+sYX
 fyf
 fyf
 fyf
@@ -73948,22 +75603,22 @@ fyf
 fyf
 fyf
 fyf
+pSk
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-aBH
-mfD
-hCg
-fyf
-fyf
+sYX
+rpu
+rpu
+rpu
+rpu
+rpu
+rpu
+rpu
+rpu
+lNT
+rkZ
+aMo
+sYX
 fyf
 fyf
 fyf
@@ -74208,20 +75863,20 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+uCO
+sDp
+uCO
+uCO
+sYX
+sDp
+szV
+szV
+sYX
+sYX
+sYX
+sYX
+sYX
 fyf
 fyf
 fyf
@@ -74465,20 +76120,20 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-mfD
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+fvu
+rpu
+rpu
+rpu
+sYX
+mxj
+iOd
+cbr
+dZT
+mPk
+sDp
+aKq
+sYX
 fyf
 fyf
 fyf
@@ -74722,20 +76377,20 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-qOV
-cWG
-cWG
-cWG
-wDc
+sYX
+wKS
+rpu
+rpu
+rpu
+sDp
+rTt
+cbr
+cbr
+fHf
+dZT
+sYX
+sYX
+sYX
 fyf
 fyf
 fyf
@@ -74979,20 +76634,20 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-mvv
-bpD
+sYX
+tCU
+rpu
+rpu
+mMO
+sYX
+xMB
+bGO
+cbr
+cbr
+cbr
+sDp
+sEI
+sYX
 fyf
 fyf
 fyf
@@ -75236,20 +76891,20 @@ gjP
 gjP
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-kzR
-bpD
+sYX
+imr
+rpu
+soS
+pKS
+sYX
+dbO
+xMB
+bGO
+cbr
+cbr
+sYX
+sYX
+sYX
 fyf
 fyf
 fyf
@@ -75493,23 +77148,23 @@ vAy
 gjP
 fyf
 fyf
+sYX
+szV
+szV
+szV
+sYX
+sYX
+mPk
+dbO
+sYX
+sYX
+sYX
+sYX
+wEo
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-xGH
-mvv
-mvv
-bpD
-fyf
-fyf
-fyf
+pSk
 kGc
 unI
 erY
@@ -75750,20 +77405,20 @@ jMN
 gjP
 fyf
 fyf
+mYa
+rjH
+rjH
+mvv
+rjH
+rjH
+doX
+wDc
+thG
 fyf
+pDa
 fyf
+thG
 fyf
-fyf
-fyf
-pSk
-fyf
-fyf
-fyf
-fyf
-nlO
-mfD
-mfD
-hCg
 fyf
 fyf
 fyf
@@ -76007,19 +77662,19 @@ vAy
 gjP
 fyf
 fyf
+mYa
+mvv
+mvv
+mvv
+qPQ
+mvv
+mvv
+doX
+uTh
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+pDa
+thG
 fyf
 fyf
 fyf
@@ -76264,19 +77919,19 @@ xdD
 gjP
 fyf
 fyf
+mYa
+rjH
+rjH
+mvv
+rjH
+rjH
+rjH
+aBH
+tRb
 fyf
+pDa
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+thG
 fyf
 fyf
 fyf
@@ -76521,19 +78176,19 @@ uRJ
 gjP
 fyf
 fyf
+mYa
+mvv
+mvv
+txv
+mvv
+mvv
+aBH
+hCg
+thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+pDa
+pDa
+thG
 fyf
 fyf
 fyf
@@ -76778,19 +78433,19 @@ vAy
 gjP
 fyf
 fyf
+fKC
+dFK
+rjH
+mvv
+rjH
+xTk
+cFg
+fyf
+thG
+pDa
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+thG
 fyf
 fyf
 fyf
@@ -77035,21 +78690,21 @@ cbk
 gjP
 fyf
 fyf
+puN
+fnB
+igc
+igc
+igc
+sYr
+uxC
+uxC
+rnt
+uxC
+uxC
+uxC
+fDm
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+pSk
 fyf
 fyf
 kGc
@@ -77552,7 +79207,7 @@ fyf
 fyf
 fyf
 fyf
-sND
+fyf
 fyf
 fyf
 fyf
@@ -78064,7 +79719,7 @@ gjP
 fyf
 fyf
 fyf
-fyf
+pSk
 fyf
 fyf
 fyf
@@ -79102,7 +80757,7 @@ fyf
 fyf
 fyf
 fyf
-sqA
+fyf
 fyf
 fyf
 fyf
@@ -80382,7 +82037,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+pSk
 fyf
 fyf
 fyf
@@ -80906,7 +82561,7 @@ qUC
 ejD
 fyf
 fyf
-fyf
+pSk
 kGc
 unI
 erY
@@ -88799,11 +90454,11 @@ sYX
 gcK
 gcK
 gcK
-ucZ
+cOU
 ggK
 kjR
 ggK
-ucZ
+cOU
 gcK
 gcK
 gcK
@@ -88854,7 +90509,7 @@ gcK
 gcK
 gcK
 gcK
-gSt
+gcK
 hgX
 uCW
 unI
@@ -89105,12 +90760,12 @@ fyf
 gcK
 gcK
 gbL
-gbL
-gbL
-gbL
-gcK
-gcK
-gcK
+jDd
+jDd
+mTd
+mTd
+jDd
+jDd
 gcK
 cpK
 cpK
@@ -89362,12 +91017,12 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
+jDd
+izj
+uDt
+ggK
+ggK
+jDd
 gcK
 uCW
 cpK
@@ -89619,12 +91274,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gbL
-gbL
-gbL
-gcK
-gcK
+mTd
+uDt
+ggK
+qDn
+oqD
+mTd
 gcK
 uCW
 uCW
@@ -89876,12 +91531,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gcK
+mTd
+ggK
+ggK
+ggK
+ggK
+mTd
 gcK
 gcK
 uCW
@@ -90133,12 +91788,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+sVl
+bcM
+ggK
+uDt
+uDt
+mTd
 gcK
 gcK
 cpK
@@ -90390,12 +92045,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+sVl
+bcM
+ggK
+ggK
+ggK
+ggK
 gcK
 gcK
 uCW
@@ -90647,13 +92302,13 @@ gcK
 gbL
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+sVl
+sVl
+bcM
+gPA
+ggK
+ggK
+jDd
 gcK
 gcK
 unI
@@ -90904,13 +92559,13 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+sVl
+sVl
+bcM
+uDt
+qDn
+ggK
+ggK
 gcK
 gcK
 sIf
@@ -91159,15 +92814,15 @@ gbL
 gbL
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+sVl
+pcu
+sVl
+sVl
+bcM
+gPA
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
@@ -91414,18 +93069,18 @@ gcK
 gcK
 gcK
 gcK
+aYS
+sVl
+sVl
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+sVl
+sVl
+sVl
+bcM
+ggK
+ggK
+ggK
+wnA
 gcK
 gcK
 gcK
@@ -91675,15 +93330,15 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+jDd
+sVl
+sVl
+sVl
+rxb
+ggK
+ggK
+wnA
+wnA
 gcK
 gcK
 gcK
@@ -91937,11 +93592,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+jDd
+wnA
+wnA
+wnA
+ggK
 gcK
 gcK
 gcK
@@ -92196,10 +93851,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+wnA
+ggK
+ggK
+sCu
 gcK
 gcK
 gcK
@@ -92442,21 +94097,21 @@ gcK
 gcK
 gcK
 gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+sqA
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ggK
+ggK
 gts
 gts
 gts
@@ -92499,7 +94154,7 @@ aau
 dUv
 xys
 xys
-jaV
+nnW
 xNm
 xDE
 oMY
@@ -92693,27 +94348,27 @@ gts
 gcK
 gcK
 gcK
-gcK
+jzN
 fyf
 gcK
-kEh
 gcK
 gcK
 gcK
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ggK
+ggK
+ggK
+ggK
+ggK
 tJk
 xya
 xya
@@ -92764,7 +94419,7 @@ hom
 wcu
 wcu
 hom
-xqQ
+cjP
 hom
 hom
 hom
@@ -92950,24 +94605,24 @@ gts
 gcK
 gcK
 gcK
-fyf
-fyf
-fyf
 thG
 fyf
 fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+fyf
+fyf
+qOV
+cWG
+cWG
+cWG
+cWG
+wDc
+sju
+fyf
+fyf
+fyf
+fyf
+fyf
+ggK
 gcK
 gcK
 gcK
@@ -93207,24 +94862,24 @@ gts
 gcK
 gcK
 fyf
-fyf
-fyf
-fyf
 thG
 fyf
 fyf
 fyf
 fyf
+tBN
+rjH
+rjH
+rjH
+rjH
+bpD
 fyf
 fyf
 fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+fyf
+fyf
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -93464,27 +95119,27 @@ gts
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
 thG
 fyf
 fyf
 fyf
 fyf
+tBN
+mvv
+mvv
+mvv
+mvv
+bpD
 fyf
 fyf
 fyf
+sYX
+sYX
+sYX
+sYX
+sYX
 fyf
 fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gts
 gts
 gts
@@ -93721,30 +95376,30 @@ gts
 fyf
 fyf
 fyf
-fyf
+thG
 sqA
+fyf
+fyf
+fyf
+tBN
+rjH
+rjH
+rjH
+rjH
+bpD
+fyf
+fyf
+sYX
+sYX
+pOi
+tCU
+wKS
+sYX
+sYX
 fyf
 thG
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gts
 rRt
 cpK
@@ -93978,30 +95633,30 @@ gts
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-kEh
-fyf
+thG
 fyf
 fyf
 fyf
 fyf
+nlO
+mfD
+mfD
+mfD
+mfD
+hCg
 fyf
 fyf
+rJo
+xjA
+rpu
+rpu
+rpu
+fvu
+sYX
+fyf
+thG
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 hej
 cpK
 uCW
@@ -94036,7 +95691,7 @@ fyf
 nlO
 xGH
 mvv
-iWi
+bct
 mvv
 mvv
 mvv
@@ -94235,9 +95890,6 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
 thG
 fyf
 fyf
@@ -94247,17 +95899,20 @@ fyf
 fyf
 fyf
 fyf
+sqA
 fyf
 fyf
 fyf
+jbx
+rpu
+rpu
+rpu
+rpu
+rpu
+rJo
 fyf
+thG
 fyf
-fyf
-fyf
-gcK
-gcK
-gcK
-gcK
 fyf
 hej
 cpK
@@ -94492,28 +96147,28 @@ fyf
 fyf
 fyf
 sqA
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 thG
 fyf
+fyf
+fyf
+qOV
+cWG
+cWG
+wDc
+fyf
+fyf
+pCt
+fyf
+fyf
+rJo
+rpu
+mjD
+jGp
+rpu
+rpu
+rJo
+fyf
+thG
 fyf
 fyf
 hej
@@ -94749,28 +96404,28 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 thG
 fyf
+fyf
+fyf
+tBN
+mvv
+pIn
+bpD
+fyf
+fyf
+sYX
+sYX
+sYX
+sYX
+uCO
+uCO
+uCO
+rpu
+nrr
+sYX
+fyf
+jzN
 fyf
 fyf
 hej
@@ -95006,28 +96661,28 @@ fyf
 fyf
 fyf
 fyf
+jzN
 fyf
 fyf
 fyf
+tBN
+mvv
+mvv
+bpD
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rtR
-fyf
-fyf
-fyf
+sYX
+oeL
+rpu
+ydf
+bgk
+pCi
+uCO
+qfV
+gOV
+sYX
 fyf
 thG
-fyf
 fyf
 fyf
 hej
@@ -95263,28 +96918,28 @@ fyf
 fyf
 fyf
 fyf
-fyf
+thG
 fyf
 sND
 fyf
+nlO
+eJH
+mfD
+hCg
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+rJo
+rpu
+pbQ
+rpu
+rpu
+aMo
+uCO
+rpu
+mMO
+sYX
 fyf
 thG
-fyf
 fyf
 fyf
 hej
@@ -95520,28 +97175,28 @@ fyf
 fyf
 fyf
 fyf
-fyf
+thG
 fyf
 hAC
 fyf
 fyf
 fyf
 fyf
-rtR
 fyf
 fyf
 fyf
-rtR
+rJo
+lNT
+rkZ
+imp
+rpu
+rkZ
+uCO
+yjG
+uCO
+sYX
 fyf
-fyf
-sND
-fyf
-fyf
-fyf
-fyf
-fyf
-kEh
-fyf
+thG
 fyf
 fyf
 hej
@@ -95777,28 +97432,28 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-trW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 thG
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+sYX
+sYX
+sYX
+rHR
+rkZ
+imp
+rpu
+plt
+uCO
+rpu
+plt
+sYX
+fyf
+thG
 fyf
 fyf
 hej
@@ -96034,28 +97689,28 @@ fyf
 fyf
 fyf
 trW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 thG
 fyf
+fyf
+fyf
+fyf
+sqA
+fyf
+fyf
+jbx
+rpu
+rpu
+rpu
+meW
+rpu
+rpu
+rpu
+jbx
+rpu
+qfV
+rJo
+fyf
+thG
 fyf
 fyf
 hej
@@ -96291,28 +97946,28 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-rtR
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rtR
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 thG
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+sYX
+vJb
+rpu
+rpu
+rpu
+wQR
+rpu
+foz
+uCO
+rpu
+rpu
+sYX
+fyf
+thG
 fyf
 fyf
 nGq
@@ -96548,28 +98203,28 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
 thG
 fyf
+fyf
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+uCO
+jbx
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
+sDp
+uCO
+sYX
+fyf
+thG
 fyf
 fyf
 hej
@@ -96609,7 +98264,7 @@ gcK
 gsV
 mUx
 oaw
-aaB
+oaw
 oaw
 oaw
 oaw
@@ -96805,28 +98460,28 @@ fyf
 fyf
 fyf
 fyf
-trW
+fCW
 fyf
+sYX
+sYX
+rkZ
+lTk
+rpu
+rpu
+sDp
+xjA
+rpu
+rpu
+sDp
+rpu
+rpu
+lTk
+rpu
+rpu
+buO
+sYX
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-trW
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-upX
-fyf
-fyf
-fyf
-fyf
-kEh
-fyf
+thG
 fyf
 fyf
 hej
@@ -97062,28 +98717,28 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
 thG
 fyf
-fyf
-fyf
-fyf
-fyf
-aar
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+rJo
+rkZ
+aqr
+rpu
+jhp
+rpu
+uCO
+uCO
+yjG
+uCO
+uCO
+oeL
+rpu
+jhp
+rpu
+lNT
+rkZ
+rJo
 fyf
 thG
-fyf
 fyf
 fyf
 hej
@@ -97319,28 +98974,28 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
 thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-rtR
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+rJo
+buO
+rpu
+rpu
+rpu
+ltS
+uCO
+kUe
+dhC
+uBm
+uCO
+kSu
+rpu
+rpu
+rpu
+rpu
+rpu
+rJo
 fyf
 thG
-fyf
 fyf
 fyf
 hej
@@ -97576,28 +99231,28 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
 thG
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+sYX
+rpu
+ccF
+ccF
+rkZ
+uCO
+dhC
+mlw
+usW
+uCO
+rkZ
+ccF
+vwW
+ccF
+rkZ
+ccF
+sYX
 fyf
 thG
-fyf
 fyf
 fyf
 hej
@@ -97833,28 +99488,28 @@ fyf
 lWZ
 fyf
 fyf
-fyf
-fyf
-fyf
 thG
 fyf
 fyf
-fyf
 sYX
 sYX
 sYX
-gEY
 sYX
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+sYX
+rJo
+sYX
+rJo
+sYX
+rJo
+sYX
 fyf
 thG
-fyf
 fyf
 fyf
 hej
@@ -98090,28 +99745,28 @@ fyf
 fyf
 fyf
 fyf
+thG
 fyf
 fyf
 fyf
-kEh
-uxC
-uxC
-uxC
-sYX
-nqU
-tRX
-mZD
-sYX
-xMP
-uxC
-uxC
-kEh
-uxC
-uxC
-uxC
-uxC
-kEh
 fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+fyf
+thG
 fyf
 fyf
 nGq
@@ -98347,28 +100002,28 @@ igz
 igz
 igz
 igz
-igz
-igz
-igz
-igz
-igz
-bEw
-gSt
-sYX
 jzN
+qUC
+qUC
+qUC
+qUC
+tCJ
+oOF
+qUC
 jzN
+qUC
+qUC
+qUC
+qUC
+qUC
 jzN
-sYX
-jkJ
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
-igz
+qUC
+qUC
+qUC
+qUC
+qUC
+qUC
+jzN
 bEw
 gSt
 hgX
@@ -99441,9 +101096,9 @@ nTO
 pIz
 okZ
 hge
-sDc
-mfD
-mfD
+aax
+mvv
+aBH
 all
 buG
 tBN
@@ -99699,7 +101354,7 @@ cRh
 hom
 uNK
 hom
-rgS
+oXw
 hom
 rgS
 egn
@@ -99959,7 +101614,7 @@ ntJ
 xNm
 uIV
 xNm
-dvo
+hFu
 mvv
 mvv
 bpD
@@ -101494,7 +103149,7 @@ abb
 spC
 jIn
 jIn
-xqQ
+eDv
 hbO
 xfy
 hbO

--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -82,20 +82,21 @@
 
 	//Desert Rose 2 Custom access
 
-#define ACCESS_BOS			120 //general BOS access
-#define ACCESS_NCR			121 //general NCR access
-#define ACCESS_DEN			122	//general den access
-#define ACCESS_LEGION		123	//general legion access
-#define ACCESS_FOLLOWER		124	//general followers access
-#define ACCESS_KHAN			125	//general khan access
-#define ACCESS_VAULT_F13	126	//general vault access
-#define ACCESS_RESTRICT		127	//general restricted access
-#define ACCESS_MILITARY		128	//general military access
-#define ACCESS_MEDICAL_F13	129	//general medical access
-#define ACCESS_COMMAND		130	//general command access
-#define ACCESS_TRIBE		131	//general tribe access
-#define ACCESS_NCROFFDUTY	132 //general NCR access
-#define ACCESS_CLINIC		133 //Oasis clinic access
+#define ACCESS_BOS					120 //general BOS access
+#define ACCESS_NCR					121 //general NCR access
+#define ACCESS_DEN					122	//general den access
+#define ACCESS_LEGION				123	//general legion access
+#define ACCESS_FOLLOWER				124	//general followers access
+#define ACCESS_KHAN					125	//general khan access
+#define ACCESS_VAULT_F13			126	//general vault access
+#define ACCESS_RESTRICT				127	//general restricted access
+#define ACCESS_MILITARY				128	//general military access
+#define ACCESS_MEDICAL_F13			129	//general medical access
+#define ACCESS_COMMAND				130	//general command access
+#define ACCESS_TRIBE				131	//general tribe access
+#define ACCESS_NCROFFDUTY			132 //general NCR access
+#define ACCESS_CLINIC				133 //Oasis clinic access
+#define ACCESS_VAULT_SECURITY_F13 	134 //security specific access for vault.
 	//The Syndicate
 #define ACCESS_SYNDICATE 150//General Syndicate Access. Includes Syndicate mechs and ruins.
 #define ACCESS_SYNDICATE_LEADER 151//Nuke Op Leader Access

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -285,40 +285,51 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/headset_vault/cogcity
 	name = "\improper Cog City radio headset"
+	bowman = TRUE
 
 /obj/item/radio/headset/headset_vault/cogcity/sci
 	name = "\improper Cog City science radio headset"
+	icon_state = "sci_headset"
 	keyslot = new /obj/item/encryptionkey/headset_vault_science
 
 /obj/item/radio/headset/headset_vault/cogcity/sec
 	name = "\improper Cog City security radio headset"
+	icon_state = "sec_headset_alt"
+	item_state = "sec_headset_alt"
 	keyslot = new /obj/item/encryptionkey/headset_vault_security
 
 /obj/item/radio/headset/headset_vault/cogcity/priest
 	name = "\improper Cog City preacher radio headset"
+	icon_state = "srv_headset"
 	keyslot = new /obj/item/encryptionkey/headset_vault_preacher
 
 /obj/item/radio/headset/headset_vault/cogcity/merch
 	name = "\improper Cog City merchant radio headset"
+	icon_state = "cargo_headset"
 	keyslot = new /obj/item/encryptionkey/headset_vault_merchant
 
 /obj/item/radio/headset/headset_vault/cogcity/overseer
 	name = "\improper Cog City command radio headset"
+	icon_state = "com_headset"
 	keyslot = new /obj/item/encryptionkey/headset_vault
 	keyslot2 = new /obj/item/encryptionkey/headset_overseer
 
 /obj/item/radio/headset/headset_vault/cogcity/sec_lead
 	name = "\improper Cog City security command radio headset"
+	icon_state = "com_headset_alt"
+	item_state = "com_headset_alt"
 	keyslot = new /obj/item/encryptionkey/headset_vault_security
 	keyslot2 = new /obj/item/encryptionkey/headset_overseer
 
 /obj/item/radio/headset/headset_vault/cogcity/sci_lead
 	name = "\improper Cog City research command radio headset"
+	icon_state = "com_headset"
 	keyslot = new /obj/item/encryptionkey/headset_vault_science
 	keyslot2 = new /obj/item/encryptionkey/headset_overseer
 
 /obj/item/radio/headset/headset_vault/cogcity/merch_lead
 	name = "\improper Cog City merchant command radio headset"
+	icon_state = "com_headset"
 	keyslot = new /obj/item/encryptionkey/headset_vault_merchant
 	keyslot2 = new /obj/item/encryptionkey/headset_overseer
 

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -622,10 +622,17 @@
 
 /obj/item/clothing/head/helmet/riot/vaultsec/vc/scout
 	name = "vtcc scout helmet"
-	desc = "(IV) A riot helmet adapted from the design of most pre-war riot helmets, painted blue."
+	desc = "(V) A riot helmet adapted from the design of most pre-war riot helmets, painted blue."
 	icon_state = "vtcc_riot_helmet"
 	item_state = "vtcc_riot_helmet"
-	armor = list("tier" = 4, "energy" = 30, "bomb" = 25, "bio" = 40, "rad" = 10, "fire" = 40, "acid" = 10)
+	armor = list("tier" = 5, "energy" = 30, "bomb" = 25, "bio" = 40, "rad" = 10, "fire" = 40, "acid" = 10)
+
+/obj/item/clothing/head/helmet/riot/vaultsec/vc/marshal
+	name = "vtcc marshal cap"
+	desc = "(VII) A peaked dark blue cap, probably worn by someone important."
+	icon_state = "hopcap"
+	item_state = "hopcap"
+	armor = list("tier" = 7, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)
 
 /obj/item/clothing/head/helmet/riot/vaultsec/vc/heavy
 	name = "vtcc heavy riot helmet"

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -613,7 +613,7 @@
 	armor = list("tier" = 5, "energy" = 5, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 50, "acid" = 50)
 
 /obj/item/clothing/head/helmet/riot/vaultsec/vc
-	name = "vtcc riot helmet"
+	name = "VTCC riot helmet"
 	desc = "(V) A riot helmet adapted from the design of most pre-war riot helmets, painted blue."
 	icon_state = "vtcc_riot_helmet"
 	item_state = "vtcc_riot_helmet"
@@ -621,21 +621,21 @@
 	can_toggle = null
 
 /obj/item/clothing/head/helmet/riot/vaultsec/vc/scout
-	name = "vtcc scout helmet"
-	desc = "(V) A riot helmet adapted from the design of most pre-war riot helmets, painted blue."
+	name = "VTCC scout helmet"
+	desc = "(IV) A riot helmet adapted from the design of most pre-war riot helmets, painted blue."
 	icon_state = "vtcc_riot_helmet"
 	item_state = "vtcc_riot_helmet"
-	armor = list("tier" = 5, "energy" = 30, "bomb" = 25, "bio" = 40, "rad" = 10, "fire" = 40, "acid" = 10)
+	armor = list("tier" = 4, "energy" = 30, "bomb" = 25, "bio" = 40, "rad" = 10, "fire" = 40, "acid" = 10)
 
 /obj/item/clothing/head/helmet/riot/vaultsec/vc/marshal
-	name = "vtcc marshal cap"
+	name = "VTCC marshal cap"
 	desc = "(VII) A peaked dark blue cap, probably worn by someone important."
 	icon_state = "hopcap"
 	item_state = "hopcap"
 	armor = list("tier" = 7, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)
 
 /obj/item/clothing/head/helmet/riot/vaultsec/vc/heavy
-	name = "vtcc heavy riot helmet"
+	name = "VTCC heavy riot helmet"
 	desc = "(VI) A heavy riot helmet adapted from the design of most pre-war riot helmets, painted black."
 	icon_state = "vtcc_heavy_riot_helmet"
 	item_state = "vtcc_heavy_riot_helmet"

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -606,11 +606,11 @@
 
 /obj/item/clothing/suit/armor/f13/riot/vault/scout
 	name = "VTCC scout armour"
-	desc = "(V) A suit of stripped back riot armour, adapted from the pre-war U.S.M.C armours and stripped back."
+	desc = "(IV) A suit of stripped back riot armour, adapted from the pre-war U.S.M.C armours and stripped back."
 	icon_state = "vtcc_scout_gear"
 	item_state = "vtcc_scout_gear"
-	armor = list("tier" = 5, "energy" = 30, "bomb" = 25, "bio" = 30, "rad" = 10, "fire" = 50, "acid" = 10)
-	
+	armor = list("tier" = 4, "energy" = 30, "bomb" = 25, "bio" = 30, "rad" = 10, "fire" = 50, "acid" = 10)
+	slowdown = -0.13
 
 /obj/item/clothing/suit/armor/f13/riot/vault/heavy
 	name = "VTCC riot supression armor"

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -602,14 +602,15 @@
 	icon_state = "vtcc_riot_gear"
 	item_state = "vtcc_riot_gear"
 	armor = list("tier" = 5, "energy" = 35, "bomb" = 35, "bio" = 40, "rad" = 10, "fire" = 60, "acid" = 10)
+	slowdown = -0.1
 
 /obj/item/clothing/suit/armor/f13/riot/vault/scout
 	name = "VTCC scout armour"
-	desc = "(IV) A suit of stripped back riot armour, adapted from the pre-war U.S.M.C armours and stripped back."
+	desc = "(V) A suit of stripped back riot armour, adapted from the pre-war U.S.M.C armours and stripped back."
 	icon_state = "vtcc_scout_gear"
 	item_state = "vtcc_scout_gear"
-	armor = list("tier" = 4, "energy" = 30, "bomb" = 25, "bio" = 30, "rad" = 10, "fire" = 50, "acid" = 10)
-	slowdown = -0.1
+	armor = list("tier" = 5, "energy" = 30, "bomb" = 25, "bio" = 30, "rad" = 10, "fire" = 50, "acid" = 10)
+	
 
 /obj/item/clothing/suit/armor/f13/riot/vault/heavy
 	name = "VTCC riot supression armor"

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -88,60 +88,59 @@
 	outfit = /datum/outfit/job/vtcc/f13marshal
 	loadout_options = list(
 		/datum/outfit/loadout/secchief,
-		/datum/outfit/loadout/gunslinger,
 		/datum/outfit/loadout/peacekeeper
 		)
 
-	access = list(ACCESS_BAR, ACCESS_CLONING, ACCESS_GATEWAY, ACCESS_VAULT_F13, ACCESS_CARGO_BOT, ACCESS_MINT_VAULT, ACCESS_CLINIC, ACCESS_KITCHEN, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS)
-	minimal_access = list(ACCESS_BAR, ACCESS_CLONING, ACCESS_GATEWAY, ACCESS_VAULT_F13, ACCESS_CARGO_BOT, ACCESS_MINT_VAULT, ACCESS_KITCHEN, ACCESS_CLINIC, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS)
+	access = list(ACCESS_BAR, ACCESS_CLONING, ACCESS_GATEWAY, ACCESS_VAULT_F13, ACCESS_VAULT_SECURITY_F13, ACCESS_CARGO_BOT, ACCESS_MINT_VAULT, ACCESS_CLINIC, ACCESS_KITCHEN, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS)
+	minimal_access = list(ACCESS_BAR, ACCESS_CLONING, ACCESS_GATEWAY, ACCESS_VAULT_F13, ACCESS_VAULT_SECURITY_F13, ACCESS_CARGO_BOT, ACCESS_MINT_VAULT, ACCESS_KITCHEN, ACCESS_CLINIC, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS)
 
 /datum/outfit/job/vtcc/f13marshal/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
+	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
+	ADD_TRAIT(H, TRAIT_SELF_AWARE, src)	
 	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 
 /datum/outfit/job/vtcc/f13marshal
 	name = "Marshal"
-	jobtype = /datum/job/vtcc/f13marshal
-
-	ears = /obj/item/radio/headset/headset_vault/cogcity/sec
+	jobtype = 		/datum/job/vtcc/f13marshal
 	id =            /obj/item/card/id/silver
-	backpack = /obj/item/storage/backpack/satchel/explorer
-	ears = /obj/item/radio/headset/headset_vault/cogcity/sec_lead
-	satchel = /obj/item/storage/backpack/satchel/explorer
-	r_pocket = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
-	belt = /obj/item/gun/ballistic/revolver/lucky37
-	suit = /obj/item/clothing/suit/armor/f13/riot/vault
-	head = /obj/item/clothing/head/helmet/riot/vaultsec/vc
+	ears = 			/obj/item/radio/headset/headset_vault/cogcity/sec_lead
+	r_pocket = 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super
+	glasses = 		/obj/item/clothing/glasses/sunglasses/big
+	belt = 			/obj/item/storage/belt/military/assault
+	neck = 			/obj/item/storage/belt/holster
 	backpack_contents = list(
-		/obj/item/restraints/handcuffs = 1,
-		/obj/item/ammo_box/a357/ap = 2,
+		/obj/item/restraints/handcuffs=1, 
+		/obj/item/melee/classic_baton=1, 
+		/obj/item/kitchen/knife/combat=1,
 		/obj/item/pda/warden=1
 		)
 
 /datum/outfit/loadout/secchief
-	name = "Chief of Security"
+	name = "Commisioner"
+	suit_store = /obj/item/gun/energy/laser/scatter
 	backpack_contents = list(
-	/obj/item/clothing/under/rank/security/officer=1,
-	/obj/item/storage/belt/security/full=1,
-	/obj/item/stack/f13Cash/caps/fivezerozero=1)
-
-/datum/outfit/loadout/gunslinger
-	name = "Gunslinger"
-	backpack_contents = list(
-	/obj/item/gun/ballistic/revolver/m29=1,
-	/obj/item/ammo_box/m44 = 2,
-	/obj/item/clothing/suit/armor/f13/battlecoat/vault/marshal=1,
-	/obj/item/clothing/head/f13/cowboy=1)
+	/obj/item/stock_parts/cell/ammo/mfc=3,	
+	/obj/item/gun/ballistic/automatic/pistol/beretta=1,
+	/obj/item/ammo_box/magazine/m9mmds = 3,
+	/obj/item/clothing/head/helmet/f13/power_armor/vaulttec=1,
+	/obj/item/clothing/suit/armor/f13/power_armor/vaulttec=1
+	)
 
 /datum/outfit/loadout/peacekeeper
-	name = "Peacekeeper"
+	name = "Sheriff"
+	suit_store = /obj/item/gun/ballistic/rifle/automatic/hunting/brush
 	backpack_contents = list(
-	/obj/item/clothing/suit/armor/f13/power_armor/vaulttec=1,
-	/obj/item/pda=1,
-	/obj/item/clothing/head/helmet/f13/power_armor/vaulttec=1)
+	/obj/item/ammo_box/tube/c4570=3,	
+	/obj/item/gun/ballistic/revolver/m29/peacekeeper=1,
+	/obj/item/ammo_box/m44=3,
+	/obj/item/clothing/head/helmet/riot/vaultsec/vc/marshal=1,
+	/obj/item/clothing/suit/armor/f13/battlecoat/vault/marshal=1
+	)
 
 /datum/outfit/job/vtcc/f13marshal/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -166,8 +165,7 @@
 
 	loadout_options = list(
 		/datum/outfit/loadout/blacksmith,
-		/datum/outfit/loadout/armsdealer,
-		/datum/outfit/loadout/sommelier,
+		/datum/outfit/loadout/armsdealer
 		)
 
 	access = list(ACCESS_BAR, ACCESS_GATEWAY, ACCESS_CARGO_BOT, ACCESS_MINT_VAULT, ACCESS_VAULT_F13)
@@ -177,20 +175,21 @@
 	..()
 	if(visualsOnly)
 		return
+	ADD_TRAIT(H, TRAIT_MASTER_GUNSMITH, src)	
+	ADD_TRAIT(H, TRAIT_TRAPPER, src)
+	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 
 /datum/outfit/job/vtcc/f13merchant
 	name = "Merchant"
-	jobtype = /datum/job/vtcc/f13merchant
-	ears = /obj/item/radio/headset/headset_vault/cogcity/merch_lead
+	jobtype = 		/datum/job/vtcc/f13merchant
+	ears = 			/obj/item/radio/headset/headset_vault/cogcity/merch_lead
 	id =            /obj/item/card/id/silver
-	backpack = /obj/item/storage/backpack/satchel/explorer
-	satchel = /obj/item/storage/backpack/satchel/explorer
-	l_pocket = /obj/item/storage/bag/money/small/settler
-	r_pocket = /obj/item/pda/quartermaster
+	l_pocket =		 /obj/item/storage/bag/money/small/settler
+	r_pocket = 		/obj/item/pda/quartermaster
 	shoes = 		/obj/item/clothing/shoes/f13/fancy
-	uniform = /obj/item/clothing/under/f13/cowboyg
-	gloves = /obj/item/clothing/gloves/f13/leather/fingerless
+	uniform = 		/obj/item/clothing/under/f13/cowboyg
+	gloves = 		/obj/item/clothing/gloves/f13/leather/fingerless
 	backpack_contents = list(
 		/obj/item/stack/f13Cash/caps/fivezerozero=1
 		)
@@ -210,17 +209,6 @@
 	/obj/item/gun/ballistic/automatic/pistol/ninemil = 7,
 	/obj/item/gun/ballistic/automatic/pistol/n99 = 4,
 	/obj/item/gun/ballistic/revolver/police =4
-	)
-
-/datum/outfit/loadout/sommelier
-	name = "Sommelier"
-	backpack_contents = list(
-	/obj/item/reagent_containers/food/drinks/bottle/wine = 2,
-	/obj/item/reagent_containers/food/drinks/bottle/lizardwine = 2,
-	/obj/item/export/bottle/wine = 5,
-	/obj/item/export/bottle/blooddrop = 2,
-	/obj/item/reagent_containers/food/drinks/bottle/champagne = 2,
-	/obj/item/reagent_containers/food/drinks/bottle/trappist = 2
 	)
 
 /* Chief Researcher */
@@ -305,12 +293,11 @@
 	exp_type = EXP_TYPE_VTCCSEC
 
 	loadout_options = list(
-		/datum/outfit/loadout/musketeer,
 		/datum/outfit/loadout/oldguard,
 		/datum/outfit/loadout/riotpolice
 		)
-	access = list(ACCESS_BAR, ACCESS_GATEWAY, ACCESS_VAULT_F13)
-	minimal_access = list(ACCESS_BAR, ACCESS_GATEWAY, ACCESS_VAULT_F13)
+	access = list(ACCESS_BAR, ACCESS_GATEWAY, ACCESS_VAULT_F13, ACCESS_VAULT_SECURITY_F13 )
+	minimal_access = list(ACCESS_BAR, ACCESS_GATEWAY, ACCESS_VAULT_F13, ACCESS_VAULT_SECURITY_F13)
 
 /datum/outfit/job/vtcc/f13citysec/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -320,36 +307,25 @@
 
 /datum/outfit/job/vtcc/f13citysec
 	name = "City Security Officer"
-	jobtype = /datum/job/vtcc/f13citysec
-
-	ears = /obj/item/radio/headset/headset_vault/cogcity/sec
+	jobtype = 		/datum/job/vtcc/f13citysec
+	ears = 			/obj/item/radio/headset/headset_vault/cogcity/sec
 	id =            /obj/item/card/id
-	backpack = /obj/item/storage/backpack/satchel/explorer
-	satchel = /obj/item/storage/backpack/satchel/explorer
-	l_hand =	/obj/item/gun/ballistic/automatic/pistol/beretta
+	glasses = 		/obj/item/clothing/glasses/sunglasses/big
+	belt = 			/obj/item/storage/belt/military/assault
+	neck = 			/obj/item/storage/belt/holster
 	shoes = 		/obj/item/clothing/shoes/jackboots
-	suit = /obj/item/clothing/suit/armor/f13/riot/vault
-	head = /obj/item/clothing/head/helmet/riot/vaultsec/vc
+	head = 			/obj/item/clothing/head/helmet/riot/vaultsec/vc
+	suit = 			/obj/item/clothing/suit/armor/f13/riot/vault
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1,
-		/obj/item/geiger_counter=1,
-		/obj/item/stock_parts/cell/ammo/ec = 1
+		/obj/item/kitchen/knife/combat=1,
+		/obj/item/pda/security=1
 		)
 
-/datum/outfit/loadout/musketeer
-	name = "Musketeer"
-	backpack_contents = list(
-	/obj/item/gun/energy/laser/aer9=1,
-	/obj/item/clothing/head/f13/cowboy=1,
-	/obj/item/stock_parts/cell/ammo/mfc=2,
-	/obj/item/clothing/suit/armor/f13/brahmin_leather_duster=1
-	)
-
 /datum/outfit/loadout/oldguard
-	name = "Old Guard"
+	name = "Officer First Class"
 	backpack_contents = list(
 	/obj/item/gun/ballistic/shotgun/automatic/combat/neostead=1,
-	/obj/item/ammo_box/shotgun/bean = 2,
 	/obj/item/ammo_box/shotgun/magnum = 2
 	)
 
@@ -357,8 +333,7 @@
 	name = "Riot Cop"
 	backpack_contents = list(
 	/obj/item/gun/ballistic/automatic/smg10mm=1,
-	/obj/item/pda/security=1,
-	/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
+	/obj/item/ammo_box/magazine/m10mm_adv/ext = 3,
 	/obj/item/shield/riot/tele=1
 	)
 
@@ -384,12 +359,11 @@
 	exp_type = EXP_TYPE_VTCC
 
 	loadout_options = list(
-		/datum/outfit/loadout/easyroad,
 		/datum/outfit/loadout/newblood,
 		/datum/outfit/loadout/deepend
 		)
-	access = list(ACCESS_BAR, ACCESS_GATEWAY, ACCESS_VAULT_F13)
-	minimal_access = list(ACCESS_BAR, ACCESS_GATEWAY, ACCESS_VAULT_F13)
+	access = list(ACCESS_BAR, ACCESS_GATEWAY, ACCESS_VAULT_F13, ACCESS_VAULT_SECURITY_F13)
+	minimal_access = list(ACCESS_BAR, ACCESS_GATEWAY, ACCESS_VAULT_F13, ACCESS_VAULT_SECURITY_F13)
 
 /datum/outfit/job/vtcc/f13citysecscout/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -400,43 +374,31 @@
 /datum/outfit/job/vtcc/f13citysecscout
 	name = "City Security Scout"
 	jobtype = /datum/job/vtcc/f13citysecscout
-
-	ears = /obj/item/radio/headset/headset_vault/cogcity/sec
+	ears = 			/obj/item/radio/headset/headset_vault/cogcity/sec
 	id =            /obj/item/card/id
-	backpack = /obj/item/storage/backpack/satchel/explorer
-	satchel = /obj/item/storage/backpack/satchel/explorer
 	shoes = 		/obj/item/clothing/shoes/jackboots
-	suit = /obj/item/clothing/suit/armor/f13/riot/vault/scout
-	head = /obj/item/clothing/head/helmet/riot/vaultsec/vc/scout
+	head = 			/obj/item/clothing/head/helmet/riot/vaultsec/vc/scout
+	suit = 			/obj/item/clothing/suit/armor/f13/riot/vault/scout
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1,
-		/obj/item/geiger_counter=1,
-		/obj/item/stock_parts/cell/ammo/ec = 1
+		/obj/item/kitchen/knife/combat=1,
+		/obj/item/pda/security=1
 		)
 
-/datum/outfit/loadout/easyroad
-	name = "The Easy Road"
-	backpack_contents = list(
-	/obj/item/gun/energy/laser/pistol=1,
-	/obj/item/clothing/head/f13/cowboy=1,
-	/obj/item/stock_parts/cell/ammo/ec=2,
-	/obj/item/clothing/suit/armor/f13/brahmin_leather_duster=1
-	)
-
 /datum/outfit/loadout/newblood
-	name = "The New Bloods"
+	name = "Officer"
 	backpack_contents = list(
 	/obj/item/gun/ballistic/shotgun/trench=1,
-	/obj/item/ammo_box/shotgun/bean = 2,
-	/obj/item/ammo_box/shotgun/magnum = 2
+	/obj/item/ammo_box/shotgun/magnum = 2,
+	/obj/item/gun/energy/laser/pistol=1,
+	/obj/item/stock_parts/cell/ammo/ec=3
 	)
 
 /datum/outfit/loadout/deepend
-	name = "The Deep End"
+	name = "Riot Cadet"
 	backpack_contents = list(
 	/obj/item/gun/ballistic/automatic/pistol/n99=1,
-	/obj/item/pda/security=1,
-	/obj/item/ammo_box/magazine/m10mm_adv = 2,
+	/obj/item/ammo_box/magazine/m10mm_adv = 3,
 	/obj/item/shield/riot/tele=1
 	)
 
@@ -468,23 +430,16 @@
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_TRAPPER, src)
-	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 
 /datum/outfit/job/vtcc/f13roadie
 	name = "Roadie"
-	jobtype = /datum/job/vtcc/f13roadie
-	neck = /obj/item/radio/headset/headset_vault/cogcity/merch
-	backpack = /obj/item/storage/backpack/satchel/explorer
-	satchel = /obj/item/storage/backpack/satchel/explorer
-	l_hand =	/obj/item/gun/ballistic/automatic/pistol/beretta
-	shoes = 		/obj/item/clothing/shoes/jackboots
-	uniform = /obj/item/clothing/under/f13/merca
-	suit = /obj/item/clothing/suit/armor/f13/battlecoat/vault/armoured/roadie
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m9mmds = 2
-		)
+	jobtype = 	/datum/job/vtcc/f13roadie
+	neck = 		/obj/item/radio/headset/headset_vault/cogcity/merch
+	shoes = 	/obj/item/clothing/shoes/jackboots
+	uniform = 	/obj/item/clothing/under/f13/merca
+	suit = 		/obj/item/clothing/suit/armor/f13/battlecoat/vault/armoured/roadie
 
 /datum/outfit/loadout/scavver
 	name = "Scavver"
@@ -861,7 +816,6 @@
 	shoes = /obj/item/clothing/shoes/workboots
 	backpack = /obj/item/storage/backpack/satchel/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer
-	r_hand = /obj/item/book/granter/trait/selection
 
 /datum/outfit/loadout/scavenger
 	name = "Scavenger"

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -45,14 +45,15 @@
 
 /datum/outfit/job/vtcc/f13alderman
 	name = "Alderman"
-	jobtype = /datum/job/vtcc/f13alderman
-	ears = /obj/item/radio/headset/headset_vault/cogcity/overseer
+	jobtype =		/datum/job/vtcc/f13alderman
+	ears = 			/obj/item/radio/headset/headset_vault/cogcity/overseer
+	neck = 			/obj/item/storage/belt/holster
 	id =            /obj/item/card/id/silver
-	r_pocket = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
-	belt = /obj/item/gun/ballistic/automatic/pistol/n99/executive
+	r_pocket = 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super
+	belt = 			/obj/item/gun/ballistic/automatic/pistol/n99/executive
 	backpack_contents = list(
 		/obj/item/storage/box/citizenship_permits = 1, \
-		/obj/item/ammo_box/magazine/m10mm/ap = 2)
+		/obj/item/ammo_box/magazine/m10mm_adv = 3 )
 
 /datum/outfit/loadout/treasurer
 	name = "Treasurer"
@@ -328,7 +329,9 @@
 	name = "Officer First Class"
 	backpack_contents = list(
 	/obj/item/gun/ballistic/shotgun/automatic/combat/neostead=1,
-	/obj/item/ammo_box/shotgun/magnum = 2
+	/obj/item/ammo_box/shotgun/magnum = 2,
+	/obj/item/gun/energy/laser/pistol=1,
+	/obj/item/stock_parts/cell/ammo/ec=3
 	)
 
 /datum/outfit/loadout/riotpolice

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -199,16 +199,18 @@
 	backpack_contents = list(
 	/obj/item/clothing/gloves/f13/blacksmith=1,
 	/obj/item/melee/smith/hammer/toolbox=1,
-	/obj/item/stack/sheet/mineral/sandstone = 37,
-	/obj/item/stack/sheet/metal/twenty=1
+	/obj/item/stack/sheet/mineral/sandstone = 50,
+	/obj/item/stack/sheet/metal/fifty=2
 	)
 
 /datum/outfit/loadout/armsdealer
 	name = "Arms Dealer"
 	backpack_contents = list(
-	/obj/item/gun/ballistic/automatic/pistol/ninemil = 7,
-	/obj/item/gun/ballistic/automatic/pistol/n99 = 4,
-	/obj/item/gun/ballistic/revolver/police =4
+	/obj/item/attachments/auto_sear=2,
+	/obj/item/attachments/burst_improvement=2,
+	/obj/item/attachments/bullet_speed=2,
+	/obj/item/attachments/recoil_decrease=2,
+	/obj/item/attachments/scope=2
 	)
 
 /* Chief Researcher */
@@ -827,6 +829,7 @@
 	/obj/item/clothing/glasses/welding=1,
 	/obj/item/twohanded/fireaxe=1,
 	/obj/item/weldingtool/largetank=1
+	/obj/item/book/granter/trait/techno=1
 	)
 
 /datum/outfit/loadout/refugee

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -828,7 +828,7 @@
 	/obj/item/ammo_box/magazine/m10mm=1,
 	/obj/item/clothing/glasses/welding=1,
 	/obj/item/twohanded/fireaxe=1,
-	/obj/item/weldingtool/largetank=1
+	/obj/item/weldingtool/largetank=1,
 	/obj/item/book/granter/trait/techno=1
 	)
 


### PR DESCRIPTION
## About The Pull Request

Changes loadouts around Cog City, mainly for security so they are more standardized and remaps security area

![unknown](https://user-images.githubusercontent.com/67122131/131366123-91200e31-88ad-49e8-8f9e-eada21891769.png)
![unknown (1)](https://user-images.githubusercontent.com/67122131/131366134-93750a4c-9648-4fad-b097-d48810b4006b.png)

Security:

Marshal - PA Wear Self Aware Yards Lifegiver
Officer - tier 5 with lower speedboost
Scout - tier 4 with speedboost

Marshal = Tribeam with regular Berreta and PA or Brush Gun Peacekeeper and tier 7 coat
Officer = 10mm SMG with Telescopic shield, AEP as sidearm or Neostead with 10mm pistol
Scout = 10mm pistol with shield or trench shotgun with wattz1k

All of them get combat knife and pipboy by default
Marshal and Officers start with belt holster and sunglasses

Outer Citizen loses diary but salvager loadout gets a book compensation for it (Salvaging book)
Merchant gets more perks and reworked loaoduts
Roadie loses hard yards
Alderman gets proper ammo and holster for his pistol

Updated armory
![Výstřižek](https://user-images.githubusercontent.com/67122131/131457792-5b1172fd-27fc-410d-b3cc-3714c8e72ecb.PNG)

//

Now for things that aren't my work but Nova's

Added and moved buildings (2 pre-rebase buildings and a grocery mart), changed wayfarer paths and shaman area, fixed defib mount in cove, added access to some legion doors, added a door from farm to medical in legion, fixed yuma roads, airlock for inner city

## Why It's Good For The Game

Just is

## Changelog
:cl:
tweak: Cog City Security Station and Jail
tweak: Cog City Headsets
balance: Security Loadouts
fix: Security Access
/:cl: