### PR TITLE
BAWLS Vendor Fix

### DIFF
--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -12,6 +12,7 @@
 #define CASH_AUR_VENDOR 100 /* 100 caps to 1 AUR */
 #define CASH_DEN_VENDOR 4 /* 4 caps to 1 DEN */
 #define CASH_NCR_VENDOR 0.4 /* $100 to 40 caps */
+#define CASH_BOS_VENDOR 2 /* 2 caps to 1 BAWLS */
 
 // Total number of caps value spent in the Trading Protectrons Vendors
 GLOBAL_VAR_INIT(vendor_cash, 0)
@@ -776,6 +777,7 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 	dat += "1 NCR dollar = [CASH_NCR_VENDOR] bottle caps value <br>"
 	dat += "1 Denarius = [CASH_DEN_VENDOR] bottle caps value <br>"
 	dat += "1 Aureus = [CASH_AUR_VENDOR] bottle caps value <br>"
+	dat += "1 BAWLS cap = [CASH_BOS_VENDOR] bottle caps value <br>"
 	dat += "</div>"
 	dat += "<br>"
 	dat +="<div class='statusDisplay'>"
@@ -863,6 +865,14 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 	else if(istype(I, /obj/item/stack/f13Cash/aureus))
 		var/obj/item/stack/f13Cash/aureus/currency = I
 		var/inserted_value = FLOOR(currency.amount * 100, 1)
+		stored_caps += inserted_value
+		I.use(currency.amount)
+		playsound(src, 'sound/items/change_jaws.ogg', 60, 1)
+		to_chat(usr, "You put [inserted_value] bottle caps value to a vending machine.")
+		src.ui_interact(usr)
+	else if(istype(I, /obj/item/stack/f13Cash/bawls))
+		var/obj/item/stack/f13Cash/bawls/currency = I
+		var/inserted_value = FLOOR(currency.amount * 2, 1)
 		stored_caps += inserted_value
 		I.use(currency.amount)
 		playsound(src, 'sound/items/change_jaws.ogg', 60, 1)

--- a/code/modules/fallout/misc/gangtool.dm
+++ b/code/modules/fallout/misc/gangtool.dm
@@ -4,6 +4,7 @@
 #define CASH_AUR_GANG 100 /* 100 caps to 1 AUR */
 #define CASH_DEN_GANG 4 /* 4 caps to 1 DEN */
 #define CASH_NCR_GANG 0.4 /* $100 to 40 caps */
+#define CASH_BOS_GANG 2 /* 2 caps to 1 BAWLS */
 
 //Gangtool device
 /obj/item/device/gangtool
@@ -41,6 +42,7 @@
 	dat += "1 NCR dollar = [CASH_NCR_GANG] influence <br>"
 	dat += "1 Denarius = [CASH_DEN_GANG] influence <br>"
 	dat += "1 Aureus = [CASH_AUR_GANG] influence <br>"
+	dat += "1 BAWLS cap = [CASH_BOS_GANG] influence <br>"
 	dat += "</div>"
 	dat += "<br>"
 
@@ -118,6 +120,14 @@
 	else if(istype(I, /obj/item/stack/f13Cash/aureus))
 		var/obj/item/stack/f13Cash/aureus/currency = I
 		var/inserted_value = currency.amount * CASH_AUR_GANG
+		gang.influence += inserted_value
+		I.use(currency.amount)
+		playsound(src, 'sound/items/change_jaws.ogg', 60, 1)
+		to_chat(usr, "You gain [inserted_value] gang influence by bribing underground suppliers.")
+		attack_self(usr)
+	else if(istype(I, /obj/item/stack/f13Cash/bawls))
+		var/obj/item/stack/f13Cash/bawls/currency = I
+		var/inserted_value = currency.amount * CASH_BOS_GANG
 		gang.influence += inserted_value
 		I.use(currency.amount)
 		playsound(src, 'sound/items/change_jaws.ogg', 60, 1)


### PR DESCRIPTION
## About The Pull Request
Makes bawls caps be accepted by vendors and gangtool to make them not-useless. Literally just that.
## Why It's Good For The Game
Keeps the currency not completely worthless
## Changelog
- Fixes BAWLS caps in Vending machines
- Fixes BAWLS caps in Gang tools