### PR TITLE
NCR Slouch and field cap back into loadouts.

### DIFF
--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -248,3 +248,42 @@
 							"NCR Rear Echelon",
 							"NCR Recruit"
 						)
+
+/datum/gear/head/ncr_flapcap
+	name = "NCR field cap"
+	subcategory = LOADOUT_SUBCATEGORY_HEAD_HATS
+	path = /obj/item/clothing/head/f13/ncr_flapcap
+	restricted_desc = "NCR"
+	restricted_roles = list("NCR Captain",
+							"NCR Commanding Officer",
+							"NCR Medical Officer",
+							"NCR Sergeant First Class",
+							"NCR Sergeant",
+							"NCR Corporal",
+							"NCR Combat Engineer",
+							"NCR Combat Medic",
+							"NCR Trooper",
+							"NCR Rear Echelon",
+							"NCR Recruit"
+						)
+
+/datum/gear/head/ncr_slouch
+	name = "NCR slouch hat"
+	subcategory = LOADOUT_SUBCATEGORY_HEAD_HATS
+	path = /obj/item/clothing/head/f13/ncr_slouch
+	restricted_desc = "NCR"
+	restricted_roles = list("NCR Captain",
+							"NCR Commanding Officer",
+							"NCR Medical Officer",
+							"NCR Sergeant First Class",
+							"NCR Sergeant",
+							"NCR Corporal",
+							"NCR Combat Engineer",
+							"NCR Combat Medic",
+							"NCR Trooper",
+							"NCR Rear Echelon",
+							"NCR Recruit",
+							"NCR Veteran Ranger",
+							"NCR Ranger Sergeant",
+							"NCR Ranger"
+						)


### PR DESCRIPTION
## About The Pull Request

This PR readds NCR Slouch and Field Cap back into the loadout and basically readds it into the loadouts as it was requested by some of the community members and all three NCR LMs said this is fine. So this finally gets readded back.
Tested.

## Why It's Good For The Game

PR adds a bit more flavor for the NCR, atleast 'irregulars' NCR Troopers that can possible roleplayed with. 

## Changelog
:cl:
add: Slouch and Field Cap back into loadouts.
/:cl:

