### PR TITLE
Makes NCR facewraps no longer hide face while lowered.

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -429,6 +429,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	flags_inv = HIDEFACE
 	flags_cover = MASKCOVERSMOUTH
+	visor_flags_inv = HIDEFACE
 	visor_flags_cover = MASKCOVERSMOUTH
 	gas_transfer_coefficient = 0.9
 	permeability_coefficient = 0.01


### PR DESCRIPTION
## About The Pull Request
It's just a single line. Does exactly what the title says, NCR face wraps no longer hide your face when you wear them lowered down.

## Why It's Good For The Game

NCR face wraps currently hide your face and flavor text while lowered for some reason. I can't imagine that was intentional- none of the other toggleable face wraps/bandanas seem to do this.

## Changelog
🆑
tweak: NCR facewraps no longer hide your face while lowered.
/:cl: