### PR TITLE
Wayfarer Rose into Loadouts, two new pens. Twin Sabre sheath fixed. Smartfridge stims.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -937,7 +937,7 @@
 
 /obj/item/storage/belt/sabre/twin
 	name = "twin sheath"
-	desc = "Two sheaths. One is capable of holding a katana (or bokken) and the other a wakizashi. You could put two wakizashis in if you really wanted to. Now you can really roleplay as a samurai."
+	desc = "Two sheaths. One is capable of holding everything and the other one is two."
 	icon_state = "2sheath"
 	item_state = "quiver" //this'll do.
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -941,7 +941,7 @@
 	icon_state = "2sheath"
 	item_state = "quiver" //this'll do.
 	w_class = WEIGHT_CLASS_BULKY
-	fitting_swords = list(/obj/item/melee/smith/wakizashi, /obj/item/melee/smith/twohand/katana, /obj/item/melee/bokken)
+	fitting_swords = list(/obj/item/melee/smith/wakizashi, /obj/item/melee/smith/twohand/katana, /obj/item/melee/bokken, /obj/item/melee/smith, /obj/item/melee/smith/twohand)
 	starting_sword = null
 
 /obj/item/storage/belt/sabre/twin/ComponentInitialize()

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -469,7 +469,12 @@
 					/obj/item/reagent_containers/glass/beaker,
 					/obj/item/reagent_containers/spray,
 					// /obj/item/reagent_containers/medigel,
-					/obj/item/reagent_containers/chem_pack
+					/obj/item/reagent_containers/chem_pack,
+					/obj/item/reagent_containers/hypospray/medipen,
+					/obj/item/reagent_containers/hypospray/medipen/stimpak,
+					/obj/item/reagent_containers/hypospray/medipen/stimpak/custom,
+					/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+					/obj/item/reagent_containers/hypospray/medipen/stimpak/super/custom
 	))
 
 	if(istype(O, /obj/item/storage/pill_bottle))

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -593,4 +593,17 @@
 	ckeywhitelist = list("dioclex")
 	restricted_roles = list("Legion Venator")
 
-
+/datum/gear/donator/wayfarerrose
+	name = "Wayfarer rose"
+	slot = SLOT_IN_BACKPACK
+	path = /obj/item/grown/wayfarer_rose
+	ckeywhitelist = list("ollieoxen",
+						"andrej99",
+						"novaskelly",
+						"loadedgun",
+						"weeps",
+						"landoorando",
+						"usotsukihime",
+						"karlov",
+						"odysiahallow",
+						"SM45HB0T")

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -605,5 +605,5 @@
 						"landoorando",
 						"usotsukihime",
 						"karlov",
-						"odysiahallow",
+						"hallow96",
 						"SM45HB0T")

--- a/modular_citadel/code/modules/client/loadout/backpack.dm
+++ b/modular_citadel/code/modules/client/loadout/backpack.dm
@@ -75,13 +75,13 @@
 	cost = 2
 
 /datum/gear/backpack/captainpen
-	name = "A captains pen"
-	name = /obj/item/pen/fountain/captain
-	cost = 2
+	name = "A captain pen"
+	path = /obj/item/pen/fountain/captain
+	cost = 3
 	
 /datum/gear/backpack/survivalpen
 	name = "A survival pen"
-	name = /obj/item/pen/survival
+	path = /obj/item/pen/survival
 	cost = 3
 
 /datum/gear/backpack/ringbox_gold

--- a/modular_citadel/code/modules/client/loadout/backpack.dm
+++ b/modular_citadel/code/modules/client/loadout/backpack.dm
@@ -74,6 +74,16 @@
 	path = /obj/item/pen/fountain
 	cost = 2
 
+/datum/gear/backpack/captainpen
+	name = "A captains pen"
+	name = /obj/item/pen/fountain/captain
+	cost = 2
+	
+/datum/gear/backpack/survivalpen
+	name = "A survival pen"
+	name = /obj/item/pen/survival
+	cost = 3
+
 /datum/gear/backpack/ringbox_gold
 	name = "A gold ring box"
 	path = /obj/item/storage/fancy/ringbox


### PR DESCRIPTION
## About The Pull Request

This PR adds the wayfarer rose into loadouts and this was requested by our LCs and some players who wanted them. This PR also adds two new pens which one is a captains pen and the other is a survival pen which works like a mini pickaxe but it doesn't work in our code im pretty sure, unless its in low pressure environments? This pen can be used by NCR with prisoners so they can mine like with a rusty spoon but it works as a pen on paper. Twin sabre is buffed to hold all of the smithed items as that way you can use it. This also adds smartfridge to hold stimpacks, super stims and even /custom/ stims, would assume so. Medipens is added for it too.

## Why It's Good For The Game

Quality of life loadout changes for the roses and even two pens for the thing so people can be added. These quality of life changes were good for the game and this is for the equal to the tribals alchemy table so stimpacks cannot be sitting around anymore. Twin Sabre sheath was a rarity and should be good now.

## Changelog
:cl:
add: loadout roses, and two pens into the loadout system.
tweak: twin sabres actually fitting things, tweaks chemistry smartfridge
/:cl:

