### PR TITLE
Fixes for R-91 and Revolvers

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -483,7 +483,7 @@ Decanii
 
 /datum/outfit/loadout/primedecmelee
 	name = "Triarius (Melee) Officer"
-	l_hand =	/obj/item/gun/ballistic/revolver/revolver44
+	l_hand =	/obj/item/gun/ballistic/revolver/m29
 	r_hand =	/obj/item/shield/riot/legion
 	backpack_contents = list(
 		/obj/item/twohanded/spear/lance=1,
@@ -721,7 +721,7 @@ Veteran Legionary
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m45/extended=2,
 		/obj/item/attachments/scope=1,
-		/obj/item/gun/ballistic/revolver/revolver44=1,
+		/obj/item/gun/ballistic/revolver/m29=1,
 		/obj/item/ammo_box/m44=2)
 
 /datum/outfit/loadout/vetshock
@@ -808,7 +808,7 @@ Prime Legionairy
 
 /datum/outfit/loadout/primemelee
 	name = "Principes (Melee)"
-	l_hand =	/obj/item/gun/ballistic/revolver/revolver44
+	l_hand =	/obj/item/gun/ballistic/revolver/m29
 	r_hand =	/obj/item/shield/riot/legion
 	backpack_contents = list(
 		/obj/item/twohanded/spear/lance=1,

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -722,7 +722,7 @@
 	/obj/item/stack/f13Cash/caps = 20,
 	/obj/item/clothing/under/singery=1,
 	/obj/item/clothing/shoes/singery=1,
-	/obj/item/gun/ballistic/revolver/detective=1
+	/obj/item/gun/ballistic/revolver/colt6520=1
 	)
 
 /*/datum/outfit/loadout/fancygal
@@ -782,7 +782,7 @@
 	/obj/item/tape=1,
 	/obj/item/clothing/under/f13/bodyguard=1,
 	/obj/item/clothing/shoes/winterboots=1,
-	/obj/item/gun/ballistic/revolver/detective=1,
+	/obj/item/gun/ballistic/revolver/m29=1,
 	/obj/item/lighter=1,
 	/obj/item/storage/fancy/cigarettes/cigars/havana=1
 	)

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -429,12 +429,10 @@ Outlaw
 		/obj/item/storage/bag/money/small/raider=1)
 
 	suit_store = pick(
-		/obj/item/gun/ballistic/revolver/detective, \
+		/obj/item/gun/ballistic/revolver/colt357, \
 		/obj/item/gun/ballistic/rifle/remington, \
-		/obj/item/gun/ballistic/revolver/zipgun, \
 		/obj/item/gun/ballistic/revolver/pipe_rifle, \
-		/obj/item/gun/ballistic/revolver/caravan_shotgun, \
-		/obj/item/gun/ballistic/revolver/single_shotgun)
+		/obj/item/gun/ballistic/revolver/caravan_shotgun)
 
 /datum/outfit/job/wasteland/f13raider/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -525,7 +523,7 @@ Outlaw
 	suit = /obj/item/clothing/suit/armor/f13/raider/desperado
 	mask = /obj/item/clothing/mask/bandana/skull
 	backpack_contents = list(
-		/obj/item/gun/ballistic/revolver/revolver44=2,
+		/obj/item/gun/ballistic/revolver/m29=2,
 		/obj/item/ammo_box/m44=4,
 		/obj/item/kitchen/knife/bowie=1
 		)
@@ -678,7 +676,6 @@ Outlaw
 		/obj/item/storage/bag/money/small/wastelander, \
 		/obj/item/kitchen/knife)
 	suit_store = pick(
-	/obj/item/gun/ballistic/revolver/detective, \
 	/obj/item/gun/ballistic/rifle/remington, \
 	/obj/item/gun/ballistic/revolver/zipgun, \
 	/obj/item/gun/ballistic/revolver/pipe_rifle)
@@ -830,7 +827,7 @@ Outlaw
 	suit = /obj/item/clothing/suit/f13/vest
 	uniform = /obj/item/clothing/under/f13/cowboyb
 	gloves = /obj/item/clothing/gloves/f13/leather
-	l_hand = /obj/item/gun/ballistic/revolver/revolver44
+	l_hand = /obj/item/gun/ballistic/revolver/m29
 	backpack_contents = list(
 		/obj/item/kitchen/knife/combat=1,
 		/obj/item/lighter=1,

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -847,7 +847,7 @@
 	name = "NCR assault carbine"
 	desc = "An assault carbine but with a reinforced stock and scrapped together polymer to it adorned with an NCR flag wrapped around the rifle's butt."
 	icon = 'icons/obj/guns/ballistic/r91.dmi'
-	icon_state = "assault_carbine_ncr"
+	icon_state = "r91_ncr"
 	fire_delay = 5
 	burst_shot_delay = 2.2
 	spread = 2
@@ -865,7 +865,7 @@
 	name = "'Pilum' assault rifle"
 	desc = "What was a perfectly good assault carbine has found itself in a somewhat mutilated state but reinforced with wood furnishing. The gun now sports its new colors and banner well; serving its purpose as an elite gun among Ceasar's ranks."
 	icon = 'icons/obj/guns/ballistic/r91.dmi'
-	icon_state = "assault_carbine_legion"
+	icon_state = "r91_legion"
 	spread = 6
 	fire_delay = 3.5
 	can_scope = FALSE

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -228,7 +228,7 @@
 /obj/item/gun/ballistic/revolver/m29
 	name = ".44 magnum revolver"
 	desc = "Being that this is the most powerful handgun in the world, and can blow your head clean-off, you've got to ask yourself one question. Do I feel lucky? Well, do ya punk? "
-	item_state = "model29"
+	item_state = "colt44"
 	icon_state = "m29"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev44
 	fire_sound = 'sound/f13weapons/44mag.ogg'


### PR DESCRIPTION
## About The Pull Request

Fixed a bunch of sprite issues with the R-91 variants and the revolver templates.

The revolver 44 sprite looked like ass so I replaced it with the now removed single action colt revolver sprite. Looks much nicer.

Also - who thought giving outlaws/wasters zip guns as a possible random chance spawn over a caravan shotgun or revolver was a good idea??

## Why It's Good For The Game

Fixes missing sprites and revolver templates.

The small balance chance is sort of helpful for outlaws and wasters. No more getting, for example, a zipgun instead of a revolver. Or a single shotgun over a caravan. It's stupid to have a chance with spawning with better or less gear instead of gear that can be seen as a trade-off.

## Changelog
:cl:
fixes: Missing sprites fixed.
fixes: No more revolver templates.
fixes: M29 sprite looked bad, replaced with the unused colt44 one.
balance: Mild changes to outlaw and waster loadout. Why give them random chances of starting with worse fucking gear - like a single shotgun instead of a caravan???
/:cl:
