### PR TITLE
Changes NCR Lieutenant to NCR Commanding Officer

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -543,7 +543,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	icon_state = "NCR Captain"
 
 /obj/effect/landmark/start/f13/ncrlieutenant
-	name = "NCR Lieutenant"
+	name = "NCR Commanding Officer"
 	icon_state = "NCR Lieutenant"
 
 /obj/effect/landmark/start/f13/ncrmedofficer

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -948,8 +948,8 @@
 	icon_state = "ncrdogtagsergeant"
 
 /obj/item/card/id/dogtag/ncrlieutenant
-	name = "lieutenant's tags"
-	desc = "A silver bar dog tag that denotes a member of the NCR military with a lieutenant commission."
+	name = "commanding officer's tags"
+	desc = "A silver bar dog tag that denotes a member of the NCR military with an officer's commission."
 	icon_state = "ncrdogtagofficer"
 
 /obj/item/card/id/dogtag/ncrcaptain

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -365,7 +365,7 @@
 	return list("Centurion", "NCR Captain", "Overseer", "Sheriff",
 				"Sentinel", "Senior Paladin", "Paladin", "Knight-Captain", "Senior Knight", "Knight", "Head Scribe", "Senior Scribe", "Scribe", "Initiate",
 				"Veteran Decanus", "Vexillarius", "Decanus", "Veteran Legionnaire", "Prime Legionary",
-				"NCR Lieutenant", "NCR Medical Officer", "NCR Sergeant First Class", "NCR Sergeant", ,"NCR Corporal", "NCR Combat Medic", "NCR Combat Engineer", "NCR Trooper",
+				"NCR Commanding Officer", "NCR Medical Officer", "NCR Sergeant First Class", "NCR Sergeant", ,"NCR Corporal", "NCR Combat Medic", "NCR Combat Engineer", "NCR Trooper",
 				"NCR Veteran Ranger", "NCR Patrol Ranger", "NCR Recon Ranger",
 				"NCR Scout", "NCR Scout Sergeant", "NCR Scout Lieutenant",
 				"Chief of Security", "Vault-tec Doctor", "Vault-tec Scientist",

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -160,17 +160,17 @@ Captain
 	/obj/item/ammo_box/magazine/m44=2
 	)
 /*
-Lieutenant
+Commanding Officer (Ranges from Lieutenant to Captain)
 */
 
-/datum/job/ncr/f13lieutenant
-	title = "NCR Lieutenant"
+/datum/job/ncr/f13lieutenant //Keeping the same path because I'm not breaking whitelists for a name change.
+	title = "NCR Commanding Officer"
 	flag = F13LIEUTENANT
 	total_positions = 1
 	spawn_positions = 1
 	req_admin_notify = 1
 	description = "You are the direct superior to the Sergeant First Class and Enlisted, and under special circumstances, Rangers. You are the CO of Camp Miller. You plan patrols, training and missions, working in some cases with Rangers in accomplishing objectives otherwise beyond the capabilities of ordinary enlisted personnel."
-	supervisors = "Captain and above"
+	supervisors = "High Command"
 	selection_color = "#ffeeaa"
 	head_announce = list("Security")
 	display_order = JOB_DISPLAY_ORDER_LIEUTENANT
@@ -183,7 +183,7 @@ Lieutenant
 	)
 
 /datum/outfit/job/ncr/f13lieutenant
