### PR TITLE
Balance Changes

### DIFF
--- a/code/modules/fallout/job/ncr.dm
+++ b/code/modules/fallout/job/ncr.dm
@@ -927,7 +927,6 @@ Veteran Ranger
 	/datum/outfit/loadout/vrclassic,	//AMR
 	/datum/outfit/loadout/vrlite, 		//Republic's Pride
 	/datum/outfit/loadout/vrbrush, 		//Scoped Brushgun
-	/datum/outfit/loadout/vrauto,		//Assault Carbine
 	/datum/outfit/loadout/vrhunting,	//5.56 Rangemaster
 	)
 
@@ -979,12 +978,6 @@ Veteran Ranger
 		/obj/item/attachments/scope=1,
 		/obj/item/ammo_box/tube/c4570=3)
 
-/datum/outfit/loadout/vrauto
-	name = "Assault Carbine Veteran Ranger"
-	suit_store = /obj/item/gun/ballistic/automatic/assault_carbine
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/c5mm=2)
-
 /datum/outfit/loadout/vrhunting
 	name = "Hunting Veteran Ranger"
 	suit_store = /obj/item/gun/ballistic/automatic/service/carbine/rangermaster
@@ -1007,7 +1000,6 @@ Veteran Ranger
 	/datum/outfit/loadout/rsclassic,	//Sniper Rifle
 	/datum/outfit/loadout/rslite, 		//Scoped Garand
 	/datum/outfit/loadout/rsbrush, 		//Scoped Brushgun
-	/datum/outfit/loadout/rsauto,		//AK112
 	/datum/outfit/loadout/rshunting		//5.56 Rangemaster
 	)
 
@@ -1065,18 +1057,10 @@ Veteran Ranger
 		/obj/item/ammo_box/tube/c4570 = 3
 		)
 
-/datum/outfit/loadout/rsauto
-	name = "Heavy Ranger"
-	suit_store = /obj/item/gun/ballistic/automatic/ak112
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/c5mm/extended = 2
-		)
-
 /datum/outfit/loadout/rshunting
 	name = "Hunting Ranger"
 	suit_store = /obj/item/gun/ballistic/automatic/service/carbine/rangermaster
 	backpack_contents = list(
-		/obj/item/attachments/scope = 1,
 		/obj/item/ammo_box/magazine/m556/rifle=3)
 
 //NCR Ranger

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -626,9 +626,9 @@
 	desc = "A true icon of California exploration, Colt Rangemaster rifles saw their post-war renaissance in the early days before and during the rise of the Republic. Falling out of use during the height of the Brotherhood War, some still cling whiteknuckle to these classic re-jiggered hunting rifles. This one's seen some battles and seems to be configured more classically rather than having many of the more common post-war upgrades."
 	icon_state = "rangermaster"
 	fire_sound = 'sound/f13weapons/hunting_rifle.ogg'
-	extra_damage = 8
+	extra_damage = 4
 	burst_size = 1
-	fire_delay = 8
+	fire_delay = 6
 	spread = 1
 	burst_size = 1
 	extra_penetration = 0.1
@@ -637,16 +637,13 @@
 	can_attachments = FALSE
 	untinkerable = TRUE
 	can_bayonet = FALSE
-	can_scope = TRUE
-	scope_state = "rifle_scope"
-	scope_x_offset = 4
-	scope_y_offset = 11
+	can_scope = FALSE
 	can_suppress = TRUE
 	unique_reskin = list("Worn Ranger's Rifle" = "rangermaster",
 						"5.56 Hunting Rifle" = "rangemaster"
 						)
 
-//'Maxson' Carbine												Keywords: BOS, 5.56, Semi-Automatic, 20 (10-50) round mags. Notes: Snowflake rifle for knights; on par with service rifle. Avoids laser spam.
+//'Maxson' Carbine												Keywords: BOS, 5.56, Semi-Automatic, 20 (10-50) round mags. Notes: Snowflake rifle for knights; on par with service rifle. Avoids laser spam. - Sprite by Rebel0
 /obj/item/gun/ballistic/automatic/service/maxson
 	name = "'Maxson' carbine"
 	desc = "A 5.56x45 semi-automatic service rifle manufactrued post-war by the Senora Brotherhood chapter. These clearly use AR-platform receivers but seem to have various surplus parts slapped to it."
@@ -663,7 +660,7 @@
 	suppressor_x_offset = 37
 	suppressor_y_offset = 18
 
-//'Maxson' Scout Carbine										Keywords: BOS, 4.73 Caseless, Semi-Automatic, 12 round mags. Notes: Snowflake rifle for knight scouts; has a scope to be similar to scout carbine for NCR.
+//'Maxson' Scout Carbine										Keywords: BOS, 4.73 Caseless, Semi-Automatic, 12 round mags. Notes: Snowflake rifle for knight scouts; has a scope to be similar to scout carbine for NCR. - Sprite by Rebel0
 /obj/item/gun/ballistic/automatic/service/maxson/caseless
 	name = "'Maxson' scout carbine"
 	desc = "A 4.73 semi-automatic service rifle manufactured post-war by the Senora Brotherhood chapter. This once fine AR-platform gun has been mangled into a strange firearm made for stealth due to its caseless ammunition and odd choice in round."
@@ -678,7 +675,7 @@
 	zoom_out_amt = 13
 	extra_damage = 2
 
