### PR TITLE
attempts to fix being unable to see your own notes

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -327,7 +327,7 @@ TICKLAG 0.5
 #AUTOMUTE_ON
 
 ## Uncomment this to let players see their own notes (they can still be set by admins only)
-SEE_OWN_NOTES
+#SEE_OWN_NOTES
 
 ### Comment these two out to prevent notes fading out over time for admins.
 ## Notes older then this will start fading out.


### PR DESCRIPTION
## About The Pull Request
unironically adds a single character as to try to make it so everyone can see their own notes and not just admemes - figured this out by comparing fortuna's config to DRs and looking for differences between their SEE_OWN_NOTES flags. with any hope, this'll work
## Why It's Good For The Game
allows people to see their own notes again rather than having to spamping an admeme to see it
## Changelog
- changes unironically a single character in the config