### PR TITLE
Fixes Grease Gun spawns

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -570,7 +570,7 @@ GLOBAL_LIST_INIT(loot_t3_range, list(
 	/obj/item/ammo_box/magazine/uzim9mm,
 	/obj/item/gun/ballistic/automatic/smg10mm,
 	/obj/item/ammo_box/magazine/m10mm_adv/ext,
-	/obj/item/gun/ballistic/automatic/greasegun,
+	/obj/item/gun/ballistic/automatic/smg/greasegun,
 	/obj/item/ammo_box/magazine/greasegun,
 	/obj/item/gun/ballistic/shotgun/trench,
 	/obj/item/ammo_box/shotgun/buck,

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -633,7 +633,7 @@
 //grease gun
 /datum/crafting_recipe/grease_gun
 	name = "Grease gun"
-	result = /obj/item/gun/ballistic/automatic/greasegun
+	result = /obj/item/gun/ballistic/automatic/smg/greasegun
 	reqs = list(/obj/item/stack/sheet/metal = 10,
 				/obj/item/advanced_crafting_components/receiver = 1,
 				/obj/item/stack/crafting/metalparts = 3

--- a/code/modules/fallout/misc/gang_items.dm
+++ b/code/modules/fallout/misc/gang_items.dm
@@ -183,7 +183,7 @@
 	name = "Grease Gun"
 	id = "greasegun"
 	cost = 150
-	item_path = /obj/item/gun/ballistic/automatic/greasegun
+	item_path = /obj/item/gun/ballistic/automatic/smg/greasegun
 
 
 ///////////////////

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -153,7 +153,7 @@ Captain
 	head =		/obj/item/clothing/head/f13/ncr_cap
 	gloves =	/obj/item/clothing/gloves/f13/leather
 	belt = 		/obj/item/storage/belt/military/assault/ncr/crossbelt
-	l_hand =	/obj/item/gun/ballistic/automatic/greasegun
+	l_hand =	/obj/item/gun/ballistic/automatic/smg/greasegun
 	backpack_contents = list(
 	/obj/item/ammo_box/magazine/greasegun=3,
 	/obj/item/gun/ballistic/automatic/pistol/deagle=1,

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -532,7 +532,7 @@ Outlaw
 	head = /obj/item/clothing/head/helmet/skull
 	shoes = /obj/item/clothing/shoes/jackboots
 	uniform = /obj/item/clothing/under/jabroni
-	l_hand = /obj/item/gun/ballistic/automatic/greasegun
+	l_hand = /obj/item/gun/ballistic/automatic/smg/greasegun
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/greasegun=3,
 		/obj/item/megaphone=1,

--- a/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
@@ -119,7 +119,7 @@
 	health = 170
 	extra_projectiles = 3
 	projectiletype = /obj/item/projectile/bullet/c45/op
-	loot = list(/obj/effect/mob_spawn/human/corpse/raiderboss, /obj/item/gun/ballistic/automatic/greasegun)
+	loot = list(/obj/effect/mob_spawn/human/corpse/raiderboss, /obj/item/gun/ballistic/automatic/smg/greasegun)
 
 /mob/living/simple_animal/hostile/raider/ranged/boss/Aggro()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Many places where the grease gun is supposed to be in loadouts and mob loot are still using the old path for the gun, and spawning an 'automatic gun template' instead of a grease gun. This PR fixes that.

## Why It's Good For The Game

Fixes bug.

## Changelog
:cl:
fix: Grease gun spawns normally and can be crafted again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
