### PR TITLE
removes ways of gibbing

### DIFF
--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -114,8 +114,7 @@
 	var/eggcolor = pick("blue","green","mime","orange","purple","rainbow","red","yellow")
 	icon_state = "egg-[eggcolor]"
 /obj/item/reagent_containers/food/snacks/egg/proc/dispensePrize(turf/where)
-	var/won = pick(/obj/item/clothing/head/bunnyhead,
-	/obj/item/clothing/suit/bunnysuit,
+	var/won = pick(/obj/item/clothing/suit/bunnysuit,
 	/obj/item/reagent_containers/food/snacks/grown/carrot,
 	/obj/item/reagent_containers/food/snacks/chocolateegg,
 	/obj/item/toy/balloon,

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -407,7 +407,7 @@
 	visible_message("<span class='warning'>You hear an ominous beep coming from [src]!</span>", "<span class='warning'>You hear an ominous beep!</span>")
 
 /mob/living/simple_animal/hostile/handy/sentrybot/proc/self_destruct()
-	explosion(src,1,2,4,4)
+	explosion(src,0,3,5,5)
 	qdel(src)
 
 /mob/living/simple_animal/hostile/handy/sentrybot/Life()

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -33,7 +33,7 @@ All ShuttleMove procs go here
 				M.stop_pulling()
 				M.visible_message("<span class='warning'>[shuttle] slams into [M]!</span>")
 				SSblackbox.record_feedback("tally", "shuttle_gib", 1, M.type)
-				M.gib()
+				M.adjustBruteLoss(250)
 
 		else //non-living mobs shouldn't be affected by shuttles, which is why this is an else
 			if(istype(thing, /obj/singularity) && !istype(thing, /obj/singularity/narsie)) //it's a singularity but not a god, ignore it.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes elevators and sentrybots gibbing you and destroying items. Buffs sentrybot explosion in return. Removes incredibly niche way of obtaining a bunny hood.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Gibbing was an IC issue, so unless you had a competent doc it just round ended you. Elevators and sentrys are still dangerous if not careful, but it won't cause your body to become unrecoverable anymore.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: bunny hood from easter eggs
tweak: elevators + sentry gibbing

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
