### PR TITLE
Custom Armor and M14/BAR fix

### DIFF
--- a/code/game/objects/items/modkit.dm
+++ b/code/game/objects/items/modkit.dm
@@ -274,8 +274,8 @@
 
 /obj/item/modkit/deth
 	name = "Midwestern BOS Modkit"
-	target_items = list(/obj/item/clothing/head/helmet/f13/power_armor/t45d,
-						/obj/item/clothing/head/helmet/f13/power_armor/t51b)
+	target_items = list(/obj/item/clothing/suit/armor/f13/power_armor/t45d,
+						/obj/item/clothing/suit/armor/f13/power_armor/t51b)
 	result_item = /obj/item/clothing/suit/armor/f13/power_armor/t45d/deth
 
 /obj/item/modkit/dethelm

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1041,14 +1041,15 @@
 		if(0)
 			select += 1
 			burst_size = 2
-			extra_damage = -3
-			spread = 5
+			extra_damage = 0
+			spread = 4
 			fire_delay = 5
 			recoil = 0.2
 			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")
 		if(1)
 			select = 0
 			burst_size = 1
+			extra_damage = 3
 			spread = 0
 			fire_delay = 4
 			recoil= 0.1
@@ -1075,7 +1076,7 @@
 	can_attachments = FALSE
 	burst_size = 1
 	fire_delay = 6
-	burst_shot_delay = 2.5
+	burst_shot_delay = 2
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 
@@ -1159,6 +1160,7 @@
 	can_attachments = FALSE
 	burst_size = 2
 	fire_delay = 6
+	spread = 6
 	burst_shot_delay = 2.5
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
@@ -1169,15 +1171,15 @@
 		if(0)
 			select = 0
 			burst_size = 2
-			spread = 10
+			spread = 6
 			extra_damage = 0
 			recoil = 0.25
 			to_chat(user, "<span class='notice'>You switch to firing in small-bursts.</span>")
 		if(1)
 			select += 1
 			burst_size = 3
-			spread = 20
-			extra_damage = -2
+			spread = 10
+			extra_damage = -1
 			recoil = 0.5
 			to_chat(user, "<span class='notice'>You switch to full auto.</span>")
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
@@ -1200,9 +1202,10 @@
 	burst_size = 1
 	fire_delay = 8
 	slowdown = 1.5
+	spread = 40
+	extra_damage = -5
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
-	spread = 30
 	var/cover_open = FALSE
 
 /obj/item/gun/ballistic/automatic/m2a1/update_icon()


### PR DESCRIPTION
## About The Pull Request

Fixed some issues with the M14 and BAR firemodes as well as their base stats.

## Why It's Good For The Game

Fixes unintended switching firemode 'features'

## Changelog
:cl:
fixes: M14 and BAR
fixes: Also misc fix to custom armor having a bad path.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
