### PR TITLE
(DNM) BoS Minibunker and main bunker changes (please nobody overwrite this or I will cry)

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -290,7 +290,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/cell_charger,
 /obj/structure/table/wood,
-/obj/item/gun/ballistic/automatic/greasegun,
+/obj/item/gun/ballistic/automatic/smg/greasegun,
+/obj/item/ammo_box/magazine/greasegun,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "ayF" = (
@@ -368,6 +369,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/bunker)
+"aFD" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "aFT" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -662,6 +669,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
+"beb" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "bew" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -1634,6 +1649,13 @@
 /obj/item/clothing/suit/f13/mfp/raider,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"cPS" = (
+/obj/structure/table/optable/abductor,
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "cQc" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13{
@@ -3301,6 +3323,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"fGP" = (
+/obj/item/suppressor,
+/obj/structure/table/abductor,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "fHR" = (
 /obj/structure/table/wood,
 /obj/machinery/light/broken{
@@ -4118,6 +4147,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
+<<<<<<< Updated upstream
+=======
+"gTx" = (
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/underground/cave)
+>>>>>>> Stashed changes
 "gTD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5685,6 +5720,16 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/bunker)
+"jjx" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "bosmini";
+	name = "To the Main Bunker"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "jjM" = (
 /obj/structure/decoration/rag,
 /obj/structure/girder/reinforced,
@@ -5896,6 +5941,15 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"jDX" = (
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/obj/structure/table/abductor,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "jEL" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -6383,6 +6437,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
+"ktT" = (
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "ktW" = (
 /obj/item/stack/crafting/electronicparts/five,
 /obj/effect/decal/cleanable/dirt,
@@ -6424,6 +6484,12 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/water,
 /area/f13/bunker)
+"kzG" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "kBU" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -6736,6 +6802,12 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
+"lbB" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "lbV" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating/tunnel{
@@ -7189,6 +7261,16 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"lXS" = (
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "lYw" = (
 /obj/machinery/light,
 /obj/machinery/power/port_gen/pacman/super{
@@ -8019,6 +8101,14 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"nsk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "nsv" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old";
@@ -9690,6 +9780,16 @@
 /obj/structure/junk/small/table,
 /turf/open/water,
 /area/f13/bunker)
+"pXw" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "pYa" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
@@ -11158,6 +11258,15 @@
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"swf" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "swg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden/snowed,
@@ -11902,6 +12011,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"tJD" = (
+/obj/item/blueprint/research,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "tKL" = (
 /obj/structure/debris/v3{
 	pixel_x = -15;
@@ -12108,6 +12223,14 @@
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"ugC" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/structure/table/abductor,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "uiV" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/spider/stickyweb,
@@ -12462,6 +12585,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"uMT" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "uNg" = (
 /obj/structure/table,
 /obj/item/crafting/board,
@@ -13026,6 +13154,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"vFt" = (
+/mob/living/simple_animal/hostile/handy/securitron,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "vGi" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/box,
@@ -13273,6 +13407,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"wbT" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "wbX" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
@@ -13686,6 +13826,14 @@
 	icon_state = "horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
+"wEw" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "wFR" = (
 /obj/effect/spawner/lootdrop/glowstick/no_turf,
 /obj/effect/decal/cleanable/dirt,
@@ -14419,6 +14567,12 @@
 	dir = 4
 	},
 /area/f13/bunker)
+"xNc" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/underground/cave)
 "xNg" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/decoration/rag,
@@ -67904,29 +68058,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+apt
+apt
+apt
+apt
+gTx
+gTx
+gTx
+gTx
+gTx
 heT
 "}
 (208,1,1) = {"
@@ -68161,29 +68315,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+cPS
+vFt
+uMT
+uMT
+jDX
+jzn
+uMT
+uMT
+uMT
+uMT
+kzG
+xNc
+pXw
+apt
+apt
+apt
+apt
+jzn
+uMT
+uMT
+uMT
+gTx
 heT
 "}
 (209,1,1) = {"
@@ -68418,29 +68572,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+ugC
+uMT
+uMT
+uMT
+fGP
+jzn
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+tJD
+apt
+apt
+apt
+apt
+jzn
+uMT
+jjx
+uMT
+gTx
 heT
 "}
 (210,1,1) = {"
@@ -68675,29 +68829,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+nsk
+uMT
+uMT
+uMT
+wbT
+jzn
+ktT
+uMT
+uMT
+uMT
+uMT
+kzG
+uMT
+apt
+apt
+apt
+apt
+jzn
+uMT
+uMT
+uMT
+gTx
 heT
 "}
 (211,1,1) = {"
@@ -68932,29 +69086,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+uMT
+uMT
+uMT
+uMT
+uMT
+jzn
+nsk
+uMT
+uMT
+uMT
+uMT
+uMT
+apt
+apt
+apt
+apt
+apt
+jzn
+nsk
+uMT
+uMT
+gTx
 heT
 "}
 (212,1,1) = {"
@@ -69189,29 +69343,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+jzn
+jzn
+aFD
+jzn
+jzn
+jzn
+uMT
+uMT
+uMT
+uMT
+apt
+apt
+apt
+apt
+apt
+apt
+apt
+jzn
+uMT
+uMT
+uMT
+gTx
 heT
 "}
 (213,1,1) = {"
@@ -69446,29 +69600,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+apt
+apt
+apt
+apt
+apt
+apt
+jzn
+jzn
+aFD
+jzn
+gTx
 heT
 "}
 (214,1,1) = {"
@@ -69703,29 +69857,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+apt
+apt
+apt
+apt
+apt
+jzn
+uMT
+uMT
+uMT
+gTx
 heT
 "}
 (215,1,1) = {"
@@ -69960,29 +70114,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+apt
+uMT
+apt
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+jzn
+jzn
+jzn
+jzn
+jzn
+jzn
+jzn
+jzn
+jzn
+uMT
+uMT
+wbT
+gTx
 heT
 "}
 (216,1,1) = {"
@@ -70217,29 +70371,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+apt
+apt
+apt
+apt
+uMT
+uMT
+uMT
+uMT
+uMT
+jzn
+beb
+uMT
+uMT
+uMT
+wEw
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+gTx
 heT
 "}
 (217,1,1) = {"
@@ -70474,29 +70628,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+apt
+apt
+apt
+apt
+apt
+uMT
+uMT
+uMT
+uMT
+aFD
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+lbB
+uMT
+lbB
+uMT
+uMT
+gTx
 heT
 "}
 (218,1,1) = {"
@@ -70731,29 +70885,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+apt
+apt
+apt
+apt
+apt
+uMT
+uMT
+uMT
+uMT
+jzn
+lXS
+uMT
+uMT
+wbT
+uMT
+uMT
+uMT
+uMT
+uMT
+uMT
+swf
+gTx
 heT
 "}
 (219,1,1) = {"
@@ -70988,29 +71142,29 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
+gTx
 heT
 "}
 (220,1,1) = {"

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -630,11 +630,8 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
 "aBq" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/lighter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "aBr" = (
 /obj/structure/simple_door/metal/fence{
@@ -647,6 +644,9 @@
 "aBv" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -717,7 +717,7 @@
 "aFi" = (
 /obj/structure/table/wood,
 /obj/item/pda/captain{
-	name = "Head Paladin PipBoy"
+	name = "Head Paladin Pip-Boy 3000"
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
@@ -834,12 +834,12 @@
 	},
 /area/f13/brotherhood/operations)
 "aJS" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "aKg" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
@@ -938,14 +938,7 @@
 /turf/open/floor/grass,
 /area/f13/tunnel)
 "aSn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
-	req_access_txt = "120"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "aSs" = (
@@ -955,7 +948,6 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "aSD" = (
-/obj/effect/decal/cleanable/insectguts,
 /obj/structure/fence/handrail{
 	density = 0;
 	dir = 4;
@@ -1462,20 +1454,6 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bpk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/power/smes/engineering,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "bpl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1822,19 +1800,7 @@
 	dir = 9
 	},
 /area/f13/tunnel)
-"bEL" = (
-/obj/effect/decal/cleanable/robot_debris,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "bES" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -1847,12 +1813,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "bFo" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor{
+	icon_state = "floordirty"
+	},
 /area/f13/brotherhood/reactor)
 "bFP" = (
 /obj/structure/grille,
@@ -1927,6 +1894,9 @@
 	},
 /area/f13/brotherhood/operations)
 "bJc" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floordirty"
 	},
@@ -2232,7 +2202,7 @@
 /area/f13/tunnel)
 "ccy" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floordirty"
@@ -2378,7 +2348,6 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/medical)
 "ckm" = (
-/obj/effect/decal/remains/human,
 /obj/machinery/light/small{
 	dir = 8;
 	light_color = "#d8b1b1"
@@ -2443,14 +2412,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
-	},
+/obj/machinery/power/port_gen/pacman/super,
 /obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "cmZ" = (
 /turf/open/floor/plasteel/floorgrime,
@@ -2715,13 +2679,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"cur" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "cus" = (
 /obj/structure/toilet{
 	dir = 1
@@ -2813,11 +2770,6 @@
 /obj/structure/debris/v3,
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
-"cyU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "cyX" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2935,13 +2887,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "cGI" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
-	},
 /obj/item/pen/fountain/captain{
 	name = "elder's fountain pen"
 	},
+/obj/structure/table/plasmaglass,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "cGZ" = (
@@ -3066,8 +3015,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cNb" = (
-/obj/structure/filingcabinet/employment,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/filingcabinet,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "cNd" = (
@@ -3099,12 +3047,14 @@
 	},
 /area/f13/brotherhood/operations)
 "cOh" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "cOn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3428,9 +3378,6 @@
 "deM" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/generic,
-/obj/structure/sign/poster/prewar/poster89{
-	pixel_x = 32
-	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "deT" = (
@@ -3788,11 +3735,8 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dxx" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
-	},
 /obj/item/documents/syndicate/blue,
+/obj/structure/table/plasmaglass,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "dxL" = (
@@ -3874,16 +3818,13 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "dBY" = (
+/obj/machinery/power/terminal,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "dCc" = (
@@ -3913,6 +3854,9 @@
 /area/f13/brotherhood/rnd)
 "dDD" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
 	dir = 8
 	},
@@ -5684,9 +5628,15 @@
 /turf/open/floor/wood,
 /area/f13/followers)
 "fai" = (
-/obj/structure/safe/floor,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "faq" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
@@ -6290,35 +6240,18 @@
 	},
 /area/f13/brotherhood/operations)
 "fDt" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "fDw" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"fDA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/power/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "fEj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_t,
@@ -6450,15 +6383,12 @@
 	},
 /area/f13/tunnel)
 "fJz" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -7147,15 +7077,6 @@
 	},
 /area/f13/tunnel)
 "gqI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -7239,9 +7160,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -8203,6 +8121,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -9075,7 +8996,6 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "hZE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -9165,8 +9085,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "icI" = (
-/obj/effect/decal/cleanable/ash/snappop_phoenix,
-/obj/item/cigbutt/cigarbutt,
 /obj/machinery/button/door{
 	id = "kcdorm";
 	normaldoorcontrol = 1;
@@ -9430,9 +9348,6 @@
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
 /obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/pda/heads/hos{
-	name = "Head Knight's PDA"
-	},
 /obj/item/storage/briefcase,
 /obj/item/clothing/suit/armor/vest/capcarapace/syndicate{
 	desc = "A sinister looking vest of advanced armor worn over a black and red fireproof jacket. The gold collar and shoulders denote that this belongs to a high ranking officer of some lost prewar army.";
@@ -9447,6 +9362,9 @@
 /obj/structure/closet/cabinet{
 	anchored = 1;
 	name = "formal attire cabinet"
+	},
+/obj/item/pda/heads/ce{
+	name = "Knight Captain Pip-Boy 3000"
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
@@ -9697,15 +9615,15 @@
 	},
 /area/f13/tunnel)
 "iEy" = (
-/obj/structure/frame/machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/power/terminal,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light/small{
-	dir = 1
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -10208,11 +10126,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "iZi" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/machinery/door/airlock/hatch{
+	name = "Power Stores";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "iZB" = (
 /obj/structure/simple_door/bunker{
@@ -11002,7 +10923,7 @@
 "jMh" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/pda/heads/cmo{
-	name = "Head Scribe PipBoy"
+	name = "Head Scribe Pip-Boy 3000"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -11557,7 +11478,6 @@
 /obj/item/reagent_containers/food/drinks/mug/coco{
 	pixel_y = 5
 	},
-/obj/effect/decal/cleanable/robot_debris/up,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "kmY" = (
@@ -11575,16 +11495,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/brotherhood/rnd)
-"koc" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "kpo" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -12248,15 +12158,11 @@
 	},
 /area/f13/brotherhood/mining)
 "kTw" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kTx" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/cable{
@@ -12847,12 +12753,9 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "luj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
@@ -13284,7 +13187,7 @@
 /obj/item/clothing/accessory/bos/elder,
 /obj/item/clothing/suit/f13/elder,
 /obj/item/pda/heads/hop{
-	name = "Elder's PDA"
+	name = "Elder's Pip-Boy 3000"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
@@ -13536,9 +13439,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "mnk" = (
@@ -14924,6 +14824,7 @@
 /area/f13/ncr)
 "nuP" = (
 /obj/machinery/workbench/pa,
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -15025,10 +14926,7 @@
 	},
 /area/f13/tunnel)
 "nDb" = (
-/obj/structure/table/abductor{
-	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
-	name = "Table 3"
-	},
+/obj/structure/table/plasmaglass,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "nDc" = (
@@ -15314,18 +15212,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "nNC" = (
-/obj/structure/frame/machine,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -15358,11 +15250,11 @@
 /obj/structure/closet/secure_closet/contraband/armory{
 	req_access_txt = "120"
 	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
@@ -15557,12 +15449,8 @@
 	},
 /area/f13/sewer)
 "nXE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "nXG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase/manuals/engineering,
@@ -15625,6 +15513,9 @@
 	name = "Power"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/reactor)
 "oaf" = (
@@ -15939,7 +15830,7 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/leisure)
 "omY" = (
-/obj/structure/bookcase/manuals/engineering,
+/obj/machinery/workbench/pa,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "onY" = (
@@ -17209,7 +17100,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "ppq" = (
-/obj/structure/decoration/vent,
+/obj/structure/fireaxecabinet,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
 "pqw" = (
@@ -17555,16 +17446,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "pDy" = (
-/obj/structure/fence/handrail{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
-	},
 /turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/area/f13/caves)
 "pDM" = (
 /obj/structure/window/reinforced/spawner{
 	color = "#777777";
@@ -17662,7 +17545,7 @@
 	},
 /area/f13/brotherhood/mining)
 "pKf" = (
-/obj/structure/closet/crate/bin,
+/obj/machinery/workbench/pa,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/offices1st)
 "pKx" = (
@@ -17729,7 +17612,6 @@
 /area/f13/ncr)
 "pNS" = (
 /obj/machinery/autolathe/ammo,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -17765,22 +17647,22 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/leisure)
 "pOV" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Power Stores";
+/obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pPa" = (
-/obj/effect/decal/cleanable/oil,
-/obj/machinery/workbench/pa,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "bosmini";
+	name = "To the Ancient Section"
 	},
-/area/f13/brotherhood/rnd)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "pPS" = (
 /obj/structure/destructible/clockwork/wall_gear,
 /obj/item/projectile/magic/animate,
@@ -18510,7 +18392,6 @@
 /obj/structure/decoration/vent{
 	layer = 2
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/lattice{
 	density = 1
 	},
@@ -18759,6 +18640,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -19140,7 +19024,6 @@
 	},
 /area/f13/brotherhood/rnd)
 "qPO" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -20275,7 +20158,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "rIh" = (
-/obj/effect/decal/cleanable/robot_debris/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/flag/bos,
 /obj/structure/lattice{
@@ -20656,9 +20538,6 @@
 	name = "Backup Power";
 	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "rWD" = (
@@ -20917,15 +20796,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "shn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "shO" = (
 /obj/structure/closet/crate/large,
 /obj/effect/decal/cleanable/dirt,
@@ -21475,13 +21350,10 @@
 	pixel_y = 23;
 	start_charge = 500
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "sLj" = (
@@ -22261,7 +22133,6 @@
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
 /obj/item/clothing/head/f13/boscap,
 /obj/item/clothing/head/f13/boscap,
 /obj/item/clothing/head/f13/boscap,
@@ -22271,8 +22142,6 @@
 /obj/item/clothing/head/f13/boscap,
 /obj/item/clothing/head/f13/boscap,
 /obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/gloves/color/white/bos,
 /obj/item/clothing/gloves/color/white/bos,
 /obj/item/clothing/gloves/color/white/bos,
 /obj/item/clothing/gloves/color/white/bos,
@@ -22286,10 +22155,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"twE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "txg" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/fountain{
@@ -23560,11 +23425,9 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "uzk" = (
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -23594,13 +23457,6 @@
 "uBh" = (
 /turf/open/floor/carpet/royalblack,
 /area/f13/tunnel)
-"uBs" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "uBO" = (
 /obj/machinery/light{
 	dir = 1
@@ -24209,6 +24065,9 @@
 	start_charge = 500
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "vdg" = (
@@ -25054,15 +24913,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"vMV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
-/area/f13/brotherhood/reactor)
 "vNw" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood{
@@ -25457,11 +25307,6 @@
 	desc = "Oh fuck, did Envy Sin sit here?";
 	name = "imprinted stool"
 	},
-/obj/item/toy/figure/warden{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel. Something's not Wright about this one.";
-	name = "Knight Action Figure";
-	toysay = "Steel be with you."
-	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "wdF" = (
@@ -25823,17 +25668,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"wzV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "wAe" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	icon_state = "neutralrusty"
@@ -26320,12 +26154,11 @@
 /area/f13/tunnel)
 "wWV" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "wXp" = (
@@ -26390,9 +26223,6 @@
 	},
 /area/f13/tunnel)
 "wZZ" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = 30
-	},
 /obj/structure/noticeboard{
 	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Head Knight on duty.";
 	dir = 4;
@@ -26493,7 +26323,6 @@
 "xcF" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
-/obj/effect/decal/cleanable/generic,
 /obj/item/toy/figure/warden{
 	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
 	name = "Head Knight Action Figure";
@@ -26570,18 +26399,6 @@
 "xfh" = (
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"xfP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "xfS" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
@@ -26913,16 +26730,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "xqA" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "xqB" = (
@@ -26971,10 +26783,6 @@
 	},
 /area/f13/clinic)
 "xvW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "xwT" = (
@@ -27203,7 +27011,7 @@
 	},
 /area/f13/tunnel)
 "xIg" = (
-/obj/structure/filingcabinet/employment,
+/obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "xIk" = (
@@ -82526,9 +82334,9 @@ vhq
 xmk
 fjt
 fjt
-shn
+qOm
 rWs
-euq
+aSn
 xvW
 mOz
 wGi
@@ -82541,8 +82349,8 @@ cql
 efF
 efF
 efF
-cql
-cOh
+fai
+fjt
 fjt
 eaX
 xmk
@@ -82783,23 +82591,23 @@ qIU
 xmk
 sJS
 luj
-kTw
+fjt
 xmk
 lGB
-cur
-euq
+xvW
+aSn
 gwf
-euq
-euq
+aSn
+aSn
 cSY
-efF
-efF
-iZi
 fjt
 fjt
 fjt
 fjt
-nXE
+fjt
+fjt
+fDt
+fjt
 fjt
 qTH
 xmk
@@ -83038,7 +82846,7 @@ xhA
 xhA
 xhA
 xmk
-bFo
+fjt
 fJz
 cmS
 xmk
@@ -83051,12 +82859,12 @@ fWj
 bVA
 wDb
 xaL
-nXE
+fjt
 qOm
 oDs
 xmk
+iZi
 xmk
-aSn
 dXQ
 xmk
 xmk
@@ -83252,7 +83060,7 @@ vYw
 nYR
 oGI
 ipv
-fai
+vYw
 xkr
 bCf
 vYw
@@ -83299,8 +83107,8 @@ tHw
 ira
 tCG
 xmk
-twE
-twE
+xvW
+xvW
 ogl
 ogl
 ogl
@@ -83542,7 +83350,7 @@ xCc
 xhA
 iMA
 pqC
-pPa
+pqC
 qWx
 hti
 tRa
@@ -83557,22 +83365,22 @@ rPg
 xhA
 xmk
 hZE
-twE
+xvW
 ogl
 ogl
 ogl
-cyU
+gqI
 xmk
 dXx
 fjt
-nXE
+fjt
 fjt
 rQj
 xmk
 dBY
 xqA
 wWV
-wzV
+xvW
 xmk
 xmk
 uoO
@@ -83813,23 +83621,23 @@ xhA
 mgz
 xhA
 xmk
-twE
-twE
+xvW
+xvW
 ogl
 ogl
 ogl
-twE
+xvW
 xmk
 nXG
 tzW
-nXE
+fjt
 rPL
 eGO
 xmk
-bEL
+dBY
 uzk
-mna
-xfP
+wWV
+xvW
 xmk
 xmk
 uoO
@@ -84070,23 +83878,23 @@ xhA
 sll
 xhA
 xmk
-twE
-twE
+xvW
+xvW
 ogl
 ogl
 ogl
-twE
+xvW
 xmk
 qkC
 aNY
-aJS
+rQj
 fgE
 qwV
 xmk
 nNC
-koc
-fDA
-bpk
+xqA
+wWV
+gqI
 xmk
 skp
 uoO
@@ -84282,7 +84090,7 @@ fEj
 vmz
 geA
 nKk
-aBq
+jGX
 vYw
 mDU
 qrJ
@@ -84328,11 +84136,11 @@ sll
 xhA
 xmk
 hZE
-twE
+xvW
 ogl
 ogl
 ogl
-cyU
+gqI
 xmk
 dNP
 gpq
@@ -84341,8 +84149,8 @@ ieR
 cby
 xmk
 xmk
-pOV
-dXQ
+xmk
+iZi
 xmk
 xmk
 xmk
@@ -84584,16 +84392,16 @@ xhA
 nkS
 xhA
 xmk
-twE
-twE
+xvW
+xvW
 ogl
 ogl
 ogl
-twE
+xvW
 xmk
 aby
 dDD
-vMV
+nir
 nir
 nir
 qkn
@@ -84827,7 +84635,7 @@ liM
 xhA
 rEj
 pqC
-nuP
+pqC
 qWx
 ycI
 jag
@@ -84841,15 +84649,15 @@ xhA
 vcT
 xhA
 xmk
-twE
-twE
+xvW
+xvW
 bES
-twE
+xvW
 bES
-twE
+xvW
 xmk
 xbA
-jBw
+bFo
 jBw
 dOc
 dJM
@@ -85050,7 +84858,7 @@ dvP
 eVi
 cNb
 agk
-oGI
+aBq
 tGP
 jGX
 nKk
@@ -85363,7 +85171,7 @@ xhA
 xhA
 iVh
 oHu
-qLd
+kFI
 qLd
 rCc
 xhA
@@ -85620,7 +85428,7 @@ xhA
 xhA
 pXY
 oHu
-qLd
+kFI
 rCi
 aYi
 xhA
@@ -85877,7 +85685,7 @@ cnl
 jlW
 lTA
 akl
-qLd
+kFI
 qLd
 aSD
 xhA
@@ -86134,7 +85942,7 @@ cPr
 jlW
 lTA
 oHu
-qLd
+kFI
 qLd
 tdP
 wHL
@@ -86648,7 +86456,7 @@ lTA
 hSU
 rIh
 jUC
-xpu
+cOh
 xpu
 ayV
 sgi
@@ -87931,7 +87739,7 @@ iOq
 xhA
 hSU
 cxO
-uBs
+lTA
 jVB
 kFI
 qLd
@@ -88449,7 +88257,7 @@ lTA
 oHu
 kFI
 qLd
-pDy
+aYi
 xhA
 eFG
 uAc
@@ -89987,7 +89795,7 @@ fuO
 xEu
 xEu
 xhA
-uBs
+lTA
 oHu
 kFI
 qLd
@@ -90248,7 +90056,7 @@ qqE
 akl
 kFI
 qLd
-fDt
+aYi
 xhA
 qth
 uAc
@@ -90478,7 +90286,7 @@ vrD
 jMh
 rfs
 enh
-gul
+aJS
 gul
 vyW
 oUj
@@ -91027,13 +90835,13 @@ uAc
 uAc
 uAc
 iZQ
+kTw
 xVz
 xVz
 xVz
 xVz
 xVz
-xVz
-mED
+shn
 aoj
 uoO
 uoO
@@ -91289,10 +91097,10 @@ xVz
 xVz
 xVz
 xVz
-uoO
-uoO
 aoj
-uoO
+aoj
+aoj
+aoj
 uoO
 uoO
 aoj
@@ -91546,8 +91354,8 @@ xVz
 xVz
 xVz
 xVz
-uoO
-uoO
+aoj
+aoj
 aoj
 aoj
 uoO
@@ -91798,11 +91606,11 @@ uAc
 uAc
 uAc
 iZQ
+kTw
 xVz
 xVz
 xVz
-aoj
-aoj
+xVz
 uoO
 uoO
 aoj
@@ -92055,11 +91863,11 @@ eXD
 ohN
 uAc
 uAc
-xVz
-xVz
-uoO
-aoj
-aoj
+nXE
+nXE
+pOV
+nXE
+nXE
 uoO
 uoO
 uoO
@@ -92312,11 +92120,11 @@ mAv
 bVi
 uAc
 uAc
-xVz
-aoj
-aoj
-aoj
-aoj
+pDy
+pDy
+pDy
+pDy
+pDy
 uoO
 uoO
 uoO
@@ -92569,11 +92377,11 @@ uAc
 uAc
 uAc
 brh
-mED
-aoj
-aoj
-uoO
-uoO
+pDy
+pDy
+pDy
+pDy
+pDy
 uoO
 uoO
 uoO
@@ -92826,11 +92634,11 @@ brh
 brh
 brh
 brh
-eLE
-uoO
-uoO
-uoO
-uoO
+pDy
+pDy
+pPa
+pDy
+pDy
 uoO
 uoO
 uoO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new minibunker for the BoS that allows them to earn the first three GnB books like everyone else, as well as some other useful things. Moved the alien alloys that were in the elder's room to the end of the bunker so we actually have to do some work for our overpowered tools, also added a suppressor to the end and a mysterious blueprint to the middle so we get some benefits to adjust for the effort needed to get what we had for free before. Redid the QoL changes I made to the main bunker before that got overwritten and made some more. Changed the Knight Captain pip-boy to be a CE model which actually has some functionality rather than the useless (and somewhat lore-breaking, with security records on everyone in the wastes) HoS model. Fixed a grease gun in the NCR minibunker that had its typepath broken

Power room (improved a bit on my previous design)
![BoS Power](https://user-images.githubusercontent.com/29682682/135702545-83270af2-9e56-4208-b486-f7db89211a24.png)
Minibunker (Random weapon and melee weapon spawn, the box spawns are medical items, there's two stims in that pile. Entrance to the minibunker is just outside the mining exit.)
![BoS Mini](https://user-images.githubusercontent.com/29682682/135702548-058e7828-ef3a-4e0f-bfaa-25f1af65b979.png)

## Why It's Good For The Game

Allows the BoS to get all three of the GnB books with a similar amount of effort to what other factions have to put in, plus some other bonuses. 

## Changelog
:cl:
Add: Minibunker for the BoS
Add: PA stands to the Head Paladin and Knight Captain rooms
Removed: Two PA stands from the workshop, they're really extraneous
Removed: GnB 3 from the BoS armory
Tweak: Elder's office tables changed to plasmaglass
Tweak: BoS heads Pip-boy names standardized to be in line with other pip-boys
Tweak: Cleanup of KC's office and moving of fire axe to not be grabbable from outside
Tweak: Other minor cleanup and QoL improvements
Tweak: Changed BoS power setup to be not made of spaghetti and Knight tears
Fix: Static greaser spawn in NCR Minibunker that was using an invalid typepath.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
