### PR TITLE
Khan/Wayfarer door ports + removal of the anvil

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -36759,10 +36759,7 @@
 	},
 /area/f13/building)
 "mnj" = (
-/obj/structure/simple_door/metal/barred{
-	req_one_access_txt = "131";
-	req_access_txt = "131"
-	},
+/obj/machinery/door/unpowered/securedoor/wayfareroor,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mnv" = (
@@ -39296,8 +39293,8 @@
 /area/f13/building)
 "niP" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/anvil,
 /obj/item/clothing/gloves/f13/blacksmith,
+/obj/structure/anvil/obtainable/basic,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -30,6 +30,25 @@
 	category = CAT_MISC
 	always_availible = FALSE
 
+/datum/crafting_recipe/gate_khanate
+	name = "Khans steel-reinforced wood door"
+	result = /obj/machinery/door/unpowered/securedoor/khandoor
+	reqs = list(/obj/item/stack/sheet/metal = 5,
+				/obj/item/stack/sheet/mineral/wood = 10,)
+	time = 60
+	subcategory = CAT_MISCELLANEOUS
+	category = CAT_MISC
+	always_availible = FALSE
+
+/datum/crafting_recipe/gate_wayfareroor
+	name = "Wayfarer steel-reinforced wood door"
+	result = /obj/machinery/door/unpowered/securedoor/wayfareroor
+	reqs = list(/obj/item/stack/sheet/metal = 5,
+				/obj/item/stack/sheet/mineral/wood = 10,)
+	time = 60
+	subcategory = CAT_MISCELLANEOUS
+	category = CAT_MISC
+	always_availible = FALSE
 
 /datum/crafting_recipe/plant
 	name = "Potted plant"

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -57,6 +57,15 @@
 	name = "Legion Castrum"
 	req_access_txt = "123"
 
+//khoor
+/obj/machinery/door/unpowered/securedoor/khandoor
+	name = "khan door"
+	req_access_txt = "125"
+
+// Wayfarer door
+/obj/machinery/door/unpowered/securedoor/wayfareroor
+	name = "wayfarer door"
+	req_access_txt = "131"
 
 //Steel version, very durable
 /obj/machinery/door/unpowered/secure_steeldoor

--- a/code/modules/fallout/job/tribals.dm
+++ b/code/modules/fallout/job/tribals.dm
@@ -42,6 +42,7 @@
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/hydra)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalshield)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/nightshield)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/gate_wayfareroor)
 
 /*
 Tribal Chief

--- a/code/modules/fallout/job/wasteland.dm
+++ b/code/modules/fallout/job/wasteland.dm
@@ -73,6 +73,7 @@ Great Khans
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/khanbatarmor)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/reinforcedkhanbatarmor)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/gate_khanate)
 
 /datum/outfit/job/wasteland/f13genghis
 	name = "Genghis Khan"
@@ -162,6 +163,7 @@ Great Khans
 	ADD_TRAIT(H, TRAIT_CHEM_USER, src)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/khanbatarmor)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/reinforcedkhanbatarmor)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/gate_khanate)
 
 	if(!H.gang)
 		var/datum/gang/greatkhans/GK = GLOB.greatkhans


### PR DESCRIPTION
## About The Pull Request

Anvil has died in this update for the wayfarers, the op anvil is removed and this brings the wayfarer door to be wayfarer only instead of what it was, and brings the khan door over.

## Why It's Good For The Game

This is really needed.

<!-- If you aren't adding a changelog, just remove everything from # changelog to the /cl. Don't leave the changelog as the default example. -->

## Changelog
:cl:
add: khan door / wayfarer door 
remove: wayfarer op anvil repalced with regular one
replace: regular wayfarer door with new one that works plentiful.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
