### PR TITLE
More AMR Fixes

### DIFF
--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -412,6 +412,13 @@
 	build_path = /obj/item/ammo_box/magazine/garand308/empty
 	category = list("initial", "Intermediate Magazines")
 
+/datum/design/ammolathe/amr50
+	name = "empty anti-materiel rifle magazine (.50MG)"
+	id = "amr50"
+	materials = list(/datum/material/iron = 10000)
+	build_path = /obj/item/ammo_box/magazine/amr/empty
+	category = list("initial", "Intermediate Magazines")
+
 //Tier 3 Ammo
 /datum/design/ammolathe/c4570
 	name = ".45-70 FMJ ammo box"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows you to actually make AMR magazines so that the gun isn't useless.

## Why It's Good For The Game

Someone forgot to add the magazines to the lathe after adding them to the game. This fixes that.

## Changelog
:cl:
fix: You can now actually print AMR magazines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
