### PR TITLE
G11 Balance

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -748,7 +748,7 @@
 
 /obj/item/ammo_box/m473
 	name = "ammo box (4.73mm caseless)"
-	icon_state = "5mmbox" //i cannot be fucked to make a new sprite for it rn so - someone else can eventually(tm, rights reserved)
+	icon_state = "5mmbox" //i cannot be fucked to make a new sprite for it rn so - someone else can eventually(tm, rights reserved exdee)
 	ammo_type = /obj/item/ammo_casing/caseless/g11
 	max_ammo = 100
 

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -748,9 +748,9 @@
 
 /obj/item/ammo_box/m473
 	name = "ammo box (4.73mm caseless)"
-	icon_state = "38box" //temporary until new sprite comes along
+	icon_state = "5mmbox" //i cannot be fucked to make a new sprite for it rn so - someone else can eventually(tm, rights reserved)
 	ammo_type = /obj/item/ammo_casing/caseless/g11
-	max_ammo = 50
+	max_ammo = 100
 
 /*
 /obj/item/ammo_box/plasmamusket

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -944,12 +944,11 @@
 	weapon_weight = WEAPON_HEAVY
 	force = 25
 	burst_size = 2
-	fire_delay = 2.5
+	fire_delay = 4
 	burst_shot_delay = 2
 	spread = 10
 	can_suppress = FALSE
 	can_attachments = TRUE
-	can_automatic = TRUE
 	can_scope = FALSE
 	zoomable = TRUE
 	zoom_amt = 10

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -147,7 +147,7 @@ Civilian round				=	-10% damage for .223. AP reduced by 50%
 
 /obj/item/projectile/bullet/a473
 	name = "4.73 FMJ bullet"
-	damage = 38
+	damage = 32
 	armour_penetration = 0.2
 	wound_bonus = 20
 	bare_wound_bonus = -20


### PR DESCRIPTION
## About The Pull Request

G11 balance PR. Apparently the guns fire rate was a bit high for its large magazine size. Also - had a missing ammo box sprite.

## Why It's Good For The Game

See above.

## Changelog
:cl:
balance: Increased fire-delay on the G11.
balance: Decreased damage of caseless ammo. Bit too much.
fix: Broken ammo boxes fixed.
/:cl: