### PR TITLE
Rule enforcement

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -8,6 +8,17 @@
  *afterattack. The return value does not matter.
  */
 /obj/item/proc/melee_attack_chain(mob/user, atom/target, params, attackchain_flags, damage_multiplier = 1)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = target
+		if(ishuman(target))
+			var/datum/component/combat_mode/combat_mode_husband = user.GetComponent(/datum/component/combat_mode)
+			var/datum/component/combat_mode/combat_mode_wife = H.GetComponent(/datum/component/combat_mode)
+			if(!(combat_mode_husband.mode_flags & COMBAT_MODE_TOGGLED) && !(combat_mode_husband.mode_flags & COMBAT_MODE_ACTIVE))
+				visible_message(SPAN_DANGER("[user] warns [target] with [src]!"), null, null, COMBAT_MESSAGE_RANGE)
+				return FALSE
+			if(!(combat_mode_wife.mode_flags & COMBAT_MODE_TOGGLED) && !(combat_mode_wife.mode_flags & COMBAT_MODE_ACTIVE))
+				visible_message(SPAN_DANGER("[target] dodges [target]'s swing with [src]!"), null, null, COMBAT_MESSAGE_RANGE)
+				return FALSE
 	if(isliving(user))
 		var/mob/living/L = user
 		if(!CHECK_MOBILITY(L, MOBILITY_USE) && !(attackchain_flags & ATTACK_IS_PARRY_COUNTERATTACK))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -326,6 +326,21 @@
 /obj/item/projectile/Bump(atom/A)
 	if(!trajectory)
 		return
+
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
+		if(ishuman(firer))
+			var/datum/component/combat_mode/combat_mode_active_shooter = firer.GetComponent(/datum/component/combat_mode)
+			var/datum/component/combat_mode/combat_mode_shot = H.GetComponent(/datum/component/combat_mode)
+			if(!(combat_mode_active_shooter.mode_flags & COMBAT_MODE_TOGGLED) && !(combat_mode_active_shooter.mode_flags & COMBAT_MODE_ACTIVE))
+				visible_message(SPAN_DANGER("[firer] shoots around [H]!"), null, null, COMBAT_MESSAGE_RANGE)
+				forceMove(H.loc)
+				return BULLET_ACT_FORCE_PIERCE
+			if(!(combat_mode_shot.mode_flags & COMBAT_MODE_TOGGLED) && !(combat_mode_shot.mode_flags & COMBAT_MODE_ACTIVE))
+				visible_message(SPAN_DANGER("[H] dodge [firer] fire!"), null, null, COMBAT_MESSAGE_RANGE)
+				forceMove(H.loc)
+				return BULLET_ACT_FORCE_PIERCE
+
 	var/turf/T = get_turf(A)
 	if(check_ricochet_flag(A) && check_ricochet(A)) //if you can ricochet, attempt to ricochet off the object
 		ricochets++


### PR DESCRIPTION

## About The Pull Request

Makes it so both players before combat must be in combat mode
If you shoot a player thats not in combat mode they will douge
If you are not in combat mode and shoot the bullet will be warrening shots

![image](https://user-images.githubusercontent.com/30435998/191189445-49ce72cc-62f6-44ec-ae61-575efc83753d.png)
Proof that it works

Melee just fast-returns


This has no affect on PvE

This does not affect throwing weapons

## Why It's Good For The Game

The rules themselfs state that you MUST both be in combat made yet you can suprize attack someone and thus rending this rule hard and overbaring on the staff to enforce with every case being hard to prove thus a more code fix is in order to help easy the job of staff

## Changelog
:cl:
fix: To do pvp both players MUST be in combat mode
/:cl:
