### PR TITLE
Small Map Fix & Loot Fix

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -38636,9 +38636,9 @@
 "rnP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/item/gun/ballistic/automatic/mini_uzi,
 /obj/item/ammo_box/magazine/uzim9mm,
 /obj/item/ammo_box/magazine/uzim9mm,
+/obj/item/gun/ballistic/automatic/smg/mini_uzi,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rof" = (
@@ -46195,9 +46195,9 @@
 /area/f13/building)
 "uwb" = (
 /obj/structure/closet/crate,
-/obj/item/gun/ballistic/automatic/greasegun,
 /obj/item/ammo_box/magazine/greasegun,
 /obj/item/ammo_box/magazine/greasegun,
+/obj/item/gun/ballistic/automatic/smg/greasegun,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uwh" = (
@@ -93588,7 +93588,7 @@ ktB
 ktB
 gcK
 fyf
-uHT
+fyf
 gcK
 uUG
 uUG

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1334,7 +1334,7 @@
 	loot = list(/obj/effect/spawner/bundle/f13/needler,
 				/obj/effect/spawner/bundle/f13/marksman,
 				/obj/effect/spawner/bundle/f13/r84,
-				/obj/effect/spawner/bundle/f13/ak112,
+				/obj/effect/spawner/bundle/f13/mp5,
 				/obj/effect/spawner/bundle/f13/bastard,
 				/obj/effect/spawner/bundle/f13/assault_rifle,
 				/obj/effect/spawner/bundle/f13/aer9,
@@ -1347,7 +1347,7 @@
 				/obj/effect/spawner/bundle/f13/chinese,
 				/obj/effect/spawner/bundle/f13/garand,
 				/obj/effect/spawner/bundle/f13/hunting,
-				/obj/effect/spawner/bundle/f13/mp5,
+				/obj/effect/spawner/bundle/f13/ak112,
 				/obj/effect/spawner/bundle/f13/assault_carbine,
 				/obj/effect/spawner/bundle/f13/citykiller,
 				/obj/effect/spawner/bundle/f13/brushgun,
@@ -1418,13 +1418,13 @@
 	lootcount = 1
 
 	loot = list(
-			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5 = 13,
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier5 = 15,
 			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier6 = 25,
 			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier7 = 35,
 			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier8 = 15,
 			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier9 = 6,
 			/obj/effect/spawner/lootdrop/f13/weapon/gun/tier10 = 3,
-			/obj/effect/spawner/lootdrop/f13/weapon/gun/unique = 3
+			/obj/effect/spawner/lootdrop/f13/weapon/gun/unique = 1
 			)
 
 /*	------------------------------------------------


### PR DESCRIPTION
## About The Pull Request

Wrong weapon path guns used on map in Khan Kamp, so I fixed them. Also moved the AK up a loot tier due to its ability to take attachments. Lessened unique spawns.

## Why It's Good For The Game

Balance related issues.

## Changelog
:cl:
balance: Moved AK112, MP5 and unique weapon spawn chances around.
fix: Khan Kamp has been fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
