### PR TITLE
Fixes .45 And Removes Syringe Gun

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -715,7 +715,7 @@
 /obj/item/ammo_box/c45rev
 	name = "speed loader (.45 ACP)"
 	desc = "Designed to quickly reload revolvers."
-	icon_state = "38"
+	icon_state = "10mm"
 	caliber = ".45"
 	ammo_type = /obj/item/ammo_casing/c45
 	max_ammo = 6

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -294,7 +294,7 @@
 	build_path = /obj/item/gun/energy/beam_rifle
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-*/
+
 
 /datum/design/decloner
 	name = "Decloner"
@@ -307,6 +307,7 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+
 /datum/design/rapidsyringe
 	name = "Rapid Syringe Gun"
 	desc = "A gun that fires many syringes."
@@ -316,6 +317,7 @@
 	build_path = /obj/item/gun/syringe/rapidsyringe
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+*/
 
 /datum/design/temp_gun
 	name = "Temperature Gun"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Because **certain admins** wanted to say the use of 'haha funny gas' chem injections via syringe gun in combat, which is not allowed by rules, is OK - congrats, another thing is going bye-bye with Myrios' allowance. Code fixes to admin solutions.

Also fixed .45 clips.

## Why It's Good For The Game


https://user-images.githubusercontent.com/47883419/146075412-7ab700ce-3b24-490b-a290-1de8e9cf2ff7.mp4



## Changelog
:cl:
removes: Syringe and decloner gun because aboose.
fixes: .45 speed loaders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