-	name = "NCR Lieutenant"
+	name = "NCR Commanding Officer"
 	jobtype	= /datum/job/ncr/f13lieutenant
 	id			= /obj/item/card/id/dogtag/ncrlieutenant
 	uniform		= /obj/item/clothing/under/f13/ncr/ncr_officer

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -49,7 +49,7 @@ GLOBAL_LIST_INIT(command_positions, list(
 	"Head Paladin",
 	"Head Knight",
 
-	"NCR Lieutenant",
+	"NCR Commanding Officer",
 	"NCR Sergeant First Class",
 	"NCR Medical Officer",
 
@@ -248,7 +248,7 @@ GLOBAL_LIST_INIT(ncr_ranger_positions, list(
 ))
 
 GLOBAL_LIST_INIT(ncr_leadership_positions, list(
-	"NCR Lieutenant",
+	"NCR Commanding Officer",
 	"NCR Sergeant First Class",
 	"NCR Medical Officer"
 ))
@@ -371,7 +371,7 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
 
 	EXP_TYPE_TRIBALCOMMAND = list("titles" = list("Chief","Shaman","Head Hunter")),
 	EXP_TYPE_FOLLOWERSCOMMAND = list("titles" = list("Followers Lead Practitioner")),
-	EXP_TYPE_NCRCOMMAND    = list("titles" = list("NCR Lieutenant","NCR Sergeant First Class","NCR Veteran Ranger","NCR Medical Officer")),
+	EXP_TYPE_NCRCOMMAND    = list("titles" = list("NCR Commanding Officer","NCR Sergeant First Class","NCR Veteran Ranger","NCR Medical Officer")),
 	EXP_TYPE_LEGIONCOMMAND = list("titles" = list("Legion Centurion","Legion Venator")),
 	EXP_TYPE_VTCCCOMMAND   = list("titles" = list("Alderman", "Marshal", "Chief Researcher"))
 

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -574,7 +574,7 @@
 	slot = SLOT_IN_BACKPACK
 	path = /obj/item/clothing/accessory/ncr/CPT
 	ckeywhitelist = list("gurking",
-						"totallyinnocent"
+						"totallyinnocent",
 						"thegreatcoward",
 						"usotsukihime")
 	restricted_roles = list("NCR Commanding Officer", "NCR Off-Duty")

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -565,12 +565,24 @@
 						"totallyinnocent")
 	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
 
+////////////////////////////
+///Ranger items end here.///
+////////////////////////////
+
+/datum/gear/donator/captainpins
+	name = "NCR Captain Pins"
+	slot = SLOT_IN_BACKPACK
+	path = /obj/item/clothing/accessory/ncr/CPT
+	ckeywhitelist = list("gurking",
+						"totallyinnocent)
+	restricted_roles = list("NCR Commanding Officer", "NCR Off-Duty")
+
 /datum/gear/donator/zirilliuniform
 	name = "Major Zirilli's service uniform"
 	slot = SLOT_W_UNIFORM
 	path = /obj/item/clothing/under/f13/ncr_formal_uniform/majzirilli
 	ckeywhitelist = list("shoi87")
-	restricted_roles = list("NCR Off-Duty", "NCR Lieutenant", "NCR Colonel", "NCR Captain")
+	restricted_roles = list("NCR Off-Duty", "NCR Commanding Officer", "NCR Colonel", "NCR Captain")
 
 /datum/gear/donator/lacertarex
 	name = "galerum lacertarex"
@@ -579,6 +591,4 @@
 	ckeywhitelist = list("dioclex")
 	restricted_roles = list("Legion Venator")
 
-////////////////////////////
-///Ranger items end here.///
-////////////////////////////
+

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -574,7 +574,9 @@
 	slot = SLOT_IN_BACKPACK
 	path = /obj/item/clothing/accessory/ncr/CPT
 	ckeywhitelist = list("gurking",
-						"totallyinnocent)
+						"totallyinnocent"
+						"thegreatcoward",
+						"usotsukihime")
 	restricted_roles = list("NCR Commanding Officer", "NCR Off-Duty")
 
 /datum/gear/donator/zirilliuniform

--- a/modular_citadel/code/modules/client/loadout/_supermutant.dm
+++ b/modular_citadel/code/modules/client/loadout/_supermutant.dm
@@ -29,7 +29,7 @@
 	path = /obj/item/clothing/shoes/f13/mutie/boots/ncr
 	restricted_desc = "NCR"
 	restricted_roles = list(
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
@@ -75,7 +75,7 @@
 	path = /obj/item/clothing/suit/armor/f13/combat/ncr/mutie
 	restricted_desc = "NCR"
 	restricted_roles = list(
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
@@ -131,7 +131,7 @@
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Veteran Ranger",
 							"NCR Ranger",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -85,7 +85,7 @@
 	name = "Wide red hat"
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_HATS
 	path = /obj/item/clothing/head/widered
-	
+
 /datum/gear/head/bowlerhat
 	name = "Bowler hat"
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_HATS
@@ -97,7 +97,7 @@
 	path = /obj/item/clothing/head/f13/ncr_cap
 	restricted_desc = "NCR"
 	restricted_roles = list(
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
@@ -151,8 +151,8 @@
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_BERET
 	path = /obj/item/clothing/head/beret/ncr_lt
 	restricted_desc = "NCR"
-	restricted_roles = list(		
-							"NCR Lieutenant",
+	restricted_roles = list(
+							"NCR Commanding Officer",
 							"NCR Off-Duty"
 						)
 
@@ -161,7 +161,7 @@
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_BERET
 	path = /obj/item/clothing/head/beret/ncr_recon
 	restricted_desc = "NCR"
-	restricted_roles = list(		
+	restricted_roles = list(
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
 							"NCR Corporal",
@@ -174,8 +174,8 @@
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_BERET
 	path = /obj/item/clothing/head/beret/ncr_recon_lt
 	restricted_desc = "NCR Officers"
-	restricted_roles = list(		
-							"NCR Lieutenant",
+	restricted_roles = list(
+							"NCR Commanding Officer",
 							"NCR Off-Duty"
 						)
 
@@ -196,8 +196,8 @@
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_BERET
 	path = /obj/item/clothing/head/beret/ncr_scout_lt
 	restricted_desc = "NCR Officers"
-	restricted_roles = list(		
-							"NCR Lieutenant",
+	restricted_roles = list(
+							"NCR Commanding Officer",
 							"NCR Off-Duty"
 						)
 
@@ -206,7 +206,7 @@
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_BERET
 	path = /obj/item/clothing/head/beret/ncr_medic
 	restricted_desc = "NCR"
-	restricted_roles = list(		
+	restricted_roles = list(
 							"NCR Combat Medic",
 							"NCR Off-Duty"
 						)
@@ -216,7 +216,7 @@
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_BERET
 	path = /obj/item/clothing/head/beret/ncr_medic_lt
 	restricted_desc = "NCR Officers"
-	restricted_roles = list(		
+	restricted_roles = list(
 							"NCR Medical Officer",
 							"NCR Off-Duty"
 						)
@@ -264,7 +264,7 @@
 	path = /obj/item/clothing/head/f13/ncr/steelpot_goggles
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
@@ -278,11 +278,11 @@
 
 /datum/gear/head/steelpot_gambler
 	name = "NCR gambler helmet"
-	subcategory = LOADOUT_SUBCATEGORY_HEAD_HELMET	
+	subcategory = LOADOUT_SUBCATEGORY_HEAD_HELMET
 	path = /obj/item/clothing/head/f13/ncr/steelpot_gambler
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
@@ -296,11 +296,11 @@
 
 datum/gear/head/steelpot_bandolier
 	name = "NCR bandolier helmet"
-	subcategory = LOADOUT_SUBCATEGORY_HEAD_HELMET	
+	subcategory = LOADOUT_SUBCATEGORY_HEAD_HELMET
 	path = /obj/item/clothing/head/f13/ncr/steelpot_bandolier
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
@@ -314,11 +314,11 @@ datum/gear/head/steelpot_bandolier
 
 datum/gear/head/steelpot_patriot
 	name = "NCR patriot helmet"
-	subcategory = LOADOUT_SUBCATEGORY_HEAD_HELMET	
+	subcategory = LOADOUT_SUBCATEGORY_HEAD_HELMET
 	path = /obj/item/clothing/head/f13/ncr/steelpot_patriot
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
@@ -332,11 +332,11 @@ datum/gear/head/steelpot_patriot
 
 /datum/gear/head/steelpot_mitchell
 	name = "NCR mitchell helmet"
-	subcategory = LOADOUT_SUBCATEGORY_HEAD_HELMET	
+	subcategory = LOADOUT_SUBCATEGORY_HEAD_HELMET
 	path = /obj/item/clothing/head/f13/ncr/steelpot_mitchell
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -34,10 +34,10 @@
 	path = /obj/item/clothing/under/f13/ncr/pants
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Veteran Ranger",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
 							"NCR Corporal",
@@ -57,10 +57,10 @@
 	path = /obj/item/clothing/under/f13/ncr/ncr_shorts
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Veteran Ranger",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
 							"NCR Corporal",
@@ -80,10 +80,10 @@
 	path = /obj/item/clothing/under/f13/ncr_sniper
 	restricted_desc = "NCR"
 	restricted_roles = list("NCR Captain",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Medical Officer",
 							"NCR Veteran Ranger",
-							"NCR Lieutenant",
+							"NCR Commanding Officer",
 							"NCR Sergeant First Class",
 							"NCR Sergeant",
 							"NCR Corporal",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the NCR Lieutenant into the NCR Commanding Officer. No balance changes are made, it's just a name change.

## Why It's Good For The Game

This allows for loremasters to award Captain rank to COs. Allows for progression even for the Leader players.

## Changelog
:cl:
add: Added Captain pins as a custom item with ckey whitelists. Current ckeys added to it are by loremaster request.
tweak: NCR Lieutenant is now named NCR Commanding Officer, to mirror NCR Medical Officer and clarify that it's not just lieutenants anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
