### PR TITLE
Fixes Funny Chem Removal PR, Provost PR and Balances/Fixes Cog Loadouts

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -942,7 +942,7 @@
 /obj/effect/spawner/bundle/f13/revolver44
 	name = ".44 revolver and ammo spawner"
 	items = list(
-				/obj/item/gun/ballistic/revolver/revolver44,
+				/obj/item/gun/ballistic/revolver/m29,
 				/obj/item/ammo_box/m44
 				)
 

--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -827,12 +827,6 @@
 	required_reagents = list(/datum/reagent/consumable/ethanol/champagne = 2, /datum/reagent/consumable/ethanol/lizardwine = 2, /datum/reagent/consumable/eggyolk = 1, /datum/reagent/gold = 1)
 	mix_message = "The liquid's color starts shifting as the nanogold is alternately corroded and redeposited."
 
-/datum/chemical_reaction/red_queen
-	name = "Red Queen"
-	id = /datum/reagent/consumable/red_queen
-	results = list(/datum/reagent/consumable/red_queen = 10)
-	required_reagents = list(/datum/reagent/consumable/tea = 6, /datum/reagent/mercury = 2, /datum/reagent/consumable/blackpepper = 1, /datum/reagent/growthserum = 1)
-
 /datum/chemical_reaction/gunfire
 	name = "Gunfire"
 	id = /datum/reagent/consumable/ethanol/gunfire

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -391,8 +391,8 @@
 /datum/job/vtcc/f13provost
 	title = "Provost"
 	flag = F13PROVOST
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the Aldermen and the Provost Sergeant."
 	description = "Participating in strike squads against raider encampments and performing surgical strikes against enemies of the Coalition, you and the rest of the elite Provosts don't so much as charge into battle as you do prevent the battle from happening; enforcing the law is still the order of the day, but destabilising real threats and taking out bands of raiders is a priority."
 

--- a/code/modules/jobs/job_types/vtcc.dm
+++ b/code/modules/jobs/job_types/vtcc.dm
@@ -399,7 +399,7 @@
 	outfit = /datum/outfit/job/vtcc/f13provost
 
 	loadout_options = list(
-		// /datum/outfit/loadout/specops, // TODO: Readd when implemented
+		/datum/outfit/loadout/specops,
 		/datum/outfit/loadout/espionage,
 		/datum/outfit/loadout/enforcer
 	)
@@ -425,13 +425,10 @@
 	neck = 			/obj/item/storage/belt/holster
 	shoes = 		/obj/item/clothing/shoes/jackboots
 	l_pocket =		/obj/item/storage/bag/money/small/vaultcity
-	r_hand =		/obj/item/gun/ballistic/automatic/pistol/n99
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/kitchen/knife/combat=1,
 		/obj/item/pda/security=1,
-		/obj/item/ammo_box/magazine/m10mm_adv=3,
-		/obj/item/autosurgeon/riotshield=1,
 		/obj/item/storage/survivalkit_aid=1,
 		/obj/item/clothing/mask/gas/sechailer=1
 	)
@@ -443,7 +440,8 @@
 		/obj/item/ammo_box/magazine/m556/rifle=3,
 		/obj/item/suppressor = 1,
 		/obj/item/storage/bag/ammo=1,
-		/obj/item/attachments/burst_improvement=1
+		/obj/item/gun/ballistic/automatic/pistol/n99=1,
+		/obj/item/ammo_box/magazine/m10mm_adv=2
 	)
 
 /datum/outfit/loadout/espionage
@@ -453,17 +451,20 @@
 		/obj/item/ammo_box/magazine/m10mm_adv/ext=3,
 		/obj/item/suppressor = 1,
 		/obj/item/camera=1,
