### PR TITLE
Revolver n' Maxson

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -370,7 +370,7 @@
 	item_state = "gun"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/shotgunrevolver
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
-	fire_delay = 10
+	fire_delay = 3.5
 	w_class = WEIGHT_CLASS_SMALL
 	weapon_weight = WEAPON_LIGHT
 	spread = 40

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -669,6 +669,6 @@
 	id = "maxson_5mm"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 20000, /datum/material/plastic = 10000, /datum/material/glass = 10000, /datum/material/titanium = 15000)
-	build_path = /obj/item/modkit/maxson
+	build_path = /obj/item/modkit/maxson_c5mm
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY


### PR DESCRIPTION
## About The Pull Request

Changes the firedelay on the Judge shotgun revolver as well as fixes the Maxson's 5mm conversion kit not printing.

## Why It's Good For The Game

Judge shotgun revolver was basically trash due to being hard-nerfed. Due to the delay in shooting people now point blank it's nowhere near as bad anymore. 

## Changelog
:cl:
balance: Edits Judge revolver from 10 fire delay to 3.5
fixes: Maxson 5mm conversion kit is printable now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
