### PR TITLE
Adds donator wastelander loadout - Wasteland Architect

### DIFF
--- a/code/modules/fallout/job/wasteland.dm
+++ b/code/modules/fallout/job/wasteland.dm
@@ -642,7 +642,8 @@ Outlaw
 	/datum/outfit/loadout/eidolon,
 	/datum/outfit/loadout/aviator,
 	/datum/outfit/loadout/trapper,
-	/datum/outfit/loadout/trouper)
+	/datum/outfit/loadout/trouper,
+	/datum/outfit/loadout/architect)
 
 /datum/outfit/job/wasteland/f13wastelander
 	name = "Wastelander"
@@ -907,6 +908,22 @@ Outlaw
 		/obj/item/reagent_containers/food/drinks/bottle/applejack=1,
 		/obj/item/reagent_containers/food/drinks/bottle/goldschlager=1,
 		/obj/item/clothing/accessory/pocketprotector/cosmetology=1)
+
+
+/datum/outfit/loadout/architect //Donator loadout - Vincieyork
+	name = "Wasteland Architect"
+	uniform = /obj/item/clothing/under/pants/jeans
+	suit = /obj/item/clothing/suit/jacket/flannel/brown
+	shoes = /obj/item/clothing/shoes/jackboots
+	head = /obj/item/clothing/head/welding/f13
+	belt = /obj/item/storage/belt/utility/full
+	l_hand = /obj/item/gun/ballistic/revolver/widowmaker
+	backpack_contents = list(
+		/obj/item/stack/sheet/metal/ten=2,
+		/obj/item/stack/sheet/glass/ten=2,
+		/obj/item/stack/sheet/mineral/wood/twenty=2,
+		/obj/item/circuitboard/machine/autolathe=1,
+		/obj/item/storage/backpack/duffelbag/engineering=1)
 
 //Note: Recipes will be gone and into a book as soon as I figure out how to do that much
 /datum/job/wasteland/f13tribal


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- FOR MAPPING PRS: Include an image of your changes. If you don't do this, you will be asked to do this. Save yourself the time and include it in the OP. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds a wastelander loadout accesible to everyone. This is a donator perk from some time ago that we finally got around to implementing.

## Why It's Good For The Game

Keeping promises, variety.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- If you aren't adding a changelog, just remove everything from # changelog to the /cl. Don't leave the changelog as the default example. -->

## Changelog
:cl:
add: Wasteland Architect loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
