### PR TITLE
Bring Throwing Stars in line with other throwing weapons.

### DIFF
--- a/code/game/objects/items/melee/weaponry.dm
+++ b/code/game/objects/items/melee/weaponry.dm
@@ -350,8 +350,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 2
 	throwforce = 10 //This is never used on mobs since this has a 100% embed chance.
 	throw_speed = 4
-	embedding = list("pain_mult" = 4, "embed_chance" = 100, "fall_chance" = 0, "embed_chance_turf_mod" = 15)
-	armour_penetration = 0.65
+	embedding = list("pain_mult" = 2, "embed_chance" = 60, "fall_chance" = 0, "embed_chance_turf_mod" = 15)
+	armour_penetration = 0.15
 
 	w_class = WEIGHT_CLASS_SMALL
 	sharpness = SHARP_EDGED


### PR DESCRIPTION

## About The Pull Request

Throwing stars had 100% embed chance, 65% armor pen, and insane pain damage.  The values have been brought in line with other throwing weapons (such as spears).

## Why It's Good For The Game

Can very easily two-tap anyone through any armor.



