### PR TITLE
Ports Fortuna's Speechspan fix

### DIFF
--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -73,6 +73,21 @@
 	if(ismob(loc))
 		var/mob/M = loc
 		M.update_inv_head()
+
+/obj/item/clothing/head/equipped(mob/user, slot)
+	. = ..()
+	if(ishuman(user) && slot == SLOT_HEAD && speechspan)
+		var/mob/living/carbon/human/H = user
+		H.speech_span = speechspan
+
+/obj/item/clothing/head/dropped(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(H.get_item_by_slot(SLOT_HEAD) == src && speechspan)
+		H.speech_span = null
+
 /*
 //Hat accessories
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the fix from Fortuna for the speechspan proc, allowing power armor to have its robotic voice back.

![image](https://user-images.githubusercontent.com/67706292/133817490-261e95b7-5c7a-40f8-a48e-1a1485b2540b.png)


## Why It's Good For The Game

Flavour

## Changelog
:cl:
add: A new speechspan proc has been added, ported from Fortuna. Power armor and similar items that change text font should work now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
