### PR TITLE
Cheaper Pipboy and Wildcard food and Cornbread fix, punctuation.

### DIFF
--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -641,8 +641,8 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 	name = "Wasteland Pip-N-Walk"
 	icon_state = "generic_idle"
 	prize_list = list(
-		new /datum/data/wasteland_equipment("Pip-boy 3000",			/obj/item/pda,																250),
-		new /datum/data/wasteland_equipment("Reprogrammable ID",	/obj/item/card/id/selfassign,												200),
+		new /datum/data/wasteland_equipment("Pip-boy 3000",			/obj/item/pda,																175),
+		new /datum/data/wasteland_equipment("Reprogrammable ID",	/obj/item/card/id/selfassign,												125),
 		new /datum/data/wasteland_equipment("E.N.H.A.N.C.E. Your Pip-boy: Reagent Scanner",	/obj/item/cartridge/chemistry,						50),
 		new /datum/data/wasteland_equipment("E.N.H.A.N.C.E. Your Pip-boy: Health Scanner",	/obj/item/cartridge/medical,						50),
 		new /datum/data/wasteland_equipment("E.N.H.A.N.C.E. Your Pip-boy: Signaler",	/obj/item/cartridge/signal,								50),
@@ -662,6 +662,7 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 	prize_list = list(
 		new /datum/data/wasteland_equipment("Random manual",					/obj/item/book/manual/random,									40),
 		new /datum/data/wasteland_equipment("Box of ingredients - American",	/obj/item/storage/box/ingredients/american,						80),
+		new /datum/data/wasteland_equipment("Box of ingredients - Wildcard",	/obj/item/storage/box/ingredients/wildcard,						80),
 		new /datum/data/wasteland_equipment("Music box",						/obj/item/holodisk/musicbox,									400),
 		new /datum/data/wasteland_equipment("Advanced Armor and You",			/obj/item/book/granter/trait/pa_wear,							2000),
 		new /datum/data/wasteland_equipment("SCAV! Issue 1",					/obj/item/book/granter/crafting_recipe/scav_one,				600),
@@ -671,6 +672,7 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 	highpop_list = list(
 		new /datum/data/wasteland_equipment("Random manual",					/obj/item/book/manual/random,									40),
 		new /datum/data/wasteland_equipment("Box of ingredients - American",	/obj/item/storage/box/ingredients/american,						80),
+		new /datum/data/wasteland_equipment("Box of ingredients - Wildcard",	/obj/item/storage/box/ingredients/wildcard,						80),
 		new /datum/data/wasteland_equipment("Music box",						/obj/item/holodisk/musicbox,									400),
 		new /datum/data/wasteland_equipment("Advanced Armor and You",			/obj/item/book/granter/trait/pa_wear,							2000),
 		new /datum/data/wasteland_equipment("SCAV! Issue 1",					/obj/item/book/granter/crafting_recipe/scav_one,				600),

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -172,7 +172,7 @@
 	desc = "Some good down-home country-style, rootin'-tootin', revolver-shootin', dad-gum yeehaw cornbread."
 	icon_state = "cornbread"
 	slice_path = /obj/item/reagent_containers/food/snacks/breadslice/corn
-	list_reagents = list(/datum/reagent/consumable/nutriment = 10)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 30, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("cornbread" = 10)
 	foodtype = GRAIN
 	w_class = WEIGHT_CLASS_SMALL
@@ -182,7 +182,7 @@
 	desc = "A chunk of crispy, cowboy-style cornbread. Consume contentedly."
 	icon_state = "cornbread_slice"
 	foodtype = GRAIN
-	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 6)
 
 /obj/item/reagent_containers/food/snacks/baguette
 	name = "baguette"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -386,6 +386,11 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(clockcultslurring)
 		message = CLOCK_CULT_SLUR(message)
 
+	var/end_char = copytext(message, length(message), length(message) + 1)
+	if(!(end_char in list(".", "?", "!", "-", "~", ",", "_", "+", "|", "*")))
+		message += "."
+
+
 	message = capitalize(message)
 
 	return message


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- FOR MAPPING PRS: Include an image of your changes. If you don't do this, you will be asked to do this. Save yourself the time and include it in the OP. -->

## About The Pull Request

Adds the wildcard box to the american like vendor, as people can chance there luck and this increases the food stats on cornbread. Cheaper pipboy basically reducing it down to 25% less in lower pop. Auto punctuation too in this PR so everything will end with a period if you dont use punctuation.

## Why It's Good For The Game

This PR basically does a cornbread fix, with adding wildcard box to the american vendor which was kinda needed in a way as who knows maybe someone would want to make food with only WILDCARD ingredients, and this also lowers the pipboy to about 25% less in lower pop. Auto punctuation is good for the game adds more immersion for players who dont use periods.

<!-- If you aren't adding a changelog, just remove everything from # changelog to the /cl. Don't leave the changelog as the default example. -->

## Changelog
:cl:
tweaks: Pipboy down vendor down when it is lower pop so it isnt full price.
adds: Wildcard to the american vendor.
adds: auto punctuation 
tweaks: stats for cornbread and slices.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
