### PR TITLE
Makes weather sounds toggleable

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -117,13 +117,13 @@
 	weather_duration = rand(weather_duration_lower, weather_duration_upper)
 	START_PROCESSING(SSweather, src)			//The reason this doesn't start and stop at main stage is because processing list is also used to see active running weathers (for example, you wouldn't want two ash storms starting at once.)
 	update_areas()
-	for(var/M in GLOB.player_list)
+	for(var/mob/M in GLOB.player_list)
 		var/turf/mob_turf = get_turf(M)
 		if(mob_turf && (mob_turf.z in impacted_z_levels))
 			if(telegraph_message)
 				to_chat(M, telegraph_message)
-			if(telegraph_sound)
-				SEND_SOUND(M, sound(telegraph_sound))
+			if(telegraph_sound &&  M.client.prefs.toggles & SOUND_SHIP_AMBIENCE)
+				SEND_SOUND(M, sound(telegraph_sound, repeat = 0, wait = 0, volume = 25, channel = CHANNEL_BUZZ))
 	addtimer(CALLBACK(src, .proc/start), telegraph_duration)
 
 /**
@@ -138,13 +138,13 @@
 		return
 	stage = MAIN_STAGE
 	update_areas()
-	for(var/M in GLOB.player_list)
+	for(var/mob/M in GLOB.player_list)
 		var/turf/mob_turf = get_turf(M)
 		if(mob_turf && (mob_turf.z in impacted_z_levels))
 			if(weather_message)
 				to_chat(M, weather_message)
-			if(weather_sound)
-				SEND_SOUND(M, sound(weather_sound))
+			if(weather_sound && M.client.prefs.toggles & SOUND_SHIP_AMBIENCE)
+				SEND_SOUND(M, sound(weather_sound, repeat = 0, wait = 0, volume = 25, channel = CHANNEL_BUZZ))
 	addtimer(CALLBACK(src, .proc/wind_down), weather_duration)
 
 /**
@@ -159,13 +159,13 @@
 		return
 	stage = WIND_DOWN_STAGE
 	update_areas()
-	for(var/M in GLOB.player_list)
+	for(var/mob/M in GLOB.player_list)
 		var/turf/mob_turf = get_turf(M)
 		if(mob_turf && (mob_turf.z in impacted_z_levels))
 			if(end_message)
 				to_chat(M, end_message)
-			if(end_sound)
-				SEND_SOUND(M, sound(end_sound))
+			if(end_sound  &&  M.client.prefs.toggles & SOUND_SHIP_AMBIENCE)
+				SEND_SOUND(M, sound(end_sound, repeat = 0, wait = 0, volume = 25, channel = CHANNEL_BUZZ))
 	addtimer(CALLBACK(src, .proc/end), end_duration)
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Places weather sounds in the wasteland ambience channel. You can now mute them in your preferences. Also lowers their volume.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I won't go insane from incredibly loud and unmuteable weather anymore.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: weather sounds are a toggle and quieter now 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
