### PR TITLE
Standardize BoS power wiring, remove uncleanable trash

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -661,6 +661,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "aBI" = (
@@ -858,9 +861,12 @@
 	},
 /area/f13/brotherhood/operations)
 "aJS" = (
-/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -954,15 +960,11 @@
 /turf/open/floor/grass,
 /area/f13/tunnel)
 "aSn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "aSs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -971,7 +973,6 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "aSD" = (
-/obj/effect/decal/cleanable/insectguts,
 /obj/structure/fence/handrail{
 	density = 0;
 	dir = 4;
@@ -1466,20 +1467,6 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bpk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/power/smes/engineering,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "bpl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1823,17 +1810,6 @@
 	dir = 9
 	},
 /area/f13/tunnel)
-"bEL" = (
-/obj/effect/decal/cleanable/robot_debris,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "bES" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -1848,12 +1824,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "bFo" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor{
+	icon_state = "floordirty"
+	},
 /area/f13/brotherhood/reactor)
 "bFP" = (
 /obj/structure/grille,
@@ -1928,6 +1905,9 @@
 	},
 /area/f13/brotherhood/operations)
 "bJc" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floordirty"
 	},
@@ -2234,7 +2214,7 @@
 /area/f13/tunnel)
 "ccy" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floordirty"
@@ -2251,10 +2231,13 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "cdz" = (
-/obj/effect/decal/cleanable/robot_debris/limb,
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "cdV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2328,12 +2311,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cgV" = (
-/obj/effect/decal/remains/robot,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "chM" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/suit_storage_unit/radsuit,
@@ -2380,7 +2366,6 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "ckm" = (
-/obj/effect/decal/remains/human,
 /obj/machinery/light/small{
 	dir = 8;
 	light_color = "#d8b1b1"
@@ -2444,13 +2429,6 @@
 "cmS" = (
 /obj/machinery/light/small{
 	dir = 4
-	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -2718,13 +2696,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"cur" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "cus" = (
 /obj/structure/toilet{
 	dir = 1
@@ -3129,10 +3100,13 @@
 /area/f13/brotherhood/operations)
 "cOh" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "cOn" = (
 /obj/machinery/light/small{
@@ -3467,7 +3441,6 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "deX" = (
-/obj/effect/decal/cleanable/robot_debris/limb,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3892,16 +3865,14 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "dBY" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/power/terminal,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "dCc" = (
@@ -3931,6 +3902,9 @@
 /area/f13/brotherhood/rnd)
 "dDD" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
 	dir = 8
 	},
@@ -4617,7 +4591,7 @@
 /area/f13/caves)
 "dXQ" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
+	name = "Security Checkpoint";
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
@@ -6291,35 +6265,18 @@
 	},
 /area/f13/brotherhood/operations)
 "fDt" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "fDw" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"fDA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/power/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "fEj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_t,
@@ -6448,12 +6405,6 @@
 	},
 /area/f13/tunnel)
 "fJz" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7139,19 +7090,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/tunnel)
-"gqI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "gqT" = (
 /turf/open/floor/f13{
 	dir = 4;
@@ -7232,9 +7170,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -8176,6 +8111,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -8184,9 +8122,6 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Security Checkpoint";
 	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -9673,15 +9608,15 @@
 	},
 /area/f13/tunnel)
 "iEy" = (
-/obj/structure/frame/machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/power/terminal,
 /obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light/small{
-	dir = 1
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -9783,7 +9718,6 @@
 	},
 /area/f13/clinic)
 "iJF" = (
-/obj/effect/decal/remains/robot,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
 	dir = 1;
@@ -9887,7 +9821,6 @@
 /obj/item/integrated_electronics/detailer,
 /obj/item/integrated_electronics/analyzer,
 /obj/item/integrated_circuit_printer,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood/rnd)
@@ -10181,11 +10114,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "iZi" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "iZB" = (
 /obj/structure/simple_door/bunker{
@@ -11524,7 +11460,6 @@
 /obj/item/reagent_containers/food/drinks/mug/coco{
 	pixel_y = 5
 	},
-/obj/effect/decal/cleanable/robot_debris/up,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "kmY" = (
@@ -11542,16 +11477,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood/rnd)
-"koc" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "kpo" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -12186,16 +12111,6 @@
 	dir = 4
 	},
 /area/f13/brotherhood/mining)
-"kTw" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "kTx" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/cable{
@@ -12793,11 +12708,10 @@
 /area/f13/brotherhood/offices2nd)
 "luj" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -13506,9 +13420,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "mnk" = (
@@ -15251,19 +15162,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "nNC" = (
-/obj/structure/frame/machine,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/power/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "nNR" = (
@@ -15484,13 +15389,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/sewer)
-"nXE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "nXG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase/manuals/engineering,
@@ -15553,6 +15451,9 @@
 	name = "Power"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/reactor)
 "oaf" = (
@@ -17471,17 +17372,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"pDy" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "pDM" = (
 /obj/structure/window/reinforced/spawner{
 	color = "#777777";
@@ -17684,16 +17574,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/f13/brotherhood/leisure)
-"pOV" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "pPa" = (
 /obj/structure/kitchenspike_frame{
 	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
@@ -17905,13 +17785,6 @@
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/tunnel)
-"pXY" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "pYd" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
@@ -18416,7 +18289,6 @@
 /obj/structure/decoration/vent{
 	layer = 2
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/lattice{
 	density = 1
 	},
@@ -18665,6 +18537,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -19043,7 +18918,6 @@
 	},
 /area/f13/brotherhood/rnd)
 "qPO" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -20044,10 +19918,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"rCi" = (
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "rCv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker,
@@ -20179,7 +20049,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "rIh" = (
-/obj/effect/decal/cleanable/robot_debris/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/flag/bos,
 /obj/structure/lattice{
@@ -20804,16 +20673,6 @@
 /obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"shn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "shO" = (
 /obj/structure/closet/crate/large,
 /obj/effect/decal/cleanable/dirt,
@@ -21358,9 +21217,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
@@ -23442,15 +23298,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
-"uzk" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "uzO" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
@@ -23477,13 +23324,6 @@
 "uBh" = (
 /turf/open/floor/carpet/royalblack,
 /area/f13/tunnel)
-"uBs" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "uBO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23663,7 +23503,6 @@
 /area/f13/tunnel)
 "uIf" = (
 /obj/effect/decal/cleanable/oil/streak,
-/obj/effect/decal/cleanable/robot_debris/down,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
@@ -24097,6 +23936,9 @@
 	start_charge = 500
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "vdg" = (
@@ -24923,15 +24765,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"vMV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
-/area/f13/brotherhood/reactor)
 "vNw" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood{
@@ -25688,17 +25521,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"wzV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "wAe" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	icon_state = "neutralrusty"
@@ -25877,20 +25699,16 @@
 	},
 /area/f13/brotherhood/rnd)
 "wIq" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/grille,
-/obj/structure/grille,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -26178,12 +25996,11 @@
 /area/f13/tunnel)
 "wWV" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "wXp" = (
@@ -26429,15 +26246,6 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "xfP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "xfS" = (
@@ -26771,16 +26579,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "xqA" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "xqB" = (
@@ -26828,13 +26630,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"xvW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "xwT" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -80780,7 +80575,7 @@ uEx
 ldc
 ajK
 dWz
-cgV
+wyp
 wyp
 wyp
 wyp
@@ -82380,12 +82175,12 @@ uoO
 uoO
 vhq
 xmk
-fjt
-fjt
-shn
+aJS
+aSn
+qOm
 rWs
-euq
-xvW
+twE
+twE
 mOz
 wGi
 wyn
@@ -82397,8 +82192,8 @@ cql
 efF
 efF
 efF
-cql
-cOh
+cgV
+fjt
 fjt
 eaX
 xmk
@@ -82639,23 +82434,23 @@ qIU
 xmk
 sJS
 luj
-kTw
+fjt
 xmk
 lGB
-cur
-euq
+xfP
+twE
 gwf
-euq
-euq
-cSY
-efF
-efF
-iZi
+twE
+twE
+iQj
 fjt
 fjt
 fjt
 fjt
-nXE
+fjt
+fjt
+fJz
+fjt
 fjt
 qTH
 xmk
@@ -82894,7 +82689,7 @@ xhA
 xhA
 xhA
 xmk
-bFo
+fjt
 fJz
 cmS
 xmk
@@ -82907,12 +82702,12 @@ fWj
 bVA
 wDb
 xaL
-nXE
+fjt
 qOm
 oDs
 xmk
-xmk
-aSn
+cOh
+bVA
 dXQ
 xmk
 xmk
@@ -83169,9 +82964,9 @@ xmk
 xmk
 xmk
 iEy
-uzk
+xqA
 mna
-gqI
+xfP
 xmk
 uoO
 uoO
@@ -83421,14 +83216,14 @@ cyU
 xmk
 dXx
 fjt
-nXE
+fjt
 fjt
 rQj
 xmk
 dBY
 xqA
 wWV
-wzV
+xfP
 xmk
 xmk
 uoO
@@ -83678,13 +83473,13 @@ twE
 xmk
 nXG
 tzW
-nXE
+fjt
 rPL
 eGO
 xmk
-bEL
-uzk
-mna
+dBY
+xqA
+wWV
 xfP
 xmk
 xmk
@@ -83935,14 +83730,14 @@ twE
 xmk
 qkC
 aNY
-aJS
+rQj
 fgE
 qwV
 xmk
 nNC
-koc
-fDA
-bpk
+xqA
+wWV
+xfP
 xmk
 skp
 uoO
@@ -84196,9 +83991,9 @@ wIq
 ieR
 cby
 xmk
+fDt
 xmk
-pOV
-dXQ
+iZi
 xmk
 xmk
 xmk
@@ -84449,7 +84244,7 @@ twE
 xmk
 aby
 dDD
-vMV
+nir
 nir
 nir
 qkn
@@ -84705,7 +84500,7 @@ bES
 twE
 xmk
 xbA
-jBw
+bFo
 jBw
 dOc
 dJM
@@ -85219,7 +85014,7 @@ xhA
 xhA
 iVh
 oHu
-qLd
+kFI
 qLd
 rCc
 xhA
@@ -85474,10 +85269,10 @@ xhA
 xhA
 xhA
 xhA
-pXY
+lTA
 oHu
-qLd
-rCi
+kFI
+tdP
 aYi
 xhA
 mtr
@@ -85733,7 +85528,7 @@ cnl
 jlW
 lTA
 akl
-qLd
+kFI
 qLd
 aSD
 xhA
@@ -85990,7 +85785,7 @@ cPr
 jlW
 lTA
 oHu
-qLd
+kFI
 qLd
 tdP
 wHL
@@ -86504,7 +86299,7 @@ lTA
 hSU
 rIh
 jUC
-xpu
+cdz
 xpu
 ayV
 sgi
@@ -87787,7 +87582,7 @@ iOq
 xhA
 hSU
 cxO
-uBs
+lTA
 jVB
 kFI
 qLd
@@ -88305,7 +88100,7 @@ lTA
 oHu
 kFI
 qLd
-pDy
+aYi
 xhA
 eFG
 uAc
@@ -89329,7 +89124,7 @@ fuO
 xEu
 xEu
 tLh
-cdz
+tLh
 tdP
 kFI
 qLd
@@ -89843,7 +89638,7 @@ fuO
 xEu
 xEu
 xhA
-uBs
+lTA
 oHu
 kFI
 qLd
@@ -90104,7 +89899,7 @@ qqE
 akl
 kFI
 qLd
-fDt
+aYi
 xhA
 qth
 uAc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The wiring for the electrical systems for the Brotherhood Bunker were a complete mess, with spaghetti wires and lots of unnecessary complication that made grown Knights weep. I redid the wiring to make it compliant with SS13 engineering standards, with a simple parallel input and output, and fixed an APC that wasn't connected to the grid at all. Overall two SMESes were removed, but we will never need more than four under any circumstance anyway. I also removed a bunch of trash that was otherwise impossible to remove, either because the items themselves were unable to be cleaned or because they were behind railings, and I removed the human remains from our foyer.
**Before:**
![Sorry for in-game screenshot](https://user-images.githubusercontent.com/29682682/132590595-4877ac46-2a6f-492d-a627-0e8de3802fe8.png)
**After:**
![Much Tidier](https://user-images.githubusercontent.com/29682682/132590690-91ff15c5-058c-4cf6-8be3-2a6f6f19e507.png)

## Why It's Good For The Game

Minor QoL changes to the Brotherhood bunker, tested it out locally and everything works as intended, got approval from majority of the loremasters. Trash to clean up is good, uncleanable trash is just a headache for those who like the bunker to be clean. Why the hell did we keep an intact human skeleton in our foyer?

## Changelog
:cl:
Tweak: Brotherhood power system wiring
Add: Cable nub under research APC to wire it into the grid
Removed: Various minor pieces of trash
Removed: Human remains from foyer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
