### PR TITLE
NCR ranger pin role fixes

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -578,8 +578,9 @@
 						"shoi87",
 						"svenja",
 						"usotsukihime",
-						"thegreatcoward")
-	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
+						"thegreatcoward"
+						"pisshole")
+	restricted_roles = list("NCR Ranger", "NCR Ranger Sergeant", "NCR Veteran Ranger", "NCR Off-Duty")
 
 /datum/gear/donator/rangerlieutenantpins
 	name = "Ranger-Lieutenant Pins"
@@ -606,7 +607,7 @@
 						"tzula",
 						"ollieoxen",
 						"pisshole")
-	restricted_roles = list("NCR Ranger", "NCR Veteran Ranger", "NCR Off-Duty")
+	restricted_roles = list("NCR Ranger", "NCR Ranger Sergeant", "NCR Veteran Ranger", "NCR Off-Duty")
 
 /datum/gear/donator/rangersergeantpins
 	name = "Ranger-Sergeant Pins"
@@ -691,7 +692,8 @@
 						"thegreatcoward",
 						"marcusstephens",
 						"usotsukihime",
-						"asterixcodix")
+						"asterixcodix"
+						"pisshole")
 	restricted_roles = list("NCR Commanding Officer", "NCR Off-Duty")
 
 /datum/gear/donator/ncrasgtpins
@@ -699,7 +701,8 @@
 	slot = SLOT_IN_BACKPACK
 	path = /obj/item/clothing/accessory/ncr/SGT
 	ckeywhitelist = list("muhsollini",
-						"weaselburg")
+						"weaselburg"
+						"pisshole")
 	restricted_roles = list("NCR Combat Medic", "NCR Combat Engineer", "NCR Heavy Trooper", "NCR Military Police")
 
 /datum/gear/donator/zirilliuniform

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -82,7 +82,7 @@
 	ckeywhitelist = list("thegreatcoward")
 
 /datum/gear/donator/kits/wolfemerson
-	name = "Wolf Emerson's belonings"
+	name = "Wolf Emerson's belongings"
 	path = /obj/item/storage/box/large/custom_kit/wolfemerson
 	ckeywhitelist = list("seabass390")
 
@@ -578,7 +578,7 @@
 						"shoi87",
 						"svenja",
 						"usotsukihime",
-						"thegreatcoward"
+						"thegreatcoward",
 						"pisshole")
 	restricted_roles = list("NCR Ranger", "NCR Ranger Sergeant", "NCR Veteran Ranger", "NCR Off-Duty")
 
@@ -692,7 +692,7 @@
 						"thegreatcoward",
 						"marcusstephens",
 						"usotsukihime",
-						"asterixcodix"
+						"asterixcodix",
 						"pisshole")
 	restricted_roles = list("NCR Commanding Officer", "NCR Off-Duty")
 
@@ -701,7 +701,7 @@
 	slot = SLOT_IN_BACKPACK
 	path = /obj/item/clothing/accessory/ncr/SGT
 	ckeywhitelist = list("muhsollini",
-						"weaselburg"
+						"weaselburg",
 						"pisshole")
 	restricted_roles = list("NCR Combat Medic", "NCR Combat Engineer", "NCR Heavy Trooper", "NCR Military Police")
 


### PR DESCRIPTION
Ranger pin loadout fixes and adding new NCR LM to lists

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- FOR MAPPING PRS: Include an image of your changes. If you don't do this, you will be asked to do this. Save yourself the time and include it in the OP. -->

## About The Pull Request

Some of the NCR Ranger pins weren't updated to be available for the Ranger Sergeant role, and since I've got NCR LM I decided to throw my name on a few pin loadout lists relevant to the faction. Also spellchecked one of the loadout kits from "belonings" to "belongings"

## Why It's Good For The Game

Fix to an overlooked thing, accessibility for my LM characters

## Changelog
:cl:
fix: Ranger pins have been updated to availability on Ranger Sergeant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
