### PR TITLE
Fix item size resetting when picked up

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -452,6 +452,10 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)
 	item_flags |= IN_INVENTORY
 
+/// called to reset an item's transform to default; typically initial, but can be overridden
+/obj/item/proc/reset_transform()
+	transform = initial(transform)
+
 // called when "found" in pockets and storage items. Returns 1 if the search should end.
 /obj/item/proc/on_found(mob/finder)
 	return

--- a/code/modules/antagonists/clockcult/clock_items/integration_cog.dm
+++ b/code/modules/antagonists/clockcult/clock_items/integration_cog.dm
@@ -14,6 +14,10 @@
 
 /obj/item/clockwork/integration_cog/Initialize()
 	. = ..()
+	reset_transform()
+
+/obj/item/clockwork/integration_cog/reset_transform()
+	..()
 	transform *= 0.5 //little cog!
 
 /obj/item/clockwork/integration_cog/Destroy()

--- a/code/modules/clothing/suits/f13armoraccessory.dm
+++ b/code/modules/clothing/suits/f13armoraccessory.dm
@@ -10,6 +10,12 @@
 	var/minimize_when_attached = TRUE // TRUE if shown as a small icon in corner, FALSE if overlayed
 	var/datum/component/storage/detached_pockets
 
+/obj/item/clothing/armoraccessory/reset_transform()
+	..()
+	if(!minimize_when_attached || !istype(/obj/item/clothing/suit, loc))
+		return
+	transform *= 0.5
+
 /obj/item/clothing/armoraccessory/proc/attach(obj/item/clothing/suit/U, user)
 	var/datum/component/storage/storage = GetComponent(/datum/component/storage)
 	if(storage)
@@ -21,8 +27,8 @@
 	forceMove(U)
 	layer = FLOAT_LAYER
 	plane = FLOAT_PLANE
+	reset_transform()
 	if(minimize_when_attached)
-		transform *= 0.5	//halve the size so it doesn't overpower the under
 		pixel_x += 8
 		pixel_y -= 8
 	U.add_overlay(src)
@@ -50,9 +56,9 @@
 		on_suit_dropped(U, user)
 
 	if(minimize_when_attached)
-		transform *= 2
 		pixel_x -= 8
 		pixel_y += 8
+	reset_transform()
 	layer = initial(layer)
 	plane = initial(plane)
 	U.cut_overlays()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -44,10 +44,14 @@
 		for(var/datum/plant_gene/trait/T in seed.genes)
 			T.on_new(src, loc)
 		seed.prepare_result(src)
-		transform *= TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.4 //Makes the resulting produce's sprite larger or smaller based on potency!
 		add_juice()
+	
+	reset_transform()
 
-
+/obj/item/reagent_containers/food/snacks/grown/reset_transform()
+	..()
+	if(seed)
+		transform *= TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.5 //Makes the resulting produce's sprite larger or smaller based on potency!
 
 /obj/item/reagent_containers/food/snacks/grown/proc/add_juice()
 	if(reagents)

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -284,8 +284,6 @@
 	reagents.maximum_volume = newvolume
 	reagents.update_total()
 
-	transform *= TRANSFORM_USING_VARIABLE(40, 100) + 0.5 //temporary fix for size?
-
 /obj/item/reagent_containers/food/snacks/grown/coconut/attack_self(mob/user)
 	if (!opened)
 		return
@@ -443,10 +441,6 @@
 								"<span class='notice'>You splash the contents of [src] onto [target].</span>")
 			reagents.reaction(target, TOUCH)
 			reagents.clear_reagents()
-
-/obj/item/reagent_containers/food/snacks/grown/coconut/dropped(mob/user)
-	. = ..()
-	transform *= TRANSFORM_USING_VARIABLE(40, 100) + 0.5 //temporary fix for size?
 
 /obj/item/reagent_containers/food/snacks/grown/coconut/ex_act(severity)
 	qdel(src)

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -29,9 +29,14 @@
 
 		if(istype(src, seed.product)) // no adding reagents if it is just a trash item
 			seed.prepare_result(src)
-		transform *= TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.5
 		add_juice()
+	
+	reset_transform()
 
+/obj/item/grown/reset_transform()
+	..()
+	if(seed)
+		transform *= TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.5
 
 /obj/item/grown/attackby(obj/item/O, mob/user, params)
 	..()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -201,8 +201,7 @@ obj/item/seeds/proc/is_gene_forbidden(typepath)
 			t_prod.seed.name = initial(new_prod.name)
 			t_prod.seed.desc = initial(new_prod.desc)
 			t_prod.seed.plantname = initial(new_prod.plantname)
-			t_prod.transform = initial(t_prod.transform)
-			t_prod.transform *= TRANSFORM_USING_VARIABLE(t_prod.seed.potency, 100) + 0.5
+			t_prod.reset_transform()
 			t_amount++
 			if(t_prod.seed)
 				//t_prod.seed = new new_prod

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -184,7 +184,7 @@
 		update_inv_hands()
 		I.pixel_x = initial(I.pixel_x)
 		I.pixel_y = initial(I.pixel_y)
-		I.transform = initial(I.transform)
+		I.reset_transform()
 		return hand_index || TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #340
Adds a helper proc, `/obj/item/proc/reset_transform()`, to handle resetting `transform` based on state. For all `/obj/item`s, most transform logic should be performed in that proc.
If it's desired, I can modify it so that fruits are normal-sized in the inventory, but that makes sorting through them difficult.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The bug is really annoying.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Item size now stays consistent after picking up an item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
