### PR TITLE
Slightly reorganizes snacks others, adds new foods, fix for tribal poison arrow.

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -320,13 +320,13 @@
 	result = /obj/item/ammo_casing/caseless/arrow/poison
 	time = 30
 	reqs = list(/obj/item/ammo_casing/caseless/arrow = 1,
-				/obj/item/grown/nettle/basic = 5)
+				/obj/item/reagent_containers/food/snacks/grown/nettle = 5)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
 /datum/crafting_recipe/arrowburn
-	name = "Burn Posion Arrow"
+	name = "Burn Arrow"
 	always_availible = FALSE
 	result = /obj/item/ammo_casing/caseless/arrow/burning
 	time = 30

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -1,5 +1,4 @@
-
-////////////////////////////////////////////OTHER////////////////////////////////////////////
+////////////////////////////////////////////CHEESES////////////////////////////////////////////
 
 /obj/item/reagent_containers/food/snacks/store/cheesewheel
 	name = "cheese wheel"
@@ -7,20 +6,10 @@
 	icon_state = "cheesewheel"
 	slice_path = /obj/item/reagent_containers/food/snacks/cheesewedge
 	slices_num = 5
+	cooked_type = /obj/item/reagent_containers/food/snacks/baked_cheese
 	list_reagents = list(/datum/reagent/consumable/nutriment = 15, /datum/reagent/consumable/nutriment/vitamin = 5)
 	w_class = WEIGHT_CLASS_NORMAL
 	tastes = list("cheese" = 1)
-	foodtype = DAIRY
-
-
-
-/obj/item/reagent_containers/food/snacks/royalcheese
-	name = "royal cheese"
-	desc = "Ascend the throne. Consume the wheel. Feel the POWER."
-	icon_state = "royalcheese"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 15, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/gold = 20, /datum/reagent/toxin/mutagen = 5)
-	w_class = WEIGHT_CLASS_BULKY
-	tastes = list("cheese" = 4, "royalty" = 1)
 	foodtype = DAIRY
 
 /obj/item/reagent_containers/food/snacks/cheesewedge
@@ -31,6 +20,84 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("cheese" = 1)
 	foodtype = DAIRY
+
+/obj/item/reagent_containers/food/snacks/curd_cheese
+	name = "curd cheese"
+	desc = "Known by many names throughout human cuisine, curd cheese is useful for a wide variety of dishes."
+	icon_state = "curd_cheese"
+	cooked_type = /obj/item/reagent_containers/food/snacks/cheese_curds
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/cream = 1)
+	tastes = list("cream" = 1, "cheese" = 1)
+	foodtype = DAIRY
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/reagent_containers/food/snacks/cheese_curds
+	name = "cheese curds"
+	desc = "Not to be mistaken for curd cheese. Tasty deep fried."
+	icon_state = "cheese_curds"
+	dried_type = /obj/item/reagent_containers/food/snacks/firm_cheese
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	tastes = list("cheese" = 1)
+	foodtype = DAIRY
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/reagent_containers/food/snacks/firm_cheese
+	name = "firm cheese"
+	desc = "Firm aged cheese, similar in texture to firm tofu. Due to its lack of moisture it's particularly useful for cooking with, as it doesn't melt easily."
+	icon_state = "firm_cheese"
+	slice_path = /obj/item/reagent_containers/food/snacks/firm_cheese_slice
+	slices_num = 5
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	tastes = list("aged cheese" = 1)
+	foodtype = DAIRY | VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/reagent_containers/food/snacks/firm_cheese_slice
+	name = "firm cheese slice"
+	desc = "A slice of firm cheese. Perfect for grilling or making into delicious pesto."
+	icon_state = "firm_cheese_slice"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	tastes = list("aged cheese" = 1)
+	foodtype = DAIRY | VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/reagent_containers/food/snacks/mozzarella
+	name = "mozzarella cheese"
+	desc = "Delicious, creamy, and cheesy, all in one simple package."
+	icon_state = "mozzarella"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	tastes = list("mozzarella" = 1)
+	foodtype = DAIRY
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/reagent_containers/food/snacks/baked_cheese
+	name = "baked cheese wheel"
+	desc = "A baked cheese wheel, melty and delicious."
+	icon_state = "baked_cheese"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/capsaicin = 1)
+	tastes = list("cheese" = 1)
+	foodtype = DAIRY
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/reagent_containers/food/snacks/herby_cheese
+	name = "herby cheese"
+	desc = "This cheese seems to be curd cheese mixed with herbs fresh from the garden."
+	icon_state = "herby_cheese"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	tastes = list("cheese" = 1, "herbs" = 1)
+	foodtype = DAIRY | VEGETABLES
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/reagent_containers/food/snacks/royalcheese
+	name = "royal cheese"
+	desc = "Ascend the throne. Consume the wheel. Feel the POWER."
+	icon_state = "royalcheese"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 15, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/gold = 20, /datum/reagent/toxin/mutagen = 5)
+	w_class = WEIGHT_CLASS_BULKY
+	tastes = list("cheese" = 4, "royalty" = 1)
+	foodtype = DAIRY
+
+///////////////////////////////////OTHER//////////////////////
 
 /obj/item/reagent_containers/food/snacks/watermelonslice
 	name = "watermelon slice"
