### PR TITLE
Ports Full Auto framework from Lonestar

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -74,10 +74,8 @@
 /obj/item/proc/onMouseUp(object, location, params, mob)
 	return
 
-/*
 /obj/item/gun/CanItemAutoclick(object, location, params)
 	. = automatic
-*/
 
 /atom/proc/IsAutoclickable()
 	. = 1

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -285,7 +285,10 @@
 		to_chat(user, "<span class='userdanger'>You need both hands free to fire \the [src]!</span>")
 		return
 
-	user.DelayNextAction(ranged_attack_speed)
+	if (automatic == 0)
+		user.DelayNextAction(ranged_attack_speed)
+	if (automatic == 1)
+		user.DelayNextAction(autofire_shot_delay)
 
 	//DUAL (or more!) WIELDING
 	var/bonus_spread = 0
@@ -323,7 +326,10 @@
 	return user.CheckActionCooldown(get_clickcd())
 
 /obj/item/gun/proc/get_clickcd()
-	return isnull(chambered?.click_cooldown_override)? CLICK_CD_RANGE : chambered.click_cooldown_override
+	if (automatic == 0)
+		return isnull(chambered?.click_cooldown_override)? CLICK_CD_RANGE : chambered.click_cooldown_override
+	if (automatic == 1)
+		return isnull(chambered?.click_cooldown_override)? autofire_shot_delay : chambered.click_cooldown_override
 
 /obj/item/gun/GetEstimatedAttackSpeed()
 	return get_clickcd()
@@ -345,7 +351,10 @@
 	return
 
 /obj/item/gun/proc/on_cooldown()
-	return busy_action || firing || ((last_fire + fire_delay) > world.time)
+	if (automatic == 0)
+		return busy_action || firing || ((last_fire + fire_delay) > world.time)
+	if (automatic == 1)
+		return busy_action || firing
 
 /obj/item/gun/proc/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, stam_cost = 0)
 	add_fingerprint(user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -40,6 +40,8 @@
 	var/burst_shot_delay = 3
 	/// The time between firing actions, this means between bursts if this is burst weapon. The reason this is 0 is because you are still, by default, limited by clickdelay.
 	var/fire_delay = 0
+	//Time between individual shots when firing full-auto.
+	var/autofire_shot_delay = 3
 	/// Last world.time this was fired
 	var/last_fire = 0
 	/// Currently firing, whether or not it's a burst or not.
@@ -119,9 +121,7 @@
 	/// Just 'slightly' snowflakey way to modify projectile damage for projectiles fired from this gun.
 //	var/projectile_damage_multiplier = 1
 
-/*
 	var/automatic = 0 //can gun use it, 0 is no, anything above 0 is the delay between clicks in ds
-*/ //Disabled because automatic fire is buggy and a bit OP.
 
 /obj/item/gun/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- FOR MAPPING PRS: Include an image of your changes. If you don't do this, you will be asked to do this. Save yourself the time and include it in the OP. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Implements the option for guns to fire in full-auto (i.e. continuing to fire while the mouse is held), ported from [Lonestar PR #188](https://github.com/LoneStarF13/LoneStar/pull/188) by Tron-117 (who has been silent for a while - I tried to contact them for permission as a courtesy, but wasn't able to). 
This **does not change anything in the player experience** unless someone varedits a gun to have `automatic` set to 1. This is a framework that will allow future or existing guns to fire full-auto.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It expands the options available to coders and may open routes for greater weapon variety.
<!-- If you aren't adding a changelog, just remove everything from # changelog to the /cl. Don't leave the changelog as the default example. -->

## Changelog
:cl:
code: re-added certain variables relating to full-auto fire, and added checks for said variables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
