### PR TITLE
Slowdown Changes, BOS Knight Armor Light-Nerf & Misc

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -1396,7 +1396,7 @@
 /datum/crafting_recipe/bospowerarmort45b
 	name = "brotherhood restored T45 power armor"
 	result = /obj/item/clothing/suit/armor/f13/power_armor/t45d/bos
-	reqs = list (/obj/item/clothing/suit/armor/f13/power_armor/t45b/restored = 1,
+	reqs = list (/obj/item/clothing/suit/armor/f13/power_armor/t45d = 1,
 				/obj/item/stack/crafting/goodparts = 3,
 				/obj/item/stack/crafting/electronicparts = 3,
 				/obj/item/toy/crayon/spraycan)
@@ -1409,7 +1409,7 @@
 /datum/crafting_recipe/bospowerarmort45b/helmet
 	name = "brotherhood restored T45 power armor helmet"
 	result = /obj/item/clothing/head/helmet/f13/power_armor/t45d/bos
-	reqs = list (/obj/item/clothing/head/helmet/f13/power_armor/t45b/restored = 1,
+	reqs = list (/obj/item/clothing/head/helmet/f13/power_armor/t45d = 1,
 				/obj/item/stack/crafting/goodparts = 1,
 				/obj/item/stack/crafting/electronicparts = 2,
 				/obj/item/toy/crayon/spraycan)
@@ -1456,28 +1456,6 @@
 	name = "brotherhood T51 power armor helmet"
 	result = /obj/item/clothing/head/helmet/f13/power_armor/t51b/bos
 	reqs = list(/obj/item/clothing/head/helmet/f13/power_armor/t51b = 1,
-				/obj/item/toy/crayon/spraycan)
-	time = 30
-	category = CAT_CLOTHING
-	subcategory = CAT_GENCLOTHES
-	always_availible = FALSE
-	tools = list(TOOL_PASTATION)
-
-/datum/crafting_recipe/bospowerarmort60
-	name = "brotherhood T60 power armor"
-	result = /obj/item/clothing/suit/armor/f13/power_armor/t60/bos
-	reqs = list(/obj/item/clothing/suit/armor/f13/power_armor/t60 = 1,
-				/obj/item/toy/crayon/spraycan)
-	time = 30
-	category = CAT_CLOTHING
-	subcategory = CAT_GENCLOTHES
-	always_availible = FALSE
-	tools = list(TOOL_PASTATION)
-
-/datum/crafting_recipe/bost60ahelm
-	name = "brotherhood T60 power armor helmet"
-	result = /obj/item/clothing/head/helmet/f13/power_armor/t60/bos
-	reqs = list(/obj/item/clothing/head/helmet/f13/power_armor/t60 = 1,
 				/obj/item/toy/crayon/spraycan)
 	time = 30
 	category = CAT_CLOTHING

--- a/code/modules/clothing/f13bosclothing.dm
+++ b/code/modules/clothing/f13bosclothing.dm
@@ -45,17 +45,19 @@
 
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/scout/senior
 	name = "brotherhood senior knight scout helmet"
-	desc = "(V) An improved combat helmet, featuring a transparent visor and bearing the symbol of the Senior Knight."
+	desc = "(IV) An improved combat helmet, featuring a transparent visor and bearing the symbol of the Senior Knight."
 	icon_state = "brotherhood_helmet_scout_senior"
 	item_state = "brotherhood_helmet_scout_senior"
-	armor = list("tier" = 5, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	armor = list("tier" = 4, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
+
+//Unused for now. Why give the Head Knight scouting armor and encourage them to scout with bad armor - when they're a head role? Let alone at all, honestly.
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/scout/captain
 	name = "brotherhood knight captain scout helmet"
-	desc = "(VI) An improved combat helmet, featuring a transparent visor and bearing the symbol of the knight captain."
+	desc = "(IV) An improved combat helmet, featuring a transparent visor and bearing the symbol of the knight captain."
 	icon_state = "brotherhood_helmet_scout_captain"
 	item_state = "brotherhood_helmet_scout_captain"
-	armor = list("tier" = 6, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	armor = list("tier" = 4, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/head/helmet/f13/combat/brotherhood/outcast
 	name = "brotherhood helmet"
@@ -161,10 +163,10 @@
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/senior
 	name = "brotherhood senior knight armor"
-	desc = "(VI) A reinforced combat armor set made by the Brotherhood of Steel, standard issue for all Senior Knights. It bears a silver stripe."
+	desc = "(V) A set of combat armor set made by the Brotherhood of Steel, standard issue for all Senior Knights. It bears a silver stripe."
 	icon_state = "brotherhood_armor_senior"
 	item_state = "brotherhood_armor_senior"
-	armor = list("tier" = 6, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	armor = list("tier" = 5, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/captain
 	name = "brotherhood knight captain armor"
@@ -197,17 +199,18 @@
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/scout/senior
 	name = "brotherhood senior knight scout armor"
-	desc = "(V) A suit of combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a silver stripe."
+	desc = "(IV) A suit of combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a silver stripe."
 	icon_state = "brotherhood_scout_senior"
 	item_state = "brotherhood_scout_senior"
-	armor = list("tier" = 5, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	armor = list("tier" = 4, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
+//Unused now - Head Knights shouldn't be running out to scout with low armor and speed; let alone at all tbh.
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/scout/captain
 	name = "brotherhood knight captain scout armor"
-	desc = "(VI) A superior combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a golden stripe."
+	desc = "(IV) A superior combat armor set made by the Brotherhood of Steel, lightened version used for recon. It bears a golden stripe."
 	icon_state = "brotherhood_scout_captain"
 	item_state = "brotherhood_scout_captain"
-	armor = list("tier" = 6, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
+	armor = list("tier" = 4, "energy" = 45, "bomb" = 60, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 	slowdown = -0.1
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/outcast

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -351,13 +351,6 @@
 	deflection_chance = 20 //10% chance to block damage from blockable bullets and redirect the bullet at a random angle. Not nearly as effective as true power armor
 	requires_training = FALSE
 
-/obj/item/clothing/head/helmet/f13/power_armor/t45b/restored
-	name = "restored T-45b helmet"
-	desc = "(VIII) It's a restored T-45b power armor helmet."
-	armor_block_chance = 80
-	deflection_chance = 20 //20% chance to block damage from blockable bullets and redirect the bullet at a random angle
-	requires_training = TRUE
-
 /obj/item/clothing/head/helmet/f13/power_armor/raiderpa_helm
 	name = "raider T-45b power helmet"
 	desc = "(VIII) This power armor helmet is so decrepit and battle-worn that it have lost most of its capability to protect the wearer from harm. This helmet seems to be heavily modified, heavy metal banding fused to the helmet"
@@ -513,31 +506,6 @@
 	item_state = "ultracitepa_helm"
 	slowdown = 0
 	actions_types = list()
-
-/obj/item/clothing/head/helmet/f13/power_armor/t60
-	name = "T-60a power helmet"
-	desc = "(X) The T-60 powered helmet, equipped with targetting software suite, Friend-or-Foe identifiers, dynamic HuD, and an internal music player."
-	icon_state = "t60helmet0"
-	item_state = "t60helmet0"
-	armor = list("tier" = 10, "energy" = 70, "bomb" = 82, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 0, "wound" = 80)
-	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	armor_block_chance = 90
-	deflection_chance = 20 //20% chance to block damage from blockable bullets and redirect the bullet at a random angle. Same deflection as T-45 due to it having the same general shape.
-
-/obj/item/clothing/head/helmet/f13/power_armor/t60/update_icon_state()
-	icon_state = "t60helmet[on]"
-	item_state = "t60helmet[on]"
-
-/obj/item/clothing/head/helmet/f13/power_armor/t60/bos
-	name = "Brotherhood T-60a power helmet"
-	desc = "(X) The T-60 powered helmet, equipped with targetting software suite, Friend-or-Foe identifiers, dynamic HuD, and an internal music player."
-	icon_state = "t60bos0"
-	item_state = "t60bos0"
-	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-
-/obj/item/clothing/head/helmet/f13/power_armor/t60/bos/update_icon_state()
-	icon_state = "t60bos[on]"
-	item_state = "t60bos[on]"
 
 /obj/item/clothing/head/helmet/f13/power_armor/excavator
 	name = "excavator power helmet"

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -435,15 +435,6 @@
 	icon_state = "dethelm[on]"
 	item_state = "dethelm[on]"
 
-/obj/item/clothing/head/helmet/f13/power_armor/t45d/gunslinger
-	name = "Gunslinger T-51b Helm"
-	desc = "(VIII) With most of the external plating stripped to allow for internal thermal and night vision scanners, as well as aided targeting assist via onboard systems, this helm provides much more utility then protection. To support these systems, secondary power cells were installed into the helm, and covered with a stylish hat."
-	icon_state = "t51bgs"
-	item_state = "t51bgs"
-	slowdown = 0
-	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR
-	actions_types = list()
-
 /obj/item/clothing/head/helmet/f13/power_armor/t45d/sierra
 	name = "sierra power helmet"
 	desc = "(VIII) A pre-war power armor helmet, issued to special NCR officers.."

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -311,17 +311,9 @@
 	item_state = "t45bpowerarmor"
 	armor = list("tier" = 8, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
 	requires_training = FALSE
-	slowdown = 1.40
+	slowdown = 1
 	armor_block_chance = 80
 	deflection_chance = 20 //10% chance to block damage from blockable bullets and redirect the bullet at a random angle. Not nearly as effective as true power armor
-
-/obj/item/clothing/suit/armor/f13/power_armor/t45b/restored
-	name = "restored T-45b power armor"
-	desc = "(VIII) It's a set of early-model T-45 power armor with a custom air conditioning module and restored servomotors. Bulky, but almost as good as the real thing."
-	requires_training = TRUE
-	slowdown = 0.24
-	armor_block_chance = 80
-	deflection_chance = 20 //20% chance to block damage from blockable bullets and redirect the bullet at a random angle
 
 
 /obj/item/clothing/suit/armor/f13/power_armor/ncr
@@ -331,7 +323,7 @@
 	item_state = "ncrpowerarmor"
 	armor = list("tier" = 8, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
 	requires_training = FALSE
-	slowdown = 1.40
+	slowdown = 1
 	armor_block_chance = 80
 	deflection_chance = 20 //20% chance to block damage from blockable bullets and redirect the bullet at a random angle. Not nearly as effective as true power armor
 
@@ -341,7 +333,7 @@
 	icon_state = "raiderpa"
 	item_state = "raiderpa"
 	armor = list("tier" = 8, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
-	slowdown = 0.4
+	slowdown = 1
 	requires_training = FALSE
 	armor_block_chance = 20
 	deflection_chance = 5 //5% chance to block damage from blockable bullets and redirect the bullet at a random angle. Stripped down version of an already stripped down version
@@ -352,7 +344,7 @@
 	icon_state = "t45hotrod"
 	item_state = "t45hotrod"
 	armor = list("tier" = 8, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
-	slowdown = 0.4
+	slowdown = 1
 	requires_training = FALSE
 	armor_block_chance = 20
 	deflection_chance = 5 //5% chance to block damage from blockable bullets and redirect the bullet at a random angle. Stripped down version of an already stripped down version
@@ -403,13 +395,6 @@
 	slowdown = 0.24
 	armor = list("tier" = 8, "energy" = 60, "bomb" = 62, "bio" = 100, "rad" = 90, "fire" = 90, "acid" = 0, "wound" = 60)
 
-/obj/item/clothing/suit/armor/f13/power_armor/t45d/gunslinger
-	name = "gunslinger T-51b"
-	desc = "(VIII) What was once a suit of T-51 Power Armor is now an almost unrecognizable piece of art or garbage, depending on who you ask. Almost all of the external plating has either been removed or stripped to allow for maximum mobility, and overlapping underplates protect the user from small arms fire. Whoever designed this had a very specific purpose in mind: mobility and aesthetics over defense."
-	icon_state = "t51bgs"
-	item_state = "t51bgs"
-	slowdown = 0
-	flags_inv = HIDEJUMPSUIT|HIDENECK
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45d/sierra
 	name = "sierra power armor"
@@ -422,8 +407,6 @@
 	desc = "(VIII) A classic set of T-45d Power Armour only to be used in armed combat, it signifies the Knight Captain and their place in the Brotherhood. A leader, and a beacon of structure in a place where chaos reigns. All must rally to his call, for he is the Knight Captain and your safety is his duty."
 	icon_state = "t45dkc"
 	item_state = "t45dkc"
-	slowdown = 0.16
-	armor = list("tier" = 8, "energy" = 60, "bomb" = 62, "bio" = 100, "rad" = 90, "fire" = 90, "acid" = 0, "wound" = 60)
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45d/bos
 	name = "brotherhood T-45d power armor"
@@ -467,13 +450,13 @@
 
 /obj/item/clothing/suit/armor/f13/power_armor/t51b/wbos
 	name = "Washington power armor"
-	desc = "(X) A dark mirror to the pinnacle of pre-war technology. This suit of power armor provides substantial protection to the wearer."
+	desc = "(IX) A dark mirror to the pinnacle of pre-war technology. This suit of power armor provides substantial protection to the wearer."
 	icon_state = "t51wbos"
 	item_state = "t51wbos"
 
 /obj/item/clothing/suit/armor/f13/power_armor/t51b/reforgedwbos
 	name = "reforged Washington power armor"
-	desc = "(X) A dark mirror to the pinnacle of pre-war technology, reforged. This suit of power armor provides substantial protection to the wearer."
+	desc = "(IX) A dark mirror to the pinnacle of pre-war technology, reforged. This suit of power armor provides substantial protection to the wearer."
 	icon_state = "t51matt"
 	item_state = "t51matt"
 
@@ -483,39 +466,6 @@
 	icon_state = "ultracitepa"
 	item_state = "ultracitepa"
 	slowdown = 0
-
-/obj/item/clothing/suit/armor/f13/power_armor/t60
-	name = "T-60a power armor"
-	desc = "(X) Developed in early 2077 after the Anchorage Reclamation, the T-60 series of power armor was designed to eventually replace the T-51b as the pinnacle of powered armor technology in the U.S. military arsenal."
-	icon_state = "t60powerarmor"
-	item_state = "t60powerarmor"
-	slowdown = 0.16
-	armor = list("tier" = 10, "energy" = 70, "bomb" = 82, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 0, "wound" = 80)
-
-	armor_block_chance = 90
-	deflection_chance = 20 //20% chance to block damage from blockable bullets and redirect the bullet at a random angle. Same deflection as T-45 due to it having the same general shape.
-
-/obj/item/clothing/suit/armor/f13/power_armor/t60/tesla
-	name = "T-60b tesla armor"
-	desc = "(X*) An experimental variant of T-60a power armor featuring an array of tesla coils. A small amount of protection has been sacrificed to give a chance to deflect energy projectiles."
-	icon_state = "t60tesla"
-	item_state = "t60tesla"
-	slowdown = 0.15
-	armor = list("tier" = 10, "linelaser" = 25, "energy" = 70, "bomb" = 82, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 0, "wound" = 80)
-	var/hit_reflect_chance = 20
-
-/obj/item/clothing/suit/armor/f13/power_armor/t60/bos
-	name = "brotherhood T-60 power armor"
-	desc = "(X) A set of T-60 power armor put into use by the Brotherhood of Steel."
-	icon_state = "t60bos"
-	item_state = "t60bos"
-
-/obj/item/clothing/suit/armor/f13/power_armor/t60/tesla/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
-	if(is_energy_reflectable_projectile(object) && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))
-		if(prob(hit_reflect_chance))
-			block_return[BLOCK_RETURN_REDIRECT_METHOD] = REDIRECT_METHOD_DEFLECT
-			return BLOCK_SHOULD_REDIRECT | BLOCK_REDIRECTED | BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
-	return ..()
 
 /obj/item/clothing/suit/armor/f13/power_armor/advanced
 	name = "advanced power armor"

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -1030,15 +1030,15 @@
 	//chance to upgrade all t45b versions to salvaged t45b, chance to upgrade salvaged t45b to t45b (new sprotes, t8 armor with no slowdown)
 	if(prob(40))
 		if(istype(A,/obj/item/clothing/suit/armor/f13/power_armor/raiderpa))//ups raider to salvaged
-			new /obj/item/clothing/suit/armor/f13/power_armor/t45b/restored(user.loc)
+			new /obj/item/clothing/suit/armor/f13/power_armor/t45d(user.loc)
 			qdel(A)
 			return
 		if(istype(A,/obj/item/clothing/suit/armor/f13/power_armor/hotrod))//ups hotrod to salvaged
-			new /obj/item/clothing/suit/armor/f13/power_armor/t45b/restored(user.loc)
+			new /obj/item/clothing/suit/armor/f13/power_armor/t45d(user.loc)
 			qdel(A)
 			return
 		if(istype(A, /obj/item/clothing/suit/armor/f13/power_armor/t45b))
-			new /obj/item/clothing/suit/armor/f13/power_armor/t45b/restored(user.loc)
+			new /obj/item/clothing/suit/armor/f13/power_armor/t45d(user.loc)
 			qdel(A)
 			return
 	qdel(src)
@@ -1047,15 +1047,15 @@
 	var/obj/item/clothing/head/helmet/f13/power_armor/H = W
 	if(prob(50))
 		if(istype(H,/obj/item/clothing/head/helmet/f13/power_armor/raiderpa_helm))//ups raider to salvaged
-			new /obj/item/clothing/head/helmet/f13/power_armor/t45b/restored(user.loc)
+			new /obj/item/clothing/head/helmet/f13/power_armor/t45d(user.loc)
 			qdel(H)
 			return
 		if(istype(H,/obj/item/clothing/head/helmet/f13/power_armor/hotrod))//ups hotrod to salvaged
-			new /obj/item/clothing/head/helmet/f13/power_armor/t45b/restored(user.loc)
+			new /obj/item/clothing/head/helmet/f13/power_armor/t45d(user.loc)
 			qdel(H)
 			return
 		if(istype(H, /obj/item/clothing/head/helmet/f13/power_armor/t45b))
-			new /obj/item/clothing/head/helmet/f13/power_armor/t45b/restored(user.loc)
+			new /obj/item/clothing/head/helmet/f13/power_armor/t45d(user.loc)
 			qdel(H)
 			return
 	qdel(src)

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -276,7 +276,6 @@ Knight Captain
 
 	loadout_options = list(
 	/datum/outfit/loadout/captech,
-	/datum/outfit/loadout/capscout,
 	/datum/outfit/loadout/capwarden
 	)
 
@@ -325,19 +324,6 @@ Knight Captain
 		/obj/item/clothing/glasses/meson=1,
 		/obj/item/storage/belt/holster=1,
 		)
-
-/datum/outfit/loadout/capscout
-	name = "Scout Captain"
-	backpack_contents = list(
-		/obj/item/clothing/head/helmet/f13/combat/brotherhood/scout/captain=1,
-		/obj/item/clothing/suit/armor/f13/combat/brotherhood/scout/captain=1,
-		/obj/item/clothing/glasses/night=1,
-		/obj/item/binoculars=1,
-		/obj/item/book/granter/trait/trekking=1,
-		/obj/item/gun/energy/laser/wattz2k/extended=1,
-		/obj/item/stock_parts/cell/ammo/mfc=3,
-		/obj/item/clothing/neck/mantle/bos/knight=1
-	)
 
 /datum/outfit/loadout/capwarden
 	name = "Warden Captain"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- **Lowered slowdown from 1.40 for all salvaged PAs to being only 1**. This may be reduced further upon tests, I'm considering 0.8 slowdown but I need to see how people function with it as is.
- Removed T-60 armor as code since it's not used anymore, unneeded as its niche is filled by other admin-spawnable armors and keeps rearing its head. Fuck the East Coast.
- At Myrios' request and my agreeance, Senior Knight armor has been reduced to tier 5; equal to knights below them. 
- All scout armors in BOS that give a speed buff have also been all nerfed to tier 4. If you want your better gun and speed up as a senior knight or head knight, you no longer get tier 5 or 6 armor **WITH** your speed-up.

## Why It's Good For The Game


https://user-images.githubusercontent.com/47883419/146865693-5fde22bb-d1d7-43b7-8ede-c393ed9b34c5.mp4



## Changelog
:cl:
removes: T-60 armor and some shit slotted in the grave yard for removal.
balance: Lowered slowdown across the board on salvaged PA. Wasters and those who cannot fix salvaged can actually USE the armor and not be nerfed by doing so now.
balance: Knight changes in BOS to scout armors and the senior knights base armors.
/:cl: