### PR TITLE
Changed Match Round Values & Misc

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1085,7 +1085,7 @@
 				/obj/item/gun/ballistic/automatic/bar
 	)
 
-/obj/effect/spawner/bundle/f13/bastard
+/obj/effect/spawner/bundle/f13/g11
 	name = "g11 spawner"
 	items = list(
 				/obj/item/gun/ballistic/automatic/g11,
@@ -1314,7 +1314,8 @@
 				/obj/effect/spawner/bundle/f13/mp5,
 				/obj/effect/spawner/bundle/f13/aer9,
 				/obj/effect/spawner/bundle/f13/ak112,
-				/obj/effect/spawner/bundle/f13/neostead
+				/obj/effect/spawner/bundle/f13/neostead,
+				/obj/effect/spawner/bundle/f13/flamethrower
 	)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier8 //TIER 8 GUN
@@ -1326,9 +1327,9 @@
 				/obj/effect/spawner/bundle/f13/brushgun,
 				/obj/effect/spawner/bundle/f13/wattz2k,
 				/obj/effect/spawner/bundle/f13/plasmapistol,
-				/obj/effect/spawner/bundle/f13/rcw,
+				/obj/effect/spawner/bundle/f13/p90,
 				/obj/effect/spawner/bundle/f13/bar,
-				/obj/effect/spawner/bundle/f13/flamethrower
+				/obj/effect/spawner/bundle/f13/g11
 	)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier9 //TIER 9 GUN
@@ -1354,7 +1355,7 @@
 				/obj/effect/spawner/bundle/f13/tribeam,
 				/obj/effect/spawner/bundle/f13/gauss,
 				/obj/effect/spawner/bundle/f13/pistol127mm,
-				/obj/effect/spawner/bundle/f13/p90
+				/obj/effect/spawner/bundle/f13/rcw
 	)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/unique //UNIQUE GUN

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -116,14 +116,24 @@ Great Khans
 /datum/outfit/loadout/classic
 	name = "Classic"
 	l_hand = /obj/item/gun/ballistic/automatic/pistol/pistol127
+	r_hand = /obj/item/gun/ballistic/automatic/smg/greasegun
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m127mm=2)
+		/obj/item/ammo_box/magazine/m127mm=2,
+		/obj/item/ammo_box/magazine/greasegun = 1)
 
 /datum/outfit/loadout/marksman
 	name = "Marksman"
 	l_hand =	/obj/item/gun/ballistic/automatic/marksman/sniper
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/w308=2)
+		/obj/item/ammo_box/magazine/w308=2,
+		/obj/item/gun/ballistic/automatic/pistol/n99=1,)
+
+/datum/outfit/loadout/runner
+	name = "Runner"
+	l_hand =	/obj/item/gun/ballistic/automatic/type93
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/m556/rifle=2,
+		)
 
 /datum/job/wasteland/f13pusher
 	title = "Great Khan"
@@ -185,11 +195,6 @@ Great Khans
 		/obj/item/reagent_containers/pill/patch/medx=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1)
 	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
-	suit_store = pick(
-		/obj/item/gun/ballistic/rifle/automatic/hunting/trail, \
-		/obj/item/gun/ballistic/shotgun/hunting, \
-		/obj/item/gun/ballistic/revolver/m29, \
-		/obj/item/gun/ballistic/automatic/pistol/ninemil)
 	head = /obj/item/clothing/head/helmet/f13/khan
 	shoes = /obj/item/clothing/shoes/f13/military/plated
 
@@ -200,13 +205,15 @@ Great Khans
 	backpack_contents = list(
 		/obj/item/reagent_containers/glass/beaker/plastic=2,
 		/obj/item/book/granter/trait/chemistry=1,
-		/obj/item/clothing/mask/gas/glass=1)
+		/obj/item/clothing/mask/gas/glass=1,
+		/obj/item/gun/ballistic/automatic/pistol/n99 = 1,
+		/obj/item/ammo_box/magazine/m10mm_adv = 1)
 
 /datum/outfit/loadout/enforcer
 	name = "Enforcer"
 	l_hand = /obj/item/gun/ballistic/shotgun/lever
 	backpack_contents = list(
-		/obj/item/ammo_box/shotgun/buck=1,
+		/obj/item/ammo_box/shotgun/buck=2,
 		/obj/item/ammo_box/shotgun/slug=1,
 		/obj/item/restraints/handcuffs=2,
 		/obj/item/restraints/legcuffs/bola=2)
@@ -215,9 +222,9 @@ Great Khans
 	name = "Brawler"
 	l_hand = /obj/item/claymore/machete/reinforced
 	backpack_contents = list(
-		/obj/item/melee/unarmed/brass/spiked=1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak/super=1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak=1,
+		/obj/item/gun/ballistic/automatic/pistol/autoloader = 1,
+		/obj/item/ammo_box/magazine/m45 = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak=2,
 		/obj/item/restraints/legcuffs/bola/tactical=1,
 		/obj/item/book/granter/trait/big_leagues=1)
 /*

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -829,6 +829,7 @@
 	can_suppress = FALSE
 	can_unsuppress = FALSE
 	can_attachments = TRUE
+	extra_damage = 4
 	suppressed = 1
 	burst_size = 2
 	fire_delay = 3
@@ -944,7 +945,7 @@
 	force = 25
 	burst_size = 2
 	fire_delay = 2.5
-	burst_shot_delay = 1.5
+	burst_shot_delay = 2
 	spread = 10
 	can_suppress = FALSE
 	can_attachments = TRUE

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -143,24 +143,24 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/a357
 	name = ".357 FMJ bullet"
-	damage = 35
-	armour_penetration = 0.15
+	damage = 37
+	armour_penetration = 0.18
 	wound_bonus = 14
 	bare_wound_bonus = -14
 
 /obj/item/projectile/bullet/a357/jhp
 	name = ".357 JHP bullet"
-	damage = 41
+	damage = 43
 	armour_penetration = 0
 	wound_bonus = -21
 	bare_wound_bonus = 21
 
 /obj/item/projectile/bullet/a357/jfp
 	name = ".357 JFP bullet"
-	damage = 38
-	armour_penetration = 0.1
-	wound_bonus = 18
-	bare_wound_bonus = 18
+	damage = 40
+	armour_penetration = 0.14
+	wound_bonus = 20
+	bare_wound_bonus = 20
 
 
 ////////////////
@@ -233,14 +233,14 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/a127mm
 	name = "12.7mm FMJ bullet"
-	damage = 60
+	damage = 52
 	armour_penetration = 0.25
-	wound_bonus = 28
-	bare_wound_bonus = -28
+	wound_bonus = 30
+	bare_wound_bonus = -30
 
 /obj/item/projectile/bullet/a127mm/jhp
 	name = "12.7mm JHP bullet"
-	damage = 70
+	damage = 62
 	armour_penetration = 0
 	wound_bonus = -56
 	bare_wound_bonus = 56

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -37,13 +37,13 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 /obj/item/projectile/bullet/a762/jhp
 	name = "7.62 JHP bullet"
 	damage = 46
-	armour_penetration = 0.1
+	armour_penetration = 0
 	wound_bonus = -30
 	bare_wound_bonus = 30
 
 /obj/item/projectile/bullet/a762/match
 	name = "7.62 match bullet"
-	damage = 40
+	damage = 36
 	armour_penetration = 0.2
 	wound_bonus = 20
 	bare_wound_bonus = -20
@@ -87,8 +87,8 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 
 /obj/item/projectile/bullet/a556/match
 	name = "5.56 match bullet"
-	damage = 33
-	armour_penetration = 0.21
+	damage = 29
+	armour_penetration = 0.18
 	wound_bonus = 16
 	bare_wound_bonus = -16
 	pixels_per_second = TILES_TO_PIXELS(20)
@@ -160,8 +160,8 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 /obj/item/projectile/bullet/c5mm
 	damage = 20
 	armour_penetration = 0.5
-	wound_bonus = -5
-	bare_wound_bonus = 5
+	wound_bonus = 10
+	bare_wound_bonus = -10
 
 
 /////////////////////////


### PR DESCRIPTION
## About The Pull Request

Small changes to match ammo - no longer objectively better than AP. Now semi-balanced. May need a buff at some point but it works OK for now.

Fixed an issue with 7.62 JHP where the rounds had 0.1 pen.

Nerfed 12.7 down 8 points of damage. No longer more powerful than an AMR but with less pen - should take 1 extra round to kill now. Big deal. Infiltrator got bonus damage since it's a unqiue.

G-11 added to loot rotation. P90 lowered due to slow fire rate. RCW increased in loot rarity. Reduced flamethrower down a tier due to being a bit high.

Added a few loadout changes to Khans - they had legacy loadouts like random guns spawning on their back. Now their loadouts basically give them choices for weapons instead.

## Why It's Good For The Game

Overall some balance and quality of life changes. Plus I honestly feel the Khans have been neglected for a long time - as evidence by their code looking like olllld Bad Deathclaw/early DR2 loadouts.

## Changelog
:cl:
add: g11 to loot rotation
balance: fixed match rounds being better than AP overall.
balance: adjusted some damage values on guns and calibers; like the infiltrator and the 12.7.
balance: fixed 7.62 JHP.
balance: Khans no longer get random guns; now guns are somewhat determined by loadouts - which contain uniqueness to them.
/:cl: