### PR TITLE
Overseer fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -470,7 +470,6 @@
 	armour_penetration = 0.5
 	movement_type = FLYING | UNSTOPPABLE
 	pixels_per_second = TILES_TO_PIXELS(15)
-	aggro_vision_range = 15
 	range = 18
 
 /mob/living/simple_animal/hostile/handy/sentrybot/nsb //NSB + Raider Bunker specific.

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -464,12 +464,12 @@
 		return FALSE
 
 /obj/item/projectile/beam/laser/pistol/ultraweak/strong
-	damage = 15
+	damage = 14
 	icon_state = "gaussstrong"
 	armour_penetration = 0.5
 	movement_type = FLYING | UNSTOPPABLE
-	pixels_per_second = TILES_TO_PIXELS(33.33)
-	range = 16
+	pixels_per_second = TILES_TO_PIXELS(15)
+	range = 18
 
 /mob/living/simple_animal/hostile/handy/sentrybot/nsb //NSB + Raider Bunker specific.
 	name = "sentry bot"

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -446,6 +446,7 @@
 	retreat_distance = 0
 	environment_smash = ENVIRONMENT_SMASH_RWALLS //wall-obliterator. perish.
 	projectiletype = /obj/item/projectile/beam/laser/pistol/ultraweak/strong
+	speed = 3
 	rapid_melee = 3
 	color = "#75FFE2"
 	aggro_vision_range = 15

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -470,6 +470,7 @@
 	armour_penetration = 0.5
 	movement_type = FLYING | UNSTOPPABLE
 	pixels_per_second = TILES_TO_PIXELS(15)
+	aggro_vision_range = 15
 	range = 18
 
 /mob/living/simple_animal/hostile/handy/sentrybot/nsb //NSB + Raider Bunker specific.

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -438,13 +438,15 @@
 
 /mob/living/simple_animal/hostile/handy/sentrybot/chew/strong
 	name = "big chew-chew"
-	desc = "An oddly scorched pre-war military robot armed with a deadly gatling laser and covered in thick, oddly blue armor plating, the name Big Chew-Chew scratched onto it's front armour crudely, highlighted by small bits of white paint. There seems to be an odd pack on the monstrosity of a sentrie's back, a chute at the bottom of it - there's the most scorch-marks on the robot here, so it's safe to assume this robot is capable of explosions. Better watch out!"
+	desc = "An oddly scorched pre-war military robot armed with a deadly gatling laser firing high-penetration experimental lasers and covered in thick, oddly blue armor plating, the name Big Chew-Chew scratched onto it's front armour crudely, highlighted by small bits of white paint. There seems to be an odd pack on the monstrosity of a sentrie's back, a chute at the bottom of it - there's the most scorch-marks on the robot here, so it's safe to assume this robot is capable of explosions. Better watch out!"
 	extra_projectiles = 6
 	health = 1000
 	maxHealth = 1000 //CHONK
 	obj_damage = 300
 	retreat_distance = 0
 	environment_smash = ENVIRONMENT_SMASH_RWALLS //wall-obliterator. perish.
+	projectiletype = /obj/item/projectile/beam/laser/pistol/ultraweak/strong
+	rapid_melee = 3
 	color = "#75FFE2"
 	aggro_vision_range = 15
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1 //cannot self-harm with it's explosion spam
@@ -460,6 +462,14 @@
 	else
 		visible_message("<span class='danger'>\The [Proj] bounces off \the [src]'s armor plating!</span>")
 		return FALSE
+
+/obj/item/projectile/beam/laser/pistol/ultraweak/strong
+	damage = 15
+	icon_state = "gaussstrong"
+	armour_penetration = 0.5
+	movement_type = FLYING | UNSTOPPABLE
+	pixels_per_second = TILES_TO_PIXELS(33.33)
+	range = 16
 
 /mob/living/simple_animal/hostile/handy/sentrybot/nsb //NSB + Raider Bunker specific.
 	name = "sentry bot"


### PR DESCRIPTION
## About The Pull Request
Removes any chance of easy-melee-cheesing the glorious Overseer sentrybot bossfight. How? The lasers penetrate walls now, have actual penetration value, and in melee it swings far faster. It's a boss for a reason, it's not meant to be able to be pushed over by one guy with a shield and and one guy with a glaive hitting it constantly.
## Why It's Good For The Game
Keeps a boss-fight a boss-fight. It's difficult.
## Changelog
- Gives the Overseer it's own unique, buffed projectile that can pen walls but is slower
- Gives the Overseer rapid_melee