@@ -780,55 +847,42 @@
 	name = "roasted bell pepper"
 	desc = "A blackened, blistered bell pepper. Great for making sauces."
 	icon_state = "roasted_bell_pepper"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/char = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/char = 1)
 	tastes = list("bell pepper" = 1, "char" = 1)
 	foodtype = VEGETABLES
 
-/obj/item/reagent_containers/food/snacks/curd_cheese
-	name = "curd cheese"
-	desc = "Known by many names throughout human cuisine, curd cheese is useful for a wide variety of dishes."
-	icon_state = "curd_cheese"
-	cooked_type = /obj/item/reagent_containers/food/snacks/cheese_curds
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/cream = 1)
-	tastes = list("cream" = 1, "cheese" = 1)
-	foodtype = DAIRY
+/obj/item/reagent_containers/food/snacks/mozzarella_sticks
+	name = "mozzarella sticks"
+	desc = "Little sticks of mozzarella, breaded and fried."
+	icon_state = "mozzarella_sticks"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 5)
+	tastes = list("creamy cheese" = 1, "breading" = 1, "oil" = 1)
+	foodtype = DAIRY | GRAIN 
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/reagent_containers/food/snacks/cheese_curds
-	name = "cheese curds"
-	desc = "Not to be mistaken for curd cheese. Tasty deep fried."
-	icon_state = "cheese_curds"
-	dried_type = /obj/item/reagent_containers/food/snacks/firm_cheese
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
-	tastes = list("cheese" = 1)
-	foodtype = DAIRY
+/obj/item/reagent_containers/food/snacks/pesto
+	name = "pesto"
+	desc = "A combination of firm cheese, salt, herbs, garlic, oil, and pine nuts. Frequently used as a sauce for pasta or pizza, or eaten on bread."
+	icon_state = "pesto"
+	list_reagents = list(/datum/reagent/consumable/nutriment/vitamin = 5)
+	tastes = list("pesto" = 1)
+	foodtype = VEGETABLES | DAIRY 
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/reagent_containers/food/snacks/firm_cheese
-	name = "firm cheese"
-	desc = "Firm aged cheese, similar in texture to firm tofu. Due to its lack of moisture it's particularly useful for cooking with, as it doesn't melt easily."
-	icon_state = "firm_cheese"
-	slice_path = /obj/item/reagent_containers/food/snacks/firm_cheese_slice
-	slices_num = 5
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
-	tastes = list("aged cheese" = 1)
-	foodtype = DAIRY | VEGETABLES
+/obj/item/reagent_containers/food/snacks/tomato_sauce
+	name = "tomato sauce"
+	desc = "Tomato sauce, perfect for pizza or pasta. Mamma mia!"
+	icon_state = "tomato_sauce"
+	list_reagents = list(/datum/reagent/consumable/nutriment/vitamin = 5)
+	tastes = list("tomato" = 1, "herbs" = 1)
+	foodtype = VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/reagent_containers/food/snacks/firm_cheese_slice
-	name = "firm cheese slice"
-	desc = "A slice of firm cheese. Perfect for grilling or making into delicious pesto."
-	icon_state = "firm_cheese_slice"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
-	tastes = list("aged cheese" = 1)
-	foodtype = DAIRY | VEGETABLES
-	w_class = WEIGHT_CLASS_SMALL
-
-/obj/item/reagent_containers/food/snacks/mozzarella
-	name = "mozzarella cheese"
-	desc = "Delicious, creamy, and cheesy, all in one simple package."
-	icon_state = "mozzarella"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
-	tastes = list("mozzarella" = 1)
-	foodtype = DAIRY
+/obj/item/reagent_containers/food/snacks/bechamel_sauce
+	name = "béchamel sauce"
+	desc = "A classic white sauce common to several European cultures."
+	icon_state = "bechamel_sauce"
+	list_reagents = list(/datum/reagent/consumable/nutriment/vitamin = 5)
+	tastes = list("cream" = 1)
+	foodtype = DAIRY | GRAIN
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -245,3 +245,54 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/trailmix
 	subcategory = CAT_MISCFOOD
+
+/datum/crafting_recipe/food/herby_cheese
+	name = "Herby cheese"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/curd_cheese = 1,
+		/obj/item/reagent_containers/food/snacks/grown/herbs = 4
+	)
+	result = /obj/item/reagent_containers/food/snacks/herby_cheese
+	subcategory = CAT_MISCFOOD
+
+/datum/crafting_recipe/food/pesto
+	name = "Pesto"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/firm_cheese_slice = 1,
+		/datum/reagent/consumable/sodiumchloride = 5,
+		/obj/item/reagent_containers/food/snacks/grown/herbs = 2,
+		/obj/item/reagent_containers/food/snacks/grown/garlic = 1,
+		/obj/item/reagent_containers/food/snacks/grown/pinyon = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/pesto
+	subcategory = CAT_MISCFOOD
+
+/datum/crafting_recipe/food/tomato_sauce
+	name = "Tomato sauce"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/grown/tomato = 1,
+		/datum/reagent/consumable/sodiumchloride = 2,
+		/obj/item/reagent_containers/food/snacks/grown/herbs = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/tomato_sauce
+	subcategory = CAT_MISCFOOD
+
+/datum/crafting_recipe/food/bechamel_sauce
+	name = "Bechamel sauce"
+	reqs = list(
+		/datum/reagent/consumable/milk = 10,
+		/datum/reagent/consumable/flour = 5,
+		/obj/item/reagent_containers/food/snacks/butter = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/bechamel_sauce
+	subcategory = CAT_MISCFOOD
+
+/datum/crafting_recipe/food/mozzarella_sticks
+	name = "Mozzarella sticks"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/mozzarella = 1,
+		/obj/item/reagent_containers/food/snacks/breadslice/custom = 2,
+		/obj/item/reagent_containers/food/snacks/tomato_sauce = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/mozzarella_sticks
+	subcategory = CAT_MISCFOOD


### PR DESCRIPTION
## About The Pull Request

This PR adds in new foods such as pesto, tomato sauce, béchamel sauce, mozzarella sticks, baked cheese and herby cheese.  This PR also slightly buffs some of the food in the category and soon to be others aswell.  All of these are craftable and uses the new hydroponics seeds that was just recently added. Also this fixes the wayfarer poison arrow bug too not being able to be crafted. This also reorganizes the snacks_other.dm a little bit and should be in cheeses category and others. This will be more organized down the road.
These sprites were made by someone in TG station and it was credited on a recent PR. 
![image](https://user-images.githubusercontent.com/29418371/146925537-978fd236-595a-47c9-83cf-d6f66312a8f4.png)
This PR was tested before hand and should work as intended.

## Why It's Good For The Game

This PR is good for the game as it adds more foods and new things that is used by the new plants that were recently added which is a good so they aren't so worthless after all.

## Changelog
:cl:
add: bechamel sauce, tomato sauce, pesto, herby cheese and baked cheese can be made and craftable.
tweak: slightly buffs the cheeses and others to give it more inline with the rest of the food.
fix: poison arrow can be crafted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
