### PR TITLE
Adds a functional species whitelist, allows super mutants to be selected in character setup

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1678,31 +1678,38 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/result = input(user, "Select a species", "Species Selection") as null|anything in GLOB.roundstart_race_names
 					if(result)
 						var/newtype = GLOB.species_list[GLOB.roundstart_race_names[result]]
-						pref_species = new newtype()
-						//let's ensure that no weird shit happens on species swapping.
-						custom_species = null
-						if(!parent.can_have_part("body_markings"))
-							features["body_markings"] = "None"
-						if(!parent.can_have_part("mam_body_markings"))
-							features["mam_body_markings"] = "None"
-						if(parent.can_have_part("mam_body_markings"))
-							if(features["mam_body_markings"] == "None")
-								features["mam_body_markings"] = "Plain"
-						if(parent.can_have_part("tail_lizard"))
-							features["tail_lizard"] = "Smooth"
-						if(pref_species.id == "felinid")
-							features["mam_tail"] = "Cat"
-							features["mam_ears"] = "Cat"
+						var/datum/species/to_check_wl = new newtype() //Instance of newtype specifically for checking whitelists
+						var/list/species_wl = to_check_wl.whitelist 
+						var/whitelist_accept = TRUE
+						if(to_check_wl.whitelisted == 1)
+							if(species_wl.Find(user.ckey) == 0)
+								to_chat(user, SPAN_DANGER("You are not whitelisted for this species!"))
+								whitelist_accept = FALSE
+						if(whitelist_accept == TRUE)
+							pref_species = new newtype()
+							//let's ensure that no weird shit happens on species swapping.
+							custom_species = null
+							if(!parent.can_have_part("body_markings"))
+								features["body_markings"] = "None"
+							if(!parent.can_have_part("mam_body_markings"))
+								features["mam_body_markings"] = "None"
+							if(parent.can_have_part("mam_body_markings"))
+								if(features["mam_body_markings"] == "None")
+									features["mam_body_markings"] = "Plain"
+							if(parent.can_have_part("tail_lizard"))
+								features["tail_lizard"] = "Smooth"
+							if(pref_species.id == "felinid")
+								features["mam_tail"] = "Cat"
+								features["mam_ears"] = "Cat"
 
-						//Now that we changed our species, we must verify that the mutant colour is still allowed.
-						var/temp_hsv = RGBtoHSV(features["mcolor"])
-						if(features["mcolor"] == "#000000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#202020")[3]))
-							features["mcolor"] = pref_species.default_color
-						if(features["mcolor2"] == "#000000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#202020")[3]))
-							features["mcolor2"] = pref_species.default_color
-						if(features["mcolor3"] == "#000000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#202020")[3]))
-							features["mcolor3"] = pref_species.default_color
-
+							//Now that we changed our species, we must verify that the mutant colour is still allowed.
+							var/temp_hsv = RGBtoHSV(features["mcolor"])
+							if(features["mcolor"] == "#000000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#202020")[3]))
+								features["mcolor"] = pref_species.default_color
+							if(features["mcolor2"] == "#000000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#202020")[3]))
+								features["mcolor2"] = pref_species.default_color
+							if(features["mcolor3"] == "#000000" || (!(MUTCOLORS_PARTSONLY in pref_species.species_traits) && ReadHSV(temp_hsv)[3] < ReadHSV("#202020")[3]))
+								features["mcolor3"] = pref_species.default_color
 				if("custom_species")
 					var/new_species = reject_bad_name(input(user, "Choose your species subtype, if unique. This will show up on examinations and health scans. Do not abuse this:", "Character Preference", custom_species) as null|text)
 					if(new_species)

--- a/code/modules/mob/living/carbon/human/species_types/supermutant.dm
+++ b/code/modules/mob/living/carbon/human/species_types/supermutant.dm
@@ -43,6 +43,12 @@
 	for(var/obj/item/bodypart/b in C.bodyparts)
 		b.max_damage = initial(b.max_damage)
 
+/datum/species/smutant/qualifies_for_rank(rank, list/features)
+	if(rank in GLOB.legion_positions) // haha, no
+		return 0
+	if(rank in GLOB.brotherhood_positions) //no.
+		return 0
+	return ..()
 
 //datum/species/smutant/get_racelist(mob/user)
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -446,6 +446,7 @@ SILICON_MAX_LAW_AMOUNT 12
 ## You probably want humans on your space station, but technically speaking you can turn them off without any ill effect
 ROUNDSTART_RACES human
 ROUNDSTART_RACES ghoul
+ROUNDSTART_RACES smutant
 
 ## Races that are strictly worse than humans that could probably be turned on without balance concerns
 #ROUNDSTART_RACES lizard


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- FOR MAPPING PRS: Include an image of your changes. If you don't do this, you will be asked to do this. Save yourself the time and include it in the OP. -->

## About The Pull Request

This re-adds whitelist checks for species, allowing the "whitelist" variable to actually be used. Now you don't have to ahelp every time you want to spawn as a super mutant!
Also locks super mutants out of Legion and Brotherhood roles, since you can actually spawn as them now.

## Why It's Good For The Game

It's convenient for players and admins alike to not need to ahelp whenever you want to use your super mutant whitelist.

<!-- If you aren't adding a changelog, just remove everything from # changelog to the /cl. Don't leave the changelog as the default example. -->

## Changelog
:cl:
tweak: locked super mutants out of spawning as Legion/Brotherhood roles
config: added super mutants to the roundstart races list
refactor: added whitelist checks when selecting a species in character setup
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
