### PR TITLE
Ranger Danger Pins

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -478,7 +478,10 @@
 						"kirshbia",
 						"jackmcintyre",
 						"lunaticluna",
-						"muhsollini")
+						"muhsollini",
+						"tzula",
+						"ollieoxen",
+						"pisshole")
 	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
 
 /datum/gear/donator/ranger44
@@ -549,7 +552,8 @@
 						"muhsollini",
 						"rangerbust",
 						"kayzach",
-						"pisshole")
+						"pisshole",
+						"tzula")
 	restricted_roles = list("NCR Ranger", "NCR Ranger Sergeant", "NCR Veteran Ranger", "NCR Off-Duty")
 
 /datum/gear/donator/ranger10mm
@@ -598,7 +602,10 @@
 						"jackmcintyre",
 						"kirshbia",
 						"lunaticluna",
-						"muhsollini")
+						"muhsollini",
+						"tzula",
+						"ollieoxen",
+						"pisshole")
 	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
 
 /datum/gear/donator/rangersergeantpins
@@ -667,7 +674,8 @@
 						"honto335",
 						"luke313",
 						"spartan2548",
-						"lunaticluna")
+						"lunaticluna",
+						"tzula")
 	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
 
 ////////////////////////////


### PR DESCRIPTION
## About The Pull Request

These are ranger pins for Tzula, Ollie, Green.  Especially 45-70, 357, LT pins and ranger pins.

## Why It's Good For The Game

Pins are good, and this adds more flavor too for the players who have earned there pins and pistols.

## Changelog
:cl:
add: Three ckeys to LT pins, 40-70 and 357.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
