### PR TITLE
removes power armor rng reflection

### DIFF
--- a/code/modules/fallout/clothing/head/f13head.dm
+++ b/code/modules/fallout/clothing/head/f13head.dm
@@ -337,19 +337,6 @@
 				armor = armor.modifyRating(linemelee = 50, linebullet = 50, linelaser = 50)
 				emped = 0
 
-/obj/item/clothing/head/helmet/f13/power_armor/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
-	if(check_armor_penetration(object) <= 0.15 && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))
-		if(prob(armor_block_chance))
-			var/ratio = rand(0,100)
-			if(ratio <= deflection_chance)
-				block_return[BLOCK_RETURN_REDIRECT_METHOD] = REDIRECT_METHOD_DEFLECT
-				return BLOCK_SHOULD_REDIRECT | BLOCK_REDIRECTED | BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
-			if(ismob(loc))
-				to_chat(loc, SPAN_WARNING("Your power armor absorbs the projectile's impact!"))
-			block_return[BLOCK_RETURN_SET_DAMAGE_TO] = 0
-			return BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
-	return ..()
-
 /obj/item/clothing/head/helmet/f13/power_armor/t45b
 	name = "salvaged T-45b helmet"
 	desc = "(VIII) It's a salvaged T-45b power armor helmet."


### PR DESCRIPTION


## About The Pull Request
Removes the RNG power armor ablity to just reflect lower calibers bullets

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/30435998/191162956-3af8a722-fe47-4181-a528-558b781aba72.png)
Its balance

## Changelog
:cl:
balance: Balance power armor rng reflection via removing
/:cl:
