### PR TITLE
Changes to burn wounds

### DIFF
--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -31,7 +31,7 @@
 /datum/wound/burn/handle_process()
 	. = ..()
 	if(strikes_to_lose_limb == 0)
-		victim.adjustToxLoss(0.5)
+		///victim.adjustToxLoss(0.5) Toxin damage shouldn't happen only on septic limbs that are completely dead.
 		if(prob(1))
 			victim.visible_message("<span class='danger'>The infection on the remnants of [victim]'s [limb.name] shift and bubble nauseatingly!</span>", "<span class='warning'>You can feel the infection on the remnants of your [limb.name] coursing through your veins!</span>")
 		return
@@ -97,6 +97,10 @@
 			else if(prob(4))
 				victim.adjustToxLoss(1)
 		if(WOUND_INFECTION_SEPTIC to INFINITY)
+			victim.adjustToxLoss(0.5) //When the infection is septic, toxin damage isn't a role of the dice anymore, it's happening.
+			if (limb.body_zone == BODY_ZONE_HEAD || limb.body_zone == BODY_ZONE_CHEST) //These limbs will never be permanently destroyed, but they've got vital organs. When they reach septic level, they deal triple the toxin damage.
+				victim.adjustToxLoss(1)
+				return
 			if(prob(infestation))
 				switch(strikes_to_lose_limb)
 					if(3 to INFINITY)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -499,7 +499,7 @@
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)
 			var/vol = reac_volume + M.reagents.get_reagent_amount(/datum/reagent/medicine/synthflesh)
 			//Has to be at less than THRESHOLD_UNHUSK burn damage and have 100 synthflesh before unhusking. Corpses dont metabolize.
-			if(HAS_TRAIT_FROM(M, TRAIT_HUSK, "burn") && M.getFireLoss() < THRESHOLD_UNHUSK && (vol > 100))
+			if(HAS_TRAIT_FROM(M, TRAIT_HUSK, "burn") && M.getFireLoss() < THRESHOLD_UNHUSK && (vol > 99))
 				M.cure_husk("burn")
 				M.visible_message("<span class='nicegreen'>Most of [M]'s burnt off or charred flesh has been restored.")
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes how burn wounds work, especially for the head and chest. Currently there is an issue of people's chest and head burns becoming septic and killing the limb entirely, such that the only fix is augmenting them since you can't use normal amputation/prosthetic replacement on them. That's fine for citadel, with its easy and consistent access to cyborg parts, not so fine here. With this change, the chest and head can never be killed entirely through sepsis, but having septic infections in the chest and head will deal much more toxin damage due to the critical organs there. Arms and legs can still be lost through sepsis and will need to be amputated if that occurs. A note for medical: because the head and chest can never be truly lost through sepsis, the infection value can get very high, and the toxin damage from those infections is significant. Make sure to keep your patient on a steady stream of anti-toxin or something else that will keep the toxin damage down (without undoing your work to sanitize the infection). 

Also makes it so that giving someone exactly 100u of synthflesh will unhusk them as intended (as opposed to needing 101u).

## Why It's Good For The Game

Wounds that make a limbs you can't safely amputate completely unusable and constantly toxic unless you replace it with a robotic part only available to tech factions is realistic, but not very fun. This makes those wounds still significant, still need a doctor's attention, but not untreatable.

## Changelog
:cl:
tweak: made 0.5 toxin damage consistently happen when a limb is septic, rather than doing no toxin damage while waiting for the limb to be fully dead
change: made it impossible to lose head and chest through infection, but increases toxin damage from septic head/chest infection to a total 1.5
fix: changed unhusking to require >99 rather than >100 synthflesh in the body. Didn't use >=100 because I wasn't sure if it would tick down to 99.x before triggering unhusking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
