### PR TITLE
Fixed the Maxson conversion

### DIFF
--- a/code/game/objects/items/modkit.dm
+++ b/code/game/objects/items/modkit.dm
@@ -303,7 +303,7 @@
 	)
 	result_item = /obj/item/gun/ballistic/automatic/service/maxson
 
-/obj/item/modkit/maxson/c5mm
+/obj/item/modkit/maxson_c5mm
 	name = "maxson carbine 5mm conversion kit"
 	target_items = list(/obj/item/gun/ballistic/automatic/service/maxson,
 						/obj/item/gun/ballistic/automatic/service/maxson/c5mm

--- a/code/modules/projectiles/guns/ballistic/Rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/Rifle.dm
@@ -373,6 +373,7 @@
 	fire_delay = 6
 	spread = 0
 	extra_damage = 8
+	extra_penetration = 0.1
 	can_bayonet = FALSE
 	can_scope = TRUE
 	scope_state = "scope_short"
@@ -391,7 +392,7 @@
 	item_state = "varmintrifle"
 	mag_type = /obj/item/ammo_box/magazine/m45exp
 	extra_damage = 8
-	extra_penetration = 0.2
+	extra_penetration = 0.1
 	fire_delay = 5
 	spread = 1
 	can_unsuppress = FALSE
@@ -410,7 +411,7 @@
 	item_state = "varmintrifle"
 	mag_type = /obj/item/ammo_box/magazine/m45exp
 	extra_damage = 10
-	extra_penetration = 0.3
+	extra_penetration = 0.15
 	fire_delay = 6
 	spread = 0
 	can_unsuppress = FALSE

--- a/code/modules/projectiles/guns/ballistic/Rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/Rifle.dm
@@ -441,6 +441,7 @@
 	icon_state = "amr"
 	item_state = "sniper"
 	mag_type = /obj/item/ammo_box/magazine/amr
+	untinkerable = TRUE
 	extra_damage = 10
 	fire_delay = 10
 	recoil = 1

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -663,7 +663,7 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/maxson/c5mm
+/datum/design/maxson_c5mm
 	name = "maxson carbine 5mm conversion kit"
 	desc = "A conversion kit for maxson carbines."
 	id = "maxson_5mm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed the Maxson rifle conversion to 5mm and the missing sprite.

Also fixed AMR being tinkerable. Fuck tinkering.

## Why It's Good For The Game

Yes.

## Changelog
:cl:
fixes: Maxson rifle now has a fixed sprite and printable 5mm. God damn pathing.
fixes: AMR being tinkerable.
balance: Commando lost a bit of AP due to JHP being abusable. Varmint got a tiny bit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
