### PR TITLE
Revert "systematically removes most instakill chems from the game"

### DIFF
--- a/code/modules/fallout/reagents/drinkmix.dm
+++ b/code/modules/fallout/reagents/drinkmix.dm
@@ -67,7 +67,7 @@
 	id = "nukaberry"
 	results = list(/datum/reagent/consumable/nukaberry = 3)
 	required_reagents = list(/datum/reagent/consumable/nukacherry = 1, /datum/reagent/consumable/nukagrape = 1, /datum/reagent/consumable/ice = 1)
-/*
+
 /datum/chemical_reaction/nukabomb
 	name = "Nuka Bombdrop"
 	id = "nukabomb"
@@ -357,4 +357,4 @@
 	id = "yuccashake"
 	results = list(/datum/reagent/consumable/yuccashake = 3)
 	required_reagents = list(/datum/reagent/consumable/yuccajuice = 1, /datum/reagent/consumable/milk = 1, /datum/reagent/consumable/cream = 1)
-*/
+

--- a/code/modules/fallout/reagents/drugs.dm
+++ b/code/modules/fallout/reagents/drugs.dm
@@ -51,7 +51,7 @@
 	if(M.hallucination < volume && prob(20))
 		M.hallucination += 10
 		M.adjustToxLoss(10, 0)
-		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2)
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 60)
 	..()
 
 /datum/reagent/drug/jet/addiction_act_stage1(mob/living/M)
@@ -71,7 +71,7 @@
 		for(var/i = 0, i < 4, i++)
 			step(M, pick(GLOB.cardinals))
 	M.adjustToxLoss(3, 0)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 	M.set_disgust(60)
 	M.Dizzy(10)
 	if(prob(40))
@@ -83,7 +83,7 @@
 		for(var/i = 0, i < 8, i++)
 			step(M, pick(GLOB.cardinals))
 	M.adjustToxLoss(5, 0)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
 	M.set_disgust(100)
 	M.Dizzy(15)
 	if(prob(50))
@@ -249,6 +249,10 @@
 	if(prob(20))
 		M.emote(pick("twitch","scream","laugh"))
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2)
+	M.set_heartattack(TRUE)
+	M.visible_message("<span class='userdanger'>[M] clutches at their chest as if their heart stopped!</span>")
+	to_chat(M, "<span class='danger'>Your vision goes black and your heart stops beating as the amount of drugs in your system shut down your organs one by one. Say hello to Elvis in the afterlife. </span>")
+	..()
 	return TRUE
 
 /datum/reagent/drug/psycho/addiction_act_stage1(mob/living/M)
@@ -275,7 +279,7 @@
 			step(M, pick(GLOB.cardinals))
 	M.Jitter(15)
 	M.Dizzy(15)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
 	if(prob(40))
 		M.emote(pick("twitch","scream","laugh"))
 	..()
@@ -288,7 +292,7 @@
 	M.Jitter(50)
 	M.Dizzy(50)
 	M.adjustToxLoss(5)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 4)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15)
 	if(prob(50))
 		M.emote(pick("twitch","scream","laugh"))
 	..()
@@ -380,6 +384,8 @@
 /datum/reagent/drug/buffout/addiction_act_stage3(mob/living/M)
 	to_chat(M, "<span class='notice'>Your muscles start to hurt badly, and everything feels like it hurts more.</span>")
 	M.adjustBruteLoss(7.5)
+	M.maxHealth -= 1.5
+	M.health -= 1.5
 	if(prob(50))
 		to_chat(M, "<span class='notice'>Your muscles spasm, making you drop what you were holding. You're not even sure if you can control your arms!</span>")
 		M.drop_all_held_items()
@@ -389,7 +395,9 @@
 
 /datum/reagent/drug/buffout/addiction_act_stage4(mob/living/M)
 	to_chat(M, "<span class='danger'>Your muscles are in incredible pain! When will it stop!?</span>")
-	M.adjustBruteLoss(5)
+	M.adjustBruteLoss(12.5)
+	M.maxHealth -= 5
+	M.health -= 5
 	if(prob(90))
 		to_chat(M, "<span class='danger'>You can't even keep control of your muscles anymore!</span>")
 		M.drop_all_held_items()

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -7,7 +7,6 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 35
 	addiction_threshold = 25
-	can_synth = FALSE
 	value = REAGENT_VALUE_COMMON
 
 /datum/reagent/medicine/stimpak/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
@@ -60,7 +59,7 @@
 
 /datum/reagent/medicine/super_stimpak
 	name = "super stim chemicals"
-	can_synth = FALSE
+
 	description = "Chemicals found in pre-war stimpaks."
 	reagent_state = LIQUID
 	color = "#e50d0d"
@@ -109,8 +108,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	color ="#A9FBFB"
 	taste_description = "bitterness and liquid pain"
 	metabolization_rate = 0.7 * REAGENTS_METABOLISM //in between powder/stimpaks and poultice/superstims?
-	overdose_threshold = 20
-	can_synth = FALSE
+	overdose_threshold = 11
 
 datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0)
@@ -143,7 +141,6 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	taste_description = "bitterness"
 	metabolization_rate = 0.6 * REAGENTS_METABOLISM
 	overdose_threshold = 31
-	can_synth = FALSE
 	var/heal_factor = -1.5 //Subtractive multiplier if you do not have the perk.
 	var/heal_factor_perk = -3 //Multiplier if you have the right perk.
 
@@ -187,7 +184,6 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30
-	can_synth = FALSE
 	heal_factor = -2
 	heal_factor_perk = -4
 
@@ -195,7 +191,6 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	name = "zombie poultice"
 	description = "Highly refined powder, usually only utilized by members of Caesar's Legion, for its effects on mind of its user."
 	color = "#a64adb"
-	can_synth = FALSE
 	metabolization_rate = 0.2 * REAGENTS_METABOLISM
 	overdose_threshold = 11
 	heal_factor = 0
@@ -360,9 +355,12 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	M.set_blurriness(30)
 	M.Unconscious(400)
 	M.Jitter(1000)
+	M.set_heartattack(TRUE)
+	M.drop_all_held_items()
 	M.Dizzy(2)
-	M.visible_message("<span class='userdanger'>[M] collapses, frothing at the mouth!</span>")
-	to_chat(M, "<span class='danger'>Oh shit. Oh fuck. That's not good. Oh fuck.</span>")
+	M.visible_message("<span class='userdanger'>[M] clutches at their chest as if their heart stopped!</span>")
+	if(prob(10))
+		to_chat(M, "<span class='danger'>Your vision goes black and your heart stops beating as the amount of drugs in your system shut down your organs one by one. Say hello to Elvis in the afterlife. </span>")
 	..()
 
 /datum/reagent/medicine/medx/addiction_act_stage1(mob/living/M)

--- a/code/modules/fallout/reagents/teas.dm
+++ b/code/modules/fallout/reagents/teas.dm
@@ -2,16 +2,16 @@
 
 /datum/reagent/consumable/tea/agavetea
 	name = "Agave Tea"
-	description = "A soothing herbal rememedy steeped from the Agave Plant. Induces increased healing of burns and sores."
+	description = "A soothing herbal rememedy steeped from the Agave Plant. Inhibits increased healing of burns and sores."
 	color = "#FFFF91"
 	nutriment_factor = 0
 	taste_description = "bitterness"
 	glass_icon_state = "tea"
 	glass_name = "Agave Tea"
-	glass_desc = "A soothing herbal rememedy steeped from the Agave Plant. Induces increased healing of burns and sores."
+	glass_desc = "A soothing herbal rememedy steeped from the Agave Plant. Inhibits increased healing of burns and sores."
 
 /datum/reagent/consumable/tea/agavetea/on_mob_life(mob/living/carbon/M)
-	M.adjustFireLoss(-1.5*REAGENTS_EFFECT_MULTIPLIER, 0)
+	M.adjustFireLoss(-3*REAGENTS_EFFECT_MULTIPLIER, 0)
 	M.nutrition = max(M.nutrition - 3, 0)
 	M.dizziness = max(0,M.dizziness-2)
 	M.drowsyness = max(0,M.drowsyness-1)

--- a/code/modules/fallout/reagents/toxins.dm
+++ b/code/modules/fallout/reagents/toxins.dm
@@ -5,4 +5,19 @@
 	toxpwr = 5
 	taste_description = "slime"
 	taste_mult = 0.9
-	can_synth = FALSE
+
+/datum/reagent/toxin/FEV_solution/reaction_mob(mob/living/carbon/M, method=TOUCH, reac_volume)
+	if(!..())
+		return
+	if(!M.has_dna())
+		return  //No robots, AIs, aliens, Ians or other mobs should be affected by this.
+	if((method==VAPOR && prob(min(25, reac_volume))) || method==INGEST || method==PATCH || method==INJECT)
+		M.easy_randmut(NEGATIVE + MINOR_NEGATIVE, sequence = FALSE)
+		M.updateappearance()
+		M.domutcheck()
+	..()
+
+/datum/reagent/toxin/FEV_solution/on_mob_life(mob/living/carbon/C)
+	C.apply_effect(30,EFFECT_IRRADIATE,0)
+	C.adjustCloneLoss(30,0)
+	return ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -14,7 +14,6 @@
 	taste_description = "alcohol"
 	var/boozepwr = 65 //Higher numbers equal higher hardness, higher hardness equals more intense alcohol poisoning
 	pH = 7.33
-	can_synth = FALSE
 	value = REAGENT_VALUE_VERY_COMMON //don't bother tweaking all drinks values, way too many can easily be done roundstart or with an upgraded dispenser.
 
 /*

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -179,7 +179,6 @@
 	color = "#FF4DD2"
 	taste_description = "laughter"
 	value = REAGENT_VALUE_RARE
-	can_synth = FALSE
 
 /datum/reagent/consumable/superlaughter/on_mob_life(mob/living/carbon/M)
 	if(prob(30))
@@ -995,7 +994,7 @@
 /datum/reagent/consumable/sol_dry/on_mob_life(mob/living/carbon/M)
 	M.adjust_disgust(-5)
 	..()
-/*
+
 /datum/reagent/consumable/red_queen
 	name = "Red Queen"
 	description = "DRINK ME."
@@ -1007,7 +1006,6 @@
 	glass_desc = "DRINK ME."
 	value = REAGENT_VALUE_COMMON //growth serum.
 	var/current_size = RESIZE_DEFAULT_SIZE
-	can_synth = FALSE
 
 /datum/reagent/consumable/red_queen/on_mob_life(mob/living/carbon/H)
 	if(prob(75))
@@ -1026,7 +1024,7 @@
 	current_size = RESIZE_DEFAULT_SIZE
 	M.update_transform()
 	..()
-*/
+
 /datum/reagent/consumable/pinkmilk
 	name = "Strawberry Milk"
 	description = "A drink of a bygone era of milk and artificial sweetener back on a rock."

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -9,7 +9,7 @@
 		SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "[type]_high")
 
 /datum/reagent/drug/space_drugs
-	name = "Generic drugs"
+	name = "Space drugs"
 	value = REAGENT_VALUE_VERY_COMMON
 	description = "An illegal chemical compound used as drug."
 	color = "#60A584" // rgb: 96, 165, 132
@@ -65,7 +65,6 @@
 	addiction_threshold = 10
 	pH = 10
 	value = REAGENT_VALUE_UNCOMMON
-	can_synth = FALSE
 
 /datum/reagent/drug/crank/on_mob_life(mob/living/carbon/M)
 	if(prob(5))
@@ -113,7 +112,6 @@
 	addiction_threshold = 15
 	pH = 9
 	value = REAGENT_VALUE_UNCOMMON
-	can_synth = FALSE
 
 
 /datum/reagent/drug/krokodil/on_mob_life(mob/living/carbon/M)
@@ -166,7 +164,6 @@
 	addiction_threshold = 20
 	pH = 9
 	value = REAGENT_VALUE_UNCOMMON
-	can_synth = FALSE
 
 
 /datum/reagent/drug/heroin/on_mob_life(mob/living/carbon/M)
@@ -298,7 +295,6 @@
 	overdose_threshold = 35
 	jitter = FALSE
 	brain_damage = FALSE
-	can_synth = FALSE
 	value = REAGENT_VALUE_RARE
 
 /datum/reagent/drug/bath_salts
@@ -312,7 +308,6 @@
 	var/datum/brain_trauma/special/psychotic_brawling/bath_salts/rage
 	pH = 8.2
 	value = REAGENT_VALUE_RARE
-	can_synth = FALSE
 
 /datum/reagent/drug/bath_salts/on_mob_metabolize(mob/living/L)
 	..()
@@ -507,7 +502,6 @@
 	color = "#E62111"
 	overdose_threshold = 6
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/syndicateadrenals/on_mob_life(mob/living/M)
 	M.adjustStaminaLoss(-5*REM)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -556,7 +556,6 @@
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#302000" // rgb: 48, 32, 0
 	taste_description = "wet and cheap noodles on fire"
-	can_synth = FALSE
 
 /datum/reagent/consumable/hell_ramen/on_mob_life(mob/living/carbon/M)
 	M.adjust_bodytemperature(10 * TEMPERATURE_DAMAGE_COEFFICIENT)
@@ -725,7 +724,6 @@
 	taste_description = "bitter mushroom"
 	pH = 12
 	value = REAGENT_VALUE_RARE
-	can_synth = FALSE
 
 /datum/reagent/consumable/entpoly/on_mob_life(mob/living/carbon/M)
 	if(current_cycle >= 10)
@@ -762,7 +760,6 @@
 	taste_description = "fruity mushroom"
 	pH = 10.4
 	value = REAGENT_VALUE_RARE
-	can_synth = FALSE
 
 /datum/reagent/consumable/vitfro/on_mob_life(mob/living/carbon/M)
 	if(prob(80))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -435,7 +435,6 @@
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
 	pH = 2.6
 	value = REAGENT_VALUE_COMMON
-	can_synth = FALSE
 
 /datum/reagent/medicine/mine_salve/on_mob_life(mob/living/carbon/C)
 	C.hal_screwyhud = SCREWYHUD_HEALTHY
@@ -1069,7 +1068,6 @@
 	overdose_threshold = 60
 	pH = 8.7
 	value = REAGENT_VALUE_RARE
-	can_synth = FALSE
 
 /datum/reagent/medicine/stimulants/on_mob_metabolize(mob/living/L)
 	..()
@@ -1274,7 +1272,6 @@
 	color = "#555555"
 	pH = 11
 	value = REAGENT_VALUE_EXCEPTIONAL
-	can_synth = FALSE
 
 /datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-5*REM, FALSE) //A ton of healing - this is a 50 telecrystal investment.
@@ -1296,7 +1293,6 @@
 	color = "#555555"
 	pH = 11
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/medicine/lesser_syndicate_nanites/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-2*REM, FALSE)
@@ -1321,7 +1317,6 @@
 	taste_description = "jelly"
 	pH = 11.8
 	value = REAGENT_VALUE_UNCOMMON
-	can_synth = FALSE
 
 /datum/reagent/medicine/neo_jelly/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-1.5*REM, FALSE)
@@ -1431,7 +1426,6 @@
 	color = "#918e53"
 	overdose_threshold = 30
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_metabolize(mob/living/L)
 	..()
@@ -1460,7 +1454,6 @@
 	color = "#669153"
 	metabolization_rate = 1
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/medicine/changelinghaste/on_mob_metabolize(mob/living/L)
 	..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -331,7 +331,6 @@
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen, but it looks kinda hollow."
 	color = "#88878777"
 	taste_description = "emptyiness"
-	can_synth = FALSE
 
 
 /datum/reagent/water/holywater
@@ -474,7 +473,6 @@
 	description = "YOUR FLESH! IT BURNS!"
 	taste_description = "burning"
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/hellwater/on_mob_life(mob/living/carbon/M)
 	M.fire_stacks = min(5,M.fire_stacks + 3)
@@ -490,7 +488,6 @@
 	description = "Oil blessed by a greater being."
 	taste_description = "metallic oil"
 	value = REAGENT_VALUE_RARE
-	can_synth = FALSE
 
 /datum/reagent/fuel/holyoil/on_mob_life(mob/living/carbon/M)
 	if(is_servant_of_ratvar(M))
@@ -549,7 +546,6 @@
 	name = "Super Duper Lube"
 	description = "This \[REDACTED\] has been outlawed after the incident on \[DATA EXPUNGED\]."
 	lube_kind = TURF_WET_SUPERLUBE
-	can_synth = FALSE
 
 /datum/reagent/spraytan
 	name = "Spray Tan"
@@ -659,7 +655,6 @@
 	color = "#13BC5E" // rgb: 19, 188, 94
 	taste_description = "slime"
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/aslimetoxin/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
 	if(method != TOUCH)
@@ -1165,7 +1160,6 @@
 	taste_description = "acid"
 	pH = 2
 	value = REAGENT_VALUE_RARE
-	can_synth = FALSE
 
 /datum/reagent/space_cleaner/ez_clean/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(3.33)
@@ -1334,7 +1328,6 @@
 	color = "#808080"
 	taste_description = "sweetness"
 	pH = 5.8
-	can_synth = FALSE
 
 /datum/reagent/nitrous_oxide/reaction_obj(obj/O, reac_volume)
 	if((!O) || (!reac_volume))
@@ -1369,7 +1362,6 @@
 	color = "E1A116"
 	taste_description = "sourness"
 	value = REAGENT_VALUE_EXCEPTIONAL
-	can_synth = FALSE
 
 /datum/reagent/stimulum/on_mob_metabolize(mob/living/L)
 	..()
@@ -1396,7 +1388,6 @@
 	taste_description = "burning"
 	pH = 2
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/nitryl/on_mob_metabolize(mob/living/L)
 	..()
@@ -1860,51 +1851,43 @@
 	name = "mutagenic agar"
 	color = "#A3C00F" // rgb: 163,192,15
 	taste_description = "sourness"
-	can_synth = FALSE
 
 /datum/reagent/toxin/mutagen/mutagenvirusfood/sugar
 	name = "sucrose agar"
 	color = "#41B0C0" // rgb: 65,176,192
 	taste_description = "sweetness"
-	can_synth = FALSE
 
 /datum/reagent/medicine/synaptizine/synaptizinevirusfood
 	name = "virus rations"
 	color = "#D18AA5" // rgb: 209,138,165
 	taste_description = "bitterness"
-	can_synth = FALSE
 
 /datum/reagent/toxin/plasma/plasmavirusfood
 	name = "virus plasma"
 	color = "#A69DA9" // rgb: 166,157,169
 	taste_description = "bitterness"
 	taste_mult = 1.5
-	can_synth = FALSE
 
 /datum/reagent/toxin/plasma/plasmavirusfood/weak
 	name = "weakened virus plasma"
 	color = "#CEC3C6" // rgb: 206,195,198
 	taste_description = "bitterness"
 	taste_mult = 1.5
-	can_synth = FALSE
 
 /datum/reagent/uranium/uraniumvirusfood
 	name = "decaying uranium gel"
 	color = "#67ADBA" // rgb: 103,173,186
 	taste_description = "the inside of a reactor"
-	can_synth = FALSE
 
 /datum/reagent/uranium/uraniumvirusfood/unstable
 	name = "unstable uranium gel"
 	color = "#2FF2CB" // rgb: 47,242,203
 	taste_description = "the inside of a reactor"
-	can_synth = FALSE
 
 /datum/reagent/uranium/uraniumvirusfood/stable
 	name = "stable uranium gel"
 	color = "#04506C" // rgb: 4,80,108
 	taste_description = "the inside of a reactor"
-	can_synth = FALSE
 
 // Bee chemicals
 
@@ -1915,7 +1898,6 @@
 	taste_description = "strange honey"
 	pH = 3
 	value = REAGENT_VALUE_UNCOMMON
-	can_synth = FALSE
 
 /datum/reagent/royal_bee_jelly/on_mob_life(mob/living/carbon/M)
 	if(prob(2))
@@ -1952,7 +1934,6 @@
 	reagent_state = LIQUID
 	color = "#00f041"
 	value = REAGENT_VALUE_EXCEPTIONAL
-	can_synth = FALSE
 
 /datum/reagent/magillitis/on_mob_life(mob/living/carbon/M)
 	..()
@@ -1966,7 +1947,6 @@
 	var/current_size = RESIZE_DEFAULT_SIZE
 	value = REAGENT_VALUE_COMMON
 	taste_description = "bitterness" // apparently what viagra tastes like
-	can_synth = FALSE
 
 /datum/reagent/growthserum/on_mob_life(mob/living/carbon/H)
 	var/newsize = current_size
@@ -2032,7 +2012,6 @@
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	value = REAGENT_VALUE_RARE
 	pH = 15
-	can_synth = FALSE
 
 /datum/reagent/pax/on_mob_metabolize(mob/living/L)
 	..()
@@ -2049,7 +2028,6 @@
 	taste_description = "acrid cinnamon"
 	metabolization_rate = 0.2 * REAGENTS_METABOLISM
 	value = REAGENT_VALUE_UNCOMMON
-	can_synth = FALSE
 
 /datum/reagent/bz_metabolites/on_mob_metabolize(mob/living/L)
 	..()
@@ -2071,7 +2049,6 @@
 	description = "A colorless liquid that suppresses violence on the subjects. Cheaper to synthetize, but wears out faster than normal Pax."
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	value = REAGENT_VALUE_COMMON
-	can_synth = FALSE
 
 /datum/reagent/peaceborg_confuse
 	name = "Dizzying Solution"
@@ -2079,7 +2056,6 @@
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	taste_description = "dizziness"
 	value = REAGENT_VALUE_COMMON
-	can_synth = FALSE
 
 /datum/reagent/peaceborg_confuse/on_mob_life(mob/living/carbon/M)
 	if(M.confused < 6)
@@ -2096,7 +2072,6 @@
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	taste_description = "tiredness"
 	value = REAGENT_VALUE_COMMON
-	can_synth = FALSE
 
 /datum/reagent/peaceborg_tire/on_mob_life(mob/living/carbon/M)
 	var/healthcomp = (100 - M.health)	//DOES NOT ACCOUNT FOR ADMINBUS THINGS THAT MAKE YOU HAVE MORE THAN 200/210 HEALTH, OR SOMETHING OTHER THAN A HUMAN PROCESSING THIS.
@@ -2166,7 +2141,6 @@
 	description = "An extremely rare metallic-white substance only found on demon-class planets."
 	color = "#FFFFFF" // rgb: 255, 255, 255
 	taste_mult = 0 // oderless and tasteless
-	can_synth = FALSE
 
 /datum/reagent/metalgen
 	name = "Metalgen"
@@ -2176,7 +2150,6 @@
 	taste_mult = 0 // oderless and tasteless
 	var/applied_material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR
 	var/minumum_material_amount = 100
-	can_synth = FALSE
 
 /datum/reagent/metalgen/reaction_obj(obj/O, volume)
 	metal_morph(O)
@@ -2324,7 +2297,6 @@ datum/reagent/eldritch
 	description = "Strange liquid that defies the laws of physics"
 	taste_description = "Ag'hsj'saje'sh"
 	color = "#1f8016"
-	can_synth = FALSE
 
 /datum/reagent/eldritch/on_mob_life(mob/living/carbon/M)
 	if(IS_HERETIC(M))

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -39,7 +39,57 @@
 	toxpwr = 5
 	taste_description = "slime"
 	taste_mult = 0.9
-	can_synth = FALSE
+
+/datum/reagent/toxin/FEV_solution/reaction_mob(mob/living/carbon/M, method=TOUCH, reac_volume)
+	if(!..())
+		return
+	if(!M.has_dna())
+		return  //No robots, AIs, aliens, Ians or other mobs should be affected by this.
+	if((method==VAPOR && prob(min(25, reac_volume))) || method==INGEST || method==PATCH || method==INJECT)
+//		M.randmutb()
+		M.updateappearance()
+		M.domutcheck()
+	..()
+
+/datum/reagent/toxin/FEV_solution/on_mob_life(mob/living/carbon/C)
+	C.apply_effect(30,EFFECT_IRRADIATE,0)
+	C.adjustCloneLoss(30,0)
+	return ..()
+
+
+/datum/reagent/toxin/mutagen
+	name = "Unstable mutagen"
+	description = "Might cause unpredictable mutations. Keep away from children."
+	color = "#00FF00"
+	toxpwr = 0
+	taste_description = "slime"
+	taste_mult = 0.9
+	value = REAGENT_VALUE_VERY_COMMON
+	pH = 2.3
+
+/datum/reagent/toxin/mutagen/reaction_mob(mob/living/carbon/M, method=TOUCH, reac_volume)
+	if(!..())
+		return
+	if(!M.has_dna())
+		return  //No robots, AIs, aliens, Ians or other mobs should be affected by this.
+	if((method==VAPOR && prob(min(33, reac_volume))) || method==INGEST || method==PATCH || method==INJECT)
+		M.randmuti()
+		if(prob(98))
+			M.easy_randmut(NEGATIVE+MINOR_NEGATIVE)
+		else
+			M.easy_randmut(POSITIVE)
+		M.updateappearance()
+		M.domutcheck()
+	..()
+
+/datum/reagent/toxin/mutagen/on_mob_life(mob/living/carbon/C)
+	C.apply_effect(5,EFFECT_IRRADIATE,0)
+	return ..()
+
+/datum/reagent/toxin/mutagen/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)
+	mytray.mutation_roll(user)
+	if(chems.has_reagent(type, 1))
+		mytray.adjustToxic(1.5) //It is still toxic, mind you, but not to the same degree.
 
 /datum/reagent/toxin/plasma
 	name = "Plasma"
@@ -85,6 +135,19 @@
 	taste_description = "acid"
 	pH = 1.2
 	value = REAGENT_VALUE_RARE
+
+/datum/reagent/toxin/lexorin/on_mob_life(mob/living/carbon/C)
+	. = TRUE
+
+	if(HAS_TRAIT(C, TRAIT_NOBREATH))
+		. = FALSE
+
+	if(.)
+		C.adjustOxyLoss(5, 0)
+		C.losebreath += 2
+		if(prob(20))
+			C.emote("gasp")
+	..()
 
 /datum/reagent/toxin/slimejelly
 	name = "Slime Jelly"
@@ -134,6 +197,68 @@
 	for(var/i in M.all_scars)
 		qdel(i)
 
+/datum/reagent/toxin/zombiepowder
+	name = "Zombie Powder"
+	description = "A strong neurotoxin that puts the subject into a death-like state."
+	reagent_state = SOLID
+	color = "#669900" // rgb: 102, 153, 0
+	toxpwr = 0.5
+	taste_description = "death"
+	var/fakedeath_active = FALSE
+	pH = 13
+	value = REAGENT_VALUE_EXCEPTIONAL
+
+/datum/reagent/toxin/zombiepowder/on_mob_metabolize(mob/living/L)
+	..()
+	ADD_TRAIT(L, TRAIT_FAKEDEATH, type)
+
+/datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/L)
+	L.cure_fakedeath(type)
+	..()
+
+/datum/reagent/toxin/zombiepowder/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
+	L.adjustOxyLoss(0.5*REM, 0)
+	if(method == INGEST)
+		fakedeath_active = TRUE
+		L.fakedeath(type)
+
+/datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/M)
+	..()
+	if(fakedeath_active)
+		return TRUE
+	switch(current_cycle)
+		if(1 to 5)
+			M.confused += 1
+			M.drowsyness += 1
+			M.slurring += 3
+		if(5 to 8)
+			M.adjustStaminaLoss(40, 0)
+		if(9 to INFINITY)
+			fakedeath_active = TRUE
+			M.fakedeath(type)
+
+/datum/reagent/toxin/ghoulpowder
+	name = "Ghoul Powder"
+	description = "A strong neurotoxin that slows metabolism to a death-like state, while keeping the patient fully active. Causes toxin buildup if used too long."
+	reagent_state = SOLID
+	color = "#664700" // rgb: 102, 71, 0
+	toxpwr = 0.8
+	taste_description = "death"
+	pH = 14.5
+	value = REAGENT_VALUE_EXCEPTIONAL
+
+/datum/reagent/toxin/ghoulpowder/on_mob_metabolize(mob/living/L)
+	..()
+	ADD_TRAIT(L, TRAIT_FAKEDEATH, type)
+
+/datum/reagent/toxin/ghoulpowder/on_mob_end_metabolize(mob/living/L)
+	REMOVE_TRAIT(L, TRAIT_FAKEDEATH, type)
+	..()
+
+/datum/reagent/toxin/ghoulpowder/on_mob_life(mob/living/carbon/M)
+	M.adjustOxyLoss(1*REM, 0)
+	..()
+	. = 1
 
 /datum/reagent/toxin/mindbreaker
 	name = "Mindbreaker Toxin"
@@ -281,7 +406,6 @@
 	glass_desc = "A freezing pint of beer."
 	pH = 2
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/toxin/fakebeer/on_mob_life(mob/living/carbon/M)
 	switch(current_cycle)
@@ -337,7 +461,6 @@
 	data = 15
 	toxpwr = 0
 	value = REAGENT_VALUE_UNCOMMON
-	can_synth = FALSE
 
 /datum/reagent/toxin/staminatoxin/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(REM * data, 0)
@@ -353,7 +476,6 @@
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	toxpwr = 0
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/toxin/polonium/on_mob_life(mob/living/carbon/M)
 	M.radiation += 4
@@ -416,7 +538,6 @@
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	toxpwr = 0
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/toxin/venom/on_mob_life(mob/living/carbon/M)
 	toxpwr = 0.2*volume
@@ -480,7 +601,6 @@
 	color = "#C8C8C8"
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
 	toxpwr = 0
-	can_synth = FALSE
 
 /datum/reagent/toxin/itching_powder/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if((method == TOUCH || method == VAPOR) && M.reagents)
@@ -513,7 +633,6 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	toxpwr = 2.5
 	value = REAGENT_VALUE_EXCEPTIONAL
-	can_synth = FALSE
 
 /datum/reagent/toxin/initropidril/on_mob_life(mob/living/carbon/C)
 	if(prob(25))
@@ -546,7 +665,6 @@
 	toxpwr = 0
 	taste_mult = 0 // undetectable, I guess?
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/toxin/pancuronium/on_mob_life(mob/living/carbon/M)
 	if(current_cycle >= 10)
@@ -564,7 +682,6 @@
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	toxpwr = 0
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/toxin/sodium_thiopental/on_mob_life(mob/living/carbon/M)
 	if(current_cycle >= 10)
@@ -580,7 +697,6 @@
 	color = "#7DC3A0"
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	toxpwr = 0.5
-	can_synth = FALSE
 
 /datum/reagent/toxin/sulfonal/on_mob_life(mob/living/carbon/M)
 	if(current_cycle >= 22)
@@ -589,12 +705,18 @@
 
 /datum/reagent/toxin/amanitin
 	name = "Amanitin"
-	description = "It's just a mushroom toxin."
+	description = "A very powerful delayed toxin. Upon full metabolization, a massive amount of toxin damage will be dealt depending on how long it has been in the victim's bloodstream."
 	reagent_state = LIQUID
 	color = "#FFFFFF"
-	toxpwr = 1
+	toxpwr = 0
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	value = REAGENT_VALUE_RARE
+
+/datum/reagent/toxin/amanitin/on_mob_end_metabolize(mob/living/M)
+	var/toxdamage = current_cycle*3*REM
+	M.log_message("has taken [toxdamage] toxin damage from amanitin toxin", LOG_ATTACK)
+	M.adjustToxLoss(toxdamage)
+	..()
 
 /datum/reagent/toxin/lipolicide
 	name = "Lipolicide"
@@ -620,7 +742,10 @@
 	metabolization_rate = 0.06 * REAGENTS_METABOLISM
 	toxpwr = 1.75
 	value = REAGENT_VALUE_EXCEPTIONAL
-	can_synth = FALSE
+
+/datum/reagent/toxin/coniine/on_mob_life(mob/living/carbon/M)
+	M.losebreath += 5
+	return ..()
 
 /datum/reagent/toxin/spewium
 	name = "Spewium"
@@ -632,7 +757,6 @@
 	toxpwr = 0
 	taste_description = "vomit"
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/toxin/spewium/on_mob_life(mob/living/carbon/C)
 	.=..()
@@ -657,7 +781,6 @@
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	toxpwr = 1
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/toxin/curare/on_mob_life(mob/living/carbon/M)
 	if(current_cycle >= 11)
@@ -684,7 +807,25 @@
 	toxpwr = 0.5
 	taste_description = "spinning"
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
+
+/datum/reagent/toxin/rotatium/on_mob_life(mob/living/carbon/M)
+	if(M.hud_used)
+		if(current_cycle >= 20 && current_cycle%20 == 0)
+			var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"],
+									M.hud_used.plane_masters["[LIGHTING_PLANE]"], M.hud_used.plane_masters["[WALL_PLANE]"],
+									M.hud_used.plane_masters["[ABOVE_WALL_PLANE]"])
+			var/rotation = min(round(current_cycle/20), 89) // By this point the player is probably puking and quitting anyway
+			for(var/whole_screen in screens)
+				animate(whole_screen, transform = matrix(rotation, MATRIX_ROTATE), time = 5, easing = QUAD_EASING, loop = -1)
+				animate(transform = matrix(-rotation, MATRIX_ROTATE), time = 5, easing = QUAD_EASING)
+	return ..()
+
+/datum/reagent/toxin/rotatium/on_mob_end_metabolize(mob/living/M)
+	if(M && M.hud_used)
+		var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"], M.hud_used.plane_masters["[LIGHTING_PLANE]"])
+		for(var/whole_screen in screens)
+			animate(whole_screen, transform = matrix(), time = 5, easing = QUAD_EASING)
+	..()
 
 /datum/reagent/toxin/skewium
 	name = "Skewium"
@@ -734,7 +875,6 @@
 	metabolization_rate = 0.08 * REAGENTS_METABOLISM
 	toxpwr = 0.15
 	value = REAGENT_VALUE_VERY_RARE
-	can_synth = FALSE
 
 /datum/reagent/toxin/anacea/on_mob_life(mob/living/carbon/M)
 	var/remove_amt = 5
@@ -805,7 +945,6 @@
 	toxpwr = 2
 	acidpwr = 150.0
 	value = REAGENT_VALUE_COMMON
-	can_synth = FALSE
 
 // ACID II: UNHEEDED WARNINGS
 /datum/reagent/toxin/acid/fluacid/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)
@@ -835,7 +974,6 @@
 	value = REAGENT_VALUE_VERY_RARE
 	var/actual_toxpwr = 5
 	var/delay = 30
-	can_synth = FALSE
 
 /datum/reagent/toxin/delayed/on_mob_life(mob/living/carbon/M)
 	if(current_cycle > delay)
@@ -928,7 +1066,6 @@
 	taste_description = "brain hurting"
 	metabolization_rate = 5
 	value = REAGENT_VALUE_EXCEPTIONAL
-	can_synth = FALSE
 
 /datum/reagent/toxin/brainhurtingjuice/on_mob_life(mob/living/carbon/M)
 	if(prob(50))
@@ -948,7 +1085,6 @@
 	toxpwr = 0
 	taste_description = "tannin"
 	value = REAGENT_VALUE_RARE
-	can_synth = FALSE
 
 /datum/reagent/toxin/bungotoxin/on_mob_life(mob/living/carbon/M)
 	M.adjustOrganLoss(ORGAN_SLOT_HEART, 3)
@@ -967,7 +1103,6 @@
 	toxpwr = 0.5
 	taste_mult = 1.3
 	taste_description = "sugary sweetness"
-	can_synth = FALSE
 
 /datum/reagent/toxin/leadacetate/on_mob_life(mob/living/carbon/M)
 	M.adjustOrganLoss(ORGAN_SLOT_EARS,1)

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -1,8 +1,25 @@
 /datum/chemical_reaction/space_drugs
-	name = "Miscellaneous Drugs"
+	name = "Space Drugs"
 	id = /datum/reagent/drug/space_drugs
 	results = list(/datum/reagent/drug/space_drugs = 3)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1)
+
+/datum/chemical_reaction/crank
+	name = "Crank"
+	id = /datum/reagent/drug/crank
+	results = list(/datum/reagent/drug/crank = 5)
+	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/ammonia = 1, /datum/reagent/lithium = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/fuel = 1)
+	mix_message = "The mixture violently reacts, leaving behind a few crystalline shards."
+	required_temp = 390
+
+
+/datum/chemical_reaction/krokodil
+	name = "Krokodil"
+	id = /datum/reagent/drug/krokodil
+	results = list(/datum/reagent/drug/krokodil = 6)
+	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/medicine/morphine = 1, /datum/reagent/space_cleaner = 1, /datum/reagent/potassium = 1, /datum/reagent/phosphorus = 1, /datum/reagent/fuel = 1)
+	mix_message = "The mixture dries into a pale blue powder."
+	required_temp = 380
 
 /datum/chemical_reaction/heroin
 	name = "Heroin"
@@ -17,6 +34,13 @@
 	id = /datum/reagent/drug/methamphetamine
 	results = list(/datum/reagent/drug/methamphetamine = 4)
 	required_reagents = list(/datum/reagent/medicine/ephedrine = 1, /datum/reagent/iodine = 1, /datum/reagent/phosphorus = 1, /datum/reagent/hydrogen = 1)
+	required_temp = 374
+
+/datum/chemical_reaction/bath_salts
+	name = "bath_salts"
+	id = /datum/reagent/drug/bath_salts
+	results = list(/datum/reagent/drug/bath_salts = 7)
+	required_reagents = list(/datum/reagent/toxin/bad_food = 1, /datum/reagent/saltpetre = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/space_cleaner = 1, /datum/reagent/consumable/enzyme = 1, /datum/reagent/consumable/tea = 1, /datum/reagent/mercury = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/aranesp

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -84,6 +84,44 @@
 	id = "synthflesh_2"
 	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1)
 
+/datum/chemical_reaction/synthtissue
+	name = "Synthtissue"
+	id = /datum/reagent/synthtissue
+	results = list(/datum/reagent/synthtissue = 5)
+	required_reagents = list(/datum/reagent/medicine/synthflesh = 1)
+	required_catalysts = list(/datum/reagent/consumable/sugar = 0.1)
+	//FermiChem vars:
+	OptimalTempMin 		= 305		// Lower area of bell curve for determining heat based rate reactions
+	OptimalTempMax 		= 315 		// Upper end for above
+	ExplodeTemp 		= 1050 		// Temperature at which reaction explodes
+	OptimalpHMin 		= 8.5 		// Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
+	OptimalpHMax 		= 9.5 		// Higest value for above
+	ReactpHLim 			= 2 		// How far out pH wil react, giving impurity place (Exponential phase)
+	CatalystFact 		= 0 		// How much the catalyst affects the reaction (0 = no catalyst)
+	CurveSharpT 		= 1 		// How sharp the temperature exponential curve is (to the power of value)
+	CurveSharppH 		= 2.5 		// How sharp the pH exponential curve is (to the power of value)
+	ThermicConstant		= 0.01 		// Temperature change per 1u produced
+	HIonRelease 		= 0.015 		// pH change per 1u reaction (inverse for some reason)
+	RateUpLim 			= 0.1 		// Optimal/max rate possible if all conditions are perfect
+	FermiChem 			= TRUE		// If the chemical uses the Fermichem reaction mechanics
+	PurityMin 			= 0
+
+/datum/chemical_reaction/synthtissue/FermiCreate(datum/reagents/holder, added_volume, added_purity)
+	var/datum/reagent/synthtissue/St = holder.has_reagent(/datum/reagent/synthtissue)
+	var/datum/reagent/N = holder.has_reagent(/datum/reagent/consumable/sugar)
+	if(!St)
+		return
+	if(holder.chem_temp > 320)
+		var/temp_ratio = 1-(330 - holder.chem_temp)/10
+		holder.remove_reagent(id, added_volume*temp_ratio)
+	if(St.purity < 1)
+		St.volume *= St.purity
+		St.purity = 1
+	var/amount = clamp(0.002, 0, N.volume)
+	N.volume -= amount
+	St.data["grown_volume"] = St.data["grown_volume"] + added_volume
+	St.name = "[initial(St.name)] [round(St.data["grown_volume"], 0.1)]u colony"
+
 /datum/chemical_reaction/styptic_powder
 	name = "Styptic Powder"
 	id = /datum/reagent/medicine/styptic_powder

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -189,6 +189,263 @@
 	results = list(/datum/reagent/nitrous_oxide = 5)
 	required_reagents = list(/datum/reagent/ammonia = 2, /datum/reagent/nitrogen = 1, /datum/reagent/oxygen = 2)
 	required_temp = 525
+	
+/datum/chemical_reaction/fermis_plush
+	name = "Fermis plush"
+	id = "fermis_plush"
+	required_reagents = list(/datum/reagent/consumable/caramel = 10, /datum/reagent/blood = 10, /datum/reagent/stable_plasma = 10)
+	mob_react = FALSE
+	required_temp = 300
+
+/datum/chemical_reaction/fermis_plush/on_reaction(datum/reagents/holder, multiplier)
+	var/location = get_turf(holder.my_atom)
+	for(var/i = 1, i <= multiplier, i+=10)
+		new /obj/item/toy/plush/catgirl/fermis(location)
+
+////////////////////////////////// VIROLOGY //////////////////////////////////////////
+
+/datum/chemical_reaction/virus_food
+	name = "Virus Food"
+	id = "virusfood"
+	results = list(/datum/reagent/consumable/virus_food = 15)
+	required_reagents = list(/datum/reagent/water = 5, /datum/reagent/consumable/milk = 5)
+
+/datum/chemical_reaction/virus_food_mutagen
+	name = "mutagenic agar"
+	id = "mutagenvirusfood"
+	results = list(/datum/reagent/toxin/mutagen/mutagenvirusfood = 1)
+	required_reagents = list(/datum/reagent/toxin/mutagen = 1, /datum/reagent/consumable/virus_food = 1)
+
+/datum/chemical_reaction/virus_food_synaptizine
+	name = "virus rations"
+	id = "synaptizinevirusfood"
+	results = list(/datum/reagent/medicine/synaptizine/synaptizinevirusfood = 1)
+	required_reagents = list(/datum/reagent/medicine/synaptizine = 1, /datum/reagent/consumable/virus_food = 1)
+
+/datum/chemical_reaction/virus_food_plasma
+	name = "virus plasma"
+	id = /datum/reagent/toxin/plasma/plasmavirusfood
+	results = list(/datum/reagent/toxin/plasma/plasmavirusfood = 1)
+	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/consumable/virus_food = 1)
+
+/datum/chemical_reaction/virus_food_plasma_synaptizine
+	name = "weakened virus plasma"
+	id = /datum/reagent/toxin/plasma/plasmavirusfood/weak
+	results = list(/datum/reagent/toxin/plasma/plasmavirusfood/weak = 2)
+	required_reagents = list(/datum/reagent/medicine/synaptizine = 1, /datum/reagent/toxin/plasma/plasmavirusfood = 1)
+
+/datum/chemical_reaction/virus_food_mutagen_sugar
+	name = "sucrose agar"
+	id = /datum/reagent/toxin/mutagen/mutagenvirusfood/sugar
+	results = list(/datum/reagent/toxin/mutagen/mutagenvirusfood/sugar = 2)
+	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/toxin/mutagen/mutagenvirusfood = 1)
+
+/datum/chemical_reaction/virus_food_mutagen_salineglucose
+	name = "sucrose agar"
+	id = "salineglucosevirusfood"
+	results = list(/datum/reagent/toxin/mutagen/mutagenvirusfood/sugar = 2)
+	required_reagents = list(/datum/reagent/medicine/salglu_solution = 1, /datum/reagent/toxin/mutagen/mutagenvirusfood = 1)
+
+/datum/chemical_reaction/virus_food_uranium
+	name = "Decaying uranium gel"
+	id = /datum/reagent/uranium/uraniumvirusfood
+	results = list(/datum/reagent/uranium/uraniumvirusfood = 1)
+	required_reagents = list(/datum/reagent/uranium = 1, /datum/reagent/consumable/virus_food = 1)
+
+/datum/chemical_reaction/virus_food_uranium_plasma
+	name = "Unstable uranium gel"
+	id = /datum/reagent/uranium/uraniumvirusfood/unstable
+	results = list(/datum/reagent/uranium/uraniumvirusfood/unstable = 1)
+	required_reagents = list(/datum/reagent/uranium = 5, /datum/reagent/toxin/plasma/plasmavirusfood = 1)
+
+/datum/chemical_reaction/virus_food_uranium_plasma_gold
+	name = "Stable uranium gel"
+	id = "uraniumvirusfood_gold"
+	results = list(/datum/reagent/uranium/uraniumvirusfood/stable = 1)
+	required_reagents = list(/datum/reagent/uranium = 10, /datum/reagent/gold = 10, /datum/reagent/toxin/plasma = 1)
+
+/datum/chemical_reaction/virus_food_uranium_plasma_silver
+	name = "Stable uranium gel"
+	id = "uraniumvirusfood_silver"
+	results = list(/datum/reagent/uranium/uraniumvirusfood/stable = 1)
+	required_reagents = list(/datum/reagent/uranium = 10, /datum/reagent/silver = 10, /datum/reagent/toxin/plasma = 1)
+
+/datum/chemical_reaction/mix_virus
+	name = "Mix Virus"
+	id = "mixvirus"
+	required_reagents = list(/datum/reagent/consumable/virus_food = 1)
+	required_catalysts = list(/datum/reagent/blood = 1)
+	var/level_min = 1
+	var/level_max = 2
+
+/datum/chemical_reaction/mix_virus/on_reaction(datum/reagents/holder, multiplier)
+	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
+	if(B && B.data)
+		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
+		if(D)
+			for(var/i in 1 to min(multiplier, 5))
+				D.Evolve(level_min, level_max)
+
+/datum/chemical_reaction/mix_virus/synth
+	id = "mixvirus_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_2
+	name = "Mix Virus 2"
+	id = "mixvirus2"
+	required_reagents = list(/datum/reagent/toxin/mutagen = 1)
+	level_min = 2
+	level_max = 4
+
+/datum/chemical_reaction/mix_virus/mix_virus_2/synth
+	id = "mixvirus2_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_3
+	name = "Mix Virus 3"
+	id = "mixvirus3"
+	required_reagents = list(/datum/reagent/toxin/plasma = 1)
+	level_min = 4
+	level_max = 6
+
+/datum/chemical_reaction/mix_virus/mix_virus_3/synth
+	id = "mixvirus3_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_4
+	name = "Mix Virus 4"
+	id = "mixvirus4"
+	required_reagents = list(/datum/reagent/uranium = 1)
+	level_min = 5
+	level_max = 6
+
+/datum/chemical_reaction/mix_virus/mix_virus_4/synth
+	id = "mixvirus4_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_5
+	name = "Mix Virus 5"
+	id = "mixvirus5"
+	required_reagents = list(/datum/reagent/toxin/mutagen/mutagenvirusfood = 1)
+	level_min = 3
+	level_max = 3
+
+/datum/chemical_reaction/mix_virus/mix_virus_5/synth
+	id = "mixvirus5_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_6
+	name = "Mix Virus 6"
+	id = "mixvirus6"
+	required_reagents = list(/datum/reagent/toxin/mutagen/mutagenvirusfood/sugar = 1)
+	level_min = 4
+	level_max = 4
+
+/datum/chemical_reaction/mix_virus/mix_virus_6/synth
+	id = "mixvirus6_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_7
+	name = "Mix Virus 7"
+	id = "mixvirus7"
+	required_reagents = list(/datum/reagent/toxin/plasma/plasmavirusfood/weak = 1)
+	level_min = 5
+	level_max = 5
+
+/datum/chemical_reaction/mix_virus/mix_virus_7/synth
+	id = "mixvirus7_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_8
+	name = "Mix Virus 8"
+	id = "mixvirus8"
+	required_reagents = list(/datum/reagent/toxin/plasma/plasmavirusfood = 1)
+	level_min = 6
+	level_max = 6
+
+/datum/chemical_reaction/mix_virus/mix_virus_8/synth
+	id = "mixvirus8_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_9
+	name = "Mix Virus 9"
+	id = "mixvirus9"
+	required_reagents = list(/datum/reagent/medicine/synaptizine/synaptizinevirusfood = 1)
+	level_min = 1
+	level_max = 1
+
+/datum/chemical_reaction/mix_virus/mix_virus_9/synth
+	id = "mixvirus9_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_10
+	name = "Mix Virus 10"
+	id = "mixvirus10"
+	required_reagents = list(/datum/reagent/uranium/uraniumvirusfood = 1)
+	level_min = 6
+	level_max = 7
+
+/datum/chemical_reaction/mix_virus/mix_virus_10/synth
+	id = "mixvirus10_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_11
+	name = "Mix Virus 11"
+	id = "mixvirus11"
+	required_reagents = list(/datum/reagent/uranium/uraniumvirusfood/unstable = 1)
+	level_min = 7
+	level_max = 7
+
+/datum/chemical_reaction/mix_virus/mix_virus_11/synth
+	id = "mixvirus11_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/mix_virus_12
+	name = "Mix Virus 12"
+	id = "mixvirus12"
+	required_reagents = list(/datum/reagent/uranium/uraniumvirusfood/stable = 1)
+	level_min = 8
+	level_max = 8
+
+/datum/chemical_reaction/mix_virus/mix_virus_12/synth
+	id = "mixvirus12_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/rem_virus
+	name = "Devolve Virus"
+	id = "remvirus"
+	required_reagents = list(/datum/reagent/medicine/synaptizine = 1)
+	required_catalysts = list(/datum/reagent/blood = 1)
+
+/datum/chemical_reaction/mix_virus/rem_virus/on_reaction(datum/reagents/holder, multiplier)
+	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
+	if(B && B.data)
+		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
+		if(D)
+			for(var/i in 1 to min(multiplier, 5))
+				D.Devolve()
+
+/datum/chemical_reaction/mix_virus/rem_virus/synth
+	id = "remvirus_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
+
+/datum/chemical_reaction/mix_virus/neuter_virus
+	name = "Neuter Virus"
+	id = "neutervirus"
+	required_reagents = list(/datum/reagent/toxin/formaldehyde = 1)
+	required_catalysts = list(/datum/reagent/blood = 1)
+
+/datum/chemical_reaction/mix_virus/neuter_virus/on_reaction(datum/reagents/holder, multiplier)
+	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
+	if(B && B.data)
+		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
+		if(D)
+			for(var/i in 1 to min(multiplier, 5))
+				D.Neuter()
+
+/datum/chemical_reaction/mix_virus/neuter_virus/synth
+	id = "neutervirus_synth"
+	required_catalysts = list(/datum/reagent/blood/synthetics = 1)
 
 ////////////////////////////////// foam and foam precursor ///////////////////////////////////////////////////
 
@@ -213,6 +470,63 @@
 	s.start()
 	holder.clear_reagents()
 	return
+
+
+/datum/chemical_reaction/metalfoam
+	name = "Metal Foam"
+	id = "metalfoam"
+	required_reagents = list(/datum/reagent/aluminium = 3, /datum/reagent/foaming_agent = 1, /datum/reagent/toxin/acid/fluacid = 1)
+	mob_react = FALSE
+
+/datum/chemical_reaction/metalfoam/on_reaction(datum/reagents/holder, multiplier)
+	var/turf/location = get_turf(holder.my_atom)
+	location.visible_message("<span class='danger'>The solution spews out a metallic foam!</span>")
+	var/datum/effect_system/foam_spread/metal/s = new()
+	s.set_up(multiplier*5, location, holder, 1)
+	s.start()
+	holder.clear_reagents()
+
+/datum/chemical_reaction/smart_foam
+	name = "Smart Metal Foam"
+	id = "smart_metal_foam"
+	required_reagents = list(/datum/reagent/aluminium = 3, /datum/reagent/smart_foaming_agent = 1, /datum/reagent/toxin/acid/fluacid = 1)
+	mob_react = TRUE
+
+/datum/chemical_reaction/smart_foam/on_reaction(datum/reagents/holder, multiplier)
+	var/turf/location = get_turf(holder.my_atom)
+	location.visible_message("<span class='danger'>The solution spews out metallic foam!</span>")
+	var/datum/effect_system/foam_spread/metal/smart/s = new()
+	s.set_up(multiplier * 5, location, holder, TRUE)
+	s.start()
+	holder.clear_reagents()
+
+/datum/chemical_reaction/ironfoam
+	name = "Iron Foam"
+	id = "ironlfoam"
+	required_reagents = list(/datum/reagent/iron = 3, /datum/reagent/foaming_agent = 1, /datum/reagent/toxin/acid/fluacid = 1)
+	mob_react = FALSE
+
+/datum/chemical_reaction/ironfoam/on_reaction(datum/reagents/holder, multiplier)
+	var/turf/location = get_turf(holder.my_atom)
+	location.visible_message("<span class='danger'>The solution spews out metallic foam!</span>")
+	var/datum/effect_system/foam_spread/metal/s = new()
+	s.set_up(multiplier*5, location, holder, 2)
+	s.start()
+	holder.clear_reagents()
+
+/datum/chemical_reaction/foaming_agent
+	name = "Foaming Agent"
+	id = /datum/reagent/foaming_agent
+	results = list(/datum/reagent/foaming_agent = 1)
+	required_reagents = list(/datum/reagent/lithium = 1, /datum/reagent/hydrogen = 1)
+
+/datum/chemical_reaction/smart_foaming_agent
+	name = "Smart foaming Agent"
+	id = /datum/reagent/smart_foaming_agent
+	results = list(/datum/reagent/smart_foaming_agent = 3)
+	required_reagents = list(/datum/reagent/foaming_agent = 3, /datum/reagent/acetone = 1, /datum/reagent/iron = 1)
+	mix_message = "The solution mixes into a frothy metal foam and conforms to the walls of its container."
+
 
 /////////////////////////////// Cleaning and hydroponics /////////////////////////////////////////////////
 
@@ -291,7 +605,36 @@
 	results = list(/datum/reagent/colorful_reagent = 5)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/radium = 1, /datum/reagent/drug/space_drugs = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/consumable/triple_citrus = 1)
 
+/datum/chemical_reaction/life
+	name = "Life"
+	id = "life"
+	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/blood = 1)
+	required_temp = 374
+
+/datum/chemical_reaction/life/on_reaction(datum/reagents/holder, multiplier)
+	chemical_mob_spawn(holder, rand(1, round(multiplier, 1)), "Life") // Lol.
+
 //This is missing, I'm adding it back (see tgwiki). Not sure why we don't have it.
+/datum/chemical_reaction/life_friendly
+	name = "Life (Friendly)"
+	id = "life_friendly"
+	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/consumable/sugar = 1)
+	required_temp = 374
+
+/datum/chemical_reaction/life_friendly/on_reaction(datum/reagents/holder, multiplier)
+	chemical_mob_spawn(holder, rand(1, round(multiplier, 1)), "Life (friendly)", FRIENDLY_SPAWN) //Pray for cute cats
+
+/datum/chemical_reaction/corgium
+	name = "corgium"
+	id = "corgium"
+	required_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/colorful_reagent = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/blood = 1)
+	required_temp = 374
+
+/datum/chemical_reaction/corgium/on_reaction(datum/reagents/holder, multiplier)
+	var/location = get_turf(holder.my_atom)
+	for(var/i = rand(1, multiplier), i <= multiplier, i++) // More lulz.
+		new /mob/living/simple_animal/pet/dog/corgi(location)
+	..()
 
 /datum/chemical_reaction/hair_dye
 	name = "hair_dye"
@@ -312,7 +655,6 @@
 	required_reagents = list(/datum/reagent/barbers_aid = 1, /datum/reagent/toxin/mutagen = 1)
 
 /datum/chemical_reaction/baldium
-	name = "baldium"
 	results = list(/datum/reagent/baldium = 1)
 	required_reagents = list(/datum/reagent/radium = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/lye = 1)
 	required_temp = 395

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -20,12 +20,31 @@
 	required_reagents = list(/datum/reagent/oil = 1, /datum/reagent/ammonia = 1, /datum/reagent/oxygen = 1)
 	required_temp = 380
 
+/datum/chemical_reaction/itching_powder
+	name = "Itching Powder"
+	id = /datum/reagent/toxin/itching_powder
+	results = list(/datum/reagent/toxin/itching_powder = 3)
+	required_reagents = list(/datum/reagent/fuel = 1, /datum/reagent/ammonia = 1, /datum/reagent/medicine/charcoal = 1)
+
 /datum/chemical_reaction/facid
 	name = "Fluorosulfuric acid"
 	id = /datum/reagent/toxin/acid/fluacid
 	results = list(/datum/reagent/toxin/acid/fluacid = 4)
 	required_reagents = list(/datum/reagent/toxin/acid = 1, /datum/reagent/fluorine = 1, /datum/reagent/hydrogen = 1, /datum/reagent/potassium = 1)
 	required_temp = 380
+
+/datum/chemical_reaction/fantiacid
+	name = "Fluoroantimonic acid"
+	id = /datum/reagent/toxin/acid/fantiacid
+	results = list(/datum/reagent/toxin/acid/fantiacid = 1)
+	required_reagents = list(/datum/reagent/toxin/acid/fluacid = 30, /datum/reagent/fluorine = 30, /datum/reagent/hydrogen = 30)
+	required_temp = 580
+
+/datum/chemical_reaction/sulfonal
+	name = "sulfonal"
+	id = /datum/reagent/toxin/sulfonal
+	results = list(/datum/reagent/toxin/sulfonal = 3)
+	required_reagents = list(/datum/reagent/acetone = 1, /datum/reagent/diethylamine = 1, /datum/reagent/sulfur = 1)
 
 /datum/chemical_reaction/lipolicide
 	name = "lipolicide"
@@ -39,11 +58,68 @@
 	results = list(/datum/reagent/toxin/mutagen = 3)
 	required_reagents = list(/datum/reagent/radium = 1, /datum/reagent/phosphorus = 1, /datum/reagent/chlorine = 1)
 
+/datum/chemical_reaction/lexorin
+	name = "Lexorin"
+	id = /datum/reagent/toxin/lexorin
+	results = list(/datum/reagent/toxin/lexorin = 3)
+	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/hydrogen = 1, /datum/reagent/oxygen = 1)
+
+/*/datum/chemical_reaction/chloralhydrate
+	name = "Chloral Hydrate"
+	id = /datum/reagent/toxin/chloralhydrate
+	results = list(/datum/reagent/toxin/chloralhydrate = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/chlorine = 3, /datum/reagent/water = 1)*/
+
+/datum/chemical_reaction/mutetoxin //i'll just fit this in here snugly between other unfun chemicals :v
+	name = "Mute Toxin"
+	id = /datum/reagent/toxin/mutetoxin
+	results = list(/datum/reagent/toxin/mutetoxin = 2)
+	required_reagents = list(/datum/reagent/uranium = 2, /datum/reagent/water = 1, /datum/reagent/carbon = 1)
+
+/datum/chemical_reaction/zombiepowder
+	name = "Zombie Powder"
+	id = /datum/reagent/toxin/zombiepowder
+	results = list(/datum/reagent/toxin/zombiepowder = 2)
+	required_reagents = list(/datum/reagent/toxin/carpotoxin = 5, /datum/reagent/medicine/morphine = 5, /datum/reagent/copper = 5)
+
+/datum/chemical_reaction/ghoulpowder
+	name = "Ghoul Powder"
+	id = /datum/reagent/toxin/ghoulpowder
+	results = list(/datum/reagent/toxin/ghoulpowder = 2)
+	required_reagents = list(/datum/reagent/toxin/zombiepowder = 1, /datum/reagent/medicine/epinephrine = 1)
+
 /datum/chemical_reaction/mindbreaker
 	name = "Mindbreaker Toxin"
 	id = /datum/reagent/toxin/mindbreaker
 	results = list(/datum/reagent/toxin/mindbreaker = 5)
 	required_reagents = list(/datum/reagent/silicon = 1, /datum/reagent/hydrogen = 1, /datum/reagent/medicine/charcoal = 1)
+
+/datum/chemical_reaction/heparin
+	name = "Heparin"
+	id = /datum/reagent/toxin/heparin
+	results = list(/datum/reagent/toxin/heparin = 4)
+	required_reagents = list(/datum/reagent/toxin/formaldehyde = 1, /datum/reagent/sodium = 1, /datum/reagent/chlorine = 1, /datum/reagent/lithium = 1)
+	mix_message = "<span class='danger'>The mixture thins and loses all color.</span>"
+
+/datum/chemical_reaction/rotatium
+	name = "Rotatium"
+	id = /datum/reagent/toxin/rotatium
+	results = list(/datum/reagent/toxin/rotatium = 3)
+	required_reagents = list(/datum/reagent/toxin/mindbreaker = 1, /datum/reagent/teslium = 1, /datum/reagent/toxin/fentanyl = 1)
+	mix_message = "<span class='danger'>After sparks, fire, and the smell of mindbreaker, the mix is constantly spinning with no stop in sight.</span>"
+
+/datum/chemical_reaction/skewium
+	name = "Skewium"
+	id = /datum/reagent/toxin/skewium
+	results = list(/datum/reagent/toxin/skewium = 5)
+	required_reagents = list(/datum/reagent/toxin/rotatium = 2, /datum/reagent/toxin/plasma = 2, /datum/reagent/toxin/acid = 1)
+	mix_message = "<span class='danger'>Wow! it turns out if you mix rotatium with some plasma and sulphuric acid, it gets even worse!</span>"
+
+/datum/chemical_reaction/anacea
+	name = "Anacea"
+	id = /datum/reagent/toxin/anacea
+	results = list(/datum/reagent/toxin/anacea = 3)
+	required_reagents = list(/datum/reagent/medicine/haloperidol = 1, /datum/reagent/impedrezene = 1, /datum/reagent/radium = 1)
 
 /datum/chemical_reaction/mimesbane
 	name = "Mime's Bane"


### PR DESCRIPTION
Reverts DesertRose2/desertrose#1102


This caused a few errors:

code\modules\reagents\reagent_dispenser.dm:291:error: /datum/reagent/consumable/red_queen: undefined type path
code\modules\food_and_drinks\recipes\drinks_recipes.dm:832:error: /datum/reagent/consumable/red_queen: undefined type path
code\modules\food_and_drinks\recipes\drinks_recipes.dm:833:error: /datum/reagent/consumable/red_queen: undefined type path

So I had to revert it, feel free to resubmit, sorry for the inconvenience.