-		/obj/item/book/granter/trait/demolitions=1
+		/obj/item/book/granter/trait/demolitions=1,
+		/obj/item/gun/ballistic/automatic/pistol/n99=1,
+		/obj/item/ammo_box/magazine/m10mm_adv=2
 	)
 
 /datum/outfit/loadout/enforcer
 	name = "Enforcer"
 	backpack_contents = list(
 		/obj/item/clothing/glasses/hud/health=1,
-		/obj/item/gun/ballistic/shotgun/automatic/combat/auto5=1,
-		/obj/item/ammo_box/shotgun/buck=2,
+		/obj/item/gun/energy/laser/aer9=1,
+		/obj/item/stock_parts/cell/ammo/mfc=2,
+		/obj/item/gun/energy/laser/pistol=1,
+		/obj/item/stock_parts/cell/ammo/ec=2,
 		/obj/item/grenade/chem_grenade/teargas=2,
-		/obj/item/book/granter/trait/trekking=1
 	)
 
 /datum/outfit/job/vtcc/f13provostsgt/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -492,8 +493,7 @@
 	loadout_options = list(
 		/datum/outfit/loadout/oldguard,
 		/datum/outfit/loadout/riotpolice,
-		/datum/outfit/loadout/vccmedic,
-		/datum/outfit/loadout/firesup
+		/datum/outfit/loadout/vccmedic
 		)
 
 	access = list(ACCESS_VTCC, ACCESS_VTCC_SEC)
@@ -528,18 +528,18 @@
 /datum/outfit/loadout/oldguard
 	name = "Shock Trooper"
 	backpack_contents = list(
-	/obj/item/gun/ballistic/automatic/m1carbine/compact=1,
-	/obj/item/ammo_box/magazine/m10mm_adv=3
+	/obj/item/gun/ballistic/automatic/m1carbine=1,
+	/obj/item/ammo_box/magazine/m10mm_adv=2
 	)
 
 /datum/outfit/loadout/riotpolice
 	name = "Riot Cop"
 	backpack_contents = list(
-	/obj/item/gun/ballistic/shotgun/trench=1,
-	/obj/item/ammo_box/shotgun/magnum=3,
-	/obj/item/shield/riot/tele=1,
-	/obj/item/clothing/mask/gas/sechailer=1,
-	/obj/item/grenade/smokebomb=2
+		/obj/item/clothing/glasses/hud/health=1,
+		/obj/item/gun/ballistic/shotgun/automatic/combat/auto5=1,
+		/obj/item/ammo_box/shotgun/buck=2,
+		/obj/item/grenade/chem_grenade/teargas=2,
+		/obj/item/book/granter/trait/trekking=1
 	)
 
 /datum/outfit/loadout/vccmedic
@@ -549,16 +549,8 @@
 	/obj/item/book/granter/trait/lowsurgery=1,
 	/obj/item/book/granter/trait/chemistry=1,
 	/obj/item/storage/box/medicine/stimpak10=1,
-	/obj/item/defibrillator/compact/combat=1,
+	/obj/item/defibrillator/compact/loaded=1,
 	/obj/item/clothing/glasses/hud/health=1
-	)
-
-/datum/outfit/loadout/firesup
-	name = "Fire Support"
-	backpack_contents = list(
-	/obj/item/clothing/mask/gas/sechailer=1,
-	/obj/item/gun/energy/laser/aer9=1,
-	/obj/item/stock_parts/cell/ammo/mfc=3
 	)
 
 /datum/outfit/job/vtcc/f13citysec/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -585,8 +577,7 @@
 	loadout_options = list(
 		/datum/outfit/loadout/newblood,
 		/datum/outfit/loadout/deepend,
-		/datum/outfit/loadout/vcfmedic,
-		/datum/outfit/loadout/backsup
+		/datum/outfit/loadout/vcfmedic
 		)
 
 	access = list(ACCESS_VTCC, ACCESS_VTCC_SEC)
