### PR TITLE
Fixes BoS knights not having gunsmith traits

### DIFF
--- a/code/modules/fallout/job/bos.dm
+++ b/code/modules/fallout/job/bos.dm
@@ -299,6 +299,8 @@ Knight Captain
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/recoil_decrease)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/bullet_speed)
 
+// Above: Band-aid fix for Knights not receiving gunsmithing knowledge round-start, simply copies recipes learned from GnB books to here.
+
 /datum/outfit/job/bos/f13knightcap
 	name = "Knight Captain"
 	jobtype = /datum/job/bos/f13knightcap
@@ -771,6 +773,8 @@ Senior Knight
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/recoil_decrease)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/bullet_speed)
 
+// Above: Band-aid fix for Knights not receiving gunsmithing knowledge round-start, simply copies recipes learned from GnB books to here.
+
 /datum/outfit/job/bos/f13seniorknight
 	name = "Senior Knight"
 	jobtype = /datum/job/bos/f13seniorknight
@@ -881,6 +885,8 @@ Knight
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/burst_improvement)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/recoil_decrease)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/bullet_speed)
+
+// Above: Band-aid fix for Knights not receiving gunsmithing knowledge round-start, simply copies recipes learned from GnB books to here.
 
 /datum/outfit/job/bos/f13knight
 	name = "Knight"

--- a/code/modules/fallout/job/bos.dm
+++ b/code/modules/fallout/job/bos.dm
@@ -316,7 +316,6 @@ Knight Captain
 	backpack_contents = list(
 		/obj/item/storage/survivalkit_aid_adv=1, \
 		/obj/item/kitchen/knife/combat=1, \
-		/obj/item/book/granter/crafting_recipe/gunsmith_three=1, \
 		/obj/item/gun/ballistic/automatic/pistol/crusader_pistol=1, \
 		/obj/item/ammo_box/magazine/m10mm_adv/simple=2, \
 		/obj/item/storage/bag/money/small/bos=1
@@ -781,14 +780,15 @@ Senior Knight
 	belt = 			/obj/item/storage/belt/military
 	id = 			/obj/item/card/id/dogtag
 	neck = 			/obj/item/clothing/neck/mantle/bos/knight
+	/*
 	gunsmith_one = TRUE
 	gunsmith_two = TRUE
 	gunsmith_three = TRUE
 	gunsmith_four = TRUE
+	*/
 	backpack_contents = list(
 		/obj/item/storage/survivalkit_aid_adv=1, \
 		/obj/item/kitchen/knife/combat=1, \
-		/obj/item/book/granter/crafting_recipe/gunsmith_three=1, \
 		/obj/item/gun/ballistic/automatic/pistol/crusader_pistol=1, \
 		/obj/item/ammo_box/magazine/m10mm_adv/simple=2, \
 		/obj/item/storage/bag/money/small/bosknight=1
@@ -890,14 +890,15 @@ Knight
 	belt = 			/obj/item/storage/belt/military
 	id = 			/obj/item/card/id/dogtag
 	neck = 			/obj/item/clothing/neck/mantle/bos/knight
+	/*
 	gunsmith_one = TRUE
 	gunsmith_two = TRUE
 	gunsmith_three = TRUE
 	gunsmith_four = TRUE
+	*/
 	backpack_contents = list(
 		/obj/item/storage/survivalkit_aid=1, \
 		/obj/item/kitchen/knife/combat=1, \
-		/obj/item/book/granter/crafting_recipe/gunsmith_three=1, \
 		/obj/item/gun/ballistic/automatic/pistol/crusader_pistol=1, \
 		/obj/item/ammo_box/magazine/m10mm_adv/simple=2, \
 		/obj/item/storage/bag/money/small/bosknight=1
@@ -1031,6 +1032,7 @@ Initiate
 		/obj/item/gun/ballistic/automatic/pistol/crusader_pistol=1,
 		/obj/item/ammo_box/magazine/m10mm_adv/simple=2,
 		/obj/item/book/granter/crafting_recipe/gunsmith_two=1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_one=1,
 		/obj/item/storage/toolbox/mechanical=1,
 		/obj/item/clothing/accessory/bos/initiateK=1
 		)

--- a/code/modules/fallout/job/bos.dm
+++ b/code/modules/fallout/job/bos.dm
@@ -284,14 +284,30 @@ Knight Captain
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ninemil)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/widowmaker)
+
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/n99)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/huntingrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/m1911)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/varmintrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/colt6520)
+
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/scope)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/suppressor)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/burst_improvement)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/recoil_decrease)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/bullet_speed)
 
 /datum/outfit/job/bos/f13knightcap
 	name = "Knight Captain"
 	jobtype = /datum/job/bos/f13knightcap
+	/*
 	gunsmith_one = TRUE
 	gunsmith_two = TRUE
 	gunsmith_three = TRUE
 	gunsmith_four = TRUE
+	*/
 	uniform =		/obj/item/clothing/under/f13/bos/bodysuit/knight
 	accessory = 	/obj/item/clothing/accessory/bos/knightcaptain
 	belt = 			/obj/item/storage/belt/security/full
@@ -737,6 +753,25 @@ Senior Knight
 	access = list(ACCESS_JANITOR, ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
 	minimal_access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
 
+/datum/outfit/job/bos/f13seniorknight/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ninemil)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/widowmaker)
+
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/n99)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/huntingrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/m1911)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/varmintrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/colt6520)
+
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/scope)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/suppressor)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/burst_improvement)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/recoil_decrease)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/bullet_speed)
+
 /datum/outfit/job/bos/f13seniorknight
 	name = "Senior Knight"
 	jobtype = /datum/job/bos/f13seniorknight
@@ -827,6 +862,25 @@ Knight
 
 	access = list(ACCESS_JANITOR, ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
 	minimal_access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
+
+/datum/outfit/job/bos/f13knight/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ninemil)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/widowmaker)
+
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/n99)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/huntingrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/m1911)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/varmintrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/colt6520)
+
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/scope)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/suppressor)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/burst_improvement)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/recoil_decrease)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/bullet_speed)
 
 /datum/outfit/job/bos/f13knight
 	name = "Knight"


### PR DESCRIPTION
## About The Pull Request

Currently, BoS Knights, Sr. Knights and Knight Cpts don't receive gunsmith training upon spawn and must read (destroy) a gunsmithing book to learn gunsmith by lore they should already know. This gives all fully fledged knight castes the knowledge of the GnB recipes at roundstart.

Note: this doesn't actually give Knights GnB 'traits', so if anyone changed the recipes of what GnB manuals taught that wouldn't be reflected here.

## Why It's Good For The Game

Currently the GnB books don't give traits and I don't know how to make them properly give traits without messing anything up. So this is a band aid fix to a fairly annoying gameplay issue.

## Changelog
:cl:
tweak: The BoS knight caste can actually do gunsmithing as their flavour description suggests.
balance: BoS Knight castes no longer start with a tier 3 gunbook; initiates start with a tier 1 and 2 gunbook (they're students so they're still studying I guess?)
/:cl:

