### PR TITLE
Removes Fastboots

### DIFF
--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -464,7 +464,7 @@
 	name = "Courier"
 	backpack_contents = list(
 	/obj/item/clothing/glasses/f13/biker=1,
-	/obj/item/clothing/shoes/jackboots/fast=1,
+	/obj/item/clothing/shoes/jackboots=1,
 	/obj/item/gun/ballistic/rifle/mag/commando=1,
 	/obj/item/stack/sheet/cardboard/twenty=1,
 	/obj/item/ammo_box/magazine/m45exp = 2


### PR DESCRIPTION
## About The Pull Request

These are absolutely horrid. Being boots allows the speed-buff given to stack with armors (ex legion armor or trail ranger armor) to further boost speed.

The loadout this object was given to was not balanced really as is due to this huge buff in speed and getting a .45 gun which is kind of better than most of the other loadout weapons as is.

## Why It's Good For The Game

Speed boots are not a good idea to have. The reason why is they can be stacked with armor. While the idea of giving a roadie loadout a tiny bit more speed to them to give a reason to select the loadout it's an oversight that with different armor, even if the boots simply get nerfed speed, can still be stacked with other speed reduction armor.

If a loadout needs different slowdown rates apply it to their suit rather than their shoes/hat.

## Changelog
:cl:
removes: Fast jackboots from Roadie.
/:cl:
