### PR TITLE
Minor closets tweaks/bugfix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -34,6 +34,7 @@
 	var/material_drop_amount = 2
 	var/delivery_icon = "deliverycloset" //which icon to use when packagewrapped. null to be unwrappable.
 	var/anchorable = TRUE
+	var/immovable = FALSE //makes the anchored state unable to be toggled with a wrench, should only be used with closets that start anchored
 	var/icon_welded = "welded"
 	var/obj/item/electronics/airlock/lockerelectronics //Installed electronics
 	var/lock_in_use = FALSE //Someone is doing some stuff with the lock here, better not proceed further
@@ -49,6 +50,8 @@
 	update_icon()
 	if(should_populate_contents)
 		PopulateContents()
+	if(anchored)
+		storage_capacity = 30
 	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
 		addtimer(CALLBACK(src, .proc/take_contents), 0)
 	if(secure)
@@ -362,6 +365,8 @@
 	if(istype(W, /obj/item/wrench) && anchorable)
 		if(isinspace() && !anchored)
 			return
+		if(immovable)
+			return
 		if((contents.len > base_storage_capacity) && anchored) //Prevents filling a locker, closing it, and then unanchoring it to move large stacks of objects. Can't just make the locker dump its contents as this could be used to empty locked/welded lockers
 			user.visible_message("<span class='notice'>[user] attempts to unanchor \the [src], however it is too weighed down by its contents.</span>", \
 						"<span class='notice'>You attempt to unanchor \the [src], however it is too weighed down by its contents.</span>")
@@ -386,7 +391,7 @@
 				welder = TRUE
 			if(W.use_tool(src, user, 40, volume=50))
 				if(eigen_teleport)
-					to_chat(user, "<span class='notice'>The unstable nature of \the [src] makes it impossible to [welder ? "slice" : "deconstruct"]!</span>")
+					to_chat(user, "<span class='notice'>The unusual construction of \the [src] makes it impossible to [welder ? "slice" : "deconstruct"]!</span>")
 					return
 				if(!opened)
 					return
@@ -408,7 +413,7 @@
 		to_chat(user, "<span class='notice'>You begin [welded ? "unwelding":"welding"] \the [src]...</span>")
 		if(W.use_tool(src, user, 40, volume=50))
 			if(eigen_teleport)
-				to_chat(user, "<span class='notice'>The unstable nature of \the [src] makes it impossible to weld!</span>")
+				to_chat(user, "<span class='notice'>The unusual construction of \the [src] makes it impossible to weld!</span>")
 				return
 			if(opened)
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Main thing here is I fixed a really old (prebase) bug that has always irritated me. Closets that start anchored will now start with the proper storage capacity of 30 and hold all the items they're supposed to instead of leaving them on the ground in an unsightly mess. I also added a new binary variable to closets, "Immovable", that makes their anchored state unable to be altered via wrench. No closet currently in existence has this set to true, but I may need it for future mapping stuff. In a similar vein, I altered slightly the text that appears when you try to weld a closet with eigen_teleport to make it more grounded in the reality I plan to use them for.

## Why It's Good For The Game

Bugfix, new minor feature that may or may not be used, and description alteration that omits SS13 stuff

## Changelog
:cl:
fix: anchored closet starting capacity
add: immovable binary for closets
tweak: some text for eigen closets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
