### PR TITLE
Added Sprite Credit into Code

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -4,6 +4,7 @@
 	icon_state = "console"
 	density = FALSE
 
+//Autodocs replacing sleepers was done by Wateronix as well as the sprites. Ultimately very good idea since it keeps with lore consistancy and provides a unique looking sprite.
 /obj/machinery/sleeper
 	name = "autodoc"
 	desc = "An old pre war machine, used to stablize and heal patients."

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -647,6 +647,7 @@
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/pill/buffout(src)
 
+//Sprite of Cateye done by Yonsi
 /obj/item/storage/pill_bottle/chem_tin/cateye
 	name = "Cateye"
 	icon_state = "pill_canister_cateye"


### PR DESCRIPTION
## About The Pull Request

Added credit for Yonsi for the cateye sprite since that was given to me in DMs ages ago.

Added credit for Wateronix's autodoc sprite as requested.

## Why It's Good For The Game

Simply adds in credit for the sprite work others did instead of one having to browse the github to find out who made the sprites. Fair request to have that done since their sprites are used.

## Changelog
:cl:
add: Lines of text in code giving credit to who made the icon/item states for the aforementioned items.
/:cl: