### PR TITLE
EMP Grenade Nerf

### DIFF
--- a/code/game/objects/items/grenades/emgrenade.dm
+++ b/code/game/objects/items/grenades/emgrenade.dm
@@ -7,5 +7,5 @@
 /obj/item/grenade/empgrenade/prime(mob/living/lanced_by)
 	. = ..()
 	update_mob()
-	empulse_using_range(src, 14)
+	empulse_using_range(src, 5)
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request

Reduced the size of EMP grenades from 14 to 5 - making it no longer cover well over a screen's range. Now should be only 5x5 area of effect if I'm right. Uses the same range as the electromagnetic_web.dm file - 

'empulse_using_range(B.loc, 5) //less than screen range, so you can stand out of range to avoid it'

If I'm wrong someone else can fix the shit. Cope, seethe.

## Why It's Good For The Game

Yeah.

## Changelog
:cl:
fixes: EMP grenade no longer has the range of Little Man, Fat Boy, the Tsar Bomba or even the average hydrogen bomb.
/:cl:
