### PR TITLE
Gun Description Fixes

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -120,8 +120,9 @@
 
 //Beretta M93R							Keywords: 9mm, Automatic, 15 round magazine
 /obj/item/gun/ballistic/automatic/pistol/beretta
-	name = "Beretta M92FS"
-	desc = "One of the more common 9mm pistols, the Beretta is popular due to its reliability. 15 round magazine and good looks; it'll get you far!"
+	name = "Beretta M93R"
+	desc = "One of the surviving Beretta model firearms. With a 15 round magazine and burst fire capability, this Italian handgun is competitive even at 9mm.
+"
 	icon_state = "m93r"
 	mag_type = /obj/item/ammo_box/magazine/m9mmds
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -158,8 +158,8 @@
 ///////////////////////
 
 /obj/item/gun/ballistic/revolver/revolver45
-	name = "Casull Cowboy .45"
-	desc = "A Casull revolver; where its name came from though is a msytery as its origins have been lost to the mists of time."
+	name = "Colt .45"
+	desc = "An old Single Action Army retooled for .45 ACP. Classic Americana, its wooden grip is worn and the steel dark from many years of use, though it is in relatively good condition."
 	item_state = "45revolver"
 	icon_state = "45revolver"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev45


### PR DESCRIPTION
I'm not waiting 6 months for rebase for the .45 to be changed from the ripoff of my ranger pistol description; it genuinely pisses me off. The beretta is just something annoying I noticed. There are probably other gun name/description issues but these were the ones I saw.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If the default .45 name/description change were to be left in for more than a week I would leave the server and take my sprites with me. It's not negotiable for me. It's exactly the kind of thing I said that if it happened when I was working on my ranger revolver project, I would do the same. So this is a fix so I don't have to do so. I made a slightly nicer description for both guns from what they had before the misleading updates as well, so it's not reverting to the apparently intolerable originals.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Fixed the remaining Beretta and default .45 revolver names and descriptions. Rewrote these partially.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