@@ -616,8 +607,9 @@
 /datum/outfit/loadout/newblood
 	name = "Shock Cadet"
 	backpack_contents = list(
-	/obj/item/gun/ballistic/shotgun/trench=1,
-	/obj/item/ammo_box/shotgun/magnum = 3
+	/obj/item/gun/ballistic/shotgun/hunting = 1,
+	/obj/item/ammo_box/shotgun/buck = 2,
+	/obj/item/ammo_box/shotgun/slug=1
 	)
 
 /datum/outfit/loadout/deepend
@@ -634,18 +626,10 @@
 	name = "Field Medic"
 	backpack_contents = list(
 	/obj/item/storage/bag/chemistry=1,
-	/obj/item/storage/survivalkit_aid=3,
-	/obj/item/storage/box/medicine/stimpak5=1,
-	/obj/item/defibrillator/compact/combat=1,
+	/obj/item/storage/survivalkit_aid=1,
+	/obj/item/storage/box/medicine/stimpak5=3,
+	/obj/item/defibrillator/compact/loaded=1,
 	/obj/item/clothing/glasses/hud/health=1
-	)
-
-/datum/outfit/loadout/backsup
-	name = "Backline Support"
-	backpack_contents = list(
-	/obj/item/gun/energy/laser/pistol=1,
-	/obj/item/stock_parts/cell/ammo/ec=3,
-	/obj/item/clothing/mask/gas/sechailer=1
 	)
 
 /datum/outfit/job/vtcc/f13citycadet/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -284,13 +284,6 @@
 	reagent_id = /datum/reagent/consumable/ethanol/narsour
 	tank_volume = 250
 
-/obj/structure/reagent_dispensers/keg/red_queen
-	name = "keg of red queen"
-	desc = "A strange keg, filled with a kind of tea."
-	icon_state = "redkeg"
-	reagent_id = /datum/reagent/consumable/red_queen
-	tank_volume = 250
-
 /obj/structure/reagent_dispensers/keg/hearty_punch
 	name = "keg of hearty punch"
 	desc = "A keg that will get you right back on your feet."

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -619,3 +619,10 @@
 	materials = list(/datum/material/iron = 8000)
 	build_path = /obj/item/ammo_box/magazine/c5mm/extended/empty
 	category = list("initial", "Advanced Magazines")
+
+/datum/design/ammolathe/needler
+	name = "needler stripper clip"
+	id = "needler"
+	materials = list(/datum/material/iron = 8000, /datum/material/titanium = 10000)
+	build_path = /obj/item/ammo_box/needle
+	category = list("initial", "Advanced Ammo")


### PR DESCRIPTION
## About The Pull Request

Fixed Astrix's PR - https://github.com/DesertRose2/desertrose/pull/1111
Fixed Frok's PR - https://github.com/DesertRose2/desertrose/pull/1102

Balanced Cog City Sec out some more along with this.

- AER-9 moved up to Provost; elite/jr leadership weapon at least for spawning with.
- Removed the trench shotguns from cog loadouts due to them only going to elites in Legion or Outlaws; they are way better than base-trooper shotguns (ex hunting rifle, lever action) and thus have been replaced with a hunting shotgun or lever action.
- Cadets had their energy pistol removed since it was a bit of a pointless loadout - also fixed cadets having a defib that had no charge and could cause heart attacks by zapping.
- Moved the pistols from the 'hand' to the loadouts so I could give a better pistol to the AER-9 loadout; making it on-par with a proper elite loadout.
- Opens a second provost slot; it wasn't meant to only have one.

Misc.

- Added needler ammo as printable.
- Fixed loot drop revolver template.

## Why It's Good For The Game

Cog City needed some changes to its loadouts; roles had way too good of gear for what their counter-ranks are in other factions. Some had incredibly meta-loadout options where it made no sense not to choose one loadout over any of the others just due to the stats of the weapon/gear availability alone.

## Changelog
:cl:
fixes: Fixed all the changes of Frok's linked PR. Removes all the funny chems, in short.
balance: Cog loadouts again.
/:cl: