### PR TITLE
Scout to Cadet, Roadies get their gear

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -919,7 +919,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	name = "City Security Officer"
 
 /obj/effect/landmark/start/f13/townsecscout
-	name = "City Security Scout"
+	name = "City Security Cadet"
 
 /obj/effect/landmark/start/f13/roadie
 	name = "Roadie"

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -101,7 +101,7 @@
 		return
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
-	ADD_TRAIT(H, TRAIT_SELF_AWARE, src)	
+	ADD_TRAIT(H, TRAIT_SELF_AWARE, src)
 	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 
@@ -115,8 +115,8 @@
 	belt = 			/obj/item/storage/belt/military/assault
 	neck = 			/obj/item/storage/belt/holster
 	backpack_contents = list(
-		/obj/item/restraints/handcuffs=1, 
-		/obj/item/melee/classic_baton=1, 
+		/obj/item/restraints/handcuffs=1,
+		/obj/item/melee/classic_baton=1,
 		/obj/item/kitchen/knife/combat=1,
 		/obj/item/pda/warden=1
 		)
@@ -125,7 +125,7 @@
 	name = "Commisioner"
 	suit_store = /obj/item/gun/energy/laser/scatter
 	backpack_contents = list(
-	/obj/item/stock_parts/cell/ammo/mfc=3,	
+	/obj/item/stock_parts/cell/ammo/mfc=3,
 	/obj/item/gun/ballistic/automatic/pistol/beretta=1,
 	/obj/item/ammo_box/magazine/m9mmds = 3,
 	/obj/item/clothing/head/helmet/f13/power_armor/vaulttec=1,
@@ -136,7 +136,7 @@
 	name = "Sheriff"
 	suit_store = /obj/item/gun/ballistic/rifle/automatic/hunting/brush
 	backpack_contents = list(
-	/obj/item/ammo_box/tube/c4570=3,	
+	/obj/item/ammo_box/tube/c4570=3,
 	/obj/item/gun/ballistic/revolver/m29/peacekeeper=1,
 	/obj/item/ammo_box/m44=3,
 	/obj/item/clothing/head/helmet/riot/vaultsec/vc/marshal=1,
@@ -176,7 +176,7 @@
 	..()
 	if(visualsOnly)
 		return
-	ADD_TRAIT(H, TRAIT_MASTER_GUNSMITH, src)	
+	ADD_TRAIT(H, TRAIT_MASTER_GUNSMITH, src)
 	ADD_TRAIT(H, TRAIT_TRAPPER, src)
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
@@ -352,7 +352,7 @@
 /* City Sec Scout */
 
 /datum/job/vtcc/f13citysecscout
-	title = "City Security Scout"
+	title = "City Security Cadet"
 	flag = F13CITYSECSCOUT
 	total_positions = 3
 	spawn_positions = 1
@@ -377,7 +377,7 @@
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 
 /datum/outfit/job/vtcc/f13citysecscout
-	name = "City Security Scout"
+	name = "City Security Cadet"
 	jobtype = /datum/job/vtcc/f13citysecscout
 	ears = 			/obj/item/radio/headset/headset_vault/cogcity/sec
 	id =            /obj/item/card/id
@@ -445,6 +445,12 @@
 	shoes = 	/obj/item/clothing/shoes/jackboots
 	uniform = 	/obj/item/clothing/under/f13/merca
 	suit = 		/obj/item/clothing/suit/armor/f13/battlecoat/vault/armoured/roadie
+	l_hand =	/obj/item/gun/ballistic/automatic/pistol/beretta
+	r_pocket = /obj/item/card/data/wpermit
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/m9mmds = 2
+		)
+
 
 /datum/outfit/loadout/scavver
 	name = "Scavver"

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -329,7 +329,7 @@ GLOBAL_LIST_INIT(vtcc_command_positions, list(
 ))
 GLOBAL_LIST_INIT(vtcc_positions, list(
 	"City Security Officer",
-	"City Security Scout",
+	"City Security Cadet",
 	"Roadie",
 	"Merchant",
 	"Innkeeper",
@@ -361,7 +361,7 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
 	EXP_TYPE_FOLLOWERS     = list("titles" = followers_positions),
 	EXP_TYPE_VTCC          = list("titles" = vtcc_positions),
 	EXP_TYPE_ROADIE        = list("titles" = list("Roadie")),
-	EXP_TYPE_VTCCSEC       = list("titles" = list("City Security Scout","City Security Officer")),
+	EXP_TYPE_VTCCSEC       = list("titles" = list("City Security Cadet","City Security Officer")),
 	EXP_TYPE_RANGER        = list("titles" = list("NCR Veteran Ranger","NCR Ranger")),
 	EXP_TYPE_SCRIBE        = list("titles" = list("Scribe", "Proctor")),
 	EXP_TYPE_KNIGHT        = list("titles" = list("Knight")),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Giving Roadies their sidearm back and a weapon's permit; renaming City Security Scout to Cadet by popular demand.

## Why It's Good For The Game

Makes more sense for a rank of new recruits in City Sec to be called "Cadet" as that's what America calls those in a police academy at the moment. 

Roadies shouldn't have lost their sidearm, and are now getting weapons permits. 

## Changelog
:cl:
tweak: Roadie loadouts
tweak: City Security Scouts to City Security Cadets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
