### PR TITLE
Re-adds the ability to construct computer and extinguisher frames with metal

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -91,8 +91,10 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("turret frame", /obj/machinery/porta_turret_construct, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("button frame", /obj/item/wallframe/button, 1), \
+	new/datum/stack_recipe("computer frame", /obj/structure/frame/computer, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("machine frame", /obj/structure/frame/machine, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
+	new/datum/stack_recipe("extinguisher cabinet frame", /obj/item/wallframe/extinguisher_cabinet, 2), \
 	new/datum/stack_recipe("light fixture frame", /obj/item/wallframe/light_fixture, 2), \
 	new/datum/stack_recipe("small light fixture frame", /obj/item/wallframe/light_fixture/small, 1), \
 	new/datum/stack_recipe("floodlight frame", /obj/structure/floodlight_frame, 5, one_per_turf = TRUE, on_floor = TRUE), \


### PR DESCRIPTION
## About The Pull Request

Computer/Extinguisher frames were inexplicably removed, probably by accident in Pebble's doors PR, preventing you from construct fire extinguisher frames (good for flavour when building bases) and computer frames (mostly used by BoS or for flavour)

## Why It's Good For The Game
Pebble's PR didn't mention removing these items, so I assume it was an accident. Afaik there's no real reason to remove them when you can still craft machine, airlock and other frames and this also means BoS can't utilize any of their computer console boards or fix broken computer consoles. 

## Changelog
:cl:
add: Ability to construct fire extinguisher frames and computer frames
/:cl:

