### PR TITLE
Magnum Buck - Damage Values

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -192,7 +192,7 @@ Snowflake Rounds (Fire, meteor,etc)				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/pellet/magnum_buckshot
 	name = "magnum buckshot pellet"
-	damage = 15
-	armour_penetration = 0.15
+	damage = 13
+	armour_penetration = 0.17
 	wound_bonus = 10
 	bare_wound_bonus = 10


### PR DESCRIPTION
## About The Pull Request

Apperantly 0.15 wasn't enough to pen PA. So magnum buck lost some damage so it can now penetrate PA instead of being deflected.

## Why It's Good For The Game

Balancing an unintended issue with Magnum buck post-ammo rework.

## Changelog
:cl:
fixes: Magnum buck penetration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