-//'Maxson' Assault Carbine										Keywords: BOS, 5mm, Automatic, 24 (or 48) round mags, No Attachments.	Notes: Automatic version; made via protolathes for BOS.
+//'Maxson' Assault Carbine										Keywords: BOS, 5mm, Automatic, 24 (or 48) round mags, No Attachments.	Notes: Automatic version; made via protolathes for BOS. - Sprite by Rebel0
 /obj/item/gun/ballistic/automatic/service/maxson/c5mm
 	name = "'Maxson' assault carbine"
 	desc = "A 5mm conversion of the 'Maxson' 5.56 carbine. This model appears to lack a fire selector but makes up for it in quick, successive bursts with decent accuracy due to the lower caliber size."
@@ -943,7 +940,7 @@
 	fire_delay = 3.5
 	can_scope = FALSE
 	can_attachments = FALSE
-	extra_damage = 2
+	extra_damage = 1
 	bayonet_state = "bayonet"
 	knife_x_offset = 22
 	knife_y_offset = 7
@@ -1052,10 +1049,9 @@
 	slot_flags = 0
 	mag_type = /obj/item/ammo_box/magazine/c5mm
 	burst_size = 3
-	fire_delay = 6
+	fire_delay = 5
 	burst_shot_delay = 2
 	spread = 4
-	extra_damage = 4
 	can_attachments = FALSE
 	can_scope = TRUE
 	scope_state = "scope_short"
@@ -1074,7 +1070,7 @@
 						"Classic" = "assault_carbine_old"
 						)
 
-//AK-112														Keywords: 5mm, Automatic, 24/48 mags
+//AK-112														Keywords: 5mm, Automatic, 24/48 mags - Sprite by Rebel0
 /obj/item/gun/ballistic/automatic/ak112
 	name = "AK-112"
 	desc = "The AK-112 assault rifle was in standard service in the 21st century but found itself replaced due to it's 5mm cartriage by common 5.56 rifles. By the time of the great war AK-112's were considered ancient guns, surpassed by the service rifle and Type-93. However.. its rate of fire remains unmatched."
@@ -1088,7 +1084,6 @@
 	force = 20
 	burst_size = 2
 	fire_delay = 3
-	extra_damage = 2
 	burst_shot_delay = 2.2
 	spread = 20
 	can_attachments = FALSE

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -191,9 +191,7 @@
 	icon_state = "executive"
 	can_suppress = TRUE
 	burst_size = 2
-	extra_damage = 4
 	can_automatic = FALSE
-	extra_penetration = 0.2 //2x 35 damage, 10 AP- hits like a 2rd burst 5.56, but more accurate
 	semi_auto = FALSE
 
 //Gobi Campaign N99 - by Pisshole		Keywords: UNIQUE, Leadership, 10mm, Semi-auto, 12/24 round magazine
@@ -206,7 +204,6 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	can_attachments = FALSE
 	fire_delay = 1
-	extra_damage = 5
 	can_suppress = FALSE
 	can_automatic = FALSE
 	can_scope = TRUE

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -128,7 +128,7 @@
 	icon_state = "colt6520"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev6520
 	fire_sound = 'sound/f13weapons/10mm_fire_02.ogg'
-	extra_damage = 5
+	extra_damage = 3
 	fire_delay = 4
 
 //Zhurong										Keywords: UNIQUE, 10mm, Double action, 12 round cylinder

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -94,21 +94,21 @@ Civilian round				=	-10% damage. AP reduced by 50%
 
 /obj/item/projectile/bullet/c10mm
 	name = "10mm FMJ bullet"
-	damage = 30
-	armour_penetration = 0.2
+	damage = 29
+	armour_penetration = 0.18
 	wound_bonus = 18
 
 /obj/item/projectile/bullet/c10mm/ap
 	name = "10mm AP bullet"
-	damage = 25
-	armour_penetration = 0.35
+	damage = 24
+	armour_penetration = 0.32
 	wound_bonus = 9
 	bare_wound_bonus = -9
 
 /obj/item/projectile/bullet/c10mm/hp
 	name = "10mm JHP bullet"
 	damage = 35
-	armour_penetration = 0.1
+	armour_penetration = 0
 	wound_bonus = -27
 	bare_wound_bonus = 27
 


### PR DESCRIPTION
## About The Pull Request

Went over a few PRs, saw some balance issues that were told to me by returning players.

These include:
- Ranger AK112 loadout. **Why this is an issue?** The AK112 is a point-blank nightmare of ~20 damage with a large burst and high AP. (AP does basically extra damage against armor users the way its coded since armor is 'simulated health'). Removed it from the range loadout and removed its bonus damage; it does not need it.
- Ranger 5.56 Rangemaster loadout. **Why this an issue?** Gun did more damage than 7.62 rifles normally with a much higher capacity (ex DKS and M1 limited to ~8 rounds vs this gun limited to **50**). Gun lost some of its extra damage so it's more on-par with 7.62 instead of better, and no longer has a scope.
- 10mm ammo balance. **Why this is an issue?** It was literally made better than .45 ammo which is supposed to have bad pen and lower capacity but higher damage. Also, giving armor pen to JHP rounds are **bad** due to the wound system and the fact, again, AP does bonus damage to armor is how it works. Not 'bypass' the armor, per-say.
- Lowers n99 special gun stats; they're.. really powerful. The Executive especially. That was supposed to be a loot item, so I've adjusted it more to a powerful role sidearm.
- Lowers 10mm revolver buffed stats; it holds more rounds than a 10mm semi-automatic pistol and can be box-loaded rather than mag-loaded; allowing for more compact inventory management. It doesn't need bonus damage on top of it.

The majority of these changes have been talked over with TEF. Feedback given from a handful of players who recently returned and saw these changes.

## Why It's Good For The Game

Rebalances some stuff that seemed to not be thought of with balance particularly in mind; albeit fair due to the server's low pop and lack of 'big battles' of pvp.

## Changelog
:cl:
balance: Can see the section listing. Basically re-balance recently done changes and additions.
/:cl: