### PR TITLE
Removes Lead

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -152,34 +152,6 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 /obj/item/stack/sheet/metal/five
 	amount = 5
 
-/obj/item/stack/sheet/lead
-	name = "lead"
-	desc = "Sheets made out of lead."
-	singular_name = "lead sheet"
-	icon_state = "sheet-lead"
-	item_state = "sheet-lead"
-	custom_materials = list(/datum/material/lead=MINERAL_MATERIAL_AMOUNT)
-	throwforce = 10
-	flags_1 = CONDUCT_1
-	resistance_flags = FIRE_PROOF
-	merge_type = /obj/item/stack/sheet/lead
-	grind_results = list(/datum/reagent/lead = 20)
-	point_value = 2
-	//tableVariant = /obj/structure/table
-	material_type = /datum/material/lead
-
-/obj/item/stack/sheet/lead/fifty
-	amount = 50
-
-/obj/item/stack/sheet/lead/twenty
-	amount = 20
-
-/obj/item/stack/sheet/lead/ten
-	amount = 10
-
-/obj/item/stack/sheet/lead/five
-	amount = 5
-
 /obj/item/stack/sheet/metal/cyborg
 	custom_materials = null
 	is_cyborg = 1

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -5,8 +5,7 @@ GLOBAL_LIST_INIT(ore_probability, list(/obj/item/stack/ore/uranium = 50,
 									   /obj/item/stack/ore/gold = 50,
 									   /obj/item/stack/ore/diamond = 25,
 									   /obj/item/stack/ore/bananium = 5,
-									   /obj/item/stack/ore/titanium = 75,
-									   /obj/item/stack/ore/lead = 80))
+									   /obj/item/stack/ore/titanium = 75))
 
 /obj/structure/spawner/ice_moon
 	name = "cave entrance"

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -238,7 +238,7 @@
 	mineralChance = 6
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/uranium = 2, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 4, /turf/closed/mineral/titanium = 4,
-		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40, /turf/closed/mineral/lead = 30, /turf/closed/mineral/limestone = 20,
+		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40, /turf/closed/mineral/limestone = 20,
 		/*/turf/closed/mineral/gibtonite = 2, *//turf/closed/mineral/bscrystal = 1)
 
 /turf/closed/mineral/random/low_chance/earth_like
@@ -348,12 +348,6 @@
 		/turf/closed/mineral/iron/ice/icemoon = 95)
 
 
-
-/turf/closed/mineral/lead
-	mineralType = /obj/item/stack/ore/lead
-	spreadChance = 20
-	spread = 1
-	scan_state = "rock_Lead"
 
 /turf/closed/mineral/limestone
 	mineralType = /obj/item/stack/sheet/mineral/limestone
@@ -499,12 +493,6 @@
 	turf_type = /turf/open/floor/plating/asteroid/snow/ice/icemoon
 	baseturfs = /turf/open/floor/plating/asteroid/snow/ice/icemoon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
-
-/turf/closed/mineral/lead
-	mineralType = /obj/item/stack/ore/lead
-	spreadChance = 5
-	spread = 1
-	scan_state = "rock_Lead"
 
 /turf/closed/mineral/silver
 	mineralType = /obj/item/stack/ore/silver

--- a/code/modules/fallout/datums/materials.dm
+++ b/code/modules/fallout/datums/materials.dm
@@ -1,11 +1,3 @@
-/datum/material/lead
-	name = "lead"
-	desc = "Common lead ore often found in sedimentary and igneous layers of the crust."
-	color = "#878687"
-	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
-	sheet_type = /obj/item/stack/sheet/lead
-	value_per_unit = 0.0025
-
 /datum/material/blackpowder
 	name = "blackpowder"
 	desc = "blackpowder"

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -17,7 +17,7 @@
 	var/ore_pickup_rate = 15
 	var/ore_multiplier = 1
 	var/point_upgrade = 1
-	var/list/ore_values = list(/datum/material/glass = 1, /datum/material/iron = 1, /datum/material/plasma = 15, /datum/material/silver = 16, /datum/material/gold = 18, /datum/material/titanium = 30, /datum/material/uranium = 30, /datum/material/diamond = 50, /datum/material/bluespace = 50, /datum/material/bananium = 60, /datum/material/lead = 3)
+	var/list/ore_values = list(/datum/material/glass = 1, /datum/material/iron = 1, /datum/material/plasma = 15, /datum/material/silver = 16, /datum/material/gold = 18, /datum/material/titanium = 30, /datum/material/uranium = 30, /datum/material/diamond = 50, /datum/material/bluespace = 50, /datum/material/bananium = 60)
 	var/message_sent = FALSE
 	var/list/ore_buffer = list()
 	var/datum/techweb/stored_research

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -82,16 +82,6 @@
 	refined_type = /obj/item/stack/sheet/metal
 	merge_type = /obj/item/stack/ore/iron
 
-/obj/item/stack/ore/lead
-	name = "lead ore"
-	icon_state = "lead ore"
-	item_state = "lead ore"
-	singular_name = "lead ore chunk"
-	points = 3
-	custom_materials = list(/datum/material/lead=MINERAL_MATERIAL_AMOUNT)
-	refined_type = /obj/item/stack/sheet/lead
-	merge_type = /obj/item/stack/ore/lead
-
 /obj/item/stack/ore/glass
 	name = "sand pile"
 	icon_state = "Glass ore"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -922,16 +922,6 @@
 		new/obj/item/stack/medical/gauze/adv(get_turf(G), reac_volume)
 		G.use(reac_volume)
 
-/datum/reagent/lead
-	name = "Lead"
-	description = "Pure lead is a metal."
-	reagent_state = SOLID
-	taste_description = "lead"
-	pH = 6
-	overdose_threshold = 30
-	color = "#c2391d"
-	material = /datum/material/lead
-
 /datum/reagent/iron
 	name = "Iron"
 	description = "Pure iron is a metal."

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -200,15 +200,6 @@
 	category = list("initial","Construction")
 	maxstack = 50
 
-/datum/design/lead
-	name = "Lead"
-	id = "lead"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/lead = 2000)
-	build_path = /obj/item/stack/sheet/lead
-	category = list("initial","Construction")
-	maxstack = 50
-
 /datum/design/rcd_ammo
 	name = "Compressed Matter Cartridge"
 	id = "rcd_ammo"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- FOR MAPPING PRS: Include an image of your changes. If you don't do this, you will be asked to do this. Save yourself the time and include it in the OP. -->

## About The Pull Request
Removes Lead as a liquid, ore, and stack due to it being not used anywhere at all. other than 0.03 points in a mining vendor. This still keeps lead acetate the toxin in the game as it doesn't seem to be related however lead acetate doesn't have a crafting recipe. If it turns out lead is used somewhere and is under a different name ill be happy to try and either remove it or remove this pr
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Literal junk laying around, no offense to whoever originally added it as it was probably for old gun code but now its just sitting there unused and taking up valuable spawns from other hard working ores.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- If you aren't adding a changelog, just remove everything from # changelog to the /cl. Don't leave the changelog as the default example. -->

## Changelog
:cl:
:del: Lead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
