### PR TITLE
4.73mm Ammo, Buffs and Balancing

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -816,6 +816,17 @@
 	custom_materials = list(MAT_METAL = 1000)
 	w_class = WEIGHT_CLASS_NORMAL
 
+/obj/item/ammo_box/m473_box
+	name = "ammo box (4.73mm caseless)"
+	icon = 'icons/fallout/objects/guns/ammo.dmi'
+	multiple_sprites = 2
+	icon_state = "5mmbox"
+	caliber = "473mm"
+	ammo_type = /obj/item/ammo_casing/caseless/g11
+	max_ammo = 50
+	w_class = WEIGHT_CLASS_NORMAL
+	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 2500)
+
 /obj/item/ammo_box/c5mm
 	name = "ammo box (5mm)"
 	icon = 'icons/fallout/objects/guns/ammo.dmi'

--- a/code/modules/projectiles/guns/ballistic/Rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/Rifle.dm
@@ -392,7 +392,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m45exp
 	extra_damage = 8
 	extra_penetration = 0.2
-	fire_delay = 6
+	fire_delay = 5
 	spread = 1
 	can_unsuppress = FALSE
 	can_scope = TRUE
@@ -411,7 +411,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m45exp
 	extra_damage = 10
 	extra_penetration = 0.3
-	fire_delay = 7
+	fire_delay = 6
 	spread = 0
 	can_unsuppress = FALSE
 	suppressed = 1
@@ -441,7 +441,7 @@
 	icon_state = "amr"
 	item_state = "sniper"
 	mag_type = /obj/item/ammo_box/magazine/amr
-	extra_damage = 20
+	extra_damage = 10
 	fire_delay = 10
 	recoil = 1
 	spread = 0

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -580,6 +580,7 @@
 	item_state = "servicerifle"
 	fire_sound = 'sound/f13weapons/varmint_rifle.ogg'
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
+	untinkerable = TRUE
 	burst_size = 1
 	fire_delay = 4
 	extra_damage = 4
@@ -748,6 +749,7 @@
 	name = "Old Glory"
 	desc = "This Machine kills communists!"
 	icon_state = "oldglory"
+	untinkerable = TRUE
 	extra_damage = 10
 
 //Pawolskis Retribution		Keywords: UNIQUE, 308/7.62mm, Semi-Auto, 8 round internal mag, No Autosear. Note: Some exta damage.
@@ -755,6 +757,7 @@
 	name = "Pawolski's Retribution"
 	desc = "'I am your rifle, you are on guard duty.'"
 	icon_state = "pawolski"
+	untinkerable = TRUE
 	extra_damage = 5
 
 //Republics Pride			Keywords: UNIQUE, NCR, 308/7.62mm, Semi-Auto, 8 round internal mag, No Autosear. Note: Normal extra damage.
@@ -763,6 +766,7 @@
 	desc = "A well-tuned scoped M1C rifle crafted by master gunsmith from the Gunrunners. Proudly issued to Scout Captains and packs a mean punch. Chambered in 7.62x51."
 	icon_state = "republics_pride"
 	item_state = "scoped308"
+	untinkerable = TRUE
 	extra_damage = 8
 	extra_penetration = 0.1
 	zoomable = TRUE
@@ -776,6 +780,7 @@
 	desc = "A well-tuned scoped M1C rifle crafted by master gunsmith from the Gunrunners. This one seems to be looted from a dead NCR Lieutenant and the flag replaced with a bull. Chambered in 7.62x51."
 	icon_state = "republics_demise"
 	item_state = "scoped308"
+	untinkerable = TRUE
 	extra_damage = 8
 	extra_penetration = 0.1
 	zoomable = TRUE
@@ -944,6 +949,7 @@
 	item_state = "sniper"
 	slot_flags = SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
+	untinkerable = TRUE
 	burst_size = 3
 	burst_shot_delay = 1.5
 	fire_delay = 3.5
@@ -964,6 +970,7 @@
 	desc = "The U.S. army carbine version of the R91, made by Colt and issued to special forces."
 	icon_state = "assault_carbine"
 	item_state = "assault_carbine"
+	untinkerable = TRUE
 	slot_flags = 0
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	burst_size = 2
@@ -1014,6 +1021,7 @@
 	mag_type = /obj/item/ammo_box/magazine/c5mm
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+	untinkerable = TRUE
 	force = 20
 	burst_size = 4
 	fire_delay = 4
@@ -1035,6 +1043,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m762
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+	extra_damage = 2
 	burst_size = 1
 	fire_delay = 4
 	spread = 2
@@ -1171,6 +1180,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+	untinkerable = TRUE
 	force = 25
 	fire_delay = 4.5
 	burst_shot_delay = 2.25
@@ -1214,11 +1224,12 @@
 	slowdown = 1.25
 	mag_type = /obj/item/ammo_box/magazine/mm762
 	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'
+	untinkerable = TRUE
 	can_suppress = FALSE
 	can_attachments = FALSE
 	burst_size = 1
 	burst_shot_delay = 1.5
-	fire_delay = 4
+	fire_delay = 6
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	spread = 12
@@ -1285,7 +1296,7 @@
 			select = 0
 			burst_size = 4
 			spread = 22
-			extra_damage = -4
+			extra_damage = -6
 			recoil = 1
 			to_chat(user, "<span class='notice'>You switch to full auto.</span>")
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
@@ -1301,10 +1312,11 @@
 	slot_flags = 0
 	mag_type = /obj/item/ammo_box/magazine/mm50
 	fire_sound = 'sound/f13weapons/antimaterielfire.ogg'
+	untinkerable = TRUE
 	can_suppress = FALSE
 	can_attachments = FALSE
 	burst_size = 1
-	fire_delay = 5.5
+	fire_delay = 8
 	slowdown = 1.5
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
@@ -1362,7 +1374,7 @@
 	var/mob/living/carbon/human/user = usr
 	switch(select)
 		if(0)
-			select = 1
+			select = 0
 			burst_size = 2
 			spread = 40
 			extra_damage = -2
@@ -1379,12 +1391,6 @@
 			spread = 60
 			extra_damage = -6
 			to_chat(user, "<span class='notice'>You switch to [burst_size]-rnd burst.</span>")
-		if(3)
-			select = 0
-			burst_size = 1
-			spread = 20
-			extra_damage = 0
-			to_chat(user, "<span class='notice'>You switch to semi-automatic.</span>")
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 	update_icon()
 	return

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -486,12 +486,26 @@
 /datum/design/ammolathe/c5mm
 	name = "5mm ammo box"
 	id = "c5mm_box"
-	materials = list(/datum/material/iron = 15000, /datum/material/blackpowder = 2000)
+	materials = list(/datum/material/iron = 25000, /datum/material/blackpowder = 3000)
 	build_path = /obj/item/ammo_box/c5mm
 	category = list("initial", "Intermediate Ammo")
 
+/datum/design/ammolathe/m473
+	name = "g11 magazine (4.73mm)"
+	id = "4.73mm_mag"
+	materials = list(/datum/material/iron = 6000)
+	build_path = /obj/item/ammo_box/magazine/m473
+	category = list("initial", "Intermediate Magazines")
+
+/datum/design/ammolathe/m473box
+	name = "ammo box (4.73mm)"
+	id = "4.73mm_mag"
+	materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 2500)
+	build_path = /obj/item/ammo_box/m473_box
+	category = list("initial", "Intermediate Ammo")
+
 /datum/design/ammolathe/c5mmag
-	name = "empty AK gun magazine (5mm)"
+	name = "empty 5mm gun magazine"
 	id = "c5mm_mag"
 	materials = list(/datum/material/iron = 6000)
 	build_path = /obj/item/ammo_box/magazine/c5mm/empty

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -499,7 +499,7 @@
 
 /datum/design/ammolathe/m473box
 	name = "ammo box (4.73mm)"
-	id = "4.73mm_mag"
+	id = "4.73mm_box"
 	materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 2500)
 	build_path = /obj/item/ammo_box/m473_box
 	category = list("initial", "Intermediate Ammo")

--- a/modular_citadel/code/modules/projectiles/guns/ballistic/flamethrower.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/flamethrower.dm
@@ -9,7 +9,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_HUGE
-	slowdown = 1
+	slowdown = 0.5
 	item_flags = SLOWS_WHILE_IN_HAND
 	var/obj/item/gun/ballistic/m2flamethrower/gun
 	var/armed = 0 //whether the gun is attached, 0 is attached, 1 is the gun is wielded.
@@ -99,13 +99,12 @@
 	icon_state = "m2_flamethrower_on"
 	item_state = "m2flamethrower"
 	flags_1 = CONDUCT_1
-	slowdown = 1
+	slowdown = 0.5
 	slot_flags = null
 	w_class = WEIGHT_CLASS_HUGE
 	custom_materials = null
 	burst_size = 2
 	burst_shot_delay = 1
-	//automatic = 0
 	fire_delay = 10
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/flamethrower.ogg'


### PR DESCRIPTION
## About The Pull Request

Added the G-11 to loot table - but forgot you couldn't make the ammo required for it. That's added now.

Fixed the AMR's damage values. Also in the same way removed the M2A1's single-shot mode so you can't use it like a worse AMR with spread. Not a huge deal but fuck firing 1 .50 round. Also nerfed its damage overall a bit.

Bolt actions have less fire delay to make them viable. 

Fire delay increase on machine guns, M14 got some bonus damage due to it being overshadowed by the other 7.62s notably rather than a trade-off.

Finally made half the guns untinkerable besides lower end weapons and non-spawn faction weapons to avoid muh ebic powergame the broken stoopid system.

## Why It's Good For The Game

Overall balances the last ammo and rifle PR quite a bit. Apparently I only get feedback and some testing after asking for help for 10 days then people suddenly realize there's a PR on the 11th day when it gets merged.

## Changelog
:cl:
add: 4.73 ammo box and mag to be printable.
balance: Fire delays on automatics and bolt actions reworked.
balance: AMR nerfed by 10 damage.
balance: M2A1 nerfed damage and fire delay wise to avoid spam .50s.
balance: M2 flamethrower has less slowdown to put it on-par with the HMG rather than way above it.
fixes: Forgot I left 'AK' in the name of the 5mm ammo mag even though it's not just for the AK now.
/:cl:
