### PR TITLE
Rain optimization - Fortuna copy-paste

### DIFF
--- a/code/datums/weather/weather_types/rain.dm
+++ b/code/datums/weather/weather_types/rain.dm
@@ -86,10 +86,15 @@
 			if(H.belt && wash_obj(H.belt))
 				H.update_inv_belt()
 
-/datum/weather/rain/weather_act_turf(turf/T)
-	for(var/O in T) //Clean cleanable decals in affected areas
-		if(is_cleanable(O))
-			qdel(O)
+/datum/weather/rain/weather_act_turf(turf/open/T)
+	var/cleaned
+	if(!cleaned)
+		for(var/obj/effect/decal/O in T) //Clean cleanable decals in affected areas
+			if(is_cleanable(O))
+				qdel(O)
+				cleaned = 1
+				CHECK_TICK
+
 
 /datum/weather/rain/proc/wash_obj(obj/O)
 	. = SEND_SIGNAL(O, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_WEAK)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Copies [this PR](https://github.com/FortunaSS13/Fortuna/pull/277) from Fortuna. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
>Optimizes rain so that it doesn't contribute too terribly to our TD when it runs. Now it will clean turfs once during it's cycle instead of once a tick. It will also not target all objects on a turf to see if every random object is cleanable, it will target only decals now and check those. i could've probably used a callback and a separate proc but this saves space
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Rain optimization
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
