### PR TITLE
Bazooka Xmas Tree Gone

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -62,7 +62,7 @@
 /obj/structure/flora/tree/pine/xmas/presents
 	icon_state = "pinepresents"
 	desc = "A wondrous decorated Christmas tree. It has presents!"
-	var/gift_type = /obj/item/a_gift/anything
+	var/gift_type = /obj/item/a_gift
 	var/list/ckeys_that_took = list()
 
 /obj/structure/flora/tree/pine/xmas/presents/on_attack_hand(mob/living/user, act_intent = user.a_intent, unarmed_attack_flags)


### PR DESCRIPTION
## About The Pull Request

The tree was giving admin presents that shouldnt be accessible from players, and now the tree should be giving regular presents. So this can actually be used by regular presents instead of admin presents. 

## Why It's Good For The Game

This is better for the game people dont get instantly zapped by super matter shards.

## Changelog
:cl:
fix: Borked code that shouldnt be spawning in by a tree.
/:cl:
