### PR TITLE
Small Inventing Balance

### DIFF
--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -1092,19 +1092,19 @@
 
 	var/obj/item/item
 
-	var/list/vhigh = list(/obj/item/melee/powerfist, /obj/item/nullrod/claymore/chainsaw_sword)
+	var/list/vhigh = list(/obj/item/melee/powerfist, /obj/item/nullrod/claymore/chainsaw_sword, /obj/item/twohanded/thermic_lance)
 
 	var/list/high = list(/obj/item/shishkebabpack, /obj/item/gun/energy/gammagun, /obj/item/clothing/suit/armor/f13/sulphitearmor,
 	/obj/item/clothing/head/helmet/f13/sulphitehelm, /obj/item/melee/powerfist/moleminer, /obj/item/circuitboard/machine/chem_master,
 	/obj/item/circuitboard/machine/cell_charger)
 
 	var/list/mid = list(/obj/item/twohanded/fireaxe/bmprsword, /obj/item/twohanded/sledgehammer, /obj/item/shield/makeshift,/obj/item/gun/ballistic/automatic/autopipe,
-	/obj/item/gun/ballistic/rifle/lasmusket, /obj/item/gun/ballistic/rifle/plasmacaster, /obj/item/clothing/suit/armor/f13/metalarmor,
+	/obj/item/grenade/homemade/dynamite, /obj/item/clothing/suit/armor/f13/metalarmor, /obj/item/gun/ballistic/rifle/mosin, /obj/item/gun/ballistic/rifle/mag/varmint,
 	/obj/item/clothing/head/helmet/f13/raider/eyebot, /obj/item/clothing/head/helmet/knight/f13/metal/reinforced)
 
-	var/list/low = list(/obj/item/gun/ballistic/revolver/zipgun,/obj/item/gun/ballistic/revolver/pipe_rifle,/obj/item/fishingrod,/obj/item/grenade/homemade/firebomb,
+	var/list/low = list(/obj/item/gun/ballistic/rifle/lasmusket,/obj/item/gun/ballistic/revolver/pipe_rifle,/obj/item/fishingrod,/obj/item/grenade/homemade/firebomb,
 	/obj/item/clothing/suit/armor/f13/slam, /obj/item/clothing/suit/armor/f13/raider/raidermetal,/obj/item/clothing/head/helmet/f13/raidermetal,
-	/obj/item/clothing/head/helmet/knight/f13/metal, /obj/item/melee/unarmed/punchdagger)
+	/obj/item/clothing/head/helmet/knight/f13/metal, /obj/item/gun/ballistic/rifle/plasmacaster)
 
 	if(prob(60))
 		item = pick(low)


### PR DESCRIPTION
## About The Pull Request

Redoes the drops on the inventing kit a good bit.

Plasma musket and laser musket replace the zipgun at the lower tier drops - because why give those if the literal garbage piles give better guns.

Mosin has been added as well as the varmint rifle to the mid-tier alongside dynamite. 

Very high has received the thermal lance.

## Why It's Good For The Game

Overall the inventing system is OK but still will require changes after this. Overall inventing should give you low-gear, equivalent to a trashpile or surface building loot spawn, to high/very high which should theoretically be mid-grade bunker loot.

## Changelog
:cl:
balances: Inventing stuff moved around; Mosin, thermal lance, varmint rifle and dynamite added - zip gun removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
