### PR TITLE
Crusader Pistol 'Buffs'

### DIFF
--- a/code/game/objects/items/modkit.dm
+++ b/code/game/objects/items/modkit.dm
@@ -317,6 +317,7 @@
 /obj/item/modkit/crusader_556
 	name = "crusader pistol 5.56mm conversion kit"
 	target_items = list(/obj/item/gun/ballistic/automatic/pistol/crusader_rifle_ncr,
+						/obj/item/gun/ballistic/automatic/pistol/crusader_rifle,
 						/obj/item/gun/ballistic/automatic/pistol/crusader_pistol,
 						/obj/item/gun/energy/laser/crusader,
 						/obj/item/gun/energy/plasma/crusader
@@ -335,6 +336,7 @@
 /obj/item/modkit/crusader_plasma
 	name = "crusader pistol plasma conversion kit"
 	target_items = list(/obj/item/gun/ballistic/automatic/pistol/crusader_rifle_ncr,
+						/obj/item/gun/ballistic/automatic/pistol/crusader_rifle,
 						/obj/item/gun/ballistic/automatic/pistol/crusader_pistol,
 						/obj/item/gun/energy/laser/crusader,
 						/obj/item/gun/ballistic/automatic/pistol/crusader_rifle

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -179,6 +179,8 @@
 	e_cost = 250
 	fire_sound = 'sound/f13weapons/aer9fire.ogg'
 
+//Crusader - funny pocket AER-9
+
 /obj/item/ammo_casing/energy/laser/crusader
 	projectile_type = /obj/item/projectile/beam/laser/lasgun
 	e_cost = 200 //10 shots

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -158,3 +158,14 @@
 
 /obj/item/ammo_box/magazine/m22/empty
 	start_empty = 1
+
+/obj/item/ammo_box/magazine/m473_pistol
+	name = "pistol magazine (4.73mm)"
+	icon_state = "mag308"
+	caliber = "473mm"
+	ammo_type = /obj/item/ammo_casing/caseless/g11
+	max_ammo = 12
+	multiple_sprites = 2
+
+/obj/item/ammo_box/magazine/m473_pistol/empty
+	start_empty = 1

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -161,7 +161,7 @@
 
 /obj/item/ammo_box/magazine/m473_pistol
 	name = "pistol magazine (4.73mm)"
-	icon_state = "mag308"
+	icon_state = "45exp"
 	caliber = "473mm"
 	ammo_type = /obj/item/ammo_casing/caseless/g11
 	max_ammo = 12

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -122,14 +122,6 @@
 /obj/item/ammo_box/magazine/m473/empty
 	start_empty = 1
 
-/obj/item/ammo_box/magazine/m473_pistol
-	name = "pistol magazine (4.73mm)"
-	icon_state = "mag308"
-	caliber = "473mm"
-	ammo_type = /obj/item/ammo_casing/caseless/g11
-	max_ammo = 10
-	multiple_sprites = 2
-
 /obj/item/ammo_box/magazine/c5mm
 	name = "AK magazine (5mm)"
 	icon_state = "r24"

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -281,19 +281,19 @@
 
 /obj/item/gun/ballistic/automatic/pistol/crusader_pistol
 	name = "Crusader pistol (10mm)"
-	desc = "A modular pistol of native Brotherhood of Steel design. Currently chambered in 10mm."
+	desc = "A modular pistol of native Brotherhood of Steel design. Currently chambered in 10mm. Complete with a threaded barrel to allow for attachments."
 	icon_state = "crusader_pistol"
 	item_state = "crusader_pistol"
-	mag_type = /obj/item/ammo_box/magazine/m10mm_adv/simple
+	mag_type = /obj/item/ammo_box/magazine/m10mm_adv
 	fire_sound = 'sound/f13weapons/10mm_fire_02.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
-	can_attachments = FALSE
+	can_attachments = TRUE
 	fire_delay = 2
 	can_suppress = FALSE
 
 /obj/item/gun/ballistic/automatic/pistol/crusader_rifle
 	name = "Crusader pistol (4.73mm caseless)"
-	desc = "A modular pistol of native Brotherhood of Steel design. Currently chambered in 4.73mm caseless."
+	desc = "A modular pistol of native Brotherhood of Steel design. Currently chambered in 4.73mm caseless. Perfect for a stealthy operator with style."
 	icon_state = "crusader_rifle"
 	item_state = "crusader_rifle"
 	mag_type = /obj/item/ammo_box/magazine/m473_pistol
@@ -305,12 +305,13 @@
 
 /obj/item/gun/ballistic/automatic/pistol/crusader_rifle_ncr
 	name = "Crusader pistol (5.56mm)"
-	desc = "A modular pistol of native Brotherhood of Steel design. Currently chambered in 5.56mm."
+	desc = "A modular pistol of native Brotherhood of Steel design. Currently chambered in 5.56mm. A pocket-rifle! Well.. if you excuse it only taking 10 round magazines."
 	icon_state = "crusader_rifle"
 	icon_state = "crusader_rifle"
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle/small
 	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
 	can_attachments = FALSE
+	can_automatic = FALSE
 	fire_delay = 2
 	can_suppress = FALSE

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -491,10 +491,17 @@
 	category = list("initial", "Intermediate Ammo")
 
 /datum/design/ammolathe/m473
-	name = "g11 magazine (4.73mm)"
+	name = "empty g11 magazine (4.73mm)"
 	id = "4.73mm_mag"
 	materials = list(/datum/material/iron = 6000)
-	build_path = /obj/item/ammo_box/magazine/m473
+	build_path = /obj/item/ammo_box/magazine/m473/empty
+	category = list("initial", "Intermediate Magazines")
+
+/datum/design/ammolathe/
+	name = "empty caseless pistol mag (4.73mm)"
+	id = "4.73mm_pistolmag"
+	materials = list(datum/material/iron = 3000)
+	build_path = /obj/item/ammo_box/magazine/m473_pistol/empty
 	category = list("initial", "Intermediate Magazines")
 
 /datum/design/ammolathe/m473box

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -500,7 +500,7 @@
 /datum/design/ammolathe/
 	name = "empty caseless pistol mag (4.73mm)"
 	id = "4.73mm_pistolmag"
-	materials = list(datum/material/iron = 3000)
+	materials = list(/datum/material/iron = 3000)
 	build_path = /obj/item/ammo_box/magazine/m473_pistol/empty
 	category = list("initial", "Intermediate Magazines")
 

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -643,6 +643,16 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/crusader_caseless
+	name = "crusader pistol 4.73mm conversion kit"
+	desc = "A conversion kit for crusader pistols."
+	id = "crusader_caseless"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 15000, /datum/material/glass = 10000, /datum/material/gold = 2500, /datum/material/silver = 2500)
+	build_path = /obj/item/modkit/crusader_473
+	category = list("Weapons")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
 /datum/design/crusader_laser
 	name = "crusader pistol laser conversion kit"
 	desc = "A conversion kit for crusader pistols."

--- a/code/modules/research/techweb/nodes/weaponry_nodes.dm
+++ b/code/modules/research/techweb/nodes/weaponry_nodes.dm
@@ -13,7 +13,7 @@
 	display_name = "Advanced Weapon Development Technology"
 	description = "Our weapons are breaking the rules of reality by now."
 	prereq_ids = list("adv_engi", "weaponry")
-	design_ids = list("bullet_shield", "ecp", "fluxcap", "focusedlenses", "superconductor", "advreceiver", "preassembly", "superalloys", "crusader_rifle", "crusader_laser", "maxson_5mm")
+	design_ids = list("bullet_shield", "ecp", "fluxcap", "focusedlenses", "superconductor", "advreceiver", "preassembly", "superalloys", "crusader_rifle", "crusader_caseless", "crusader_laser", "maxson_5mm")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 
 /datum/techweb_node/electric_weapons


### PR DESCRIPTION
## About The Pull Request

Crusader pistol was stoopid in that its 10mm could not take attachments like an N-99 and could not take extended mags of 10mm. Also added the 4.37 crusader to rotation since G-11 is used already.

So I've rectified it.

## Why It's Good For The Game

Crusader was weaker than an N-99 as a spawning pistol for BOS. Why? No clue.

## Changelog
:cl:
balance: Adjusts Crusader 10mm stats.
adds: 4.73 Crusader to the game
/:cl: