### PR TITLE
Automatic train calling

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -62,6 +62,7 @@
 #define ADMIN_COORDJMP(src) "[src ? "[COORD(src)] [ADMIN_JMP(src)]" : "nonexistent location"]"
 #define ADMIN_VERBOSEJMP(src) "[src ? "[AREACOORD(src)] [ADMIN_JMP(src)]" : "nonexistent location"]"
 #define ADMIN_INDIVIDUALLOG(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];individuallog=[REF(user)]'>LOGS</a>)"
+#define ADMIN_RECALL(user) "<a href='?_src_=holder;[HrefToken(TRUE)];adminrecall=[REF(user)]'>Cancel Train</a>"
 
 #define ADMIN_PUNISHMENT_LIGHTNING "Lightning bolt"
 #define ADMIN_PUNISHMENT_BRAINDAMAGE "Brain damage"

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -378,16 +378,8 @@ SUBSYSTEM_DEF(vote)
 					if(C)
 						C.post_status("shuttle") // austation end
 	if(restart)
-		var/active_admins = 0
-		for(var/client/C in GLOB.admins)
-			if(!C.is_afk() && check_rights_for(C, R_ADMIN))
-				active_admins = 1
-				break
-		if(!active_admins)
-			SSshuttle.emergency.request()
-		else
-			to_chat(world, "<span style='boldannounce'>Notice:Restart vote will not restart the server automatically because there are active admins on.</span>")
-			message_admins("A restart vote has passed, but there are active admins on with +admin, so it has been canceled. If you wish, you may restart the server.")
+		SSshuttle.emergency.request()
+		message_admins("A restart vote has passed and the train has been automatically called. [ADMIN_RECALL(src)]")
 
 	return .
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2292,6 +2292,13 @@
 			return
 
 		show_individual_logging_panel(M, href_list["log_src"], href_list["log_type"])
+
+	else if(href_list["adminrecall"])
+		if(!check_rights(R_ADMIN))
+			return
+			
+		SSshuttle.emergency.cancel()
+
 	else if(href_list["languagemenu"])
 		if(!check_rights(R_ADMIN))
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This changes the restart vote to autocall the train anytime the restart votes passes. Also adds a handy admin message to quickly recall it for events and the like.

## Why It's Good For The Game

No more hard 1 minute restarts when no higher admins are online, and staff no longer has to come online to call the train when Corvo is AFK.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
server: auto train calling
admin: recall message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
