### PR TITLE
spawn objectives

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -495,6 +495,22 @@ SUBSYSTEM_DEF(job)
 			else
 				handle_auto_deadmin_roles(M.client, rank) */
 
+	if (!job.objectives)//if objectives aren't set yet
+		if(LAZYLEN(job.objectivesList))
+			job.objectives = pick(job.objectivesList)
+		if (job.department_flag == LEGION)
+			job.objectives = job.objectivesList[rand(0,2)]//get a random one from the faction.dm objetives list
+		if (job.department_flag == NCR)
+			job.objectives = job.objectivesList[rand(0,2)]
+		if (job.department_flag == BOS)
+			job.objectives = job.objectivesList[rand(0,2)]
+		if (job.department_flag == VTCC)
+			job.objectives = job.objectivesList[rand(0,2)]
+		if (job.department_flag == TRIBAL)
+			job.objectives = job.objectivesList[rand(0,2)]
+		if (job.department_flag == FOLLOWERS)
+			job.objectives = job.objectivesList[rand(0,2)]
+
 	to_chat(M, "<b>You are the [rank].</b>")
 	if(job)
 		to_chat(M, "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
@@ -502,6 +518,7 @@ SUBSYSTEM_DEF(job)
 		to_chat(M, "<FONT color='blue'><B>[job.description]</b>")
 		to_chat(M, "<FONT color='red'><b>[job.forbids]</b>")
 		to_chat(M, "<FONT color='green'><b>[job.enforces]</b>")
+		to_chat(M, "<FONT color='black'><b>[job.objectives]</b>")
 		if(job.req_admin_notify)
 			to_chat(M, "<b>You are playing a job that is important for Game Progression. If you have to disconnect immediately, please notify the admins via adminhelp. Otherwise put your locker gear back into the locker and cryo out.</b>")
 		if(job.custom_spawn_text)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -501,9 +501,9 @@ SUBSYSTEM_DEF(job)
 		if (job.department_flag == LEGION)
 			job.objectives = job.objectivesList[rand(0,2)]//get a random one from the faction.dm objetives list
 		if (job.department_flag == NCR)
-			job.objectives = job.objectivesList[rand(0,2)]
+			job.objectives = job.objectivesList[rand(0,3)]
 		if (job.department_flag == BOS)
-			job.objectives = job.objectivesList[rand(0,2)]
+			job.objectives = job.objectivesList[rand(0,3)]
 		if (job.department_flag == VTCC)
 			job.objectives = job.objectivesList[rand(0,2)]
 		if (job.department_flag == TRIBAL)

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -12,7 +12,7 @@ Main doors: ACCESS_CAPTAIN 20
 	outfit = /datum/outfit/job/bos/
 	exp_type = EXP_TYPE_BROTHERHOOD
 
-	objectivesList = list("Leadership recommends the following goal for this week: Establish an outpost at the radio tower","Leadership recommends the following goal for this week: Acquire blueprints for research and preservation", "Leadership recommends the following goal for this week: Acquire or confiscate dangerous tech by any means necessary.")
+	objectivesList = list("The Elders recommend the following goal for this week: Establish an outpost at the radio tower and monitor frequencies."," The Elders recommend the following goal for this week: Study technology that can benefit our cause","The Elders recommend the following goal for this week: Acquire or confiscate dangerous technology, adhering to the codex","The Elders recommend the following goal for this week: Open a village topside where wasters can learn of our rightful mission")
 
 /datum/outfit/job/bos
 	name = "bosdatums"
@@ -108,6 +108,7 @@ Head Paladin
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the elder"
 	selection_color = "#7f8c8d"
+	req_admin_notify = 1
 
 	loadout_options = list(
 	/datum/outfit/loadout/sentlead, //Gatling for suppressive fire but holds a cooldown after roughly 30~ rounds fired. Low power, low damage, high rate of fire. Infinate ammo.
@@ -185,6 +186,7 @@ Head Scribe
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the elder"
 	selection_color = "#7f8c8d"
+	req_admin_notify = 1
 
 	loadout_options = list(
 	/datum/outfit/loadout/hssword,
@@ -271,6 +273,7 @@ Knight Captain
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Sentinel"
 	selection_color = "#7f8c8d"
+	req_admin_notify = 1
 
 	loadout_options = list(
 	/datum/outfit/loadout/captech,

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -4,7 +4,7 @@
 	exp_type = EXP_TYPE_FOLLOWERS
 	forbids = "Aligning oneself with a faction exclusively. Acting in an aggressive and violent way on the offensive, not in defense. Abandoning your facility, peers, and community."
 	enforces = "Preaching humanitarianism and valuing human life. Assist and provide medical services to any who require it, regardless of faction. Provide free education for all those who are willing to learn."
-	objectivesList = list("Leadership recommends the following goal for this week: Establish medical outposts throughout the wasteland","Leadership recommends the following goal for this week: Experiment with and improve medical techniques and equipment", "Leadership recommends the following goal for this week: Replenish the operation's funds through donations and sales.")
+	objectivesList = list("Administration recommends the following goal for this week: Establish medical outposts throughout the wasteland","Administration recommends the following goal for this week: Experiment with and improve medical techniques and equipment","Administration recommends the following goal for this week: Replenish the operation's funds through donations and sales")
 
 /datum/outfit/job/followers/
 	name =		"FOLLOWERSdatums"
@@ -48,6 +48,7 @@ Administrator
 	selection_color = "#FF95FF"
 	exp_requirements = 1080
 	exp_type = EXP_TYPE_FOLLOWERS
+	req_admin_notify = 1
 
 	outfit = /datum/outfit/job/followers/f13leadpractitioner
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -7,7 +7,7 @@
 
 	forbids = "The Legion forbids: Ghouls joining the Legion. Women in armed roles. Chems and drugs such as jet or alcohol. Reliance on technology. Lethally harming any servants of Caesar without proper reason."
 	enforces = "The Legion expects: Obeying orders of superiors. A roman style name. Wearing the uniform, unless acting as a nonlethal infiltrator."
-	objectivesList = list("Leadership recommends the following goal for this week: Establish an outpost at the radio tower","Leadership recommends the following goal for this week: Establish patrols and fortifications around the main road", "Leadership recommends the following goal for this week: Acquire and train slaves")
+	objectivesList = list("The Legate recommends the following goal for this week: Establish an outpost at the radio tower","The Legate recommends the following goal for this week: Establish patrols and fortifications around the main road","The Legate recommends the following goal for this week: Acquire and train slaves")
 
 	exp_type = EXP_TYPE_LEGION
 
@@ -204,6 +204,7 @@ Centurion
 	selection_color = "#ffdddd"
 	display_order = JOB_DISPLAY_ORDER_CENTURION
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13centurion
+	req_admin_notify = 1
 
 	loadout_options = list(
 	/datum/outfit/loadout/centstandard,	//Ripper, .223 pistol, most balanced out armor

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -9,7 +9,7 @@
 	minimal_access = list(ACCESS_NCR)
 	forbids = "The NCR forbids: Chem and drug use such as jet or alcohol while on duty. Execution of unarmed or otherwise subdued targets without authorisation."
 	enforces = "The NCR expects: Obeying the lawful orders of superiors. Proper treatment of prisoners.  Good conduct within the Republic's laws. Wearing the uniform."
-	objectivesList = list("Leadership recommends the following goal for this week: Establish an outpost at the radio tower","Leadership recommends the following goal for this week: Neutralize and capture dangerous criminals", "Leadership recommends the following goal for this week: Free slaves and establish good relations with unaligned individuals.")
+	objectivesList = list("High command recommends the following goal for this week: Establish an outpost at the radio tower","High command recommends the following goal for this week: Scout the region for raider activity and detain any individuals breaking NCR law in our territory","High command recommends the following goal for this week: Establish good relations with unaligned individuals and improve the diplomatic standing of the NCR","High command recommends the following goal for this week: Gather funds from the wasteland by providing a service and taxing people")
 
 /datum/outfit/job/ncr/
 	name = "NCRdatums"
@@ -176,6 +176,7 @@ Commanding Officer (Ranges from Lieutenant to Captain)
 	head_announce = list("Security")
 	display_order = JOB_DISPLAY_ORDER_LIEUTENANT
 	outfit = /datum/outfit/job/ncr/f13lieutenant
+	req_admin_notify = 1
 
 	loadout_options = list(
 	/datum/outfit/loadout/ltline,	//NCR R91
@@ -292,6 +293,7 @@ Sergeant First Class
 	head_announce = list("Security")
 	display_order = JOB_DISPLAY_ORDER_FIRSTSERGEANT
 	outfit = /datum/outfit/job/ncr/f13firstsergeant
+	req_admin_notify = 1
 
 	loadout_options = list(
 	/datum/outfit/loadout/sfcinfantry, 	//NCR R91
@@ -828,6 +830,7 @@ Veteran Ranger
 	selection_color = "#ffeeaa"
 	display_order = JOB_DISPLAY_ORDER_VETRANGE
 	outfit = /datum/outfit/job/ncr/f13vetranger
+	req_admin_notify = 1
 
 	loadout_options = list(
 	/datum/outfit/loadout/vrclassic,	//AMR

--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -3,7 +3,7 @@
 	selection_color = "#ffeeaa"
 	forbids = "The use of pre-war technology, especially prewar weapons of war."
 	enforces = "The tribe operate as if they are a part of a singular clan. Any harm dealt upon another member is likened to harm placed upon your brother or sister. Above all things, the tribe comes first."
-	objectivesList = list("Leadership recommends the following goal for this week: Recruit worthy outlanders into the tribe","Leadership recommends the following goal for this week: Hunt dangerous creatures to improve the clan's standing", "Leadership recommends the following goal for this week: Preserve dangerous technology to prevent it from falling into the wrong hands.")
+	objectivesList = list("The village elders suggest the following goal for this week: Recruit worthy outlanders into the tribe and teach them of Yabhat","The village elders suggest the following goal for this week: Hunt dangerous creatures to improve the clan's standing","The village elders suggest the following goal for this week: Throw a generous feast for the tribe and invite friendly outsiders to partake in the blessing of Ghostis")
 
 /datum/outfit/job/tribal/
 	name = "TRIBALdatums"

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -3,6 +3,7 @@
 	selection_color = "#ADD8E6"
 	faction = "VTCC"
 	exp_type = EXP_TYPE_VTCC
+	objectivesList = list("The Overseer recommends the following goal for this week: Work together to maximize profits","The Overseer recommends the following goal for this week: Establish good relations with two or more major factions","The Overseer recommends the following goal for this week: Stay neutral at all costs")
 
 /datum/outfit/job/vtcc/
 	name = "VTCCdatums"
@@ -24,6 +25,7 @@
 	spawn_positions = 1
 	supervisors = "the Overseer"
 	description = "A subordinate of the Overseer of the Vaults and Cities, you are the primary face of the town. Handling the day to day dealings of the denizens of our fair city falls to you. Those wasters outside the walls are an unknown factor, so it falls to you to maintain relations with the Wastelands many players. Be wary of the Machine down below, as with the trades and treaties in place. Balance the budget, but don't step on the Merchant's toes. Organise defences, but do not encroach on the Marshal's office. Most of all: don't lose your head."
+	req_admin_notify = 1
 
 	outfit = /datum/outfit/job/vtcc/f13alderman
 	loadout_options = list(
@@ -81,6 +83,7 @@
 	spawn_positions = 1
 	supervisors = "the Alderman, High Marshals and Overseer"
 	description = "As the head of the security forces, you are the face of justice in the town. Uphold the law, or bend it to suit your needs, you set the precedent for how justice is doled out in the town, so bear that in mind when you sentence that pickpocket to death. Maintain the armoury and keep that watchful eye on the elevator to the Vault below. Whatever you do, don't lose your head."
+	req_admin_notify = 1
 
 	outfit = /datum/outfit/job/vtcc/f13marshal
 	loadout_options = list(
@@ -152,6 +155,7 @@
 	spawn_positions = 1
 	supervisors = "the Alderman and the Overseer"
 	description = "Trade deals fall upon your shoulders to negotiate with those around the town, so ensure you never give more than you've got. Of course, selling the town is the worst thing you could do, so it should go without saying that you can't do that. Negotiate with the traders of the wastes, extort them for the shirt on their back, or set them up for life, it's up to you to decide. Just don't lose your head."
+	req_admin_notify = 1
 
 	outfit = /datum/outfit/job/vtcc/f13merchant
 	exp_requirements = 600
@@ -215,6 +219,7 @@
 	spawn_positions = 1
 	supervisors = "the Alderman and the Overseer"
 	description = "Doctor, Scientist, Roboticist, each of you under the Vault's employ stands under the title of Researcher. The Vault's servers are regularly wiped by some glitch in the system, and it's down to the Scientists to restore these data files. To be a Roboticist is to uphold a tradition in the Vault that bears itself a marred reputation, so don't lose your head. The Medical Professionals, even those who handle quarantined patients, are the clinical cornerstone of the town, so long as the price is right."
+	req_admin_notify = 1
 
 	outfit = /datum/outfit/job/vtcc/f13chresearcher
 	loadout_options = list(

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -56,6 +56,7 @@ Great Khans
 	description = "You are the Genghis Khan. One of the Sonoran Khan gang Leaders. You've put your time in and have shown you're not an idiot and can be trusted. You can lead, you understand how things are around here, you're not some run of the mill Khan hustling for pocket change and pussy.. You've earned your strips. You put blood down for the Khans. Your job is to keep your family safe, LEAD them and show them how we roll. Show them what it means to be a fucking Khan."
 	supervisors = "Your pride"
 	selection_color = "#f86a29"
+	req_admin_notify = 1
 
 	outfit = /datum/outfit/job/wasteland/f13genghis
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds back a list of curated randomized objetives that get displayed on spawn for Legion, NCR, BoS, VTCC, Tribe and Follower roles. Makes leadership roles get the proper admin notifcation at round start.

## Why It's Good For The Game

Gives players something to fall back on if they or leadership can't come up with their own objectives. The objectives are purely optional and are made to encourage organic conflict and RP scenarios.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: roundstart objectives
fix: leadership admin notification
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
