### PR TITLE
Vendor buying guns!

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -550,10 +550,7 @@
 /area/f13/wasteland)
 "ags" = (
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
-	max_integrity = 300;
 	name = "Khan Khamp";
-	obj_integrity = 300;
 	req_access_txt = "125"
 	},
 /turf/open/floor/wood/f13/old,
@@ -4274,10 +4271,7 @@
 /area/f13/building)
 "bnU" = (
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
-	max_integrity = 300;
 	name = "Farm";
-	obj_integrity = 300;
 	req_one_access_txt = "124; 135"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4416,7 +4410,6 @@
 /area/f13/building)
 "bpz" = (
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
 	max_integrity = 500;
 	name = "store";
 	req_one_access_txt = "139"
@@ -11657,10 +11650,7 @@
 	color = "#363636"
 	},
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
-	max_integrity = 300;
 	name = "Khan Khamp";
-	obj_integrity = 300;
 	req_access_txt = "125"
 	},
 /turf/open/floor/f13{
@@ -12920,7 +12910,6 @@
 /area/f13/tunnel)
 "emM" = (
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
 	name = "Bar";
 	req_one_access_txt = "138"
 	},
@@ -16206,10 +16195,7 @@
 	color = "#363636"
 	},
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
-	max_integrity = 300;
 	name = "Khan Khamp";
-	obj_integrity = 300;
 	req_access_txt = "125"
 	},
 /turf/open/floor/wood/f13/carpet,
@@ -32292,7 +32278,6 @@
 /area/f13/building)
 "keM" = (
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
 	name = "Bar";
 	req_one_access_txt = "138"
 	},
@@ -33778,9 +33763,6 @@
 	pixel_y = -15
 	},
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
-	max_integrity = 300;
-	obj_integrity = 300;
 	req_access_txt = "131"
 	},
 /turf/open/floor/plasteel/cult,
@@ -41481,9 +41463,6 @@
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/slab/cracked,
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
-	max_integrity = 300;
-	obj_integrity = 300;
 	req_access_txt = "131"
 	},
 /turf/open/indestructible/ground/inside/mountain,
@@ -54454,10 +54433,7 @@
 /area/f13/wasteland)
 "rjN" = (
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
-	max_integrity = 300;
 	name = "Farm";
-	obj_integrity = 300;
 	req_one_access_txt = "124; 135"
 	},
 /turf/open/indestructible/ground/outside/road{
@@ -55148,7 +55124,6 @@
 "rxQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
 	name = "Bar";
 	req_one_access_txt = "138"
 	},
@@ -65522,19 +65497,11 @@
 /turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "uKA" = (
-/obj/item/storage/bag/money{
-	anchored = 1;
-	pixel_x = 32
-	},
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_x = 32
-	},
+/obj/machinery/mineral/wasteland_trader,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/city)
 "uKB" = (
 /obj/effect/decal/remains/human,
 /obj/machinery/light{
@@ -88365,7 +88332,7 @@ ycD
 xnT
 ycD
 ycD
-uKA
+ycD
 bFJ
 qDU
 uMZ
@@ -88622,8 +88589,8 @@ gLx
 gLx
 fdT
 ycD
-ycD
-gdY
+uKA
+uaf
 sIf
 cWB
 qJR

--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -14,16 +14,16 @@
 	var/expected_price = 0
 	var/list/prize_list = list()  //if you add something to this, please, for the love of god, sort it by price/type. use tabs and not spaces.
 
-	var/list/goods_list = list( /obj/item/stack/ore/diamond = 50,
+	var/list/goods_list = list( /*obj/item/stack/ore/diamond = 50,
 								/obj/item/stack/ore/gold = 7,
 								/obj/item/stack/ore/silver = 2,
 								/obj/item/stack/ore/iron = 1,
-								/obj/item/stack/sheet/leather = 3,
+								/obj/item/stack/sheet/leather = 3,*/
 								/obj/item/reagent_containers/pill/patch/f13/jet = 5,
 								/obj/item/reagent_containers/hypospray/medipen/f13/psycho = 15,
 								/obj/item/reagent_containers/hypospray/medipen/f13/medx = 10,
-								/obj/item/invention = 25,
-								/obj/item/experimental = 25,
+								/*obj/item/invention = 25,
+								/obj/item/experimental = 25,*/
 								/obj/item/gun/ballistic/automatic/pistol/ninemil = 25,
 								/obj/item/gun/ballistic/revolver/colt6520 = 30,
 								/obj/item/gun/ballistic/rifle/enfield = 35,

--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -23,7 +23,13 @@
 								/obj/item/reagent_containers/hypospray/medipen/f13/psycho = 15,
 								/obj/item/reagent_containers/hypospray/medipen/f13/medx = 10,
 								/obj/item/invention = 25,
-								/obj/item/experimental = 25
+								/obj/item/experimental = 25,
+								/obj/item/gun/ballistic/automatic/pistol/ninemil = 25,
+								/obj/item/gun/ballistic/revolver/colt6520 = 30,
+								/obj/item/gun/ballistic/rifle/enfield = 35,
+								/obj/item/gun/ballistic/automatic/pistol/n99 = 30,
+								/obj/item/gun/ballistic/automatic/pistol/pistol22 = 20,
+								/obj/item/gun/ballistic/revolver/widowmaker = 40
 								)
 
 /obj/machinery/mineral/wasteland_trader/general


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts the Trading Point vendor so it'll buy the literal trash tier guns. These being, the ones that you can get from digging through the piles of garbage, some of which can be crafting after reading the first 2 G&B books.

## Why It's Good For The Game

Another source of caps!

## Changelog
:cl:
add: Added 2 Trading Point vendors to the map
tweak: Trading Point vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
