### PR TITLE
BoS Armor fix/adjustment, Knight Captain spawner fix

### DIFF
--- a/code/modules/clothing/f13bosclothing.dm
+++ b/code/modules/clothing/f13bosclothing.dm
@@ -13,10 +13,11 @@
 	desc = "(VI) An improved combat helmet, bearing the symbol of a Senior Knight."
 	icon_state = "brotherhood_helmet_senior"
 	item_state = "brotherhood_helmet_senior"
+	armor = list("tier" = 6, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/captain
-	name = "brotherhood knight-captain helmet"
-	desc = "(VII) An improved combat helmet, bearing the symbol of the Knight-Captain."
+	name = "brotherhood knight captain helmet"
+	desc = "(VII) An improved combat helmet, bearing the symbol of the Knight Captain."
 	icon_state = "brotherhood_helmet_captain"
 	item_state = "brotherhood_helmet_captain"
 	armor = list("tier" = 7, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
@@ -30,27 +31,28 @@
 
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/mk2
 	name = "reinforced knight helmet"
-	desc = "(V) An advanced pre-war titanium plated, ceramic coated, kevlar, padded helmet designed to withstand extreme punishment of all forms, repainted to the colour scheme of the Brotherhood of Steel."
+	desc = "(VI) An advanced pre-war titanium plated, ceramic coated, kevlar, padded helmet designed to withstand extreme punishment of all forms, repainted to the colour scheme of the Brotherhood of Steel."
 	icon_state = "brotherhood_helmet"
 	item_state = "brotherhood_helmet"
-	armor = list("tier" = 5, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	armor = list("tier" = 6, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/scout
 	name = "brotherhood scout helmet"
-	desc = "(V) An improved combat helmet, featuring a transparent visor and bearing the symbol of the Knights."
+	desc = "(IV) An improved combat helmet, featuring a transparent visor and bearing the symbol of the Knights."
 	icon_state = "brotherhood_helmet_scout_knight"
 	item_state = "brotherhood_helmet_scout_knight"
-	armor = list("tier" = 5, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	armor = list("tier" = 4, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
 
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/scout/senior
 	name = "brotherhood senior knight scout helmet"
 	desc = "(V) An improved combat helmet, featuring a transparent visor and bearing the symbol of the Senior Knight."
 	icon_state = "brotherhood_helmet_scout_senior"
 	item_state = "brotherhood_helmet_scout_senior"
+	armor = list("tier" = 5, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/scout/captain
-	name = "brotherhood knight-Captain scout helmet"
-	desc = "(VI) An improved combat helmet, featuring a transparent visor and bearing the symbol of the Knight-Captain."
+	name = "brotherhood Knight Captain scout helmet"
+	desc = "(VI) An improved combat helmet, featuring a transparent visor and bearing the symbol of the Knight Captain."
 	icon_state = "brotherhood_helmet_scout_captain"
 	item_state = "brotherhood_helmet_scout_captain"
 	armor = list("tier" = 6, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
@@ -162,10 +164,11 @@
 	desc = "(VI) A reinforced combat armor set made by the Brotherhood of Steel, standard issue for all Senior Knights. It bears a silver stripe."
 	icon_state = "brotherhood_armor_senior"
 	item_state = "brotherhood_armor_senior"
+	armor = list("tier" = 6, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/captain
-	name = "brotherhood knight-captain armor"
-	desc = "(VII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Knight-Captains. It bears golden embroidery."
+	name = "brotherhood Knight Captain armor"
+	desc = "(VII) A superior combat armor set made by the Brotherhood of Steel, standard issue for all Knight Captains. It bears golden embroidery."
 	icon_state = "brotherhood_armor_captain"
 	item_state = "brotherhood_armor_captain"
 	armor = list("tier" = 7, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
@@ -189,7 +192,7 @@
 	desc = "(IV) A half-suit of combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a red stripe."
 	icon_state = "brotherhood_scout_knight"
 	item_state = "brotherhood_scout_knight"
-	armor = list("tier" = 5, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	armor = list("tier" = 4, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
 	slowdown = -0.1
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/scout/senior
@@ -197,9 +200,10 @@
 	desc = "(V) A suit of combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a silver stripe."
 	icon_state = "brotherhood_scout_senior"
 	item_state = "brotherhood_scout_senior"
+	armor = list("tier" = 5, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/scout/captain
-	name = "brotherhood knight-captain scout armor"
+	name = "brotherhood Knight Captain scout armor"
 	desc = "(VI) A superior combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a golden stripe."
 	icon_state = "brotherhood_scout_captain"
 	item_state = "brotherhood_scout_captain"

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -397,7 +397,7 @@
 	item_state = "sierra"
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45d/knightcaptain
-	name = "Knight Captain's T-45d Power Armour"
+	name = "knight captain's T-45d Power Armour"
 	desc = "(VIII) A classic set of T-45d Power Armour only to be used in armed combat, it signifies the Knight Captain and their place in the Brotherhood. A leader, and a beacon of structure in a place where chaos reigns. All must rally to his call, for he is the Knight Captain and your safety is his duty."
 	icon_state = "t45dkc"
 	item_state = "t45dkc"

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -397,8 +397,8 @@
 	item_state = "sierra"
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45d/knightcaptain
-	name = "knight-captain's T-45d Power Armour"
-	desc = "(VIII) A classic set of T-45d Power Armour only to be used in armed combat, it signifies the Knight-Captain and their place in the Brotherhood. A leader, and a beacon of structure in a place where chaos reigns. All must rally to his call, for he is the Knight-Captain and your safety is his duty."
+	name = "Knight Captain's T-45d Power Armour"
+	desc = "(VIII) A classic set of T-45d Power Armour only to be used in armed combat, it signifies the Knight Captain and their place in the Brotherhood. A leader, and a beacon of structure in a place where chaos reigns. All must rally to his call, for he is the Knight Captain and your safety is his duty."
 	icon_state = "t45dkc"
 	item_state = "t45dkc"
 	slowdown = 0.16

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -435,8 +435,8 @@
 	minimize_when_attached = TRUE
 
 /obj/item/clothing/accessory/bos/knightcaptain
-	name = "Knight-Captain pins"
-	desc = "A gold-plated, silver lined pin with one device and two outstretched wings on the side; a golden sword centered on blue-cloth. Worn by the Knight-Captain."
+	name = "Knight Captain pins"
+	desc = "A gold-plated, silver lined pin with one device and two outstretched wings on the side; a golden sword centered on blue-cloth. Worn by the Knight Captain."
 	icon_state = "knight-captain"
 	item_color = "knight-captain"
 	minimize_when_attached = TRUE

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -363,7 +363,7 @@
 
 /proc/get_all_jobs()
 	return list("Centurion", "NCR Captain", "Overseer", "Sheriff",
-				"Sentinel", "Senior Paladin", "Paladin", "Knight-Captain", "Senior Knight", "Knight", "Head Scribe", "Senior Scribe", "Scribe", "Initiate",
+				"Sentinel", "Senior Paladin", "Paladin", "Knight Captain", "Senior Knight", "Knight", "Head Scribe", "Senior Scribe", "Scribe", "Initiate",
 				"Veteran Decanus", "Vexillarius", "Decanus", "Veteran Legionnaire", "Prime Legionary",
 				"NCR Commanding Officer", "NCR Medical Officer", "NCR Sergeant First Class", "NCR Sergeant", ,"NCR Corporal", "NCR Combat Medic", "NCR Combat Engineer", "NCR Trooper",
 				"NCR Veteran Ranger", "NCR Patrol Ranger", "NCR Recon Ranger",

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -264,17 +264,17 @@ Head Scribe
 		)
 
 /*
-Knight-Captain
+Knight Captain
 */
 
 /datum/job/bos/f13knightcap
-	title = "Knight-Captain"
+	title = "Knight Captain"
 	flag = F13KNIGHTCAPTAIN
 	head_announce = list("Security")
 	faction = "BOS"
 	total_positions = 1
 	spawn_positions = 1
-	description = "You are the Knight-Captain, leader of your respective division in the Chapter. Your knowledge of pre-war materials and engineering is almost unparalleled, and you have basic combat training and experience. You are in charge of the Chapter's engineering Corps, and your Knights. Delegate to them as necessary. As Chief Armorer, you are also in charge of the armory."
+	description = "You are the Knight Captain, leader of your respective division in the Chapter. Your knowledge of pre-war materials and engineering is almost unparalleled, and you have basic combat training and experience. You are in charge of the Chapter's engineering Corps, and your Knights. Delegate to them as necessary. As Chief Armorer, you are also in charge of the armory."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Sentinel"
@@ -740,10 +740,10 @@ datum/job/bos/f13seniorknight
 	faction = "BOS"
 	total_positions = 2
 	spawn_positions = 2
-	description = "You report directly to the Knight-Captain. You are the Brotherhood Senior Knight. Having served the Knight Caste for some time now, you are versatile and experienced in both basic combat and repairs, and also a primary maintainer of the Bunker's facilities. As your seniormost Knight, you may be assigned initiates or Junior Knights to mentor."
+	description = "You report directly to the Knight Captain. You are the Brotherhood Senior Knight. Having served the Knight Caste for some time now, you are versatile and experienced in both basic combat and repairs, and also a primary maintainer of the Bunker's facilities. As your seniormost Knight, you may be assigned initiates or Junior Knights to mentor."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
-	supervisors = "the Knight-Captain"
+	supervisors = "the Knight Captain"
 	selection_color = "#95a5a6"
 	exp_requirements = 3000
 	exp_type = EXP_TYPE_KNIGHT
@@ -839,7 +839,7 @@ Knight
 	description = " You are the Brotherhood Knight, the veritable lifeblood of your organization. You are a versatile and adaptably trained person: from your primary duties of weapon & armor repair to basic combat, survival and stealth skills, the only thing you lack is proper experience. You are also in charge of Initiates."
 	forbids = "TheBrotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
-	supervisors = "the Senior Knight, or Knight-Captain"
+	supervisors = "the Senior Knight, or Knight Captain"
 	selection_color = "#95a5a6"
 	exp_requirements = 600
 
@@ -1036,7 +1036,7 @@ Lancer
 	spawn_positions = 1
 	description = "You are a Lancer, one of the esteemed and few pilots within the Brotherhood. Whether flying a vertibird or performing maintenance on them, you know everything there is to know about these VTOL aircraft. If it involves flying, it's your responsibilty. The only thing you lack, is experience."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
-	supervisors = "the Senior Lancers and the Knight-Captain"
+	supervisors = "the Senior Lancers and the Knight Captain"
 	selection_color = "#95a5a6"
 	outfit = /datum/outfit/job/bos/f13lancer
 	access = list(ACCESS_JANITOR, ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
@@ -1077,7 +1077,7 @@ Off-Duty
 	/datum/outfit/loadout/offa, //Junior Knight
 	/datum/outfit/loadout/offb, //Knight
 	/datum/outfit/loadout/offc, //Senior Knight
-	/datum/outfit/loadout/offd, //Knight-Captain
+	/datum/outfit/loadout/offd, //Knight Captain
 	/datum/outfit/loadout/offe, //Junior Scribe
 	/datum/outfit/loadout/offf, //Scribe
 	/datum/outfit/loadout/offg, //Senior Scribe
@@ -1129,7 +1129,7 @@ Off-Duty
 		)
 
 /datum/outfit/loadout/offd
-	name = "Knight-Captain"
+	name = "Knight Captain"
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/knightcaptain=1
 		)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -47,7 +47,7 @@ GLOBAL_LIST_INIT(command_positions, list(
 	"Elder",
 	"Head Scribe",
 	"Head Paladin",
-	"Knight-Captain",
+	"Knight Captain",
 
 	"NCR Commanding Officer",
 	"NCR Sergeant First Class",
@@ -82,7 +82,7 @@ GLOBAL_LIST_INIT(faction_whitelist_positions, list(
 "Head Scribe",
 "Elder",
 "Head Paladin",
-"Knight-Captain",
+"Knight Captain",
 "Head Scribe",
 "Senior Paladin",
 "Paladin",
@@ -182,7 +182,7 @@ GLOBAL_LIST_INIT(brotherhood_paladin_positions, list(
 GLOBAL_LIST_INIT(brotherhood_command_positions, list(
 	"Elder",
 	"Head Paladin",
-	"Knight-Captain",
+	"Knight Captain",
 	"Head Scribe"
 ))
 

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -245,7 +245,7 @@
 	restricted_desc = "BoS"
 	restricted_roles = list(
 							"Head Paladin",
-							"Knight-Captain",
+							"Knight Captain",
 							"Head Scribe",
 							"Senior Paladin",
 							"Senior Knight",

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -123,7 +123,7 @@
 	restricted_desc = "BoS"
 	restricted_roles = list(
 							"Head Paladin",
-							"Knight-Captain",
+							"Knight Captain",
 							"Head Scribe",
 							"Senior Paladin",
 							"Senior Knight",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I noticed while looking through the armor file for the Brotherhood that the values were often wrong compared to what they should be. Knight scout armor was one tier higher than it should be, Senior Knight regular armor was one tier lower than it should be, and there were a couple other similar cases. After confirming what the right tiers are with Rebel, I went through and changed them to be in alignment with that list. Also fixes the Knight Captain spawner. The issue was caused by inconsistent hyphenation, and as such I went through our code and standardized every single use to the non-hyphenated version, since it doesn't make sense to have exactly one hyphenated rank in the Brotherhood. Compiled it, tested it, confirmed all armor tiers are where they're actually supposed to be and that the Knight Captain spawns where they should.

## Why It's Good For The Game

Adjusts the actual code to match the design documents. Fixes KC spawning and standardizes the spelling of the rank across the board. If the lore team wants to switch back to hyphenated, it's not too hard to simply do the same thing in reverse.

## Changelog
:cl:
tweaked: Brotherhood Knight armor values
fixed: KC spawner
standardized: non-hypenation of Knight Captain across the board.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
