### PR TITLE
Dramatically reduces timelocks

### DIFF
--- a/code/modules/fallout/job/bos.dm
+++ b/code/modules/fallout/job/bos.dm
@@ -519,8 +519,8 @@ Proctor
 	selection_color = "#95a5a6"
 
 	outfit = /datum/outfit/job/bos/f13seniorscribe
-	exp_requirements = 3000
-	exp_type = EXP_TYPE_SCRIBE
+	exp_requirements = 1000
+	exp_type = EXP_TYPE_BROTHERHOOD
 
 	loadout_options = list(
 	/datum/outfit/loadout/proctorsw,
@@ -601,7 +601,8 @@ Scribe
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Proctor, or Head Scribe"
 	selection_color = "#95a5a6"
-	exp_requirements = 600
+	exp_requirements = 300
+	exp_type = EXP_TYPE_BROTHERHOOD
 
 
 	loadout_options = list(
@@ -724,8 +725,8 @@ Senior Knight
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Knight Captain"
 	selection_color = "#95a5a6"
-	exp_requirements = 3000
-	exp_type = EXP_TYPE_KNIGHT
+	exp_requirements = 1000
+	exp_type = EXP_TYPE_BROTHERHOOD
 
 	loadout_options = list(
 	/datum/outfit/loadout/sknighta,
@@ -813,7 +814,8 @@ Knight
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Senior Knight, or Knight Captain"
 	selection_color = "#95a5a6"
-	exp_requirements = 600
+	exp_requirements = 300
+	exp_type = EXP_TYPE_BROTHERHOOD
 
 	loadout_options = list(
 	/datum/outfit/loadout/knighta,
@@ -1042,7 +1044,8 @@ Off-Duty
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "your superior rank."
 	selection_color = "#95a5a6"
-	exp_requirements = 600
+	exp_requirements = 300
+	exp_type = EXP_TYPE_BROTHERHOOD
 
 	loadout_options = list(
 	/datum/outfit/loadout/offa, //Junior Knight

--- a/code/modules/fallout/job/followers.dm
+++ b/code/modules/fallout/job/followers.dm
@@ -143,7 +143,7 @@ Practitioner
 	forbids = "Causing harm to others except in times of self-defense."
 	enforces = "Followers are not fond of the NCR due to their corruption, but they will help them. They dislike the Brotherhood for hoarding tech, but will make deals to work with them if it furthers the spreading of knowledge. Legion is our mistake and its our job to correct the mistake by speaking of the truth, but recognize that the best way to fight the legion is to teach them and sometimes that can mean helping them.Preaching humanitarianism and valuing human life. Assist and provide medical services to any who require it, regardless of faction. Provide free education for all those who are willing to learn."
 	selection_color = "#FFDDFF"
-	exp_requirements = 1080
+	exp_requirements = 500
 	exp_type = EXP_TYPE_FOLLOWERS
 
 	outfit = /datum/outfit/job/followers/f13practitioner

--- a/code/modules/fallout/job/legion.dm
+++ b/code/modules/fallout/job/legion.dm
@@ -426,8 +426,8 @@ Decanii
 	supervisors = "the Veteran Decanus and the Centurion"
 	display_order = JOB_DISPLAY_ORDER_DECAN
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13decan
-	exp_requirements = 3000
-	exp_type = EXP_TYPE_DECANUS
+	exp_requirements = 1500
+	exp_type = EXP_TYPE_LEGION
 
 	loadout_options = list(
 	/datum/outfit/loadout/primedecline,		//Trail Carbine, .45 Revolver
@@ -503,8 +503,8 @@ Decanii
 	supervisors = "the Prime Decanus and the Centurion"
 	display_order = JOB_DISPLAY_ORDER_DECANREC
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13decanrec
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_PRIME
+	exp_requirements = 600
+	exp_type = EXP_TYPE_LEGION
 
 	loadout_options = list(
 	/datum/outfit/loadout/recdecline,	//Trail Carbine
@@ -579,8 +579,8 @@ Camp Prefect (formerly slave master)
 	supervisors = "The Veteran Decanus, Venator and the Centurion"
 	display_order = JOB_DISPLAY_ORDER_SLAVEMASTER
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13campprefect
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_PRIME
+	exp_requirements = 600
+	exp_type = EXP_TYPE_LEGION
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13campprefect/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -624,8 +624,8 @@ Libritor
 	description = "You answer to the Decani and the Centurion. Acting as a loyal soldier of the Centuria, you have the great honour of serving under Caesar in his quest to unite the scattered tribes of The Sonora. You are entrusted with suit of power armor and heavy weapons, and have been waging war with the Legion for many years."
 	supervisors = "the Decani and Centurion"
 	display_order = JOB_DISPLAY_ORDER_LIBRITOR
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_PRIME
+	exp_requirements = 600
+	exp_type = EXP_TYPE_LEGION
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13libritor
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13legionary/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -1035,7 +1035,7 @@ Auxilia
 	supervisors = "the Decani and Centurion"
 	display_order = JOB_DISPLAY_ORDER_AUXILIA
 	outfit = /datum/outfit/job/CaesarsLegion/f13auxilia
-	exp_requirements = 1200
+	exp_requirements = 600
 	exp_type = EXP_TYPE_CAMP
 
 	loadout_options = list(

--- a/code/modules/fallout/job/ncr.dm
+++ b/code/modules/fallout/job/ncr.dm
@@ -392,8 +392,8 @@ Sergeant
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_SERGEANT
 	outfit = /datum/outfit/job/ncr/f13sergeant
-	exp_requirements = 3000
-	exp_type = EXP_TYPE_NCRNCO
+	exp_requirements = 1500
+	exp_type = EXP_TYPE_NCR
 
 	loadout_options = list(
 	/datum/outfit/loadout/serreg,	//Service
@@ -477,8 +477,8 @@ Corporal
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_CORPORAL
 	outfit = /datum/outfit/job/ncr/f13corporal
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_NCRTPR
+	exp_requirements = 600
+	exp_type = EXP_TYPE_NCR
 
 	loadout_options = list(
 	/datum/outfit/loadout/corpreg,		//Service
@@ -563,8 +563,7 @@ Combat Medic (to be reworked into Supply)
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_COMBATMEDIC
 	outfit = /datum/outfit/job/ncr/f13combatmedic
-	exp_requirements = 900
-	exp_type = EXP_TYPE_NCRTPR
+	exp_requirements = 300
 
 /datum/outfit/job/ncr/f13combatmedic
 	name = "NCR Combat Medic"
@@ -609,8 +608,8 @@ NCR Specialist (formerly only Combat Engineer)
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_COMBATENGINEER
 	outfit = /datum/outfit/job/ncr/f13combatengineer
-	exp_requirements = 900
-	exp_type = EXP_TYPE_NCRTPR
+	exp_requirements = 300
+	exp_type = EXP_TYPE_NCR
 
 	loadout_options = list(
 	/datum/outfit/loadout/ncrcombatengi,	//Combat Engineer
@@ -692,8 +691,8 @@ Mp
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_MILITARY_POLICE
 	outfit = /datum/outfit/job/ncr/f13militarypolice
-	exp_requirements = 3000
-	exp_type = EXP_TYPE_NCRNCO
+	exp_requirements = 1500
+	exp_type = EXP_TYPE_NCR
 
 /datum/outfit/job/ncr/f13militarypolice
 	name = "NCR Military Police"
@@ -742,8 +741,8 @@ Heavy Trooper
 	supervisors = "Corporals and above"
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_HEAVYTROOPER
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_NCRTPR
+	exp_requirements = 600
+	exp_type = EXP_TYPE_NCR
 	outfit = /datum/outfit/job/ncr/f13heavytrooper
 
 /datum/outfit/job/ncr/f13heavytrooper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -785,7 +784,8 @@ Trooper
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_TROOPER
 	outfit = /datum/outfit/job/ncr/f13trooper
-	exp_requirements = 600
+	exp_requirements = 300
+	exp_type = EXP_TYPE_NCR
 
 	loadout_options = list(
 	/datum/outfit/loadout/troopreg,		//Service

--- a/code/modules/fallout/job/silicon.dm
+++ b/code/modules/fallout/job/silicon.dm
@@ -4,18 +4,18 @@ AI
 /datum/job/ai
 	title = "AI"
 	//
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	selection_color = "#ccffcc"
 	supervisors = "your laws"
 	req_admin_notify = TRUE
 	minimal_player_age = 30
 	exp_requirements = 180
-	exp_type = EXP_TYPE_CREW
+	exp_type = EXP_TYPE_WASTELAND
 	exp_type_department = EXP_TYPE_SILICON
 	display_order = JOB_DISPLAY_ORDER_AI
 	var/do_special_check = TRUE
-	
+
 	starting_modifiers = list(/datum/skill_modifier/job/level/wiring/basic)
 
 /datum/job/ai/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin, datum/outfit/outfit_override, client/preference_source = null)
@@ -85,7 +85,7 @@ Cyborg
 	selection_color = "#ddffdd"
 	minimal_player_age = 21
 	exp_requirements = 120
-	exp_type = EXP_TYPE_CREW
+	exp_type = EXP_TYPE_WASTELAND
 
 /datum/job/cyborg/equip(mob/living/carbon/human/H, visualsOnly = FALSE, announce = TRUE, latejoin = FALSE, datum/outfit/outfit_override = null, client/preference_source)
 	return H.Robotize(FALSE, latejoin)

--- a/code/modules/fallout/job/vtcc.dm
+++ b/code/modules/fallout/job/vtcc.dm
@@ -301,7 +301,7 @@
 	spawn_positions = 2
 	supervisors = "the Aldermen and the Marshal."
 	description = "Participating in strike squads against raider encampments and performing surgical strikes against enemies of the Coalition, you and the rest of the elite Provosts don't so much as charge into battle as you do prevent the battle from happening; enforcing the law is still the order of the day, but destabilising real threats and taking out bands of raiders is a priority."
-	exp_requirements = 1500
+	exp_requirements = 600
 	exp_type = EXP_TYPE_VTCCSEC
 
 	outfit = /datum/outfit/job/vtcc/f13provost
@@ -396,7 +396,7 @@
 	description = "Day or night, you watch the walls with diligence. The wastes outside are lawless, but that's not your problem until they drag it in with them, inside the outer ring. It's there that you will learn to dispense justice with an iron fist, dragging those that would break laws penned by the Overseers to serve their sentences by any means necessary. The citizens of the inner ring are rarely a concern and should get off lighter than their counterparts in the outer ring."
 
 	outfit = /datum/outfit/job/vtcc/f13citysecscout
-	exp_requirements = 600
+	exp_requirements = 300
 	exp_type = EXP_TYPE_VTCC
 
 	loadout_options = list(
@@ -475,7 +475,7 @@
 	description = "Operate the shop for the Merchant and push your products on anyone in town you can. Sell to everyone; sell as much as you can - it's a firesale!"
 
 	outfit = /datum/outfit/job/vtcc/f13shopkeep
-	exp_requirements = 900
+	exp_requirements = 600
 	exp_type = EXP_TYPE_ROADIE
 
 	access = list(ACCESS_VTCC, ACCESS_VTCC_ROADIE, ACCESS_VTCC_SHOP)
@@ -519,7 +519,7 @@
 	forbids = "Using the stock to go bunker busting. The stock is to be sold, not to be taken and used by personnel."
 
 	outfit = /datum/outfit/job/vtcc/f13roadie
-	exp_requirements = 600
+	exp_requirements = 300
 	exp_type = EXP_TYPE_VTCC
 
 	loadout_options = list(
@@ -591,7 +591,7 @@
 	description = "Doctor, Scientist, Roboticist, each of you under the Vault's employ stands under the title of Researcher. The Vault's servers are regularly wiped by some glitch in the system, and it's down to the Scientists to restore these data files. To be a Roboticist is to uphold a tradition in the Vault that bears itself a marred reputation, so don't lose your head. The Medical Professionals, even those who handle quarantined patients, are the clinical cornerstone of the town, so long as the price is right."
 
 	outfit = /datum/outfit/job/vtcc/f13researcher
-	exp_requirements = 3000
+	exp_requirements = 1500
 	exp_type = EXP_TYPE_VTCC
 
 	loadout_options = list(


### PR DESCRIPTION
Reduces time-locks and changes exp types for most factions, i feel this will be a net positive for RP as some of the old ones were insane, and were causing good players to be stuck at lower roles.

The solution to that was to ask admins for an exemption, exemptions should be exemptions not the default, reducing these numbers will
1. Allow players to climb the ranks faster and contribute to RP in senior positions
2. Be less intimidating to new players when they open the job screen
3. Attract new players because of that reason