### PR TITLE
Ladder Peeking & Delay for Ladders and Matrix

### DIFF
--- a/code/__DEFINES/dcs/helpers.dm
+++ b/code/__DEFINES/dcs/helpers.dm
@@ -6,6 +6,10 @@
 
 #define SEND_GLOBAL_SIGNAL(sigtype, arguments...) ( SEND_SIGNAL(SSdcs, sigtype, ##arguments) )
 
+/// Signifies that this proc is used to handle signals.
+/// Every proc you pass to RegisterSignal must have this.
+#define SIGNAL_HANDLER SHOULD_NOT_SLEEP(TRUE)
+
 /// A wrapper for _AddElement that allows us to pretend we're using normal named arguments
 #define AddElement(arguments...) _AddElement(list(##arguments))
 

--- a/code/datums/cinematic.dm
+++ b/code/datums/cinematic.dm
@@ -93,7 +93,7 @@
 		toggle_ooc(TRUE)
 
 /datum/cinematic/proc/show_to(mob/M, client/C)
-	SIGNAL_HANDLER //must not wait.
+	//SIGNAL_HANDLER //must not wait.
 
 	if(!M.mob_transforming)
 		locked += M

--- a/code/datums/cinematic.dm
+++ b/code/datums/cinematic.dm
@@ -93,7 +93,7 @@
 		toggle_ooc(TRUE)
 
 /datum/cinematic/proc/show_to(mob/M, client/C)
-	//SIGNAL_HANDLER //must not wait.
+	SIGNAL_HANDLER //must not wait.
 
 	if(!M.mob_transforming)
 		locked += M

--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -205,6 +205,7 @@ turf/closed/wall/f13/wood/house/update_damage_overlay()
 	name = "matrix"
 	desc = "<font color='#6eaa2c'>You suddenly realize the truth - there is no spoon.<br>Digital simulation ends here.</font>"
 	icon_state = "matrix"
+	var/in_use = FALSE
 
 /turf/closed/indestructible/f13/matrix/MouseDrop_T(atom/dropping, mob/user)
 	. = ..()
@@ -212,6 +213,8 @@ turf/closed/wall/f13/wood/house/update_damage_overlay()
 		return //No ghosts or incapacitated folk allowed to do this.
 	if(!ishuman(dropping))
 		return //Only humans have job slots to be freed.
+	if(in_use) // Someone's already going in.
+		return
 	var/mob/living/carbon/human/departing_mob = dropping
 	if(departing_mob != user && departing_mob.client)
 		to_chat(user, "<span class='warning'>This one retains their free will. It's their choice if they want to depart or not.</span>")
@@ -223,6 +226,17 @@ turf/closed/wall/f13/wood/house/update_damage_overlay()
 	if(departing_mob.logout_time && departing_mob.logout_time + 5 MINUTES > world.time)
 		to_chat(user, "<span class='warning'>This mind has only recently departed. Better give it some more time before taking such a drastic measure.</span>")
 		return
+	user.visible_message("<span class='warning'>[user] [departing_mob == user ? "is trying to leave the wasteland!" : "is trying to send [departing_mob] away!"]</span>", "<span class='notice'>You [departing_mob == user ? "are trying to leave the wasteland." : "are trying to send [departing_mob] away."]</span>")
+	icon_state = "matrix_going" // ALERT, WEE WOO
+	update_icon()
+	in_use = TRUE
+	if(!do_after(user, 50, target = src))
+		icon_state = "matrix"
+		in_use = FALSE
+		return
+	icon_state = "matrix"
+	in_use = FALSE
+	update_icon()
 	var/dat = "[key_name(user)] has despawned [departing_mob == user ? "themselves" : departing_mob], job [departing_mob.job], at [AREACOORD(src)]. Contents despawned along:"
 	if(!length(departing_mob.contents))
 		dat += " none."


### PR DESCRIPTION
## About The Pull Request

Ports two PRs from Fortune/Fortuna by Rohesie ( https://github.com/fortune13-ss13/Fortune13/pull/359 ) and EgorDinamit ( https://github.com/fortune13-ss13/Fortune13/pull/320 )

Basically you can now peek up or down ladders to see what is at the other side before you make the climb up or down it; allowing you to know what's awaiting you. Also ports the timer for going up and down ladders to no longer be instant; same with matrixing.

## Why It's Good For The Game

**Peeking** - Ladder peeking is a generally good mechanic many other servers have and allows people to judge if they wish to fight what is on the other side. I am tempted to look how Sojourn has it so you can toss grenades down ladders as well but we'll see about that one. None the less this is very handy for cautious players.

**Timers for Ladders** - Ladders are currently instant to climb up or down. This makes it an easy way to run from mobs or bait them to ladders to fuck over others; such as what happens often with claws. Or even grabbing them and bringing them to surface. Without a timer players use ladders as a quick way of escaping escalation. This would make it so ladders have a small timer, roughly the same as getting up from resting. No more instant ladder climbing to encourage people to think about strategy rather than rapid-click b-line.

**Timers for Matrix** - Players already matrix instantly. This has been used time and time again as ways to escape combat wordlessly for some dumb reason. While this is against rules it also will discourage it, giving players a moment to decide if they really wish to matrix, if a player really wishes to matrix someone else and, in cases of escalation, players can see they person is attempting to avoid. There really is no downside to this since if someone has to go it changes nothing - you can just close the game after click and dragging still or just leave the window open or tab out even in a rush.

## Changelog
:cl:
add: Adds ladder travel delay.
add: Adds ladder peeking up/down.
add: Slight delay to matrix.
/:cl:
