### PR TITLE
Small recipe edit

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_bottling.dm
+++ b/code/datums/components/crafting/recipes/recipes_bottling.dm
@@ -1,10 +1,9 @@
 /datum/crafting_recipe/bottler
 	name = "Bottle Press"
 	result = /obj/machinery/workbench/bottler
-	reqs = list(/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/crafting/goodparts = 10,
-				/obj/item/stack/cable_coil = 10,
-				/obj/item/wrench = 1)
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 10,
+				/obj/item/stack/crafting/metalparts = 2,
+				/obj/item/crafting/reloader = 1)
 	tools = list(TOOL_WRENCH, TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	time = 80
 	category = CAT_MISC
@@ -46,3 +45,10 @@
 /datum/crafting_recipe/bottle/beerbottle
 	name = "beer bottle"
 	result = /obj/item/reagent_containers/food/drinks/bottle/brown/beer
+
+/datum/crafting_recipe/bottle/metalflask
+	name = "Metal flask"
+	result = /obj/item/reagent_containers/food/drinks/flask
+	reqs = list(/obj/item/stack/sheet/metal = 2,
+				/obj/item/stack/f13Cash = 1)
+

--- a/code/datums/components/crafting/recipes/recipes_throwables.dm
+++ b/code/datums/components/crafting/recipes/recipes_throwables.dm
@@ -95,8 +95,7 @@ datum/crafting_recipe/tomahawk
 	reqs = list(/datum/reagent/fuel = 50,
 				/obj/item/stack/cable_coil = 1,
 				/obj/item/assembly/igniter = 1,
-				/obj/item/stack/sheet/metal = 5,
-				/obj/item/reagent_containers/food/drinks/bottle = 1)
+				/obj/item/reagent_containers/food/drinks/flask = 1)
 	time = 10 SECONDS
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_THROWABLE
@@ -108,7 +107,7 @@ datum/crafting_recipe/tomahawk
 	reqs = list(/datum/reagent/blackpowder = 50,
 				/obj/item/crafting/coffee_pot = 1,
 				/obj/item/stack/cable_coil = 1,
-				/obj/item/crafting/timer = 1,)
+				/obj/item/crafting/timer = 1)
 	time = 15 SECONDS
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_THROWABLE

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -63,56 +63,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
-/*
-/datum/crafting_recipe/stunprod
-	name = "Stunprod"
-	result = /obj/item/melee/baton/cattleprod
-	reqs = list(/obj/item/restraints/handcuffs/cable = 1,
-				/obj/item/stack/rods = 1,
-				/obj/item/assembly/igniter = 1)
-	time = 40
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-
-/datum/crafting_recipe/teleprod
-	name = "Teleprod"
-	result = /obj/item/melee/baton/cattleprod/teleprod
-	reqs = list(/obj/item/restraints/handcuffs/cable = 1,
-				/obj/item/stack/rods = 1,
-				/obj/item/assembly/igniter = 1,
-				/obj/item/stack/ore/bluespace_crystal = 1)
-	time = 40
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-*/
-
-/datum/crafting_recipe/tailclub
-	name = "Tail Club"
-	result = /obj/item/tailclub
-	reqs = list(/obj/item/organ/tail/lizard = 1,
-				/obj/item/stack/sheet/metal = 1)
-	time = 40
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-
-/datum/crafting_recipe/tailwhip
-	name = "Liz O' Nine Tails"
-	result = /obj/item/melee/chainofcommand/tailwhip
-	reqs = list(/obj/item/organ/tail/lizard = 1,
-				/obj/item/stack/cable_coil = 1)
-	time = 40
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-
-/datum/crafting_recipe/catwhip
-	name = "Cat O' Nine Tails"
-	result = /obj/item/melee/chainofcommand/tailwhip/kitty
-	reqs = list(/obj/item/organ/tail/cat = 1,
-				/obj/item/stack/cable_coil = 1)
-	time = 40
-	category = CAT_WEAPONRY
-	subcategory = CAT_MELEE
-
 /datum/crafting_recipe/chainsaw
 	name = "Chainsaw"
 	result = /obj/item/twohanded/chainsaw
@@ -189,9 +139,10 @@
 	name = "Laser musket"
 	result = /obj/item/gun/ballistic/rifle/lasmusket
 	reqs = list(/obj/item/stack/crafting/electronicparts = 2,
-	/obj/item/gun/ballistic/revolver/pipe_rifle = 1,
-	/obj/item/reagent_containers/food/drinks/bottle/f13nukacola = 1,
-	/obj/item/stack/cable_coil = 3)
+		/obj/item/gun/ballistic/revolver/pipe_rifle = 1,
+		/obj/item/reagent_containers/food/drinks/bottle/f13nukacola = 1,
+		/obj/item/stack/cable_coil = 1,
+		/obj/item/trash/f13/electronic/toaster = 1,)
 	tools = list(TOOL_WORKBENCH, TOOL_MULTITOOL)
 	time = 120
 	category = CAT_WEAPONRY
@@ -583,21 +534,6 @@
 	subcategory = CAT_WEAPON
 	always_availible = FALSE
 
-//mg34
-/*
-/datum/crafting_recipe/mg34
-	name = "Maschinengewehr 34"
-	result = /obj/item/gun/ballistic/automatic/mg34
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/advanced_crafting_components/flux = 1,
-				/obj/item/stack/crafting/metalparts = 3
-				)
-	tools = list(TOOL_WORKBENCH)
-	time = 120
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-	always_availible = FALSE
-*/
 //plasma pistol
 /datum/crafting_recipe/plasmapistol
 	name = "plasma pistol"


### PR DESCRIPTION
# About The Pull Request

The ported firebomb lacks its recipe. The flavor text still refers to the metal flask, so just finishes the port I guess.
Recipes adjusted:
Firebomb uses metal flask instead of random glass bottle (in line with sprite, desc, and concept)
Bottler recipe much, much cheaper (Used to be 10!! HQ parts, now mostly wood and a reloader since it got a screw thingy and why not give it a use, makes some sense unlike 50 titanium cost.)
Adds metal flask recipe to bottler (2 metal sheets + 1 cap)
Adds toaster to laser musket recipe (laser musket pretty good, toaster deserves a use)
Removes a few of the unused obsolete legacy recipes thats just useless clutter.

## Changelog
:cl:
tweak: Few recipe edits (bottler, firebomb, lasmusket)
/:cl:

